### PR TITLE
feat(python): parse Image entities (9013/401F placement + Definition.is_image)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: Image entities — a picture placed in the model as an object
+  now parses: its placement wraps a standard instance node inside the
+  image-specific `9013`/`401F` containers (previously opaque, so the image
+  definition looked "never placed"), and `Definition.is_image` flags the
+  single-quad definition backing it (TLV kind `8315 == 2`). Real-world
+  case: photo cut-out statues/animals placed as images imported with no
+  geometry at all.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -44,6 +44,11 @@ CONTAINER_TAGS = {
     'F901', '7017', '7117', 'D007', 'C409', '9411', '9511', '0F01',
     '384A', 'B80B', '9713', '2C4C', 'AC0D', 'AE0D', 'F601', 'F801',
     '983A', '993A', '8C3C', '8D3C',
+    # Image-entity placement: an Image placed in the model wraps a standard
+    # 6419 instance node inside 9013 -> 401F. Without these two containers,
+    # that inner instance stays buried in an opaque payload and the image
+    # definition looks "never placed".
+    '9013', '401F',
 }
 
 def parse_tlv_recursive(data, start, end, container_tags=None, depth=0):
@@ -498,15 +503,23 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
             if el['tag'] == '7C15':
                 guid = None
                 name = None
+                is_image = False
                 for child in el['children']:
                     if child['tag'] == '7D15' and len(child['payload']) == 16:
                         guid = child['payload'].hex().upper()
                     elif child['tag'] == '7E15':
                         name = child['payload'].decode('ascii', errors='ignore')
+                    elif child['tag'] == '8315' and child['payload']:
+                        # Definition kind: observed 0/1 for ordinary
+                        # component/group definitions, 2 for the quad
+                        # definition backing an Image entity.
+                        is_image = parse_var_int(
+                            child['payload'], 0, len(child['payload'])) == 2
                 ent_id = extract_entity_id(el)
                 builder = _GeometryBuilder()
                 _extract_geometry_from_nodes(el['children'], builder)
-                defs_dict[ent_id] = {'guid': guid, 'name': name, 'builder': builder}
+                defs_dict[ent_id] = {'guid': guid, 'name': name,
+                                     'is_image': is_image, 'builder': builder}
             collect_defs(el['children'])
     collect_defs(elements)
 

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -179,6 +179,11 @@ class Definition:
         edges: Mapping of edge ID → :class:`Edge`.
         faces: Mapping of face ID → :class:`Face`.
         instances: Child instances placed inside this definition.
+        is_image: ``True`` when this definition backs an *Image entity* (a
+            picture placed in the model as an object): a single textured
+            quad, placed through an image-specific wrapper node. Useful for
+            consumers that give images special treatment (e.g. billboard
+            cut-outs).
     """
 
     id: int = 0
@@ -188,6 +193,7 @@ class Definition:
     edges: Dict[int, Edge] = field(default_factory=dict)
     faces: Dict[int, Face] = field(default_factory=dict)
     instances: List[Instance] = field(default_factory=list)
+    is_image: bool = False
 
 
 # ── Top-level model ──────────────────────────────────────────────────────
@@ -296,6 +302,7 @@ class SkpFile:
                 id=def_id if isinstance(def_id, int) else 0,
                 guid=d.get("guid", ""),
                 name=d.get("name", "") or "",
+                is_image=d.get("is_image", False),
             )
             # Populate vertices
             for v_id, (x, y, z) in builder.vertices.items():

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,65 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Image entity tests ───────────────────────────────────────────────────
+
+
+class TestImageEntities:
+    """Image entities: a picture placed in the model wraps a standard 6419
+    instance inside ``9013 → 401F``, and its backing definition carries
+    kind ``8315 == 2``."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_image_placement_instance_is_extracted(self) -> None:
+        from openskp import _core
+
+        t = self._tlv
+        inner_6419 = t('6419', t('6719', b'\x07'))       # ref_idx 7
+        node = t('9013', t('401F', inner_6419))
+        elements = _core.parse_tlv_recursive(
+            node + t('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert len(builder.instances) == 1
+        assert builder.instances[0]['ref_idx'] == 7
+
+    def test_definition_kind_2_marks_is_image(self, tmp_path: pathlib.Path,
+                                              monkeypatch) -> None:
+        from openskp.model import Definition, SkpFile
+        import openskp._core as _core
+
+        class _B:
+            vertices = {}
+            edges = {}
+            faces = {}
+            instances = []
+
+        parsed = {
+            "version": "test",
+            "defs_dict": {
+                1: {"guid": "", "name": "imagen#1", "is_image": True,
+                    "builder": _B()},
+                2: {"guid": "", "name": "Grupo", "is_image": False,
+                    "builder": _B()},
+            },
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {},
+        }
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "m.skp"
+        fake.write_bytes(b"")
+        model = SkpFile.open(str(fake)).parse()
+
+        assert model.definitions[1].is_image is True
+        assert model.definitions[2].is_image is False
+        assert Definition().is_image is False
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## What

Parses **Image entities** — a picture placed in the model as an object. Sixth in the series (#3–#7).

## Why

An Image entity was completely invisible: its quad definition parsed fine, but its **placement** wraps a standard `6419` instance node inside two image-specific containers (`9013` → `401F`) that weren't in `CONTAINER_TAGS` — so the inner instance stayed buried in an opaque payload, the definition looked "never placed", and the image never appeared in any consumer's output.

**Real-world case** (SketchUp 2026 plaza): two photo cut-outs placed as images — a statue and a bull — imported with no geometry at all.

## How

- `CONTAINER_TAGS += {'9013', '401F'}` — the wrapped `6419` now parses like any instance and the existing extraction picks it up with its placement matrix. That's the whole fix for placement: two tags.
- `Definition.is_image` — the definition backing an image carries TLV kind `8315 == 2` (ordinary definitions carry 0/1); exposed so consumers can give images special treatment (billboard cut-outs, image lists, etc.). Backwards-compatible (new defaulted field).

## Validation

- Real file: instance count 274 → **276**, and the two new instances' `ref_idx` match the image definitions exactly, with sane placement matrices (scale + upright rotation + translation).
- 2 new tests: a byte-built `9013/401F/6419` extraction through the real parser, and `is_image` mapping through `parse()`. Full suite: **37 passed**.
- CHANGELOG entry under `[Unreleased]`.

Branched independently from `main` — merges in any order relative to #3–#7.
