### PR TITLE
Resolve shared texture bytes + expose colorized materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: texture extraction — `Material.texture` (`Texture` dataclass:
+  `filename`, tile `width`/`height` in inches, raw image `data` bytes,
+  `save()` helper). Images are read from the material's folder inside the
+  embedded ZIP, with a sibling fallback when the stored image name differs
+  from `textureFilename`.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -362,6 +362,60 @@ def extract_dynamic_properties(d007):
     return properties
 
 
+# ── Texture extraction ───────────────────────────────────────────────────
+
+def _extract_texture(zf, xml_name, mat_elem, ns):
+    """Extract a material's texture from its ``<mat:texture>`` block.
+
+    SketchUp stores the texture image next to the ``material.xml`` inside the
+    ZIP (``materials/<folder>/<image>``), and the real-world tile size in the
+    ``xScale`` / ``yScale`` attributes (inches).
+
+    Args:
+        zf: The open ZIP file.
+        xml_name: Archive name of the ``material.xml`` being parsed.
+        mat_elem: Its ``<mat:material>`` element.
+        ns: Namespace map for the material schema.
+
+    Returns:
+        Dict with keys ``filename``, ``x_scale``, ``y_scale`` (inches, 0.0
+        when absent) and ``data`` (raw image bytes, or ``None`` when the
+        image entry is missing) — or ``None`` when the material carries no
+        texture.
+    """
+    tex_elem = mat_elem.find('mat:texture', ns)
+    if tex_elem is None:
+        return None
+    filename = tex_elem.get('textureFilename', '') or ''
+    try:
+        x_scale = float(tex_elem.get('xScale', 0) or 0)
+    except ValueError:
+        x_scale = 0.0
+    try:
+        y_scale = float(tex_elem.get('yScale', 0) or 0)
+    except ValueError:
+        y_scale = 0.0
+
+    folder = xml_name.rsplit('/', 1)[0]
+    data = None
+    candidate = folder + '/' + filename if filename else None
+    names = zf.namelist()
+    if candidate and candidate in names:
+        data = zf.read(candidate)
+    else:
+        # Image name may differ from textureFilename (observed: e.g.
+        # "Saftey" vs "Safety") — take the folder's non-XML sibling.
+        for entry in names:
+            if (entry.startswith(folder + '/') and entry != xml_name
+                    and not entry.lower().endswith('.xml')):
+                data = zf.read(entry)
+                if not filename:
+                    filename = entry.rsplit('/', 1)[-1]
+                break
+    return {'filename': filename, 'x_scale': x_scale, 'y_scale': y_scale,
+            'data': data}
+
+
 # ── Full parse pipeline ──────────────────────────────────────────────────
 
 def full_parse(skp_path: str) -> Dict[str, Any]:
@@ -425,6 +479,9 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                     trans = float(mat_elem.get('trans', 0.5))
                     folder_name = name.split('/')[1] if len(name.split('/')) > 1 else ''
                     mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans}
+                    tex = _extract_texture(zf, name, mat_elem, MAT_NS)
+                    if tex is not None:
+                        mat_obj['texture'] = tex
                     materials[mat_name] = mat_obj
                     if folder_name:
                         materials_by_folder[folder_name] = mat_obj

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -412,6 +412,19 @@ def _extract_texture(zf, xml_name, mat_elem, ns):
                 if not filename:
                     filename = entry.rsplit('/', 1)[-1]
                 break
+    if data is None:
+        # Colourized copies ("[Name]1", type="2") keep no image of their
+        # own — their <mat:image path> points into the SOURCE material's
+        # folder ("materials/<other>/<image>"), sometimes prefixed "./".
+        img_elem = tex_elem.find('mat:images/mat:image', ns)
+        img_path = (img_elem.get('path', '') or '') if img_elem is not None else ''
+        img_path = img_path.lstrip('./')
+        for cand in (img_path, folder + '/' + img_path):
+            if cand and cand in names:
+                data = zf.read(cand)
+                if not filename:
+                    filename = cand.rsplit('/', 1)[-1]
+                break
     return {'filename': filename, 'x_scale': x_scale, 'y_scale': y_scale,
             'data': data}
 
@@ -478,7 +491,17 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                     b = int(mat_elem.get('colorBlue', 128))
                     trans = float(mat_elem.get('trans', 0.5))
                     folder_name = name.split('/')[1] if len(name.split('/')) > 1 else ''
-                    mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans}
+                    # type="2" marks a colourized copy ("[Name]1"): the
+                    # shared texture must be re-tinted toward the material
+                    # colour before display. colorizeType 0 = hue shift,
+                    # 1 = tint (greyscale then colour).
+                    colorized = mat_elem.get('type') == '2'
+                    try:
+                        colorize_type = int(mat_elem.get('colorizeType', 0) or 0)
+                    except ValueError:
+                        colorize_type = 0
+                    mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans,
+                               'colorized': colorized, 'colorize_type': colorize_type}
                     tex = _extract_texture(zf, name, mat_elem, MAT_NS)
                     if tex is not None:
                         mat_obj['texture'] = tex

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -164,12 +164,23 @@ class Material:
             ``1.0`` is fully opaque.
         texture: The material's :class:`Texture`, or ``None`` for a plain
             colour material.
+        colorized: ``True`` for a colourized copy of a textured material
+            (SketchUp's ``[Name]1`` materials, ``type="2"`` in the XML).
+            The texture image is shared with the source material as stored;
+            viewers must re-tint it toward :attr:`color` for faithful
+            display.
+        colorize_type: How to re-tint when :attr:`colorized` — ``0`` shifts
+            every pixel's hue/lightness/saturation by the delta between the
+            image average and :attr:`color`; ``1`` tints (greyscales the
+            image, then applies the colour's hue/saturation).
     """
 
     name: str
     color: Tuple[int, int, int, int] = (200, 200, 200, 255)
     transparency: float = 1.0
     texture: Optional[Texture] = None
+    colorized: bool = False
+    colorize_type: int = 0
 
 
 # ── Component hierarchy ───────────────────────────────────────────────────
@@ -380,6 +391,8 @@ class SkpFile:
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
                 texture=texture,
+                colorized=mat_data.get("colorized", False),
+                colorize_type=mat_data.get("colorize_type", 0),
             ))
 
         # Store raw parsed data for export use

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -119,6 +119,41 @@ class Layer:
 
 
 @dataclass
+class Texture:
+    """A material's texture image, extracted from the SKP container.
+
+    SketchUp stores the image next to the material's XML inside the embedded
+    ZIP, and the real-world tile size (how many inches one repetition of the
+    image covers) in the material definition.
+
+    Attributes:
+        filename: Image file name as referenced by the material.
+        width: Tile width in **inches** (SketchUp's internal unit); ``0.0``
+            when the file does not specify it.
+        height: Tile height in inches; ``0.0`` when unspecified.
+        data: Raw image bytes (PNG/JPG as stored), or ``None`` when the
+            image entry was missing from the container.
+    """
+
+    filename: str = ""
+    width: float = 0.0
+    height: float = 0.0
+    data: Optional[bytes] = None
+
+    def save(self, filepath: str | pathlib.Path) -> pathlib.Path:
+        """Write the image bytes to *filepath* and return the path.
+
+        Raises:
+            ValueError: If the texture carries no image data.
+        """
+        if self.data is None:
+            raise ValueError(f"Texture {self.filename!r} has no image data")
+        p = pathlib.Path(filepath)
+        p.write_bytes(self.data)
+        return p
+
+
+@dataclass
 class Material:
     """A surface material.
 
@@ -127,11 +162,14 @@ class Material:
         color: RGBA colour tuple ``(r, g, b, a)`` with each value in 0–255.
         transparency: Opacity factor where ``0.0`` is fully transparent and
             ``1.0`` is fully opaque.
+        texture: The material's :class:`Texture`, or ``None`` for a plain
+            colour material.
     """
 
     name: str
     color: Tuple[int, int, int, int] = (200, 200, 200, 255)
     transparency: float = 1.0
+    texture: Optional[Texture] = None
 
 
 # ── Component hierarchy ───────────────────────────────────────────────────
@@ -328,10 +366,20 @@ class SkpFile:
         # Convert materials
         for mat_data in parsed["materials"].values():
             c = mat_data.get("color", {})
+            tex_data = mat_data.get("texture")
+            texture = None
+            if tex_data is not None:
+                texture = Texture(
+                    filename=tex_data.get("filename", ""),
+                    width=tex_data.get("x_scale", 0.0),
+                    height=tex_data.get("y_scale", 0.0),
+                    data=tex_data.get("data"),
+                )
             model.materials.append(Material(
                 name=mat_data.get("name", ""),
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
+                texture=texture,
             ))
 
         # Store raw parsed data for export use

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -427,6 +427,48 @@ class TestTextureExtraction:
         assert glass.texture is not None
         assert glass.texture.data == jpeg
 
+    def test_colorized_copy_shares_source_image(
+        self, tmp_path: "pathlib.Path"
+    ) -> None:
+        # A colourized material ("[Name]1", type="2") stores no image of
+        # its own — its <mat:image path> points into the SOURCE material's
+        # folder. The shared bytes must be resolved, and the colorized
+        # flag exposed so viewers can re-tint.
+        from openskp.model import SkpFile
+
+        png = b"\x89PNGsharedchainlink"
+        colorized_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="[Fence]1" type="2" colorRed="27" colorGreen="135"
+                colorBlue="59" colorizeType="0" trans="1" hasTexture="1">
+    <mat:texture textureFilename="fence.png" xScale="2.75" yScale="2.75">
+      <mat:images>
+        <mat:image id="1" path="materials/Fence/fence.png"
+                   file_name="fence.png"/>
+      </mat:images>
+    </mat:texture>
+  </mat:material>
+</materialDocument>
+"""
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Fence/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Fence", b"fence.png"),
+            "materials/Fence/fence.png": png,
+            "materials/[Fence]1/material.xml": colorized_xml,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        by_name = {m.name: m for m in model.materials}
+        copy = by_name["[Fence]1"]
+        assert copy.texture is not None
+        assert copy.texture.data == png       # borrowed from materials/Fence/
+        assert copy.colorized is True
+        assert copy.colorize_type == 0
+        assert copy.color[:3] == (27, 135, 59)
+        base = by_name["Fence"]
+        assert base.colorized is False
+
 
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,102 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Texture extraction tests ─────────────────────────────────────────────
+
+
+_MATERIAL_XML_TEXTURED = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="%s" type="1" colorRed="10" colorGreen="20"
+                colorBlue="30" trans="1" hasTexture="1">
+    <mat:texture textureFilename="%s" xScale="24" yScale="12"/>
+  </mat:material>
+</materialDocument>
+"""
+
+_MATERIAL_XML_PLAIN = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="Plain" type="0" colorRed="1" colorGreen="2"
+                colorBlue="3" trans="1" hasTexture="0"/>
+</materialDocument>
+"""
+
+
+def _write_synthetic_skp(tmp_path: "pathlib.Path",
+                         entries: dict) -> "pathlib.Path":
+    """Build a minimal ``.skp``: the UTF-16 header marker followed by an
+    embedded ZIP with ``model.dat`` plus *entries*."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("model.dat", b"")
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    path = tmp_path / "synthetic.skp"
+    path.write_bytes(b"\xFF\xFE\xFF\x0E" + b"\x00" * 28 + buf.getvalue())
+    return path
+
+
+class TestTextureExtraction:
+    """Tests for material texture extraction (``Material.texture``)."""
+
+    def test_texture_dataclass_save(self, tmp_path: "pathlib.Path") -> None:
+        from openskp.model import Texture
+
+        tex = Texture(filename="wood.jpg", width=24.0, height=12.0,
+                      data=b"\xff\xd8fakejpeg")
+        out = tex.save(tmp_path / "out.jpg")
+        assert out.read_bytes() == b"\xff\xd8fakejpeg"
+
+    def test_texture_save_without_data_raises(self) -> None:
+        from openskp.model import Texture
+
+        with pytest.raises(ValueError, match="no image data"):
+            Texture(filename="missing.jpg").save("/tmp/never-written.jpg")
+
+    def test_textured_material_roundtrip(self, tmp_path: "pathlib.Path") -> None:
+        from openskp.model import SkpFile
+
+        jpeg = b"\xff\xd8syntheticjpegbytes"
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Wood/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Wood", b"wood.jpg"),
+            "materials/Wood/wood.jpg": jpeg,
+            "materials/Plain/material.xml": _MATERIAL_XML_PLAIN,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        by_name = {m.name: m for m in model.materials}
+        wood = by_name["Wood"]
+        assert wood.texture is not None
+        assert wood.texture.filename == "wood.jpg"
+        assert wood.texture.width == 24.0    # inches, from xScale
+        assert wood.texture.height == 12.0
+        assert wood.texture.data == jpeg
+        assert by_name["Plain"].texture is None
+
+    def test_image_name_mismatch_falls_back_to_sibling(
+        self, tmp_path: "pathlib.Path"
+    ) -> None:
+        # Observed in real files: the XML says "..._Safety.jpg" while the
+        # stored image is "..._Saftey.jpg" — the folder sibling must win.
+        from openskp.model import SkpFile
+
+        jpeg = b"\xff\xd8siblingbytes"
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Glass/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Glass", b"glass_safety.jpg"),
+            "materials/Glass/glass_saftey.jpg": jpeg,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        glass = {m.name: m for m in model.materials}["Glass"]
+        assert glass.texture is not None
+        assert glass.texture.data == jpeg
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
Builds on #4 (texture extraction) — the last commit is the one to review.

## What

Colourized copies of textured materials (the `[Name]1` materials SketchUp creates when you re-colour a textured material, `type="2"` in the material XML) store **no image of their own** — their `<mat:images>/<mat:image path>` points into the **source** material's folder (`materials/<other>/<image>`, sometimes prefixed `./`). Before this change, `Material.texture.data` came back `None` for every colourized material.

- `_extract_texture` now follows the `<mat:image path>` attribute (both archive-relative and `./`-prefixed forms) when the material's own folder holds no image, so the shared bytes resolve.
- `Material` gains `colorized` (`type == "2"`) and `colorize_type` (the `colorizeType` attribute: `0` = hue shift, `1` = tint) so viewers can re-tint the shared image toward `Material.color` the way SketchUp renders these copies.

## Why it matters

Real-world files use colourized materials heavily (e.g. a green-tinted `Fencing_Chain_Link`). Without the shared bytes the material silently loses its texture; with them + the flag a viewer can reproduce SketchUp's exact rendering. Validated against a real SketchUp 2021+ file where 4 colourized materials (`[Fencing Chain Link]1`, `[Wood Board Cork]1`, …) previously returned `data=None` and now resolve their images.

## Tests

`test_colorized_copy_shares_source_image` — synthetic .skp with a base material + a colourized copy whose image path points across folders; asserts the shared bytes, the `colorized` flag, `colorize_type` and the material colour. 40 tests green on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)