### PR TITLE
feat(python): expose instance-level materials (Instance.material_id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: `Instance.material_id` — the material painted onto a component
+  instance itself (SketchUp's "paint the component", the same `D007`/`D107`
+  structure faces use). Faces with no material of their own inherit it;
+  consumers can now resolve that inheritance like the official SDK does.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -282,12 +282,27 @@ def _extract_geometry_from_nodes(elements, builder):
                 for idx in range(13):
                     matrix.append(read_f64(mat_node['payload'], idx * 8))
 
+            # Instance-level material (SketchUp "paint the component"):
+            # same D007/D107 structure faces use. Faces whose own material
+            # is None inherit this — the SDK resolves that inheritance when
+            # exporting, so consumers need the raw value to do the same.
+            inst_mat_id = None
+            d007 = next((c for c in el['children'] if c['tag'] == 'D007'),
+                        None)
+            if d007:
+                d107 = next((c for c in d007['children']
+                             if c['tag'] == 'D107'), None)
+                if d107:
+                    inst_mat_id = parse_var_int(
+                        d107['payload'], 0, len(d107['payload']))
+
             builder.instances.append({
                 'offset': el['offset'],
                 'ref_guid': guid,
                 'ref_idx': def_idx,
                 'name': name,
                 'matrix': matrix,
+                'material_id': inst_mat_id,
                 'children': el['children']
             })
 

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -151,6 +151,11 @@ class Instance:
         layer: Layer name this instance belongs to.
         properties: Arbitrary key/value dynamic attributes.
         children: Nested child instances forming a subtree.
+        material_id: Numeric material ID painted onto the instance itself
+            (SketchUp's "paint the component"), or ``None``.  Faces inside
+            the placed definition whose own :attr:`Face.material_id` is
+            ``None`` inherit this material — consumers must resolve that
+            inheritance themselves, like the official SDK does on export.
     """
 
     name: str = ""
@@ -165,6 +170,7 @@ class Instance:
     layer: str = ""
     properties: Dict[str, str] = field(default_factory=dict)
     children: List["Instance"] = field(default_factory=list)
+    material_id: Optional[int] = None
 
 
 @dataclass
@@ -318,6 +324,7 @@ class SkpFile:
                     ref_idx=inst.get("ref_idx"),
                     guid=inst.get("ref_guid", ""),
                     matrix=inst.get("matrix", []),
+                    material_id=inst.get("material_id"),
                 ))
             model.definitions[def_id] = defn
 

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,54 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Instance material tests ──────────────────────────────────────────────
+
+
+class TestInstanceMaterial:
+    """Tests for instance-level materials (``Instance.material_id``)."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_instance_material_defaults_to_none(self) -> None:
+        from openskp.model import Instance
+
+        assert Instance().material_id is None
+
+    def test_extractor_reads_instance_d007_material(self) -> None:
+        # A 6419 instance node carrying D007/D107 — the same material
+        # structure faces use ("paint the component" in SketchUp).
+        from openskp import _core
+
+        d107 = self._tlv('D107', bytes([0x33, 0x73]))          # id 0x7333
+        d007 = self._tlv('D007', d107)
+        ref = self._tlv('6719', bytes([0x05]))                  # ref_idx 5
+        matrix = self._tlv('6619', struct.pack('<13d', *([1.0] * 13)))
+        node = self._tlv('6419', ref + matrix + d007)
+
+        elements = _core.parse_tlv_recursive(
+            node + self._tlv('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert len(builder.instances) == 1
+        inst = builder.instances[0]
+        assert inst['ref_idx'] == 5
+        assert inst['material_id'] == 0x7333
+
+    def test_instance_without_material_stays_none(self) -> None:
+        from openskp import _core
+
+        ref = self._tlv('6719', bytes([0x05]))
+        node = self._tlv('6419', ref)
+        elements = _core.parse_tlv_recursive(
+            node + self._tlv('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert builder.instances[0]['material_id'] is None
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## What

Exposes **instance-level materials**: `Instance.material_id` — the material painted onto a component instance itself. Third in the series (#3 face materials, #4 textures); with this one, full material fidelity is reachable from the public API.

## Why

In SketchUp it's very common to paint a whole component rather than its faces ("paint the component"): the faces inside keep material `None` and **inherit** the instance's material. The instance node (`6419`) carries that material in the same `D007`/`D107` structure faces use — but the parser ignored it, so every instance-painted component came out uncoloured and consumers had no way to resolve the inheritance.

Found on a real SketchUp 2026 file: **24 of 274 instances carry a material** (granite pergolas, wood floors, paver walks) — ~444 m² of painted surface that parsed as unpainted.

## How

- `_core`: read `D007`/`D107` under the `6419` instance node into the builder's instance dict as `material_id`.
- `model.py`: `Instance.material_id: Optional[int]` (default `None`), with the inheritance rule documented — faces whose own `material_id` is `None` inherit it, as the official SDK resolves on export.

Backwards-compatible (new defaulted field only).

## Validation

- **3 new tests**, including an end-to-end TLV extraction: a synthetic `6419` node carrying `D007`/`D107` built byte-by-byte and run through the real `parse_tlv_recursive` + `_extract_geometry_from_nodes` — no fixture file needed. Full suite: **38 passed**.
- Real-file spot check (SU2026): all 24 instance materials resolve to known material names via `material_id_to_name`.
- CHANGELOG entry under `[Unreleased]`.

Branched independently from `main` — merges in any order relative to #3/#4.
