### PR TITLE
feat(python): extract material textures (image bytes + tile size)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: texture extraction — `Material.texture` (`Texture` dataclass:
+  `filename`, tile `width`/`height` in inches, raw image `data` bytes,
+  `save()` helper). Images are read from the material's folder inside the
+  embedded ZIP, with a sibling fallback when the stored image name differs
+  from `textureFilename`.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -362,6 +362,60 @@ def extract_dynamic_properties(d007):
     return properties
 
 
+# ── Texture extraction ───────────────────────────────────────────────────
+
+def _extract_texture(zf, xml_name, mat_elem, ns):
+    """Extract a material's texture from its ``<mat:texture>`` block.
+
+    SketchUp stores the texture image next to the ``material.xml`` inside the
+    ZIP (``materials/<folder>/<image>``), and the real-world tile size in the
+    ``xScale`` / ``yScale`` attributes (inches).
+
+    Args:
+        zf: The open ZIP file.
+        xml_name: Archive name of the ``material.xml`` being parsed.
+        mat_elem: Its ``<mat:material>`` element.
+        ns: Namespace map for the material schema.
+
+    Returns:
+        Dict with keys ``filename``, ``x_scale``, ``y_scale`` (inches, 0.0
+        when absent) and ``data`` (raw image bytes, or ``None`` when the
+        image entry is missing) — or ``None`` when the material carries no
+        texture.
+    """
+    tex_elem = mat_elem.find('mat:texture', ns)
+    if tex_elem is None:
+        return None
+    filename = tex_elem.get('textureFilename', '') or ''
+    try:
+        x_scale = float(tex_elem.get('xScale', 0) or 0)
+    except ValueError:
+        x_scale = 0.0
+    try:
+        y_scale = float(tex_elem.get('yScale', 0) or 0)
+    except ValueError:
+        y_scale = 0.0
+
+    folder = xml_name.rsplit('/', 1)[0]
+    data = None
+    candidate = folder + '/' + filename if filename else None
+    names = zf.namelist()
+    if candidate and candidate in names:
+        data = zf.read(candidate)
+    else:
+        # Image name may differ from textureFilename (observed: e.g.
+        # "Saftey" vs "Safety") — take the folder's non-XML sibling.
+        for entry in names:
+            if (entry.startswith(folder + '/') and entry != xml_name
+                    and not entry.lower().endswith('.xml')):
+                data = zf.read(entry)
+                if not filename:
+                    filename = entry.rsplit('/', 1)[-1]
+                break
+    return {'filename': filename, 'x_scale': x_scale, 'y_scale': y_scale,
+            'data': data}
+
+
 # ── Full parse pipeline ──────────────────────────────────────────────────
 
 def full_parse(skp_path: str) -> Dict[str, Any]:
@@ -425,6 +479,9 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                     trans = float(mat_elem.get('trans', 0.5))
                     folder_name = name.split('/')[1] if len(name.split('/')) > 1 else ''
                     mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans}
+                    tex = _extract_texture(zf, name, mat_elem, MAT_NS)
+                    if tex is not None:
+                        mat_obj['texture'] = tex
                     materials[mat_name] = mat_obj
                     if folder_name:
                         materials_by_folder[folder_name] = mat_obj

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -119,6 +119,41 @@ class Layer:
 
 
 @dataclass
+class Texture:
+    """A material's texture image, extracted from the SKP container.
+
+    SketchUp stores the image next to the material's XML inside the embedded
+    ZIP, and the real-world tile size (how many inches one repetition of the
+    image covers) in the material definition.
+
+    Attributes:
+        filename: Image file name as referenced by the material.
+        width: Tile width in **inches** (SketchUp's internal unit); ``0.0``
+            when the file does not specify it.
+        height: Tile height in inches; ``0.0`` when unspecified.
+        data: Raw image bytes (PNG/JPG as stored), or ``None`` when the
+            image entry was missing from the container.
+    """
+
+    filename: str = ""
+    width: float = 0.0
+    height: float = 0.0
+    data: Optional[bytes] = None
+
+    def save(self, filepath: str | pathlib.Path) -> pathlib.Path:
+        """Write the image bytes to *filepath* and return the path.
+
+        Raises:
+            ValueError: If the texture carries no image data.
+        """
+        if self.data is None:
+            raise ValueError(f"Texture {self.filename!r} has no image data")
+        p = pathlib.Path(filepath)
+        p.write_bytes(self.data)
+        return p
+
+
+@dataclass
 class Material:
     """A surface material.
 
@@ -127,11 +162,14 @@ class Material:
         color: RGBA colour tuple ``(r, g, b, a)`` with each value in 0–255.
         transparency: Opacity factor where ``0.0`` is fully transparent and
             ``1.0`` is fully opaque.
+        texture: The material's :class:`Texture`, or ``None`` for a plain
+            colour material.
     """
 
     name: str
     color: Tuple[int, int, int, int] = (200, 200, 200, 255)
     transparency: float = 1.0
+    texture: Optional[Texture] = None
 
 
 # ── Component hierarchy ───────────────────────────────────────────────────
@@ -328,10 +366,20 @@ class SkpFile:
         # Convert materials
         for mat_data in parsed["materials"].values():
             c = mat_data.get("color", {})
+            tex_data = mat_data.get("texture")
+            texture = None
+            if tex_data is not None:
+                texture = Texture(
+                    filename=tex_data.get("filename", ""),
+                    width=tex_data.get("x_scale", 0.0),
+                    height=tex_data.get("y_scale", 0.0),
+                    data=tex_data.get("data"),
+                )
             model.materials.append(Material(
                 name=mat_data.get("name", ""),
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
+                texture=texture,
             ))
 
         # Store raw parsed data for export use

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,102 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Texture extraction tests ─────────────────────────────────────────────
+
+
+_MATERIAL_XML_TEXTURED = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="%s" type="1" colorRed="10" colorGreen="20"
+                colorBlue="30" trans="1" hasTexture="1">
+    <mat:texture textureFilename="%s" xScale="24" yScale="12"/>
+  </mat:material>
+</materialDocument>
+"""
+
+_MATERIAL_XML_PLAIN = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="Plain" type="0" colorRed="1" colorGreen="2"
+                colorBlue="3" trans="1" hasTexture="0"/>
+</materialDocument>
+"""
+
+
+def _write_synthetic_skp(tmp_path: "pathlib.Path",
+                         entries: dict) -> "pathlib.Path":
+    """Build a minimal ``.skp``: the UTF-16 header marker followed by an
+    embedded ZIP with ``model.dat`` plus *entries*."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("model.dat", b"")
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    path = tmp_path / "synthetic.skp"
+    path.write_bytes(b"\xFF\xFE\xFF\x0E" + b"\x00" * 28 + buf.getvalue())
+    return path
+
+
+class TestTextureExtraction:
+    """Tests for material texture extraction (``Material.texture``)."""
+
+    def test_texture_dataclass_save(self, tmp_path: "pathlib.Path") -> None:
+        from openskp.model import Texture
+
+        tex = Texture(filename="wood.jpg", width=24.0, height=12.0,
+                      data=b"\xff\xd8fakejpeg")
+        out = tex.save(tmp_path / "out.jpg")
+        assert out.read_bytes() == b"\xff\xd8fakejpeg"
+
+    def test_texture_save_without_data_raises(self) -> None:
+        from openskp.model import Texture
+
+        with pytest.raises(ValueError, match="no image data"):
+            Texture(filename="missing.jpg").save("/tmp/never-written.jpg")
+
+    def test_textured_material_roundtrip(self, tmp_path: "pathlib.Path") -> None:
+        from openskp.model import SkpFile
+
+        jpeg = b"\xff\xd8syntheticjpegbytes"
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Wood/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Wood", b"wood.jpg"),
+            "materials/Wood/wood.jpg": jpeg,
+            "materials/Plain/material.xml": _MATERIAL_XML_PLAIN,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        by_name = {m.name: m for m in model.materials}
+        wood = by_name["Wood"]
+        assert wood.texture is not None
+        assert wood.texture.filename == "wood.jpg"
+        assert wood.texture.width == 24.0    # inches, from xScale
+        assert wood.texture.height == 12.0
+        assert wood.texture.data == jpeg
+        assert by_name["Plain"].texture is None
+
+    def test_image_name_mismatch_falls_back_to_sibling(
+        self, tmp_path: "pathlib.Path"
+    ) -> None:
+        # Observed in real files: the XML says "..._Safety.jpg" while the
+        # stored image is "..._Saftey.jpg" — the folder sibling must win.
+        from openskp.model import SkpFile
+
+        jpeg = b"\xff\xd8siblingbytes"
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Glass/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Glass", b"glass_safety.jpg"),
+            "materials/Glass/glass_saftey.jpg": jpeg,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        glass = {m.name: m for m in model.materials}["Glass"]
+        assert glass.texture is not None
+        assert glass.texture.data == jpeg
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## What

Extracts material **textures** — the second gap we hit integrating OpenSKP into IngeTrazo (#2, follows #3):

- **`Texture` dataclass** — `filename`, tile `width`/`height` (**inches**, SketchUp's internal unit), raw image `data` bytes, and a `save()` helper.
- **`Material.texture: Optional[Texture]`** — `None` for plain-colour materials. Backwards-compatible (new defaulted field only).

## Why

A material with `hasTexture="1"` carries a `<mat:texture>` block in its `material.xml`, and the image itself sits right next to the XML inside the embedded ZIP (`materials/<folder>/<image>`). Neither was surfaced, so a textured material parsed as its solid colour only — no way to render or export it faithfully.

The `xScale`/`yScale` attributes are the real-world tile size (how many inches one repetition of the image covers), which is exactly what a consumer needs to map the texture without per-face UVs (SketchUp's default projected-texture behaviour).

## How

`_core._extract_texture` reads the `<mat:texture>` element and the image bytes from the material's ZIP folder. One robustness detail found in real files: the stored image name can differ from `textureFilename` (observed: `"..._Safety.jpg"` in the XML vs `"..._Saftey.jpg"` on disk) — the folder's non-XML sibling is used as fallback.

## Validation

- **Real file (SketchUp 2022):** 2/2 textured materials extract with correct JPEG bytes (`FFD8` magic) and tile sizes (24×24 in and 6×6 in) — including the one that needs the sibling fallback.
- **4 new tests**, including an **end-to-end parse of a synthetic in-memory `.skp`** (header marker + embedded ZIP) that exercises the real `_core` extraction path — no fixture file needed. Full suite: **39 passed**.
- CHANGELOG entry under `[Unreleased]`.

Branched independently from `main` so it can merge before/after #3 in any order. Together with #3, a consumer can now resolve `Face.material_id → Material → colour or texture` — full material fidelity from the public API.
