### PR TITLE
fix(python): decode entity names as UTF-8, not ASCII-with-ignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Python**: entity names (materials, layers, definitions, instances,
+  dynamic properties) now decode as **UTF-8** instead of ASCII-with-ignore.
+  Dropping the non-ASCII bytes silently corrupted any accented name
+  ("cópia" → "cpia", "Diseño" → "Diseo") and — critically — broke the
+  material-name join between the TLV stream and the XML material files,
+  leaving those materials unresolvable from geometry.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -276,7 +276,7 @@ def _extract_geometry_from_nodes(elements, builder):
                 def_idx = parse_var_int(def_idx_node['payload'], 0, len(def_idx_node['payload']))
             name_node = find_child_tag(nodes_to_search, '6519')
             if name_node:
-                name = name_node['payload'].decode('ascii', errors='ignore')
+                name = name_node['payload'].decode('utf-8', errors='replace')
             mat_node = find_child_tag(nodes_to_search, '6619')
             if mat_node and len(mat_node['payload']) >= 104:
                 for idx in range(13):
@@ -352,9 +352,9 @@ def extract_dynamic_properties(d007):
         for n in nodes:
             tag = n['tag']
             if tag == 'B636':
-                current_key = n['payload'].decode('ascii', errors='ignore')
+                current_key = n['payload'].decode('utf-8', errors='replace')
             elif tag == 'AD38' and current_key:
-                val = n['payload'].decode('ascii', errors='ignore')
+                val = n['payload'].decode('utf-8', errors='replace')
                 properties[current_key] = val
                 current_key = None
             extract_props(n['children'])
@@ -462,7 +462,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                                 l_id = parse_var_int(payload, 6, de05_len)
                             else:
                                 l_id = parse_var_int(payload, 0, len(payload))
-                            l_name = name_node['payload'].decode('ascii', errors='ignore')
+                            l_name = name_node['payload'].decode('utf-8', errors='replace')
                             layer_id_to_name[l_id] = l_name
             collect_layers(el['children'])
     collect_layers(elements)
@@ -486,7 +486,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                         m_id = parse_var_int(payload, 6, de05_len)
                     else:
                         m_id = parse_var_int(payload, 0, len(payload))
-                    m_name = name_node['payload'].decode('ascii', errors='ignore')
+                    m_name = name_node['payload'].decode('utf-8', errors='replace')
                     material_id_to_name[m_id] = m_name
             collect_material_ids(el['children'])
     collect_material_ids(elements)
@@ -502,7 +502,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                     if child['tag'] == '7D15' and len(child['payload']) == 16:
                         guid = child['payload'].hex().upper()
                     elif child['tag'] == '7E15':
-                        name = child['payload'].decode('ascii', errors='ignore')
+                        name = child['payload'].decode('utf-8', errors='replace')
                 ent_id = extract_entity_id(el)
                 builder = _GeometryBuilder()
                 _extract_geometry_from_nodes(el['children'], builder)

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,36 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── UTF-8 entity name tests ──────────────────────────────────────────────
+
+
+class TestUtf8EntityNames:
+    """Entity names must decode as UTF-8, not ASCII-with-ignore.
+
+    SketchUp stores names UTF-8 encoded. Decoding them as ASCII and
+    *dropping* the non-ASCII bytes silently corrupts any accented name
+    ("cópia" → "cpia", "Diseño" → "Diseo") — and, worse, breaks the
+    material-name join between the TLV stream and the XML material files,
+    leaving those materials unresolvable.
+    """
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_instance_name_keeps_accents(self) -> None:
+        from openskp import _core
+
+        name = "Diseño de árbol".encode("utf-8")
+        node = self._tlv('6419', self._tlv('6519', name)
+                         + self._tlv('6719', b'\x05'))
+        elements = _core.parse_tlv_recursive(
+            node + self._tlv('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert builder.instances[0]['name'] == "Diseño de árbol"
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## What

One-word fix with outsized impact: entity names decode as **UTF-8** instead of `ascii, errors='ignore'`.

## Why

SketchUp stores names UTF-8 encoded. Decoding as ASCII and *ignoring* the non-ASCII bytes silently corrupts any accented name — `"cópia"` → `"cpia"`, `"Diseño"` → `"Diseo"`. That's a guaranteed hit for files authored in Spanish, Portuguese, French, German…

And it's worse than cosmetics: **the TLV material name is the join key to the XML material files.** A corrupted name never matches its XML entry, so the material becomes unresolvable from geometry.

**Real-world case** (SketchUp 2026 plaza, authored in Spanish): the tree-foliage material `Celtis_australis_s cópia` decoded as `..._s cpia`, failed the join, and every tree crown in the model rendered colourless — we chased this as a "missing Image entities" bug for a while before finding it was an encoding bug all along.

## How

All six decode sites in `_core` (material names, layer names, definition names, instance names, dynamic-property keys/values) switch to `utf-8, errors='replace'`. ASCII names are byte-identical under UTF-8, so nothing changes for English files.

## Validation

- Real file: `material_id_to_name[3319170]` now yields `'Celtis_australis_s cópia'`, matching its XML entry — the join resolves and the foliage gets its texture.
- New TLV-built test: an instance named `"Diseño de árbol"` survives extraction intact. Full suite: **36 passed**.
- CHANGELOG entry under `[Unreleased]` (Fixed).

Branched independently from `main` — merges in any order relative to #3/#4/#5/#6.
