### PR TITLE
feat(python): parse style face colors (SkpModel.styles)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: styles — `SkpModel.styles` (`Style`: name, `front_color`,
+  `back_color` RGB) parsed from `styles/*/style.xml` (signed-int32 ARGB
+  items 4000/4001). Viewers need them to shade unpainted faces the way
+  SketchUp does.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -438,6 +438,38 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
     if 'meta/model_thumbnail.png' in zf.namelist():
         thumbnail_data = zf.read('meta/model_thumbnail.png')
 
+    # Styles: face colors live in styles/*/style.xml as signed-int32 ARGB
+    # variants — item id 4000 is the front (default) face color, 4001 the
+    # back face color. Viewers need them to shade unpainted faces the way
+    # SketchUp does (an author may e.g. set a green back color so unpainted
+    # garden faces read as grass).
+    styles = []
+    for name in zf.namelist():
+        if not (name.startswith('styles/') and name.endswith('style.xml')):
+            continue
+        try:
+            sroot = ET.fromstring(zf.read(name))
+        except ET.ParseError:
+            continue
+        STY = '{http://sketchup.google.com/schemas/sketchup/1.0/style}'
+        TYP = '{http://sketchup.google.com/schemas/1.0/types}'
+        style_el = sroot.find(f'{STY}style')
+        if style_el is None:
+            continue
+        colors = {}
+        for item in style_el.findall(f'{STY}item'):
+            iid = item.get('id')
+            var = item.find(f'{TYP}variant')
+            if iid in ('4000', '4001') and var is not None and var.text:
+                try:
+                    v = int(var.text) & 0xFFFFFFFF
+                except ValueError:
+                    continue
+                colors[iid] = ((v >> 16) & 255, (v >> 8) & 255, v & 255)
+        styles.append({'name': style_el.get('name', ''),
+                       'front_color': colors.get('4000'),
+                       'back_color': colors.get('4001')})
+
     model_dat = zf.read('model.dat')
     zf.close()
 
@@ -527,6 +559,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
         'defs_dict': defs_dict,
         'elements': elements,
         'thumbnail_data': thumbnail_data,
+        'styles': styles,
     }
 
 

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -119,6 +119,24 @@ class Layer:
 
 
 @dataclass
+class Style:
+    """A rendering style bundled in the file (SketchUp's Styles browser).
+
+    Attributes:
+        name: Style name.
+        front_color: Default front face color ``(r, g, b)`` 0-255, or
+            ``None``. Unpainted faces show it.
+        back_color: Back face color ``(r, g, b)`` 0-255, or ``None``.
+            Unpainted faces seen from behind show it — an author may e.g.
+            pick a green back color so unpainted garden faces read as grass.
+    """
+
+    name: str = ""
+    front_color: Optional[Tuple[int, int, int]] = None
+    back_color: Optional[Tuple[int, int, int]] = None
+
+
+@dataclass
 class Material:
     """A surface material.
 
@@ -213,6 +231,7 @@ class SkpModel:
     layers: List[Layer] = field(default_factory=list)
     materials: List[Material] = field(default_factory=list)
     scene_hierarchy: List[Instance] = field(default_factory=list)
+    styles: List[Style] = field(default_factory=list)
     mesh_index: Dict[int, Any] = field(default_factory=dict)
 
 
@@ -332,6 +351,14 @@ class SkpFile:
                 name=mat_data.get("name", ""),
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
+            ))
+
+        # Convert styles
+        for st in parsed.get("styles", []):
+            model.styles.append(Style(
+                name=st.get("name", ""),
+                front_color=st.get("front_color"),
+                back_color=st.get("back_color"),
             ))
 
         # Store raw parsed data for export use

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,44 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Style tests ──────────────────────────────────────────────────────────
+
+
+class TestStyles:
+    """Face colors from styles/*/style.xml (items 4000 front / 4001 back)."""
+
+    def test_style_colors_via_synthetic_skp(self, tmp_path: pathlib.Path) -> None:
+        import io
+        import struct as _struct
+        import zipfile
+        from openskp.model import SkpFile
+
+        style_xml = b"""<?xml version="1.0"?>
+<styleDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/style"
+               xmlns:sty="http://sketchup.google.com/schemas/sketchup/1.0/style">
+  <sty:style xmlns:t="http://sketchup.google.com/schemas/1.0/types" name="Verde">
+    <sty:item id="4000"><t:variant type="4">-3552052</t:variant></sty:item>
+    <sty:item id="4001"><t:variant type="4">-3093050</t:variant></sty:item>
+  </sty:style>
+</styleDocument>
+"""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("model.dat", b"")
+            zf.writestr("styles/Verde/style.xml", style_xml)
+        path = tmp_path / "s.skp"
+        path.write_bytes(b"\xFF\xFE\xFF\x0E" + b"\x00" * 28 + buf.getvalue())
+
+        model = SkpFile.open(str(path)).parse()
+        assert len(model.styles) == 1
+        st = model.styles[0]
+        assert st.name == "Verde"
+        # -3552052 -> 0xFFC9CCCC-ish ARGB: decode matches int32 & 0xFFFFFF
+        v = (-3552052) & 0xFFFFFFFF
+        assert st.front_color == ((v >> 16) & 255, (v >> 8) & 255, v & 255)
+        v2 = (-3093050) & 0xFFFFFFFF
+        assert st.back_color == ((v2 >> 16) & 255, (v2 >> 8) & 255, v2 & 255)
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## What

Parses the file's **style face colors** — `SkpModel.styles` with `Style(name, front_color, back_color)`. Eighth in the series (#3–#9).

## Why

Unpainted faces take their look from the file's style. Without it, a viewer shades them with its own defaults and diverges from what the author saw — back-face tints are often picked deliberately (e.g. to read as grass or paper).

## How

`styles/*/style.xml` in the embedded ZIP stores signed-int32 ARGB variants: item **4000** = default front face color, **4001** = back face color. Decoded to RGB 0-255 tuples.

## Validation

Synthetic end-to-end `.skp` test (byte-built ZIP with a hand-written style.xml) through `parse()`; real-file check on a SU2026 model returns both colors. Full suite: **36 passed**. CHANGELOG under [Unreleased]. Backwards-compatible.

Branched independently from `main`.