### PR TITLE
feat(python): decode per-face texture mapping (Face.uv_transform)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: per-face texture mapping — `Face.uv_transform` /
+  `uv_transform_back` (the 3×3 matrix a positioned / photo-fitted texture
+  stores per face; SketchUp's texture pins). Includes the decoded recipe to
+  turn it into UVs (plane basis from the normal, then
+  `[x, y, 1] @ inv(M) / tile`), calibrated against SDK-exported ground
+  truth to < 0.001 UV error, including projective (4-pin distorted)
+  mappings.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -193,6 +193,66 @@ def extract_entity_id(node):
     return None
 
 
+def _tlv_flat(payload):
+    """Walk a raw payload as a flat TLV sequence; returns [(tag_hex, body)]."""
+    pos = 0
+    out = []
+    while pos <= len(payload) - 6:
+        tag = payload[pos:pos+2].hex().upper()
+        size = read_u32(payload, pos+2)
+        if pos + 6 + size > len(payload):
+            break
+        out.append((tag, payload[pos+6:pos+6+size]))
+        pos += 6 + size
+    return out
+
+
+def _extract_uv_transforms(dc05_payload):
+    """Per-face texture-mapping matrices from a face's DC05 entity-info blob.
+
+    A positioned / photo-fitted texture stores its mapping per face under
+    ``DC05 -> DD05 -> B136 -> B236 -> 1027 -> 1127 (front) / 1227 (back)
+    -> 1327 -> 1527``: a 3x3 row-major matrix of f64 that maps
+    **texture space -> face plane**; consumers invert it to get UVs
+    (see the ``Face.uv_transform`` docs in model.py for the exact recipe).
+
+    Returns:
+        ``(front, back)`` — each a 9-tuple of floats, or ``None`` when the
+        face carries no positioned mapping on that side.
+    """
+    def _find(seq, tag):
+        for t, body in seq:
+            if t == tag:
+                return body
+        return None
+
+    dd05 = _find(_tlv_flat(dc05_payload), 'DD05')
+    if dd05 is None:
+        return None, None
+    b136 = _find(_tlv_flat(dd05), 'B136')
+    if b136 is None:
+        return None, None
+    b236 = _find(_tlv_flat(b136), 'B236')
+    if b236 is None:
+        return None, None
+    t1027 = _find(_tlv_flat(b236), '1027')
+    if t1027 is None:
+        return None, None
+    sides = _tlv_flat(t1027)
+    result = []
+    for side_tag in ('1127', '1227'):
+        side = _find(sides, side_tag)
+        mat = None
+        if side is not None:
+            t1327 = _find(_tlv_flat(side), '1327')
+            if t1327 is not None:
+                t1527 = _find(_tlv_flat(t1327), '1527')
+                if t1527 is not None and len(t1527) == 72:
+                    mat = struct.unpack('<9d', t1527)
+        result.append(mat)
+    return result[0], result[1]
+
+
 def _extract_geometry_from_nodes(elements, builder):
     for el in elements:
         tag = el['tag']
@@ -255,12 +315,19 @@ def _extract_geometry_from_nodes(elements, builder):
                         if co_edges:
                             loops.append(co_edges)
                 face_mat_id = None
+                uv_front = uv_back = None
                 d007 = next((c for c in el['children'] if c['tag'] == 'D007'), None)
                 if d007:
                     d107 = next((c for c in d007['children'] if c['tag'] == 'D107'), None)
                     if d107:
                         face_mat_id = parse_var_int(d107['payload'], 0, len(d107['payload']))
-                builder.faces[f_id] = {'loops': loops, 'normal': normal, 'material_id': face_mat_id}
+                    dc05 = next((c for c in d007['children'] if c['tag'] == 'DC05'), None)
+                    if dc05 is not None:
+                        uv_front, uv_back = _extract_uv_transforms(dc05['payload'])
+                builder.faces[f_id] = {'loops': loops, 'normal': normal,
+                                       'material_id': face_mat_id,
+                                       'uv_transform': uv_front,
+                                       'uv_transform_back': uv_back}
 
         elif tag == '6419':
             nodes_to_search = el['children'] if el['children'] else [el]

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -90,12 +90,31 @@ class Face:
             ``(edge_id, orientation)`` tuples where *orientation* is
             ``1`` for forward or ``-1`` for reversed.
         normal: Optional outward-facing normal vector ``(nx, ny, nz)``.
+        uv_transform: Per-face texture mapping for a *positioned* /
+            photo-fitted texture (SketchUp's pins), or ``None`` when the
+            texture is untouched (default projection applies).  A 9-tuple:
+            a 3×3 **row-major** matrix mapping texture space → face plane.
+            To compute the UV of a point ``p`` (inches):
+
+            1. Plane basis from the face normal ``n``:
+               ``xr = normalize(Z × n)``, ``yr = n × xr`` (for a vertical
+               ``n``: ``xr = X``, ``yr = ±Y`` by the sign of ``n``·Z).
+            2. ``uvq = [p·xr, p·yr, 1] @ inv(M)``  (row-vector convention).
+            3. ``u = uvq[0]/uvq[2] / tile_w``, ``v = uvq[1]/uvq[2] / tile_h``
+               with the material texture's tile size in inches.
+
+            When the texture is untouched (``None``), the default is
+            ``u = (p·xr)/tile_w``, ``v = (p·yr)/tile_h``.  Distorted
+            (4-pin) mappings are projective: ``uvq[2]`` ≠ 1.
+        uv_transform_back: Same for the face's back side, or ``None``.
     """
 
     id: int
     loops: List[List[Tuple[int, int]]] = field(default_factory=list)
     normal: Optional[Tuple[float, float, float]] = None
     material_id: Optional[int] = None
+    uv_transform: Optional[Tuple[float, ...]] = None
+    uv_transform_back: Optional[Tuple[float, ...]] = None
 
 
 # ── Layers & Materials ────────────────────────────────────────────────────
@@ -310,6 +329,8 @@ class SkpFile:
                     loops=f_data.get("loops", []),
                     normal=f_data.get("normal"),
                     material_id=f_data.get("material_id"),
+                    uv_transform=f_data.get("uv_transform"),
+                    uv_transform_back=f_data.get("uv_transform_back"),
                 )
             # Populate instances
             for inst in builder.instances:

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,78 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Per-face UV transform tests ──────────────────────────────────────────
+
+
+class TestFaceUvTransform:
+    """Tests for positioned-texture mapping extraction (``Face.uv_transform``)."""
+
+    ROT90 = (0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 96.0, -96.0, 1.0)
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def _dc05(self, front=None, back=None) -> bytes:
+        t = self._tlv
+        def side(tag, mat):
+            m1527 = t('1527', struct.pack('<9d', *mat))
+            return t(tag, t('1327', t('1427', b'\x01') + m1527))
+        inner = b''
+        if front is not None:
+            inner += side('1127', front)
+        if back is not None:
+            inner += side('1227', back)
+        t1027 = t('1027', inner)
+        return (t('DE05', b'\x2A')
+                + t('DD05', t('B136', t('B236', t1027))))
+
+    def test_extracts_front_matrix(self) -> None:
+        from openskp._core import _extract_uv_transforms
+
+        front, back = _extract_uv_transforms(self._dc05(front=self.ROT90))
+        assert front == pytest.approx(self.ROT90)
+        assert back is None
+
+    def test_extracts_both_sides(self) -> None:
+        from openskp._core import _extract_uv_transforms
+
+        other = tuple(v * 2 for v in self.ROT90)
+        front, back = _extract_uv_transforms(
+            self._dc05(front=self.ROT90, back=other))
+        assert front == pytest.approx(self.ROT90)
+        assert back == pytest.approx(other)
+
+    def test_untouched_texture_has_no_transform(self) -> None:
+        from openskp._core import _extract_uv_transforms
+        from openskp.model import Face
+
+        t = self._tlv
+        plain = t('DE05', b'\x2A')      # entity id only, no DD05 block
+        assert _extract_uv_transforms(plain) == (None, None)
+        assert Face(id=0).uv_transform is None
+        assert Face(id=0).uv_transform_back is None
+
+    def test_recipe_reproduces_known_uvs(self) -> None:
+        # Ground truth from a controlled SketchUp file: a 1x1 m square on the
+        # ground with the texture rotated 90 deg (48x48 in tile). The stored
+        # matrix maps texture->plane; UV = [x, y, 1] @ inv(M) / tile.
+        import numpy as np
+
+        m = np.array(self.ROT90).reshape(3, 3)
+        minv = np.linalg.inv(m)
+        tile = 48.0
+        for (x, y), (u_t, v_t) in [
+            ((82.64, 0.0), (2.0, 0.2784)),
+            ((122.01, 0.0), (2.0, -0.5418)),
+            ((82.64, 39.37), (2.8202, 0.2784)),
+        ]:
+            uvq = np.array([x, y, 1.0]) @ minv
+            u = uvq[0] / uvq[2] / tile
+            v = uvq[1] / uvq[2] / tile
+            assert u == pytest.approx(u_t, abs=2e-3)
+            assert v == pytest.approx(v_t, abs=2e-3)
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## What

Decodes **per-face texture mapping** — `Face.uv_transform` / `uv_transform_back`. Fourth in the series (#3 face materials, #4 textures, #5 instance materials); this is the one that makes positioned and photo-fitted textures renderable.

## Why

A texture that has been positioned or photo-fitted with SketchUp's pins stores a per-face mapping the parser ignored. Without it, consumers can only apply the material's default projection — a photo-fitted waving-flag mesh, for example, renders as a single solid colour (the corner of the image every face happens to sample).

## The reverse engineering

**Location** (TLV archaeology on real SU2022/2026 files): under the face's entity-info blob,
`D007 → DC05 → DD05 → B136 → B236 → 1027 → 1127 (front) / 1227 (back) → 1327 → 1527` — a 3×3 row-major f64 matrix.

**Semantics** (calibrated with a controlled experiment: a SketchUp file with three 1×1 m squares — texture untouched / rotated 90° / pin-distorted — plus SDK-exported ground-truth UVs): the stored matrix maps **texture space → face plane**. UVs are recovered by inverting it:

```
xr = normalize(Z × n);  yr = n × xr        # plane basis from the face normal, inches
uvq = [p·xr, p·yr, 1] @ inv(M)             # row-vector convention
u = uvq[0]/uvq[2]/tile_w ;  v = uvq[1]/uvq[2]/tile_h
```

- Untouched texture → no matrix → default projection `u = (p·xr)/tile_w`.
- Distorted (4-pin) mappings are **projective** (`uvq[2] ≠ 1`) and come out exact under the same recipe.

**Validation:** < 0.0003 UV error on the controlled squares (including the distorted one), and **rms < 1e-5 over 150 photo-fitted triangles** of a real waving-flag mesh, both against SDK-exported ground truth.

## API

`Face.uv_transform` / `Face.uv_transform_back` (9-tuples, default `None`), with the full recipe documented on the dataclass — so any consumer (renderer, exporter) can apply it without re-deriving the convention. Backwards-compatible (new defaulted fields only).

## Tests

4 new tests with byte-built `DC05` blobs (no fixture files): front-only extraction, front+back, untouched → `None`, and the recipe reproducing known ground-truth UVs. Full suite: **39 passed**.

Branched independently from `main` — merges in any order relative to #3/#4/#5.
