### PR TITLE
feat(python): expose Material.id and materials_by_id for face-material resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: `Material.id` and `SkpModel.materials_by_id` — expose the TLV
+  material IDs that `Face.material_id` references, so callers can resolve a
+  face's material (colour/transparency) from the public API. Previously the
+  join existed only inside the internal exporter.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -127,11 +127,18 @@ class Material:
         color: RGBA colour tuple ``(r, g, b, a)`` with each value in 0–255.
         transparency: Opacity factor where ``0.0`` is fully transparent and
             ``1.0`` is fully opaque.
+        id: Numeric material ID from the TLV stream — the value that
+            :attr:`Face.material_id` references, so callers can resolve a
+            face's material.  ``None`` when the file assigns the material no
+            ID (e.g. it is never referenced by geometry).  When several TLV
+            IDs alias the same material, this holds the first one seen; every
+            ID still resolves through :attr:`SkpModel.materials_by_id`.
     """
 
     name: str
     color: Tuple[int, int, int, int] = (200, 200, 200, 255)
     transparency: float = 1.0
+    id: Optional[int] = None
 
 
 # ── Component hierarchy ───────────────────────────────────────────────────
@@ -202,6 +209,9 @@ class SkpModel:
         definitions: Mapping of definition index → :class:`Definition`.
         layers: List of :class:`Layer` objects found in the file.
         materials: List of :class:`Material` objects found in the file.
+        materials_by_id: Mapping of TLV material ID → :class:`Material`,
+            the join table for :attr:`Face.material_id`.  Several IDs may
+            alias the same :class:`Material` object.
         scene_hierarchy: Top-level :class:`Instance` list forming the
             scene graph.
         mesh_index: Pre-built index mapping definition IDs to triangulated
@@ -212,6 +222,7 @@ class SkpModel:
     definitions: Dict[int, Definition] = field(default_factory=dict)
     layers: List[Layer] = field(default_factory=list)
     materials: List[Material] = field(default_factory=list)
+    materials_by_id: Dict[int, Material] = field(default_factory=dict)
     scene_hierarchy: List[Instance] = field(default_factory=list)
     mesh_index: Dict[int, Any] = field(default_factory=dict)
 
@@ -326,13 +337,30 @@ class SkpFile:
             model.layers.append(Layer(name=name, color_r=r, color_g=g, color_b=b))
 
         # Convert materials
+        mat_for_data: Dict[int, Material] = {}   # id(raw dict) -> Material
         for mat_data in parsed["materials"].values():
             c = mat_data.get("color", {})
-            model.materials.append(Material(
+            mat = Material(
                 name=mat_data.get("name", ""),
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
-            ))
+            )
+            model.materials.append(mat)
+            mat_for_data[id(mat_data)] = mat
+
+        # Join the TLV material IDs (what Face.material_id references) onto
+        # the parsed materials, so callers can resolve face -> material.
+        # Same name-then-folder resolution the internal exporter uses.
+        materials_by_folder = parsed.get("materials_by_folder", {})
+        for m_id, m_name in parsed.get("material_id_to_name", {}).items():
+            mat_data = (parsed["materials"].get(m_name)
+                        or materials_by_folder.get(m_name))
+            mat = mat_for_data.get(id(mat_data)) if mat_data is not None else None
+            if mat is None:
+                continue
+            if mat.id is None:
+                mat.id = m_id
+            model.materials_by_id[m_id] = mat
 
         # Store raw parsed data for export use
         self._parsed = parsed

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,88 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+class TestMaterialIdJoin:
+    """Tests for the ``Face.material_id`` → :class:`Material` join that
+    :meth:`SkpFile.parse` exposes (``Material.id`` +
+    ``SkpModel.materials_by_id``).
+
+    ``full_parse`` is stubbed out, so no real ``.skp`` file is needed.
+    """
+
+    @staticmethod
+    def _parse_with(monkeypatch, tmp_path: pathlib.Path, parsed: dict):
+        import openskp._core as _core
+        from openskp.model import SkpFile
+
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "model.skp"
+        fake.write_bytes(b"")
+        return SkpFile.open(str(fake)).parse()
+
+    def test_material_id_defaults_to_none(self) -> None:
+        from openskp.model import Material
+
+        assert Material(name="Wood").id is None
+
+    def test_face_material_resolves_through_materials_by_id(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {
+                "Wood": {"name": "Wood",
+                         "color": {"r": 10, "g": 20, "b": 30},
+                         "transparency": 1.0},
+            },
+            "materials_by_folder": {},
+            "material_id_to_name": {29491: "Wood"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert model.materials[0].id == 29491
+        mat = model.materials_by_id[29491]
+        assert mat is model.materials[0]
+        assert mat.color == (10, 20, 30)
+
+    def test_folder_alias_resolves_to_same_material(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        # The TLV name may match the ZIP folder rather than the XML name —
+        # the same name-then-folder fallback the internal exporter uses.
+        wood = {"name": "Wood", "color": {"r": 1, "g": 2, "b": 3},
+                "transparency": 1.0}
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {"Wood": wood},
+            "materials_by_folder": {"m0": wood},
+            "material_id_to_name": {7: "Wood", 8: "m0"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert len(model.materials) == 1
+        assert model.materials_by_id[7] is model.materials_by_id[8]
+        # The first ID seen sticks as the Material's own id; both resolve.
+        assert model.materials[0].id in (7, 8)
+
+    def test_unresolvable_id_is_skipped(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {99: "Ghost"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert model.materials_by_id == {}
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## What

Exposes the face → material join on the public API:

- **`Material.id: Optional[int]`** — the TLV material ID this material is known by (`None` when geometry never references it).
- **`SkpModel.materials_by_id: Dict[int, Material]`** — the full join table for `Face.material_id`. Several TLV IDs may alias one `Material`; each resolves here.

## Why

`Face.material_id` carries the numeric IDs from the TLV stream (e.g. `29491`), but `Material` exposed only `name/color/transparency` — no ID to join on. So a consumer of the public API could extract geometry *and* materials, yet had no way to tell **which face has which colour**. The join already existed, but only inside the internal exporter (`_core.build_scene`'s `material_id_to_name` + name-then-folder lookup); this PR surfaces that same resolution on `SkpFile.parse()`.

Context: this is the first concrete gap we hit wiring OpenSKP into [IngeTrazo](https://github.com/tuxiasumari/ingetrazo) as its pure-Python `.skp` importer (see #2) — geometry parses with an exact bounding box vs. our SketchUp-SDK oracle, but no per-face colours could be applied.

## How

In `SkpFile.parse()`, after converting materials, walk `parsed["material_id_to_name"]` and resolve each name through `parsed["materials"]` then `parsed["materials_by_folder"]` — the identical fallback the internal exporter uses — attaching the first ID seen to `Material.id` and every ID to `materials_by_id`.

Both fields are new with defaults → fully backwards-compatible.

## Validation

- **Real file (SketchUp 2022):** all **19/19** distinct `Face.material_id` values in the model resolve to their `Material` (correct name + RGB spot-checked).
- **4 new tests** in `tests/test_parser.py` (`TestMaterialIdJoin`): basic join, folder-alias resolution, unresolvable ID skipped, `id` defaults to `None`. They stub `full_parse`, so no `.skp` fixture is needed — same approach as the existing suite. Full suite: **39 passed**.
- CHANGELOG entry added under `[Unreleased]`.

Happy to adjust naming/placement to your taste — and if you'd rather expose a resolver method instead of the dict, glad to rework it.
