### PR TITLE
feat(python): expose the face's back-side material (Face.back_material_id)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: `Face.back_material_id` — the material of a face's BACK side
+  (the `AF0D` child of the face node). A face painted only on its back is
+  common when the author paints the visible side of a downward-facing cap;
+  without this field such faces looked unpainted.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -260,7 +260,17 @@ def _extract_geometry_from_nodes(elements, builder):
                     d107 = next((c for c in d007['children'] if c['tag'] == 'D107'), None)
                     if d107:
                         face_mat_id = parse_var_int(d107['payload'], 0, len(d107['payload']))
-                builder.faces[f_id] = {'loops': loops, 'normal': normal, 'material_id': face_mat_id}
+                # Back-side material: the AF0D child of the face node (a face
+                # painted only on its back — common when the author paints the
+                # visible side of a downward-facing cap — carries AF0D but no
+                # D107).
+                back_mat_id = None
+                af0d = next((c for c in el['children'] if c['tag'] == 'AF0D'), None)
+                if af0d and af0d['payload']:
+                    back_mat_id = parse_var_int(af0d['payload'], 0, len(af0d['payload']))
+                builder.faces[f_id] = {'loops': loops, 'normal': normal,
+                                       'material_id': face_mat_id,
+                                       'back_material_id': back_mat_id}
 
         elif tag == '6419':
             nodes_to_search = el['children'] if el['children'] else [el]

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -90,12 +90,19 @@ class Face:
             ``(edge_id, orientation)`` tuples where *orientation* is
             ``1`` for forward or ``-1`` for reversed.
         normal: Optional outward-facing normal vector ``(nx, ny, nz)``.
+        material_id: Material of the face's FRONT side, or ``None``.
+        back_material_id: Material of the face's BACK side, or ``None``.
+            A face painted only on its back (front unpainted) is common when
+            the author painted the visible side of a downward-facing cap;
+            renderers should show this material on the back side, as
+            SketchUp does.
     """
 
     id: int
     loops: List[List[Tuple[int, int]]] = field(default_factory=list)
     normal: Optional[Tuple[float, float, float]] = None
     material_id: Optional[int] = None
+    back_material_id: Optional[int] = None
 
 
 # ── Layers & Materials ────────────────────────────────────────────────────
@@ -310,6 +317,7 @@ class SkpFile:
                     loops=f_data.get("loops", []),
                     normal=f_data.get("normal"),
                     material_id=f_data.get("material_id"),
+                    back_material_id=f_data.get("back_material_id"),
                 )
             # Populate instances
             for inst in builder.instances:

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,37 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Back material tests ──────────────────────────────────────────────────
+
+
+class TestBackMaterial:
+    """The AF0D child of a face node is the material of its BACK side."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_back_material_extracted(self) -> None:
+        from openskp import _core
+
+        t = self._tlv
+        node = t('AC0D', (t('DC05', t('DE05', b'\x2A'))
+                          + t('AF0D', bytes([0x85, 0x8B, 0x06]))))
+        elements = _core.parse_tlv_recursive(
+            node + t('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert 0x2A in builder.faces
+        f = builder.faces[0x2A]
+        assert f['material_id'] is None          # front unpainted
+        assert f['back_material_id'] == 0x68B85  # back painted
+
+    def test_face_defaults(self) -> None:
+        from openskp.model import Face
+
+        assert Face(id=0).back_material_id is None
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## What

Exposes the material of a face's **back side** — `Face.back_material_id`, read from the `AF0D` child of the face node. Ninth in the series (#3–#10).

## Why

SketchUp faces have independent front and back materials. A face painted **only on its back** is common in real files: authors paint the *visible* side of a downward-facing cap (e.g. garden beds modeled as caps whose front faces down — the user paints the up-facing back with grass). Without this field such faces parse as unpainted and render colourless.

**Real-world case** (SU2026 plaza): 4 garden-bed faces carry the grass material only in `AF0D` — front `D107` absent. In SketchUp they read green from above; consumers of the parser showed them unpainted.

## How

`AF0D` (a direct child of `AC0D`, sibling of `D007`) holds the back material id — verified by tracing every raw occurrence of a known material id through the TLV tree (5× `D107` fronts + 4× `AF0D` backs in the case file, matching SketchUp's Entity Info exactly: "Front: default / Back: grass").

## Validation

Byte-built `AC0D` node test through the real extractor (front stays `None`, back resolves). Full suite: **37 passed**. CHANGELOG under [Unreleased]. Backwards-compatible (new defaulted field).

Branched independently from `main`.