### PR TITLE
0.3.0: integrate 10 approved additive PRs (#3, #5, #6, #7, #8, #9, #10, #11, #13, #15)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (the `AF0D` child of the face node). A face painted only on its back is
   common when the author paints the visible side of a downward-facing cap;
   without this field such faces looked unpainted.
+- **Python**: `Definition.always_faces_camera` — SketchUp's "always face
+  camera" component behavior (2D people / tree cut-outs), decoded from the
+  definition's behavior block (`581B` → sub-TLV `5D1B == 1`; its companion
+  `5E1B` is "shadows face sun"). Consumers can now render such instances
+  as billboards, like SketchUp does.
 
 ## [0.2.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: `Definition.always_faces_camera` — SketchUp's "always face
+  camera" component behavior (2D people / tree cut-outs), decoded from the
+  definition's behavior block (`581B` → sub-TLV `5D1B == 1`; its companion
+  `5E1B` is "shadows face sun"). Consumers can now render such instances
+  as billboards, like SketchUp does.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: per-face texture mapping — `Face.uv_transform` /
+  `uv_transform_back` (the 3×3 matrix a positioned / photo-fitted texture
+  stores per face; SketchUp's texture pins). Includes the decoded recipe to
+  turn it into UVs (plane basis from the normal, then
+  `[x, y, 1] @ inv(M) / tile`), calibrated against SDK-exported ground
+  truth to < 0.001 UV error, including projective (4-pin distorted)
+  mappings.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instance itself (SketchUp's "paint the component", the same `D007`/`D107`
   structure faces use). Faces with no material of their own inherit it;
   consumers can now resolve that inheritance like the official SDK does.
+- **Python**: styles — `SkpModel.styles` (`Style`: name, `front_color`,
+  `back_color` RGB) parsed from `styles/*/style.xml` (signed-int32 ARGB
+  items 4000/4001). Viewers need them to shade unpainted faces the way
+  SketchUp does.
 
 ## [0.2.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: `Face.back_material_id` — the material of a face's BACK side
+  (the `AF0D` child of the face node). A face painted only on its back is
+  common when the author paints the visible side of a downward-facing cap;
+  without this field such faces looked unpainted.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `[x, y, 1] @ inv(M) / tile`), calibrated against SDK-exported ground
   truth to < 0.001 UV error, including projective (4-pin distorted)
   mappings.
+- **Python**: `Face.back_material_id` — the material of a face's BACK side
+  (the `AF0D` child of the face node). A face painted only on its back is
+  common when the author paints the visible side of a downward-facing cap;
+  without this field such faces looked unpainted.
 
 ## [0.2.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Python**: entity names (materials, layers, definitions, instances,
+  dynamic properties) now decode as **UTF-8** instead of ASCII-with-ignore.
+  Dropping the non-ASCII bytes silently corrupted any accented name
+  ("cópia" → "cpia", "Diseño" → "Diseo") and — critically — broke the
+  material-name join between the TLV stream and the XML material files,
+  leaving those materials unresolvable from geometry.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: Image entities — a picture placed in the model as an object
+  now parses: its placement wraps a standard instance node inside the
+  image-specific `9013`/`401F` containers (previously opaque, so the image
+  definition looked "never placed"), and `Definition.is_image` flags the
+  single-quad definition backing it (TLV kind `8315 == 2`). Real-world
+  case: photo cut-out statues/animals placed as images imported with no
+  geometry at all.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: styles — `SkpModel.styles` (`Style`: name, `front_color`,
+  `back_color` RGB) parsed from `styles/*/style.xml` (signed-int32 ARGB
+  items 4000/4001). Viewers need them to shade unpainted faces the way
+  SketchUp does.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,29 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+All additions below are backwards-compatible (new defaulted dataclass
+fields only; no existing field or behaviour removed).
+
 ### Added
 
 - **Python**: `Material.id` and `SkpModel.materials_by_id` — expose the TLV
   material IDs that `Face.material_id` references, so callers can resolve a
   face's material (colour/transparency) from the public API. Previously the
   join existed only inside the internal exporter.
-
-### Fixed
-
-- **Python**: entity names (materials, layers, definitions, instances,
-  dynamic properties) now decode as **UTF-8** instead of ASCII-with-ignore.
-  Dropping the non-ASCII bytes silently corrupted any accented name
-  ("cópia" → "cpia", "Diseño" → "Diseo") and — critically — broke the
-  material-name join between the TLV stream and the XML material files,
-  leaving those materials unresolvable from geometry.
 - **Python**: `Instance.material_id` — the material painted onto a component
   instance itself (SketchUp's "paint the component", the same `D007`/`D107`
   structure faces use). Faces with no material of their own inherit it;
   consumers can now resolve that inheritance like the official SDK does.
-- **Python**: styles — `SkpModel.styles` (`Style`: name, `front_color`,
-  `back_color` RGB) parsed from `styles/*/style.xml` (signed-int32 ARGB
-  items 4000/4001). Viewers need them to shade unpainted faces the way
-  SketchUp does.
+- **Python**: texture extraction — `Material.texture` (`Texture` dataclass:
+  `filename`, tile `width`/`height` in inches, raw image `data` bytes,
+  `save()` helper). Images are read from the material's folder inside the
+  embedded ZIP, with a sibling fallback when the stored image name differs
+  from `textureFilename`.
+- **Python**: colourized materials — `Material.colorized` /
+  `colorize_type`, and shared-texture resolution so a colourized copy
+  (SketchUp's `[Name]1`, `type="2"`) resolves the image bytes it borrows
+  from its source material's folder instead of returning `None`.
 - **Python**: per-face texture mapping — `Face.uv_transform` /
   `uv_transform_back` (the 3×3 matrix a positioned / photo-fitted texture
   stores per face; SketchUp's texture pins). Includes the decoded recipe to
@@ -41,6 +40,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (the `AF0D` child of the face node). A face painted only on its back is
   common when the author paints the visible side of a downward-facing cap;
   without this field such faces looked unpainted.
+- **Python**: `Edge.soft` / `smooth` / `hidden` — per-edge display flags
+  decoded from the edge's `D307` byte, so viewers/exporters can hide facet
+  lines of curved surfaces while keeping author-drawn coplanar edges.
+- **Python**: styles — `SkpModel.styles` (`Style`: name, `front_color`,
+  `back_color` RGB) parsed from `styles/*/style.xml` (signed-int32 ARGB
+  items 4000/4001). Viewers need them to shade unpainted faces the way
+  SketchUp does.
 - **Python**: `Definition.always_faces_camera` — SketchUp's "always face
   camera" component behavior (2D people / tree cut-outs), decoded from the
   definition's behavior block (`581B` → sub-TLV `5D1B == 1`; its companion
@@ -53,11 +59,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single-quad definition backing it (TLV kind `8315 == 2`). Real-world
   case: photo cut-out statues/animals placed as images imported with no
   geometry at all.
-- **Python**: texture extraction — `Material.texture` (`Texture` dataclass:
-  `filename`, tile `width`/`height` in inches, raw image `data` bytes,
-  `save()` helper). Images are read from the material's folder inside the
-  embedded ZIP, with a sibling fallback when the stored image name differs
-  from `textureFilename`.
+
+### Fixed
+
+- **Python**: entity names (materials, layers, definitions, instances,
+  dynamic properties) now decode as **UTF-8** instead of ASCII-with-ignore.
+  Dropping the non-ASCII bytes silently corrupted any accented name
+  ("cópia" → "cpia", "Diseño" → "Diseo") and — critically — broke the
+  material-name join between the TLV stream and the XML material files,
+  leaving those materials unresolvable from geometry.
 
 ## [0.2.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: `Instance.material_id` — the material painted onto a component
+  instance itself (SketchUp's "paint the component", the same `D007`/`D107`
+  structure faces use). Faces with no material of their own inherit it;
+  consumers can now resolve that inheritance like the official SDK does.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   single-quad definition backing it (TLV kind `8315 == 2`). Real-world
   case: photo cut-out statues/animals placed as images imported with no
   geometry at all.
+- **Python**: texture extraction — `Material.texture` (`Texture` dataclass:
+  `filename`, tile `width`/`height` in inches, raw image `data` bytes,
+  `save()` helper). Images are read from the material's folder inside the
+  embedded ZIP, with a sibling fallback when the stored image name differs
+  from `textureFilename`.
 
 ## [0.2.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   definition's behavior block (`581B` → sub-TLV `5D1B == 1`; its companion
   `5E1B` is "shadows face sun"). Consumers can now render such instances
   as billboards, like SketchUp does.
+- **Python**: Image entities — a picture placed in the model as an object
+  now parses: its placement wraps a standard instance node inside the
+  image-specific `9013`/`401F` containers (previously opaque, so the image
+  definition looked "never placed"), and `Definition.is_image` flags the
+  single-quad definition backing it (TLV kind `8315 == 2`). Real-world
+  case: photo cut-out statues/animals placed as images imported with no
+  geometry at all.
 
 ## [0.2.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: `Material.id` and `SkpModel.materials_by_id` — expose the TLV
+  material IDs that `Face.material_id` references, so callers can resolve a
+  face's material (colour/transparency) from the public API. Previously the
+  join existed only inside the internal exporter.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `back_color` RGB) parsed from `styles/*/style.xml` (signed-int32 ARGB
   items 4000/4001). Viewers need them to shade unpainted faces the way
   SketchUp does.
+- **Python**: per-face texture mapping — `Face.uv_transform` /
+  `uv_transform_back` (the 3×3 matrix a positioned / photo-fitted texture
+  stores per face; SketchUp's texture pins). Includes the decoded recipe to
+  turn it into UVs (plane basis from the normal, then
+  `[x, y, 1] @ inv(M) / tile`), calibrated against SDK-exported ground
+  truth to < 0.001 UV error, including projective (4-pin distorted)
+  mappings.
 
 ## [0.2.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Python**: `Material.id` and `SkpModel.materials_by_id` — expose the TLV
+  material IDs that `Face.material_id` references, so callers can resolve a
+  face's material (colour/transparency) from the public API. Previously the
+  join existed only inside the internal exporter.
+
 ### Fixed
 
 - **Python**: entity names (materials, layers, definitions, instances,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ("cópia" → "cpia", "Diseño" → "Diseo") and — critically — broke the
   material-name join between the TLV stream and the XML material files,
   leaving those materials unresolvable from geometry.
+- **Python**: `Instance.material_id` — the material painted onto a component
+  instance itself (SketchUp's "paint the component", the same `D007`/`D107`
+  structure faces use). Faces with no material of their own inherit it;
+  consumers can now resolve that inheritance like the official SDK does.
 
 ## [0.2.0] — 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Python**: texture extraction — `Material.texture` (`Texture` dataclass:
+  `filename`, tile `width`/`height` in inches, raw image `data` bytes,
+  `save()` helper). Images are read from the material's folder inside the
+  embedded ZIP, with a sibling fallback when the stored image name differs
+  from `textureFilename`.
+
 ## [0.2.0] — 2026-06-18
 
 ### Added

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -362,6 +362,60 @@ def extract_dynamic_properties(d007):
     return properties
 
 
+# ── Texture extraction ───────────────────────────────────────────────────
+
+def _extract_texture(zf, xml_name, mat_elem, ns):
+    """Extract a material's texture from its ``<mat:texture>`` block.
+
+    SketchUp stores the texture image next to the ``material.xml`` inside the
+    ZIP (``materials/<folder>/<image>``), and the real-world tile size in the
+    ``xScale`` / ``yScale`` attributes (inches).
+
+    Args:
+        zf: The open ZIP file.
+        xml_name: Archive name of the ``material.xml`` being parsed.
+        mat_elem: Its ``<mat:material>`` element.
+        ns: Namespace map for the material schema.
+
+    Returns:
+        Dict with keys ``filename``, ``x_scale``, ``y_scale`` (inches, 0.0
+        when absent) and ``data`` (raw image bytes, or ``None`` when the
+        image entry is missing) — or ``None`` when the material carries no
+        texture.
+    """
+    tex_elem = mat_elem.find('mat:texture', ns)
+    if tex_elem is None:
+        return None
+    filename = tex_elem.get('textureFilename', '') or ''
+    try:
+        x_scale = float(tex_elem.get('xScale', 0) or 0)
+    except ValueError:
+        x_scale = 0.0
+    try:
+        y_scale = float(tex_elem.get('yScale', 0) or 0)
+    except ValueError:
+        y_scale = 0.0
+
+    folder = xml_name.rsplit('/', 1)[0]
+    data = None
+    candidate = folder + '/' + filename if filename else None
+    names = zf.namelist()
+    if candidate and candidate in names:
+        data = zf.read(candidate)
+    else:
+        # Image name may differ from textureFilename (observed: e.g.
+        # "Saftey" vs "Safety") — take the folder's non-XML sibling.
+        for entry in names:
+            if (entry.startswith(folder + '/') and entry != xml_name
+                    and not entry.lower().endswith('.xml')):
+                data = zf.read(entry)
+                if not filename:
+                    filename = entry.rsplit('/', 1)[-1]
+                break
+    return {'filename': filename, 'x_scale': x_scale, 'y_scale': y_scale,
+            'data': data}
+
+
 # ── Full parse pipeline ──────────────────────────────────────────────────
 
 def full_parse(skp_path: str) -> Dict[str, Any]:
@@ -425,6 +479,9 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                     trans = float(mat_elem.get('trans', 0.5))
                     folder_name = name.split('/')[1] if len(name.split('/')) > 1 else ''
                     mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans}
+                    tex = _extract_texture(zf, name, mat_elem, MAT_NS)
+                    if tex is not None:
+                        mat_obj['texture'] = tex
                     materials[mat_name] = mat_obj
                     if folder_name:
                         materials_by_folder[folder_name] = mat_obj

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -276,7 +276,7 @@ def _extract_geometry_from_nodes(elements, builder):
                 def_idx = parse_var_int(def_idx_node['payload'], 0, len(def_idx_node['payload']))
             name_node = find_child_tag(nodes_to_search, '6519')
             if name_node:
-                name = name_node['payload'].decode('ascii', errors='ignore')
+                name = name_node['payload'].decode('utf-8', errors='replace')
             mat_node = find_child_tag(nodes_to_search, '6619')
             if mat_node and len(mat_node['payload']) >= 104:
                 for idx in range(13):
@@ -352,9 +352,9 @@ def extract_dynamic_properties(d007):
         for n in nodes:
             tag = n['tag']
             if tag == 'B636':
-                current_key = n['payload'].decode('ascii', errors='ignore')
+                current_key = n['payload'].decode('utf-8', errors='replace')
             elif tag == 'AD38' and current_key:
-                val = n['payload'].decode('ascii', errors='ignore')
+                val = n['payload'].decode('utf-8', errors='replace')
                 properties[current_key] = val
                 current_key = None
             extract_props(n['children'])
@@ -462,7 +462,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                                 l_id = parse_var_int(payload, 6, de05_len)
                             else:
                                 l_id = parse_var_int(payload, 0, len(payload))
-                            l_name = name_node['payload'].decode('ascii', errors='ignore')
+                            l_name = name_node['payload'].decode('utf-8', errors='replace')
                             layer_id_to_name[l_id] = l_name
             collect_layers(el['children'])
     collect_layers(elements)
@@ -486,7 +486,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                         m_id = parse_var_int(payload, 6, de05_len)
                     else:
                         m_id = parse_var_int(payload, 0, len(payload))
-                    m_name = name_node['payload'].decode('ascii', errors='ignore')
+                    m_name = name_node['payload'].decode('utf-8', errors='replace')
                     material_id_to_name[m_id] = m_name
             collect_material_ids(el['children'])
     collect_material_ids(elements)
@@ -502,7 +502,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                     if child['tag'] == '7D15' and len(child['payload']) == 16:
                         guid = child['payload'].hex().upper()
                     elif child['tag'] == '7E15':
-                        name = child['payload'].decode('ascii', errors='ignore')
+                        name = child['payload'].decode('utf-8', errors='replace')
                 ent_id = extract_entity_id(el)
                 builder = _GeometryBuilder()
                 _extract_geometry_from_nodes(el['children'], builder)

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -260,7 +260,17 @@ def _extract_geometry_from_nodes(elements, builder):
                     d107 = next((c for c in d007['children'] if c['tag'] == 'D107'), None)
                     if d107:
                         face_mat_id = parse_var_int(d107['payload'], 0, len(d107['payload']))
-                builder.faces[f_id] = {'loops': loops, 'normal': normal, 'material_id': face_mat_id}
+                # Back-side material: the AF0D child of the face node (a face
+                # painted only on its back — common when the author paints the
+                # visible side of a downward-facing cap — carries AF0D but no
+                # D107).
+                back_mat_id = None
+                af0d = next((c for c in el['children'] if c['tag'] == 'AF0D'), None)
+                if af0d and af0d['payload']:
+                    back_mat_id = parse_var_int(af0d['payload'], 0, len(af0d['payload']))
+                builder.faces[f_id] = {'loops': loops, 'normal': normal,
+                                       'material_id': face_mat_id,
+                                       'back_material_id': back_mat_id}
 
         elif tag == '6419':
             nodes_to_search = el['children'] if el['children'] else [el]

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -412,6 +412,19 @@ def _extract_texture(zf, xml_name, mat_elem, ns):
                 if not filename:
                     filename = entry.rsplit('/', 1)[-1]
                 break
+    if data is None:
+        # Colourized copies ("[Name]1", type="2") keep no image of their
+        # own — their <mat:image path> points into the SOURCE material's
+        # folder ("materials/<other>/<image>"), sometimes prefixed "./".
+        img_elem = tex_elem.find('mat:images/mat:image', ns)
+        img_path = (img_elem.get('path', '') or '') if img_elem is not None else ''
+        img_path = img_path.lstrip('./')
+        for cand in (img_path, folder + '/' + img_path):
+            if cand and cand in names:
+                data = zf.read(cand)
+                if not filename:
+                    filename = cand.rsplit('/', 1)[-1]
+                break
     return {'filename': filename, 'x_scale': x_scale, 'y_scale': y_scale,
             'data': data}
 
@@ -478,7 +491,17 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                     b = int(mat_elem.get('colorBlue', 128))
                     trans = float(mat_elem.get('trans', 0.5))
                     folder_name = name.split('/')[1] if len(name.split('/')) > 1 else ''
-                    mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans}
+                    # type="2" marks a colourized copy ("[Name]1"): the
+                    # shared texture must be re-tinted toward the material
+                    # colour before display. colorizeType 0 = hue shift,
+                    # 1 = tint (greyscale then colour).
+                    colorized = mat_elem.get('type') == '2'
+                    try:
+                        colorize_type = int(mat_elem.get('colorizeType', 0) or 0)
+                    except ValueError:
+                        colorize_type = 0
+                    mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans,
+                               'colorized': colorized, 'colorize_type': colorize_type}
                     tex = _extract_texture(zf, name, mat_elem, MAT_NS)
                     if tex is not None:
                         mat_obj['texture'] = tex

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -631,15 +631,33 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
             if el['tag'] == '7C15':
                 guid = None
                 name = None
+                faces_camera = False
                 for child in el['children']:
                     if child['tag'] == '7D15' and len(child['payload']) == 16:
                         guid = child['payload'].hex().upper()
                     elif child['tag'] == '7E15':
                         name = child['payload'].decode('utf-8', errors='replace')
+                    elif child['tag'] == '581B':
+                        # Component behavior flags: sub-TLV 5D1B == 1 marks
+                        # "always faces camera" (2D people/tree cut-outs);
+                        # its companion 5E1B is "shadows face sun".
+                        pos = 0
+                        pl = child['payload']
+                        while pos <= len(pl) - 6:
+                            sub_tag = pl[pos:pos+2].hex().upper()
+                            sub_size = read_u32(pl, pos+2)
+                            if pos + 6 + sub_size > len(pl):
+                                break
+                            if sub_tag == '5D1B' and sub_size >= 1:
+                                faces_camera = parse_var_int(
+                                    pl, pos+6, sub_size) == 1
+                            pos += 6 + sub_size
                 ent_id = extract_entity_id(el)
                 builder = _GeometryBuilder()
                 _extract_geometry_from_nodes(el['children'], builder)
-                defs_dict[ent_id] = {'guid': guid, 'name': name, 'builder': builder}
+                defs_dict[ent_id] = {'guid': guid, 'name': name,
+                                     'always_faces_camera': faces_camera,
+                                     'builder': builder}
             collect_defs(el['children'])
     collect_defs(elements)
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -468,6 +468,73 @@ def extract_dynamic_properties(d007):
     return properties
 
 
+# ── Texture extraction ───────────────────────────────────────────────────
+
+def _extract_texture(zf, xml_name, mat_elem, ns):
+    """Extract a material's texture from its ``<mat:texture>`` block.
+
+    SketchUp stores the texture image next to the ``material.xml`` inside the
+    ZIP (``materials/<folder>/<image>``), and the real-world tile size in the
+    ``xScale`` / ``yScale`` attributes (inches).
+
+    Args:
+        zf: The open ZIP file.
+        xml_name: Archive name of the ``material.xml`` being parsed.
+        mat_elem: Its ``<mat:material>`` element.
+        ns: Namespace map for the material schema.
+
+    Returns:
+        Dict with keys ``filename``, ``x_scale``, ``y_scale`` (inches, 0.0
+        when absent) and ``data`` (raw image bytes, or ``None`` when the
+        image entry is missing) — or ``None`` when the material carries no
+        texture.
+    """
+    tex_elem = mat_elem.find('mat:texture', ns)
+    if tex_elem is None:
+        return None
+    filename = tex_elem.get('textureFilename', '') or ''
+    try:
+        x_scale = float(tex_elem.get('xScale', 0) or 0)
+    except ValueError:
+        x_scale = 0.0
+    try:
+        y_scale = float(tex_elem.get('yScale', 0) or 0)
+    except ValueError:
+        y_scale = 0.0
+
+    folder = xml_name.rsplit('/', 1)[0]
+    data = None
+    candidate = folder + '/' + filename if filename else None
+    names = zf.namelist()
+    if candidate and candidate in names:
+        data = zf.read(candidate)
+    else:
+        # Image name may differ from textureFilename (observed: e.g.
+        # "Saftey" vs "Safety") — take the folder's non-XML sibling.
+        for entry in names:
+            if (entry.startswith(folder + '/') and entry != xml_name
+                    and not entry.lower().endswith('.xml')):
+                data = zf.read(entry)
+                if not filename:
+                    filename = entry.rsplit('/', 1)[-1]
+                break
+    if data is None:
+        # Colourized copies ("[Name]1", type="2") keep no image of their
+        # own — their <mat:image path> points into the SOURCE material's
+        # folder ("materials/<other>/<image>"), sometimes prefixed "./".
+        img_elem = tex_elem.find('mat:images/mat:image', ns)
+        img_path = (img_elem.get('path', '') or '') if img_elem is not None else ''
+        img_path = img_path.lstrip('./')
+        for cand in (img_path, folder + '/' + img_path):
+            if cand and cand in names:
+                data = zf.read(cand)
+                if not filename:
+                    filename = cand.rsplit('/', 1)[-1]
+                break
+    return {'filename': filename, 'x_scale': x_scale, 'y_scale': y_scale,
+            'data': data}
+
+
 # ── Full parse pipeline ──────────────────────────────────────────────────
 
 def full_parse(skp_path: str) -> Dict[str, Any]:
@@ -530,7 +597,20 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                     b = int(mat_elem.get('colorBlue', 128))
                     trans = float(mat_elem.get('trans', 0.5))
                     folder_name = name.split('/')[1] if len(name.split('/')) > 1 else ''
-                    mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans}
+                    # type="2" marks a colourized copy ("[Name]1"): the
+                    # shared texture must be re-tinted toward the material
+                    # colour before display. colorizeType 0 = hue shift,
+                    # 1 = tint (greyscale then colour).
+                    colorized = mat_elem.get('type') == '2'
+                    try:
+                        colorize_type = int(mat_elem.get('colorizeType', 0) or 0)
+                    except ValueError:
+                        colorize_type = 0
+                    mat_obj = {'name': mat_name, 'color': {'r': r, 'g': g, 'b': b}, 'transparency': trans,
+                               'colorized': colorized, 'colorize_type': colorize_type}
+                    tex = _extract_texture(zf, name, mat_elem, MAT_NS)
+                    if tex is not None:
+                        mat_obj['texture'] = tex
                     materials[mat_name] = mat_obj
                     if folder_name:
                         materials_by_folder[folder_name] = mat_obj

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -334,8 +334,17 @@ def _extract_geometry_from_nodes(elements, builder):
                     dc05 = next((c for c in d007['children'] if c['tag'] == 'DC05'), None)
                     if dc05 is not None:
                         uv_front, uv_back = _extract_uv_transforms(dc05['payload'])
+                # Back-side material: the AF0D child of the face node (a face
+                # painted only on its back — common when the author paints the
+                # visible side of a downward-facing cap — carries AF0D but no
+                # D107).
+                back_mat_id = None
+                af0d = next((c for c in el['children'] if c['tag'] == 'AF0D'), None)
+                if af0d and af0d['payload']:
+                    back_mat_id = parse_var_int(af0d['payload'], 0, len(af0d['payload']))
                 builder.faces[f_id] = {'loops': loops, 'normal': normal,
                                        'material_id': face_mat_id,
+                                       'back_material_id': back_mat_id,
                                        'uv_transform': uv_front,
                                        'uv_transform_back': uv_back}
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -498,15 +498,33 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
             if el['tag'] == '7C15':
                 guid = None
                 name = None
+                faces_camera = False
                 for child in el['children']:
                     if child['tag'] == '7D15' and len(child['payload']) == 16:
                         guid = child['payload'].hex().upper()
                     elif child['tag'] == '7E15':
                         name = child['payload'].decode('ascii', errors='ignore')
+                    elif child['tag'] == '581B':
+                        # Component behavior flags: sub-TLV 5D1B == 1 marks
+                        # "always faces camera" (2D people/tree cut-outs);
+                        # its companion 5E1B is "shadows face sun".
+                        pos = 0
+                        pl = child['payload']
+                        while pos <= len(pl) - 6:
+                            sub_tag = pl[pos:pos+2].hex().upper()
+                            sub_size = read_u32(pl, pos+2)
+                            if pos + 6 + sub_size > len(pl):
+                                break
+                            if sub_tag == '5D1B' and sub_size >= 1:
+                                faces_camera = parse_var_int(
+                                    pl, pos+6, sub_size) == 1
+                            pos += 6 + sub_size
                 ent_id = extract_entity_id(el)
                 builder = _GeometryBuilder()
                 _extract_geometry_from_nodes(el['children'], builder)
-                defs_dict[ent_id] = {'guid': guid, 'name': name, 'builder': builder}
+                defs_dict[ent_id] = {'guid': guid, 'name': name,
+                                     'always_faces_camera': faces_camera,
+                                     'builder': builder}
             collect_defs(el['children'])
     collect_defs(elements)
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -463,6 +463,38 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
     if 'meta/model_thumbnail.png' in zf.namelist():
         thumbnail_data = zf.read('meta/model_thumbnail.png')
 
+    # Styles: face colors live in styles/*/style.xml as signed-int32 ARGB
+    # variants — item id 4000 is the front (default) face color, 4001 the
+    # back face color. Viewers need them to shade unpainted faces the way
+    # SketchUp does (an author may e.g. set a green back color so unpainted
+    # garden faces read as grass).
+    styles = []
+    for name in zf.namelist():
+        if not (name.startswith('styles/') and name.endswith('style.xml')):
+            continue
+        try:
+            sroot = ET.fromstring(zf.read(name))
+        except ET.ParseError:
+            continue
+        STY = '{http://sketchup.google.com/schemas/sketchup/1.0/style}'
+        TYP = '{http://sketchup.google.com/schemas/1.0/types}'
+        style_el = sroot.find(f'{STY}style')
+        if style_el is None:
+            continue
+        colors = {}
+        for item in style_el.findall(f'{STY}item'):
+            iid = item.get('id')
+            var = item.find(f'{TYP}variant')
+            if iid in ('4000', '4001') and var is not None and var.text:
+                try:
+                    v = int(var.text) & 0xFFFFFFFF
+                except ValueError:
+                    continue
+                colors[iid] = ((v >> 16) & 255, (v >> 8) & 255, v & 255)
+        styles.append({'name': style_el.get('name', ''),
+                       'front_color': colors.get('4000'),
+                       'back_color': colors.get('4001')})
+
     model_dat = zf.read('model.dat')
     zf.close()
 
@@ -552,6 +584,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
         'defs_dict': defs_dict,
         'elements': elements,
         'thumbnail_data': thumbnail_data,
+        'styles': styles,
     }
 
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -193,6 +193,66 @@ def extract_entity_id(node):
     return None
 
 
+def _tlv_flat(payload):
+    """Walk a raw payload as a flat TLV sequence; returns [(tag_hex, body)]."""
+    pos = 0
+    out = []
+    while pos <= len(payload) - 6:
+        tag = payload[pos:pos+2].hex().upper()
+        size = read_u32(payload, pos+2)
+        if pos + 6 + size > len(payload):
+            break
+        out.append((tag, payload[pos+6:pos+6+size]))
+        pos += 6 + size
+    return out
+
+
+def _extract_uv_transforms(dc05_payload):
+    """Per-face texture-mapping matrices from a face's DC05 entity-info blob.
+
+    A positioned / photo-fitted texture stores its mapping per face under
+    ``DC05 -> DD05 -> B136 -> B236 -> 1027 -> 1127 (front) / 1227 (back)
+    -> 1327 -> 1527``: a 3x3 row-major matrix of f64 that maps
+    **texture space -> face plane**; consumers invert it to get UVs
+    (see the ``Face.uv_transform`` docs in model.py for the exact recipe).
+
+    Returns:
+        ``(front, back)`` — each a 9-tuple of floats, or ``None`` when the
+        face carries no positioned mapping on that side.
+    """
+    def _find(seq, tag):
+        for t, body in seq:
+            if t == tag:
+                return body
+        return None
+
+    dd05 = _find(_tlv_flat(dc05_payload), 'DD05')
+    if dd05 is None:
+        return None, None
+    b136 = _find(_tlv_flat(dd05), 'B136')
+    if b136 is None:
+        return None, None
+    b236 = _find(_tlv_flat(b136), 'B236')
+    if b236 is None:
+        return None, None
+    t1027 = _find(_tlv_flat(b236), '1027')
+    if t1027 is None:
+        return None, None
+    sides = _tlv_flat(t1027)
+    result = []
+    for side_tag in ('1127', '1227'):
+        side = _find(sides, side_tag)
+        mat = None
+        if side is not None:
+            t1327 = _find(_tlv_flat(side), '1327')
+            if t1327 is not None:
+                t1527 = _find(_tlv_flat(t1327), '1527')
+                if t1527 is not None and len(t1527) == 72:
+                    mat = struct.unpack('<9d', t1527)
+        result.append(mat)
+    return result[0], result[1]
+
+
 def _extract_geometry_from_nodes(elements, builder):
     for el in elements:
         tag = el['tag']
@@ -255,12 +315,19 @@ def _extract_geometry_from_nodes(elements, builder):
                         if co_edges:
                             loops.append(co_edges)
                 face_mat_id = None
+                uv_front = uv_back = None
                 d007 = next((c for c in el['children'] if c['tag'] == 'D007'), None)
                 if d007:
                     d107 = next((c for c in d007['children'] if c['tag'] == 'D107'), None)
                     if d107:
                         face_mat_id = parse_var_int(d107['payload'], 0, len(d107['payload']))
-                builder.faces[f_id] = {'loops': loops, 'normal': normal, 'material_id': face_mat_id}
+                    dc05 = next((c for c in d007['children'] if c['tag'] == 'DC05'), None)
+                    if dc05 is not None:
+                        uv_front, uv_back = _extract_uv_transforms(dc05['payload'])
+                builder.faces[f_id] = {'loops': loops, 'normal': normal,
+                                       'material_id': face_mat_id,
+                                       'uv_transform': uv_front,
+                                       'uv_transform_back': uv_back}
 
         elif tag == '6419':
             nodes_to_search = el['children'] if el['children'] else [el]

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -194,6 +194,66 @@ def extract_entity_id(node):
     return None
 
 
+def _tlv_flat(payload):
+    """Walk a raw payload as a flat TLV sequence; returns [(tag_hex, body)]."""
+    pos = 0
+    out = []
+    while pos <= len(payload) - 6:
+        tag = payload[pos:pos+2].hex().upper()
+        size = read_u32(payload, pos+2)
+        if pos + 6 + size > len(payload):
+            break
+        out.append((tag, payload[pos+6:pos+6+size]))
+        pos += 6 + size
+    return out
+
+
+def _extract_uv_transforms(dc05_payload):
+    """Per-face texture-mapping matrices from a face's DC05 entity-info blob.
+
+    A positioned / photo-fitted texture stores its mapping per face under
+    ``DC05 -> DD05 -> B136 -> B236 -> 1027 -> 1127 (front) / 1227 (back)
+    -> 1327 -> 1527``: a 3x3 row-major matrix of f64 that maps
+    **texture space -> face plane**; consumers invert it to get UVs
+    (see the ``Face.uv_transform`` docs in model.py for the exact recipe).
+
+    Returns:
+        ``(front, back)`` — each a 9-tuple of floats, or ``None`` when the
+        face carries no positioned mapping on that side.
+    """
+    def _find(seq, tag):
+        for t, body in seq:
+            if t == tag:
+                return body
+        return None
+
+    dd05 = _find(_tlv_flat(dc05_payload), 'DD05')
+    if dd05 is None:
+        return None, None
+    b136 = _find(_tlv_flat(dd05), 'B136')
+    if b136 is None:
+        return None, None
+    b236 = _find(_tlv_flat(b136), 'B236')
+    if b236 is None:
+        return None, None
+    t1027 = _find(_tlv_flat(b236), '1027')
+    if t1027 is None:
+        return None, None
+    sides = _tlv_flat(t1027)
+    result = []
+    for side_tag in ('1127', '1227'):
+        side = _find(sides, side_tag)
+        mat = None
+        if side is not None:
+            t1327 = _find(_tlv_flat(side), '1327')
+            if t1327 is not None:
+                t1527 = _find(_tlv_flat(t1327), '1527')
+                if t1527 is not None and len(t1527) == 72:
+                    mat = struct.unpack('<9d', t1527)
+        result.append(mat)
+    return result[0], result[1]
+
+
 def _extract_geometry_from_nodes(elements, builder):
     for el in elements:
         tag = el['tag']
@@ -265,12 +325,19 @@ def _extract_geometry_from_nodes(elements, builder):
                         if co_edges:
                             loops.append(co_edges)
                 face_mat_id = None
+                uv_front = uv_back = None
                 d007 = next((c for c in el['children'] if c['tag'] == 'D007'), None)
                 if d007:
                     d107 = next((c for c in d007['children'] if c['tag'] == 'D107'), None)
                     if d107:
                         face_mat_id = parse_var_int(d107['payload'], 0, len(d107['payload']))
-                builder.faces[f_id] = {'loops': loops, 'normal': normal, 'material_id': face_mat_id}
+                    dc05 = next((c for c in d007['children'] if c['tag'] == 'DC05'), None)
+                    if dc05 is not None:
+                        uv_front, uv_back = _extract_uv_transforms(dc05['payload'])
+                builder.faces[f_id] = {'loops': loops, 'normal': normal,
+                                       'material_id': face_mat_id,
+                                       'uv_transform': uv_front,
+                                       'uv_transform_back': uv_back}
 
         elif tag == '6419':
             nodes_to_search = el['children'] if el['children'] else [el]

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -282,12 +282,27 @@ def _extract_geometry_from_nodes(elements, builder):
                 for idx in range(13):
                     matrix.append(read_f64(mat_node['payload'], idx * 8))
 
+            # Instance-level material (SketchUp "paint the component"):
+            # same D007/D107 structure faces use. Faces whose own material
+            # is None inherit this — the SDK resolves that inheritance when
+            # exporting, so consumers need the raw value to do the same.
+            inst_mat_id = None
+            d007 = next((c for c in el['children'] if c['tag'] == 'D007'),
+                        None)
+            if d007:
+                d107 = next((c for c in d007['children']
+                             if c['tag'] == 'D107'), None)
+                if d107:
+                    inst_mat_id = parse_var_int(
+                        d107['payload'], 0, len(d107['payload']))
+
             builder.instances.append({
                 'offset': el['offset'],
                 'ref_guid': guid,
                 'ref_idx': def_idx,
                 'name': name,
                 'matrix': matrix,
+                'material_id': inst_mat_id,
                 'children': el['children']
             })
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -44,6 +44,11 @@ CONTAINER_TAGS = {
     'F901', '7017', '7117', 'D007', 'C409', '9411', '9511', '0F01',
     '384A', 'B80B', '9713', '2C4C', 'AC0D', 'AE0D', 'F601', 'F801',
     '983A', '993A', '8C3C', '8D3C',
+    # Image-entity placement: an Image placed in the model wraps a standard
+    # 6419 instance node inside 9013 -> 401F. Without these two containers,
+    # that inner instance stays buried in an opaque payload and the image
+    # definition looks "never placed".
+    '9013', '401F',
 }
 
 def parse_tlv_recursive(data, start, end, container_tags=None, depth=0):
@@ -498,15 +503,23 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
             if el['tag'] == '7C15':
                 guid = None
                 name = None
+                is_image = False
                 for child in el['children']:
                     if child['tag'] == '7D15' and len(child['payload']) == 16:
                         guid = child['payload'].hex().upper()
                     elif child['tag'] == '7E15':
                         name = child['payload'].decode('ascii', errors='ignore')
+                    elif child['tag'] == '8315' and child['payload']:
+                        # Definition kind: observed 0/1 for ordinary
+                        # component/group definitions, 2 for the quad
+                        # definition backing an Image entity.
+                        is_image = parse_var_int(
+                            child['payload'], 0, len(child['payload'])) == 2
                 ent_id = extract_entity_id(el)
                 builder = _GeometryBuilder()
                 _extract_geometry_from_nodes(el['children'], builder)
-                defs_dict[ent_id] = {'guid': guid, 'name': name, 'builder': builder}
+                defs_dict[ent_id] = {'guid': guid, 'name': name,
+                                     'is_image': is_image, 'builder': builder}
             collect_defs(el['children'])
     collect_defs(elements)
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -158,6 +158,7 @@ class _GeometryBuilder:
     def __init__(self):
         self.vertices = {}
         self.edges = {}
+        self.edge_flags = {}      # edge id -> display flag byte (D307)
         self.faces = {}
         self.instances = []
 
@@ -214,6 +215,15 @@ def _extract_geometry_from_nodes(elements, builder):
                 v1 = parse_var_int(v1_node['payload'], 0, len(v1_node['payload'])) if v1_node else None
                 v2 = parse_var_int(v2_node['payload'], 0, len(v2_node['payload'])) if v2_node else None
                 builder.edges[e_id] = (v1, v2)
+                # D007 -> D307 = edge display flags: base 0x06, plus
+                # 0x01 hidden, 0x08|0x10 soft/smooth (cross-validated
+                # against the same models in the classic MFC format,
+                # 26k edges: 0x06 plain, 0x07 hidden, 0x1E soft+smooth)
+                d007 = next((c for c in el['children'] if c['tag'] == 'D007'), None)
+                if d007:
+                    d307 = next((c for c in d007['children'] if c['tag'] == 'D307'), None)
+                    if d307 is not None and d307['payload']:
+                        builder.edge_flags[e_id] = d307['payload'][0]
 
         elif tag == 'AC0D':
             f_id = extract_entity_id(el)

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -44,6 +44,11 @@ CONTAINER_TAGS = {
     'F901', '7017', '7117', 'D007', 'C409', '9411', '9511', '0F01',
     '384A', 'B80B', '9713', '2C4C', 'AC0D', 'AE0D', 'F601', 'F801',
     '983A', '993A', '8C3C', '8D3C',
+    # Image-entity placement: an Image placed in the model wraps a standard
+    # 6419 instance node inside 9013 -> 401F. Without these two containers,
+    # that inner instance stays buried in an opaque payload and the image
+    # definition looks "never placed".
+    '9013', '401F',
 }
 
 def parse_tlv_recursive(data, start, end, container_tags=None, depth=0):
@@ -632,6 +637,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                 guid = None
                 name = None
                 faces_camera = False
+                is_image = False
                 for child in el['children']:
                     if child['tag'] == '7D15' and len(child['payload']) == 16:
                         guid = child['payload'].hex().upper()
@@ -652,12 +658,18 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                                 faces_camera = parse_var_int(
                                     pl, pos+6, sub_size) == 1
                             pos += 6 + sub_size
+                    elif child['tag'] == '8315' and child['payload']:
+                        # Definition kind: observed 0/1 for ordinary
+                        # component/group definitions, 2 for the quad
+                        # definition backing an Image entity.
+                        is_image = parse_var_int(
+                            child['payload'], 0, len(child['payload'])) == 2
                 ent_id = extract_entity_id(el)
                 builder = _GeometryBuilder()
                 _extract_geometry_from_nodes(el['children'], builder)
                 defs_dict[ent_id] = {'guid': guid, 'name': name,
                                      'always_faces_camera': faces_camera,
-                                     'builder': builder}
+                                     'is_image': is_image, 'builder': builder}
             collect_defs(el['children'])
     collect_defs(elements)
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -438,6 +438,38 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
     if 'meta/model_thumbnail.png' in zf.namelist():
         thumbnail_data = zf.read('meta/model_thumbnail.png')
 
+    # Styles: face colors live in styles/*/style.xml as signed-int32 ARGB
+    # variants — item id 4000 is the front (default) face color, 4001 the
+    # back face color. Viewers need them to shade unpainted faces the way
+    # SketchUp does (an author may e.g. set a green back color so unpainted
+    # garden faces read as grass).
+    styles = []
+    for name in zf.namelist():
+        if not (name.startswith('styles/') and name.endswith('style.xml')):
+            continue
+        try:
+            sroot = ET.fromstring(zf.read(name))
+        except ET.ParseError:
+            continue
+        STY = '{http://sketchup.google.com/schemas/sketchup/1.0/style}'
+        TYP = '{http://sketchup.google.com/schemas/1.0/types}'
+        style_el = sroot.find(f'{STY}style')
+        if style_el is None:
+            continue
+        colors = {}
+        for item in style_el.findall(f'{STY}item'):
+            iid = item.get('id')
+            var = item.find(f'{TYP}variant')
+            if iid in ('4000', '4001') and var is not None and var.text:
+                try:
+                    v = int(var.text) & 0xFFFFFFFF
+                except ValueError:
+                    continue
+                colors[iid] = ((v >> 16) & 255, (v >> 8) & 255, v & 255)
+        styles.append({'name': style_el.get('name', ''),
+                       'front_color': colors.get('4000'),
+                       'back_color': colors.get('4001')})
+
     model_dat = zf.read('model.dat')
     zf.close()
 
@@ -527,6 +559,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
         'defs_dict': defs_dict,
         'elements': elements,
         'thumbnail_data': thumbnail_data,
+        'styles': styles,
     }
 
 

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -246,6 +246,11 @@ class Definition:
             behavior (2D people / tree cut-outs that rotate to face the
             viewer). Consumers typically render such instances as
             billboards.
+        is_image: ``True`` when this definition backs an *Image entity* (a
+            picture placed in the model as an object): a single textured
+            quad, placed through an image-specific wrapper node. Useful for
+            consumers that give images special treatment (e.g. billboard
+            cut-outs).
     """
 
     id: int = 0
@@ -256,6 +261,7 @@ class Definition:
     faces: Dict[int, Face] = field(default_factory=dict)
     instances: List[Instance] = field(default_factory=list)
     always_faces_camera: bool = False
+    is_image: bool = False
 
 
 # ── Top-level model ──────────────────────────────────────────────────────
@@ -370,6 +376,7 @@ class SkpFile:
                 guid=d.get("guid", ""),
                 name=d.get("name", "") or "",
                 always_faces_camera=d.get("always_faces_camera", False),
+                is_image=d.get("is_image", False),
             )
             # Populate vertices
             for v_id, (x, y, z) in builder.vertices.items():

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -179,6 +179,11 @@ class Definition:
         edges: Mapping of edge ID → :class:`Edge`.
         faces: Mapping of face ID → :class:`Face`.
         instances: Child instances placed inside this definition.
+        is_image: ``True`` when this definition backs an *Image entity* (a
+            picture placed in the model as an object): a single textured
+            quad, placed through an image-specific wrapper node. Useful for
+            consumers that give images special treatment (e.g. billboard
+            cut-outs).
     """
 
     id: int = 0
@@ -188,6 +193,7 @@ class Definition:
     edges: Dict[int, Edge] = field(default_factory=dict)
     faces: Dict[int, Face] = field(default_factory=dict)
     instances: List[Instance] = field(default_factory=list)
+    is_image: bool = False
 
 
 # ── Top-level model ──────────────────────────────────────────────────────
@@ -296,6 +302,7 @@ class SkpFile:
                 id=def_id if isinstance(def_id, int) else 0,
                 guid=d.get("guid", ""),
                 name=d.get("name", "") or "",
+                is_image=d.get("is_image", False),
             )
             # Populate vertices
             for v_id, (x, y, z) in builder.vertices.items():

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -90,12 +90,19 @@ class Face:
             ``(edge_id, orientation)`` tuples where *orientation* is
             ``1`` for forward or ``-1`` for reversed.
         normal: Optional outward-facing normal vector ``(nx, ny, nz)``.
+        material_id: Material of the face's FRONT side, or ``None``.
+        back_material_id: Material of the face's BACK side, or ``None``.
+            A face painted only on its back (front unpainted) is common when
+            the author painted the visible side of a downward-facing cap;
+            renderers should show this material on the back side, as
+            SketchUp does.
     """
 
     id: int
     loops: List[List[Tuple[int, int]]] = field(default_factory=list)
     normal: Optional[Tuple[float, float, float]] = None
     material_id: Optional[int] = None
+    back_material_id: Optional[int] = None
 
 
 # ── Layers & Materials ────────────────────────────────────────────────────
@@ -310,6 +317,7 @@ class SkpFile:
                     loops=f_data.get("loops", []),
                     normal=f_data.get("normal"),
                     material_id=f_data.get("material_id"),
+                    back_material_id=f_data.get("back_material_id"),
                 )
             # Populate instances
             for inst in builder.instances:

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -179,6 +179,10 @@ class Definition:
         edges: Mapping of edge ID → :class:`Edge`.
         faces: Mapping of face ID → :class:`Face`.
         instances: Child instances placed inside this definition.
+        always_faces_camera: SketchUp's "always face camera" component
+            behavior (2D people / tree cut-outs that rotate to face the
+            viewer). Consumers typically render such instances as
+            billboards.
     """
 
     id: int = 0
@@ -188,6 +192,7 @@ class Definition:
     edges: Dict[int, Edge] = field(default_factory=dict)
     faces: Dict[int, Face] = field(default_factory=dict)
     instances: List[Instance] = field(default_factory=list)
+    always_faces_camera: bool = False
 
 
 # ── Top-level model ──────────────────────────────────────────────────────
@@ -296,6 +301,7 @@ class SkpFile:
                 id=def_id if isinstance(def_id, int) else 0,
                 guid=d.get("guid", ""),
                 name=d.get("name", "") or "",
+                always_faces_camera=d.get("always_faces_camera", False),
             )
             # Populate vertices
             for v_id, (x, y, z) in builder.vertices.items():

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -96,6 +96,12 @@ class Face:
             ``(edge_id, orientation)`` tuples where *orientation* is
             ``1`` for forward or ``-1`` for reversed.
         normal: Optional outward-facing normal vector ``(nx, ny, nz)``.
+        material_id: Material of the face's FRONT side, or ``None``.
+        back_material_id: Material of the face's BACK side, or ``None``.
+            A face painted only on its back (front unpainted) is common when
+            the author painted the visible side of a downward-facing cap;
+            renderers should show this material on the back side, as
+            SketchUp does.
         uv_transform: Per-face texture mapping for a *positioned* /
             photo-fitted texture (SketchUp's pins), or ``None`` when the
             texture is untouched (default projection applies).  A 9-tuple:
@@ -119,6 +125,7 @@ class Face:
     loops: List[List[Tuple[int, int]]] = field(default_factory=list)
     normal: Optional[Tuple[float, float, float]] = None
     material_id: Optional[int] = None
+    back_material_id: Optional[int] = None
     uv_transform: Optional[Tuple[float, ...]] = None
     uv_transform_back: Optional[Tuple[float, ...]] = None
 
@@ -376,6 +383,7 @@ class SkpFile:
                     loops=f_data.get("loops", []),
                     normal=f_data.get("normal"),
                     material_id=f_data.get("material_id"),
+                    back_material_id=f_data.get("back_material_id"),
                     uv_transform=f_data.get("uv_transform"),
                     uv_transform_back=f_data.get("uv_transform_back"),
                 )

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -242,6 +242,10 @@ class Definition:
         edges: Mapping of edge ID → :class:`Edge`.
         faces: Mapping of face ID → :class:`Face`.
         instances: Child instances placed inside this definition.
+        always_faces_camera: SketchUp's "always face camera" component
+            behavior (2D people / tree cut-outs that rotate to face the
+            viewer). Consumers typically render such instances as
+            billboards.
     """
 
     id: int = 0
@@ -251,6 +255,7 @@ class Definition:
     edges: Dict[int, Edge] = field(default_factory=dict)
     faces: Dict[int, Face] = field(default_factory=dict)
     instances: List[Instance] = field(default_factory=list)
+    always_faces_camera: bool = False
 
 
 # ── Top-level model ──────────────────────────────────────────────────────
@@ -364,6 +369,7 @@ class SkpFile:
                 id=def_id if isinstance(def_id, int) else 0,
                 guid=d.get("guid", ""),
                 name=d.get("name", "") or "",
+                always_faces_camera=d.get("always_faces_camera", False),
             )
             # Populate vertices
             for v_id, (x, y, z) in builder.vertices.items():

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -119,6 +119,24 @@ class Layer:
 
 
 @dataclass
+class Style:
+    """A rendering style bundled in the file (SketchUp's Styles browser).
+
+    Attributes:
+        name: Style name.
+        front_color: Default front face color ``(r, g, b)`` 0-255, or
+            ``None``. Unpainted faces show it.
+        back_color: Back face color ``(r, g, b)`` 0-255, or ``None``.
+            Unpainted faces seen from behind show it — an author may e.g.
+            pick a green back color so unpainted garden faces read as grass.
+    """
+
+    name: str = ""
+    front_color: Optional[Tuple[int, int, int]] = None
+    back_color: Optional[Tuple[int, int, int]] = None
+
+
+@dataclass
 class Material:
     """A surface material.
 
@@ -213,6 +231,7 @@ class SkpModel:
     layers: List[Layer] = field(default_factory=list)
     materials: List[Material] = field(default_factory=list)
     scene_hierarchy: List[Instance] = field(default_factory=list)
+    styles: List[Style] = field(default_factory=list)
     mesh_index: Dict[int, Any] = field(default_factory=dict)
 
 
@@ -332,6 +351,14 @@ class SkpFile:
                 name=mat_data.get("name", ""),
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
+            ))
+
+        # Convert styles
+        for st in parsed.get("styles", []):
+            model.styles.append(Style(
+                name=st.get("name", ""),
+                front_color=st.get("front_color"),
+                back_color=st.get("back_color"),
             ))
 
         # Store raw parsed data for export use

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -90,12 +90,31 @@ class Face:
             ``(edge_id, orientation)`` tuples where *orientation* is
             ``1`` for forward or ``-1`` for reversed.
         normal: Optional outward-facing normal vector ``(nx, ny, nz)``.
+        uv_transform: Per-face texture mapping for a *positioned* /
+            photo-fitted texture (SketchUp's pins), or ``None`` when the
+            texture is untouched (default projection applies).  A 9-tuple:
+            a 3×3 **row-major** matrix mapping texture space → face plane.
+            To compute the UV of a point ``p`` (inches):
+
+            1. Plane basis from the face normal ``n``:
+               ``xr = normalize(Z × n)``, ``yr = n × xr`` (for a vertical
+               ``n``: ``xr = X``, ``yr = ±Y`` by the sign of ``n``·Z).
+            2. ``uvq = [p·xr, p·yr, 1] @ inv(M)``  (row-vector convention).
+            3. ``u = uvq[0]/uvq[2] / tile_w``, ``v = uvq[1]/uvq[2] / tile_h``
+               with the material texture's tile size in inches.
+
+            When the texture is untouched (``None``), the default is
+            ``u = (p·xr)/tile_w``, ``v = (p·yr)/tile_h``.  Distorted
+            (4-pin) mappings are projective: ``uvq[2]`` ≠ 1.
+        uv_transform_back: Same for the face's back side, or ``None``.
     """
 
     id: int
     loops: List[List[Tuple[int, int]]] = field(default_factory=list)
     normal: Optional[Tuple[float, float, float]] = None
     material_id: Optional[int] = None
+    uv_transform: Optional[Tuple[float, ...]] = None
+    uv_transform_back: Optional[Tuple[float, ...]] = None
 
 
 # ── Layers & Materials ────────────────────────────────────────────────────
@@ -310,6 +329,8 @@ class SkpFile:
                     loops=f_data.get("loops", []),
                     normal=f_data.get("normal"),
                     material_id=f_data.get("material_id"),
+                    uv_transform=f_data.get("uv_transform"),
+                    uv_transform_back=f_data.get("uv_transform_back"),
                 )
             # Populate instances
             for inst in builder.instances:

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -151,6 +151,11 @@ class Instance:
         layer: Layer name this instance belongs to.
         properties: Arbitrary key/value dynamic attributes.
         children: Nested child instances forming a subtree.
+        material_id: Numeric material ID painted onto the instance itself
+            (SketchUp's "paint the component"), or ``None``.  Faces inside
+            the placed definition whose own :attr:`Face.material_id` is
+            ``None`` inherit this material — consumers must resolve that
+            inheritance themselves, like the official SDK does on export.
     """
 
     name: str = ""
@@ -165,6 +170,7 @@ class Instance:
     layer: str = ""
     properties: Dict[str, str] = field(default_factory=dict)
     children: List["Instance"] = field(default_factory=list)
+    material_id: Optional[int] = None
 
 
 @dataclass
@@ -318,6 +324,7 @@ class SkpFile:
                     ref_idx=inst.get("ref_idx"),
                     guid=inst.get("ref_guid", ""),
                     matrix=inst.get("matrix", []),
+                    material_id=inst.get("material_id"),
                 ))
             model.definitions[def_id] = defn
 

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -169,6 +169,41 @@ class Style:
 
 
 @dataclass
+class Texture:
+    """A material's texture image, extracted from the SKP container.
+
+    SketchUp stores the image next to the material's XML inside the embedded
+    ZIP, and the real-world tile size (how many inches one repetition of the
+    image covers) in the material definition.
+
+    Attributes:
+        filename: Image file name as referenced by the material.
+        width: Tile width in **inches** (SketchUp's internal unit); ``0.0``
+            when the file does not specify it.
+        height: Tile height in inches; ``0.0`` when unspecified.
+        data: Raw image bytes (PNG/JPG as stored), or ``None`` when the
+            image entry was missing from the container.
+    """
+
+    filename: str = ""
+    width: float = 0.0
+    height: float = 0.0
+    data: Optional[bytes] = None
+
+    def save(self, filepath: str | pathlib.Path) -> pathlib.Path:
+        """Write the image bytes to *filepath* and return the path.
+
+        Raises:
+            ValueError: If the texture carries no image data.
+        """
+        if self.data is None:
+            raise ValueError(f"Texture {self.filename!r} has no image data")
+        p = pathlib.Path(filepath)
+        p.write_bytes(self.data)
+        return p
+
+
+@dataclass
 class Material:
     """A surface material.
 
@@ -183,12 +218,26 @@ class Material:
             ID (e.g. it is never referenced by geometry).  When several TLV
             IDs alias the same material, this holds the first one seen; every
             ID still resolves through :attr:`SkpModel.materials_by_id`.
+        texture: The material's :class:`Texture`, or ``None`` for a plain
+            colour material.
+        colorized: ``True`` for a colourized copy of a textured material
+            (SketchUp's ``[Name]1`` materials, ``type="2"`` in the XML).
+            The texture image is shared with the source material as stored;
+            viewers must re-tint it toward :attr:`color` for faithful
+            display.
+        colorize_type: How to re-tint when :attr:`colorized` — ``0`` shifts
+            every pixel's hue/lightness/saturation by the delta between the
+            image average and :attr:`color`; ``1`` tints (greyscales the
+            image, then applies the colour's hue/saturation).
     """
 
     name: str
     color: Tuple[int, int, int, int] = (200, 200, 200, 255)
     transparency: float = 1.0
     id: Optional[int] = None
+    texture: Optional[Texture] = None
+    colorized: bool = False
+    colorize_type: int = 0
 
 
 # ── Component hierarchy ───────────────────────────────────────────────────
@@ -419,10 +468,22 @@ class SkpFile:
         mat_for_data: Dict[int, Material] = {}   # id(raw dict) -> Material
         for mat_data in parsed["materials"].values():
             c = mat_data.get("color", {})
+            tex_data = mat_data.get("texture")
+            texture = None
+            if tex_data is not None:
+                texture = Texture(
+                    filename=tex_data.get("filename", ""),
+                    width=tex_data.get("x_scale", 0.0),
+                    height=tex_data.get("y_scale", 0.0),
+                    data=tex_data.get("data"),
+                )
             mat = Material(
                 name=mat_data.get("name", ""),
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
+                texture=texture,
+                colorized=mat_data.get("colorized", False),
+                colorize_type=mat_data.get("colorize_type", 0),
             )
             model.materials.append(mat)
             mat_for_data[id(mat_data)] = mat

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -125,6 +125,24 @@ class Layer:
 
 
 @dataclass
+class Style:
+    """A rendering style bundled in the file (SketchUp's Styles browser).
+
+    Attributes:
+        name: Style name.
+        front_color: Default front face color ``(r, g, b)`` 0-255, or
+            ``None``. Unpainted faces show it.
+        back_color: Back face color ``(r, g, b)`` 0-255, or ``None``.
+            Unpainted faces seen from behind show it — an author may e.g.
+            pick a green back color so unpainted garden faces read as grass.
+    """
+
+    name: str = ""
+    front_color: Optional[Tuple[int, int, int]] = None
+    back_color: Optional[Tuple[int, int, int]] = None
+
+
+@dataclass
 class Material:
     """A surface material.
 
@@ -236,6 +254,7 @@ class SkpModel:
     materials: List[Material] = field(default_factory=list)
     materials_by_id: Dict[int, Material] = field(default_factory=dict)
     scene_hierarchy: List[Instance] = field(default_factory=list)
+    styles: List[Style] = field(default_factory=list)
     mesh_index: Dict[int, Any] = field(default_factory=dict)
 
 
@@ -379,6 +398,14 @@ class SkpFile:
             if mat.id is None:
                 mat.id = m_id
             model.materials_by_id[m_id] = mat
+
+        # Convert styles
+        for st in parsed.get("styles", []):
+            model.styles.append(Style(
+                name=st.get("name", ""),
+                front_color=st.get("front_color"),
+                back_color=st.get("back_color"),
+            ))
 
         # Store raw parsed data for export use
         self._parsed = parsed

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -73,11 +73,17 @@ class Edge:
         id: Unique edge identifier within its definition.
         v1_id: Start-vertex ID.
         v2_id: End-vertex ID.
+        soft: Soft edge (merges the faces it borders into one surface).
+        smooth: Smooth edge (normals interpolate across it).
+        hidden: Edge hidden by the user.
     """
 
     id: int
     v1_id: int
     v2_id: int
+    soft: bool = False
+    smooth: bool = False
+    hidden: bool = False
 
 
 @dataclass
@@ -318,8 +324,13 @@ class SkpFile:
             for v_id, (x, y, z) in builder.vertices.items():
                 defn.vertices[v_id] = Vertex(id=v_id, x=x, y=y, z=z)
             # Populate edges
+            flags_map = getattr(builder, "edge_flags", {})
             for e_id, (v1, v2) in builder.edges.items():
-                defn.edges[e_id] = Edge(id=e_id, v1_id=v1 or 0, v2_id=v2 or 0)
+                flags = flags_map.get(e_id, 0)
+                defn.edges[e_id] = Edge(id=e_id, v1_id=v1 or 0, v2_id=v2 or 0,
+                                        soft=bool(flags & 0x08),
+                                        smooth=bool(flags & 0x10),
+                                        hidden=bool(flags & 0x01))
             # Populate faces
             for f_id, f_data in builder.faces.items():
                 defn.faces[f_id] = Face(

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -127,11 +127,18 @@ class Material:
         color: RGBA colour tuple ``(r, g, b, a)`` with each value in 0–255.
         transparency: Opacity factor where ``0.0`` is fully transparent and
             ``1.0`` is fully opaque.
+        id: Numeric material ID from the TLV stream — the value that
+            :attr:`Face.material_id` references, so callers can resolve a
+            face's material.  ``None`` when the file assigns the material no
+            ID (e.g. it is never referenced by geometry).  When several TLV
+            IDs alias the same material, this holds the first one seen; every
+            ID still resolves through :attr:`SkpModel.materials_by_id`.
     """
 
     name: str
     color: Tuple[int, int, int, int] = (200, 200, 200, 255)
     transparency: float = 1.0
+    id: Optional[int] = None
 
 
 # ── Component hierarchy ───────────────────────────────────────────────────
@@ -202,6 +209,9 @@ class SkpModel:
         definitions: Mapping of definition index → :class:`Definition`.
         layers: List of :class:`Layer` objects found in the file.
         materials: List of :class:`Material` objects found in the file.
+        materials_by_id: Mapping of TLV material ID → :class:`Material`,
+            the join table for :attr:`Face.material_id`.  Several IDs may
+            alias the same :class:`Material` object.
         scene_hierarchy: Top-level :class:`Instance` list forming the
             scene graph.
         mesh_index: Pre-built index mapping definition IDs to triangulated
@@ -212,6 +222,7 @@ class SkpModel:
     definitions: Dict[int, Definition] = field(default_factory=dict)
     layers: List[Layer] = field(default_factory=list)
     materials: List[Material] = field(default_factory=list)
+    materials_by_id: Dict[int, Material] = field(default_factory=dict)
     scene_hierarchy: List[Instance] = field(default_factory=list)
     mesh_index: Dict[int, Any] = field(default_factory=dict)
 
@@ -326,13 +337,30 @@ class SkpFile:
             model.layers.append(Layer(name=name, color_r=r, color_g=g, color_b=b))
 
         # Convert materials
+        mat_for_data: Dict[int, Material] = {}   # id(raw dict) -> Material
         for mat_data in parsed["materials"].values():
             c = mat_data.get("color", {})
-            model.materials.append(Material(
+            mat = Material(
                 name=mat_data.get("name", ""),
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
-            ))
+            )
+            model.materials.append(mat)
+            mat_for_data[id(mat_data)] = mat
+
+        # Join the TLV material IDs (what Face.material_id references) onto
+        # the parsed materials, so callers can resolve face -> material.
+        # Same name-then-folder resolution the internal exporter uses.
+        materials_by_folder = parsed.get("materials_by_folder", {})
+        for m_id, m_name in parsed.get("material_id_to_name", {}).items():
+            mat_data = (parsed["materials"].get(m_name)
+                        or materials_by_folder.get(m_name))
+            mat = mat_for_data.get(id(mat_data)) if mat_data is not None else None
+            if mat is None:
+                continue
+            if mat.id is None:
+                mat.id = m_id
+            model.materials_by_id[m_id] = mat
 
         # Store raw parsed data for export use
         self._parsed = parsed

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -164,12 +164,23 @@ class Material:
             ``1.0`` is fully opaque.
         texture: The material's :class:`Texture`, or ``None`` for a plain
             colour material.
+        colorized: ``True`` for a colourized copy of a textured material
+            (SketchUp's ``[Name]1`` materials, ``type="2"`` in the XML).
+            The texture image is shared with the source material as stored;
+            viewers must re-tint it toward :attr:`color` for faithful
+            display.
+        colorize_type: How to re-tint when :attr:`colorized` — ``0`` shifts
+            every pixel's hue/lightness/saturation by the delta between the
+            image average and :attr:`color`; ``1`` tints (greyscales the
+            image, then applies the colour's hue/saturation).
     """
 
     name: str
     color: Tuple[int, int, int, int] = (200, 200, 200, 255)
     transparency: float = 1.0
     texture: Optional[Texture] = None
+    colorized: bool = False
+    colorize_type: int = 0
 
 
 # ── Component hierarchy ───────────────────────────────────────────────────
@@ -380,6 +391,8 @@ class SkpFile:
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
                 texture=texture,
+                colorized=mat_data.get("colorized", False),
+                colorize_type=mat_data.get("colorize_type", 0),
             ))
 
         # Store raw parsed data for export use

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -96,12 +96,31 @@ class Face:
             ``(edge_id, orientation)`` tuples where *orientation* is
             ``1`` for forward or ``-1`` for reversed.
         normal: Optional outward-facing normal vector ``(nx, ny, nz)``.
+        uv_transform: Per-face texture mapping for a *positioned* /
+            photo-fitted texture (SketchUp's pins), or ``None`` when the
+            texture is untouched (default projection applies).  A 9-tuple:
+            a 3×3 **row-major** matrix mapping texture space → face plane.
+            To compute the UV of a point ``p`` (inches):
+
+            1. Plane basis from the face normal ``n``:
+               ``xr = normalize(Z × n)``, ``yr = n × xr`` (for a vertical
+               ``n``: ``xr = X``, ``yr = ±Y`` by the sign of ``n``·Z).
+            2. ``uvq = [p·xr, p·yr, 1] @ inv(M)``  (row-vector convention).
+            3. ``u = uvq[0]/uvq[2] / tile_w``, ``v = uvq[1]/uvq[2] / tile_h``
+               with the material texture's tile size in inches.
+
+            When the texture is untouched (``None``), the default is
+            ``u = (p·xr)/tile_w``, ``v = (p·yr)/tile_h``.  Distorted
+            (4-pin) mappings are projective: ``uvq[2]`` ≠ 1.
+        uv_transform_back: Same for the face's back side, or ``None``.
     """
 
     id: int
     loops: List[List[Tuple[int, int]]] = field(default_factory=list)
     normal: Optional[Tuple[float, float, float]] = None
     material_id: Optional[int] = None
+    uv_transform: Optional[Tuple[float, ...]] = None
+    uv_transform_back: Optional[Tuple[float, ...]] = None
 
 
 # ── Layers & Materials ────────────────────────────────────────────────────
@@ -357,6 +376,8 @@ class SkpFile:
                     loops=f_data.get("loops", []),
                     normal=f_data.get("normal"),
                     material_id=f_data.get("material_id"),
+                    uv_transform=f_data.get("uv_transform"),
+                    uv_transform_back=f_data.get("uv_transform_back"),
                 )
             # Populate instances
             for inst in builder.instances:

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -119,6 +119,41 @@ class Layer:
 
 
 @dataclass
+class Texture:
+    """A material's texture image, extracted from the SKP container.
+
+    SketchUp stores the image next to the material's XML inside the embedded
+    ZIP, and the real-world tile size (how many inches one repetition of the
+    image covers) in the material definition.
+
+    Attributes:
+        filename: Image file name as referenced by the material.
+        width: Tile width in **inches** (SketchUp's internal unit); ``0.0``
+            when the file does not specify it.
+        height: Tile height in inches; ``0.0`` when unspecified.
+        data: Raw image bytes (PNG/JPG as stored), or ``None`` when the
+            image entry was missing from the container.
+    """
+
+    filename: str = ""
+    width: float = 0.0
+    height: float = 0.0
+    data: Optional[bytes] = None
+
+    def save(self, filepath: str | pathlib.Path) -> pathlib.Path:
+        """Write the image bytes to *filepath* and return the path.
+
+        Raises:
+            ValueError: If the texture carries no image data.
+        """
+        if self.data is None:
+            raise ValueError(f"Texture {self.filename!r} has no image data")
+        p = pathlib.Path(filepath)
+        p.write_bytes(self.data)
+        return p
+
+
+@dataclass
 class Material:
     """A surface material.
 
@@ -127,11 +162,14 @@ class Material:
         color: RGBA colour tuple ``(r, g, b, a)`` with each value in 0–255.
         transparency: Opacity factor where ``0.0`` is fully transparent and
             ``1.0`` is fully opaque.
+        texture: The material's :class:`Texture`, or ``None`` for a plain
+            colour material.
     """
 
     name: str
     color: Tuple[int, int, int, int] = (200, 200, 200, 255)
     transparency: float = 1.0
+    texture: Optional[Texture] = None
 
 
 # ── Component hierarchy ───────────────────────────────────────────────────
@@ -328,10 +366,20 @@ class SkpFile:
         # Convert materials
         for mat_data in parsed["materials"].values():
             c = mat_data.get("color", {})
+            tex_data = mat_data.get("texture")
+            texture = None
+            if tex_data is not None:
+                texture = Texture(
+                    filename=tex_data.get("filename", ""),
+                    width=tex_data.get("x_scale", 0.0),
+                    height=tex_data.get("y_scale", 0.0),
+                    data=tex_data.get("data"),
+                )
             model.materials.append(Material(
                 name=mat_data.get("name", ""),
                 color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
                 transparency=mat_data.get("transparency", 0.5),
+                texture=texture,
             ))
 
         # Store raw parsed data for export use

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -73,11 +73,17 @@ class Edge:
         id: Unique edge identifier within its definition.
         v1_id: Start-vertex ID.
         v2_id: End-vertex ID.
+        soft: Soft edge (merges the faces it borders into one surface).
+        smooth: Smooth edge (normals interpolate across it).
+        hidden: Edge hidden by the user.
     """
 
     id: int
     v1_id: int
     v2_id: int
+    soft: bool = False
+    smooth: bool = False
+    hidden: bool = False
 
 
 @dataclass
@@ -301,8 +307,13 @@ class SkpFile:
             for v_id, (x, y, z) in builder.vertices.items():
                 defn.vertices[v_id] = Vertex(id=v_id, x=x, y=y, z=z)
             # Populate edges
+            flags_map = getattr(builder, "edge_flags", {})
             for e_id, (v1, v2) in builder.edges.items():
-                defn.edges[e_id] = Edge(id=e_id, v1_id=v1 or 0, v2_id=v2 or 0)
+                flags = flags_map.get(e_id, 0)
+                defn.edges[e_id] = Edge(id=e_id, v1_id=v1 or 0, v2_id=v2 or 0,
+                                        soft=bool(flags & 0x08),
+                                        smooth=bool(flags & 0x10),
+                                        hidden=bool(flags & 0x01))
             # Populate faces
             for f_id, f_data in builder.faces.items():
                 defn.faces[f_id] = Face(

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -158,6 +158,11 @@ class Instance:
         layer: Layer name this instance belongs to.
         properties: Arbitrary key/value dynamic attributes.
         children: Nested child instances forming a subtree.
+        material_id: Numeric material ID painted onto the instance itself
+            (SketchUp's "paint the component"), or ``None``.  Faces inside
+            the placed definition whose own :attr:`Face.material_id` is
+            ``None`` inherit this material — consumers must resolve that
+            inheritance themselves, like the official SDK does on export.
     """
 
     name: str = ""
@@ -172,6 +177,7 @@ class Instance:
     layer: str = ""
     properties: Dict[str, str] = field(default_factory=dict)
     children: List["Instance"] = field(default_factory=list)
+    material_id: Optional[int] = None
 
 
 @dataclass
@@ -329,6 +335,7 @@ class SkpFile:
                     ref_idx=inst.get("ref_idx"),
                     guid=inst.get("ref_guid", ""),
                     matrix=inst.get("matrix", []),
+                    material_id=inst.get("material_id"),
                 ))
             model.definitions[def_id] = defn
 

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -427,6 +427,48 @@ class TestTextureExtraction:
         assert glass.texture is not None
         assert glass.texture.data == jpeg
 
+    def test_colorized_copy_shares_source_image(
+        self, tmp_path: "pathlib.Path"
+    ) -> None:
+        # A colourized material ("[Name]1", type="2") stores no image of
+        # its own — its <mat:image path> points into the SOURCE material's
+        # folder. The shared bytes must be resolved, and the colorized
+        # flag exposed so viewers can re-tint.
+        from openskp.model import SkpFile
+
+        png = b"\x89PNGsharedchainlink"
+        colorized_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="[Fence]1" type="2" colorRed="27" colorGreen="135"
+                colorBlue="59" colorizeType="0" trans="1" hasTexture="1">
+    <mat:texture textureFilename="fence.png" xScale="2.75" yScale="2.75">
+      <mat:images>
+        <mat:image id="1" path="materials/Fence/fence.png"
+                   file_name="fence.png"/>
+      </mat:images>
+    </mat:texture>
+  </mat:material>
+</materialDocument>
+"""
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Fence/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Fence", b"fence.png"),
+            "materials/Fence/fence.png": png,
+            "materials/[Fence]1/material.xml": colorized_xml,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        by_name = {m.name: m for m in model.materials}
+        copy = by_name["[Fence]1"]
+        assert copy.texture is not None
+        assert copy.texture.data == png       # borrowed from materials/Fence/
+        assert copy.colorized is True
+        assert copy.colorize_type == 0
+        assert copy.color[:3] == (27, 135, 59)
+        base = by_name["Fence"]
+        assert base.colorized is False
+
 
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,37 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Back material tests ──────────────────────────────────────────────────
+
+
+class TestBackMaterial:
+    """The AF0D child of a face node is the material of its BACK side."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_back_material_extracted(self) -> None:
+        from openskp import _core
+
+        t = self._tlv
+        node = t('AC0D', (t('DC05', t('DE05', b'\x2A'))
+                          + t('AF0D', bytes([0x85, 0x8B, 0x06]))))
+        elements = _core.parse_tlv_recursive(
+            node + t('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert 0x2A in builder.faces
+        f = builder.faces[0x2A]
+        assert f['material_id'] is None          # front unpainted
+        assert f['back_material_id'] == 0x68B85  # back painted
+
+    def test_face_defaults(self) -> None:
+        from openskp.model import Face
+
+        assert Face(id=0).back_material_id is None
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -445,5 +445,54 @@ class TestMaterialIdJoin:
         assert model.materials_by_id == {}
 
 
+# ── Instance material tests ──────────────────────────────────────────────
+
+
+class TestInstanceMaterial:
+    """Tests for instance-level materials (``Instance.material_id``)."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_instance_material_defaults_to_none(self) -> None:
+        from openskp.model import Instance
+
+        assert Instance().material_id is None
+
+    def test_extractor_reads_instance_d007_material(self) -> None:
+        # A 6419 instance node carrying D007/D107 — the same material
+        # structure faces use ("paint the component" in SketchUp).
+        from openskp import _core
+
+        d107 = self._tlv('D107', bytes([0x33, 0x73]))          # id 0x7333
+        d007 = self._tlv('D007', d107)
+        ref = self._tlv('6719', bytes([0x05]))                  # ref_idx 5
+        matrix = self._tlv('6619', struct.pack('<13d', *([1.0] * 13)))
+        node = self._tlv('6419', ref + matrix + d007)
+
+        elements = _core.parse_tlv_recursive(
+            node + self._tlv('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert len(builder.instances) == 1
+        inst = builder.instances[0]
+        assert inst['ref_idx'] == 5
+        assert inst['material_id'] == 0x7333
+
+    def test_instance_without_material_stays_none(self) -> None:
+        from openskp import _core
+
+        ref = self._tlv('6719', bytes([0x05]))
+        node = self._tlv('6419', ref)
+        elements = _core.parse_tlv_recursive(
+            node + self._tlv('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert builder.instances[0]['material_id'] is None
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,78 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Per-face UV transform tests ──────────────────────────────────────────
+
+
+class TestFaceUvTransform:
+    """Tests for positioned-texture mapping extraction (``Face.uv_transform``)."""
+
+    ROT90 = (0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 96.0, -96.0, 1.0)
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def _dc05(self, front=None, back=None) -> bytes:
+        t = self._tlv
+        def side(tag, mat):
+            m1527 = t('1527', struct.pack('<9d', *mat))
+            return t(tag, t('1327', t('1427', b'\x01') + m1527))
+        inner = b''
+        if front is not None:
+            inner += side('1127', front)
+        if back is not None:
+            inner += side('1227', back)
+        t1027 = t('1027', inner)
+        return (t('DE05', b'\x2A')
+                + t('DD05', t('B136', t('B236', t1027))))
+
+    def test_extracts_front_matrix(self) -> None:
+        from openskp._core import _extract_uv_transforms
+
+        front, back = _extract_uv_transforms(self._dc05(front=self.ROT90))
+        assert front == pytest.approx(self.ROT90)
+        assert back is None
+
+    def test_extracts_both_sides(self) -> None:
+        from openskp._core import _extract_uv_transforms
+
+        other = tuple(v * 2 for v in self.ROT90)
+        front, back = _extract_uv_transforms(
+            self._dc05(front=self.ROT90, back=other))
+        assert front == pytest.approx(self.ROT90)
+        assert back == pytest.approx(other)
+
+    def test_untouched_texture_has_no_transform(self) -> None:
+        from openskp._core import _extract_uv_transforms
+        from openskp.model import Face
+
+        t = self._tlv
+        plain = t('DE05', b'\x2A')      # entity id only, no DD05 block
+        assert _extract_uv_transforms(plain) == (None, None)
+        assert Face(id=0).uv_transform is None
+        assert Face(id=0).uv_transform_back is None
+
+    def test_recipe_reproduces_known_uvs(self) -> None:
+        # Ground truth from a controlled SketchUp file: a 1x1 m square on the
+        # ground with the texture rotated 90 deg (48x48 in tile). The stored
+        # matrix maps texture->plane; UV = [x, y, 1] @ inv(M) / tile.
+        import numpy as np
+
+        m = np.array(self.ROT90).reshape(3, 3)
+        minv = np.linalg.inv(m)
+        tile = 48.0
+        for (x, y), (u_t, v_t) in [
+            ((82.64, 0.0), (2.0, 0.2784)),
+            ((122.01, 0.0), (2.0, -0.5418)),
+            ((82.64, 39.37), (2.8202, 0.2784)),
+        ]:
+            uvq = np.array([x, y, 1.0]) @ minv
+            u = uvq[0] / uvq[2] / tile
+            v = uvq[1] / uvq[2] / tile
+            assert u == pytest.approx(u_t, abs=2e-3)
+            assert v == pytest.approx(v_t, abs=2e-3)
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,44 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Style tests ──────────────────────────────────────────────────────────
+
+
+class TestStyles:
+    """Face colors from styles/*/style.xml (items 4000 front / 4001 back)."""
+
+    def test_style_colors_via_synthetic_skp(self, tmp_path: pathlib.Path) -> None:
+        import io
+        import struct as _struct
+        import zipfile
+        from openskp.model import SkpFile
+
+        style_xml = b"""<?xml version="1.0"?>
+<styleDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/style"
+               xmlns:sty="http://sketchup.google.com/schemas/sketchup/1.0/style">
+  <sty:style xmlns:t="http://sketchup.google.com/schemas/1.0/types" name="Verde">
+    <sty:item id="4000"><t:variant type="4">-3552052</t:variant></sty:item>
+    <sty:item id="4001"><t:variant type="4">-3093050</t:variant></sty:item>
+  </sty:style>
+</styleDocument>
+"""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("model.dat", b"")
+            zf.writestr("styles/Verde/style.xml", style_xml)
+        path = tmp_path / "s.skp"
+        path.write_bytes(b"\xFF\xFE\xFF\x0E" + b"\x00" * 28 + buf.getvalue())
+
+        model = SkpFile.open(str(path)).parse()
+        assert len(model.styles) == 1
+        st = model.styles[0]
+        assert st.name == "Verde"
+        # -3552052 -> 0xFFC9CCCC-ish ARGB: decode matches int32 & 0xFFFFFF
+        v = (-3552052) & 0xFFFFFFFF
+        assert st.front_color == ((v >> 16) & 255, (v >> 8) & 255, v & 255)
+        v2 = (-3093050) & 0xFFFFFFFF
+        assert st.back_color == ((v2 >> 16) & 255, (v2 >> 8) & 255, v2 & 255)
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,54 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Instance material tests ──────────────────────────────────────────────
+
+
+class TestInstanceMaterial:
+    """Tests for instance-level materials (``Instance.material_id``)."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_instance_material_defaults_to_none(self) -> None:
+        from openskp.model import Instance
+
+        assert Instance().material_id is None
+
+    def test_extractor_reads_instance_d007_material(self) -> None:
+        # A 6419 instance node carrying D007/D107 — the same material
+        # structure faces use ("paint the component" in SketchUp).
+        from openskp import _core
+
+        d107 = self._tlv('D107', bytes([0x33, 0x73]))          # id 0x7333
+        d007 = self._tlv('D007', d107)
+        ref = self._tlv('6719', bytes([0x05]))                  # ref_idx 5
+        matrix = self._tlv('6619', struct.pack('<13d', *([1.0] * 13)))
+        node = self._tlv('6419', ref + matrix + d007)
+
+        elements = _core.parse_tlv_recursive(
+            node + self._tlv('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert len(builder.instances) == 1
+        inst = builder.instances[0]
+        assert inst['ref_idx'] == 5
+        assert inst['material_id'] == 0x7333
+
+    def test_instance_without_material_stays_none(self) -> None:
+        from openskp import _core
+
+        ref = self._tlv('6719', bytes([0x05]))
+        node = self._tlv('6419', ref)
+        elements = _core.parse_tlv_recursive(
+            node + self._tlv('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert builder.instances[0]['material_id'] is None
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -494,5 +494,44 @@ class TestInstanceMaterial:
         assert builder.instances[0]['material_id'] is None
 
 
+# ── Style tests ──────────────────────────────────────────────────────────
+
+
+class TestStyles:
+    """Face colors from styles/*/style.xml (items 4000 front / 4001 back)."""
+
+    def test_style_colors_via_synthetic_skp(self, tmp_path: pathlib.Path) -> None:
+        import io
+        import struct as _struct
+        import zipfile
+        from openskp.model import SkpFile
+
+        style_xml = b"""<?xml version="1.0"?>
+<styleDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/style"
+               xmlns:sty="http://sketchup.google.com/schemas/sketchup/1.0/style">
+  <sty:style xmlns:t="http://sketchup.google.com/schemas/1.0/types" name="Verde">
+    <sty:item id="4000"><t:variant type="4">-3552052</t:variant></sty:item>
+    <sty:item id="4001"><t:variant type="4">-3093050</t:variant></sty:item>
+  </sty:style>
+</styleDocument>
+"""
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("model.dat", b"")
+            zf.writestr("styles/Verde/style.xml", style_xml)
+        path = tmp_path / "s.skp"
+        path.write_bytes(b"\xFF\xFE\xFF\x0E" + b"\x00" * 28 + buf.getvalue())
+
+        model = SkpFile.open(str(path)).parse()
+        assert len(model.styles) == 1
+        st = model.styles[0]
+        assert st.name == "Verde"
+        # -3552052 -> 0xFFC9CCCC-ish ARGB: decode matches int32 & 0xFFFFFF
+        v = (-3552052) & 0xFFFFFFFF
+        assert st.front_color == ((v >> 16) & 255, (v >> 8) & 255, v & 255)
+        v2 = (-3093050) & 0xFFFFFFFF
+        assert st.back_color == ((v2 >> 16) & 255, (v2 >> 8) & 255, v2 & 255)
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,36 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── UTF-8 entity name tests ──────────────────────────────────────────────
+
+
+class TestUtf8EntityNames:
+    """Entity names must decode as UTF-8, not ASCII-with-ignore.
+
+    SketchUp stores names UTF-8 encoded. Decoding them as ASCII and
+    *dropping* the non-ASCII bytes silently corrupts any accented name
+    ("cópia" → "cpia", "Diseño" → "Diseo") — and, worse, breaks the
+    material-name join between the TLV stream and the XML material files,
+    leaving those materials unresolvable.
+    """
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_instance_name_keeps_accents(self) -> None:
+        from openskp import _core
+
+        name = "Diseño de árbol".encode("utf-8")
+        node = self._tlv('6419', self._tlv('6519', name)
+                         + self._tlv('6719', b'\x05'))
+        elements = _core.parse_tlv_recursive(
+            node + self._tlv('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert builder.instances[0]['name'] == "Diseño de árbol"
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,102 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Texture extraction tests ─────────────────────────────────────────────
+
+
+_MATERIAL_XML_TEXTURED = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="%s" type="1" colorRed="10" colorGreen="20"
+                colorBlue="30" trans="1" hasTexture="1">
+    <mat:texture textureFilename="%s" xScale="24" yScale="12"/>
+  </mat:material>
+</materialDocument>
+"""
+
+_MATERIAL_XML_PLAIN = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="Plain" type="0" colorRed="1" colorGreen="2"
+                colorBlue="3" trans="1" hasTexture="0"/>
+</materialDocument>
+"""
+
+
+def _write_synthetic_skp(tmp_path: "pathlib.Path",
+                         entries: dict) -> "pathlib.Path":
+    """Build a minimal ``.skp``: the UTF-16 header marker followed by an
+    embedded ZIP with ``model.dat`` plus *entries*."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("model.dat", b"")
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    path = tmp_path / "synthetic.skp"
+    path.write_bytes(b"\xFF\xFE\xFF\x0E" + b"\x00" * 28 + buf.getvalue())
+    return path
+
+
+class TestTextureExtraction:
+    """Tests for material texture extraction (``Material.texture``)."""
+
+    def test_texture_dataclass_save(self, tmp_path: "pathlib.Path") -> None:
+        from openskp.model import Texture
+
+        tex = Texture(filename="wood.jpg", width=24.0, height=12.0,
+                      data=b"\xff\xd8fakejpeg")
+        out = tex.save(tmp_path / "out.jpg")
+        assert out.read_bytes() == b"\xff\xd8fakejpeg"
+
+    def test_texture_save_without_data_raises(self) -> None:
+        from openskp.model import Texture
+
+        with pytest.raises(ValueError, match="no image data"):
+            Texture(filename="missing.jpg").save("/tmp/never-written.jpg")
+
+    def test_textured_material_roundtrip(self, tmp_path: "pathlib.Path") -> None:
+        from openskp.model import SkpFile
+
+        jpeg = b"\xff\xd8syntheticjpegbytes"
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Wood/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Wood", b"wood.jpg"),
+            "materials/Wood/wood.jpg": jpeg,
+            "materials/Plain/material.xml": _MATERIAL_XML_PLAIN,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        by_name = {m.name: m for m in model.materials}
+        wood = by_name["Wood"]
+        assert wood.texture is not None
+        assert wood.texture.filename == "wood.jpg"
+        assert wood.texture.width == 24.0    # inches, from xScale
+        assert wood.texture.height == 12.0
+        assert wood.texture.data == jpeg
+        assert by_name["Plain"].texture is None
+
+    def test_image_name_mismatch_falls_back_to_sibling(
+        self, tmp_path: "pathlib.Path"
+    ) -> None:
+        # Observed in real files: the XML says "..._Safety.jpg" while the
+        # stored image is "..._Saftey.jpg" — the folder sibling must win.
+        from openskp.model import SkpFile
+
+        jpeg = b"\xff\xd8siblingbytes"
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Glass/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Glass", b"glass_safety.jpg"),
+            "materials/Glass/glass_saftey.jpg": jpeg,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        glass = {m.name: m for m in model.materials}["Glass"]
+        assert glass.texture is not None
+        assert glass.texture.data == jpeg
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -606,5 +606,37 @@ class TestFaceUvTransform:
             assert v == pytest.approx(v_t, abs=2e-3)
 
 
+# ── Back material tests ──────────────────────────────────────────────────
+
+
+class TestBackMaterial:
+    """The AF0D child of a face node is the material of its BACK side."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_back_material_extracted(self) -> None:
+        from openskp import _core
+
+        t = self._tlv
+        node = t('AC0D', (t('DC05', t('DE05', b'\x2A'))
+                          + t('AF0D', bytes([0x85, 0x8B, 0x06]))))
+        elements = _core.parse_tlv_recursive(
+            node + t('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert 0x2A in builder.faces
+        f = builder.faces[0x2A]
+        assert f['material_id'] is None          # front unpainted
+        assert f['back_material_id'] == 0x68B85  # back painted
+
+    def test_face_defaults(self) -> None:
+        from openskp.model import Face
+
+        assert Face(id=0).back_material_id is None
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -691,5 +691,65 @@ class TestFaceCameraBehavior:
         assert by_name['Silla'].always_faces_camera is False
 
 
+# ── Image entity tests ───────────────────────────────────────────────────
+
+
+class TestImageEntities:
+    """Image entities: a picture placed in the model wraps a standard 6419
+    instance inside ``9013 → 401F``, and its backing definition carries
+    kind ``8315 == 2``."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_image_placement_instance_is_extracted(self) -> None:
+        from openskp import _core
+
+        t = self._tlv
+        inner_6419 = t('6419', t('6719', b'\x07'))       # ref_idx 7
+        node = t('9013', t('401F', inner_6419))
+        elements = _core.parse_tlv_recursive(
+            node + t('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert len(builder.instances) == 1
+        assert builder.instances[0]['ref_idx'] == 7
+
+    def test_definition_kind_2_marks_is_image(self, tmp_path: pathlib.Path,
+                                              monkeypatch) -> None:
+        from openskp.model import Definition, SkpFile
+        import openskp._core as _core
+
+        class _B:
+            vertices = {}
+            edges = {}
+            faces = {}
+            instances = []
+
+        parsed = {
+            "version": "test",
+            "defs_dict": {
+                1: {"guid": "", "name": "imagen#1", "is_image": True,
+                    "builder": _B()},
+                2: {"guid": "", "name": "Grupo", "is_image": False,
+                    "builder": _B()},
+            },
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {},
+        }
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "m.skp"
+        fake.write_bytes(b"")
+        model = SkpFile.open(str(fake)).parse()
+
+        assert model.definitions[1].is_image is True
+        assert model.definitions[2].is_image is False
+        assert Definition().is_image is False
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,88 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+class TestMaterialIdJoin:
+    """Tests for the ``Face.material_id`` → :class:`Material` join that
+    :meth:`SkpFile.parse` exposes (``Material.id`` +
+    ``SkpModel.materials_by_id``).
+
+    ``full_parse`` is stubbed out, so no real ``.skp`` file is needed.
+    """
+
+    @staticmethod
+    def _parse_with(monkeypatch, tmp_path: pathlib.Path, parsed: dict):
+        import openskp._core as _core
+        from openskp.model import SkpFile
+
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "model.skp"
+        fake.write_bytes(b"")
+        return SkpFile.open(str(fake)).parse()
+
+    def test_material_id_defaults_to_none(self) -> None:
+        from openskp.model import Material
+
+        assert Material(name="Wood").id is None
+
+    def test_face_material_resolves_through_materials_by_id(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {
+                "Wood": {"name": "Wood",
+                         "color": {"r": 10, "g": 20, "b": 30},
+                         "transparency": 1.0},
+            },
+            "materials_by_folder": {},
+            "material_id_to_name": {29491: "Wood"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert model.materials[0].id == 29491
+        mat = model.materials_by_id[29491]
+        assert mat is model.materials[0]
+        assert mat.color == (10, 20, 30)
+
+    def test_folder_alias_resolves_to_same_material(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        # The TLV name may match the ZIP folder rather than the XML name —
+        # the same name-then-folder fallback the internal exporter uses.
+        wood = {"name": "Wood", "color": {"r": 1, "g": 2, "b": 3},
+                "transparency": 1.0}
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {"Wood": wood},
+            "materials_by_folder": {"m0": wood},
+            "material_id_to_name": {7: "Wood", 8: "m0"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert len(model.materials) == 1
+        assert model.materials_by_id[7] is model.materials_by_id[8]
+        # The first ID seen sticks as the Material's own id; both resolve.
+        assert model.materials[0].id in (7, 8)
+
+    def test_unresolvable_id_is_skipped(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {99: "Ghost"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert model.materials_by_id == {}
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,58 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Face-camera behavior tests ───────────────────────────────────────────
+
+
+class TestFaceCameraBehavior:
+    """Component behavior flag 5D1B inside the definition's 581B block marks
+    SketchUp's "always face camera" (2D people / tree cut-outs)."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def _def_node(self, flags: bytes) -> bytes:
+        t = self._tlv
+        return t('7C15', t('7E15', b'Susan') + t('581B', flags))
+
+    def test_flag_set(self) -> None:
+        from openskp import _core
+
+        t = self._tlv
+        flags = t('5B1B', b'\x00') + t('5D1B', b'\x01') + t('5E1B', b'\x01')
+        node = self._def_node(flags)
+        elements = _core.parse_tlv_recursive(
+            node + t('0100', b'\x00'), 0, len(node) + 7)
+        # run the def-collection path via full parse plumbing: emulate by
+        # scanning like collect_defs does — simplest is a synthetic file, but
+        # the flag logic is inline; exercise it through a minimal .skp below.
+        assert elements[0]['tag'] == '7C15'
+
+    def test_flag_via_synthetic_skp(self, tmp_path: pathlib.Path) -> None:
+        import io
+        import zipfile
+        from openskp.model import SkpFile
+
+        t = self._tlv
+        on = t('7C15', (t('7D15', b'\x11' * 16) + t('7E15', b'Susan')
+                        + t('581B', t('5D1B', b'\x01'))
+                        + t('DC05', t('DE05', b'\x05'))))
+        off = t('7C15', (t('7D15', b'\x22' * 16) + t('7E15', b'Silla')
+                         + t('581B', t('5D1B', b'\x00'))
+                         + t('DC05', t('DE05', b'\x06'))))
+        model_dat = t('F901', t('7017', t('7117', on + off)))
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('model.dat', model_dat)
+        path = tmp_path / 's.skp'
+        path.write_bytes(b'\xFF\xFE\xFF\x0E' + b'\x00' * 28 + buf.getvalue())
+
+        model = SkpFile.open(str(path)).parse()
+        by_name = {d.name: d for d in model.definitions.values()}
+        assert by_name['Susan'].always_faces_camera is True
+        assert by_name['Silla'].always_faces_camera is False
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -638,5 +638,58 @@ class TestBackMaterial:
         assert Face(id=0).back_material_id is None
 
 
+# ── Face-camera behavior tests ───────────────────────────────────────────
+
+
+class TestFaceCameraBehavior:
+    """Component behavior flag 5D1B inside the definition's 581B block marks
+    SketchUp's "always face camera" (2D people / tree cut-outs)."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def _def_node(self, flags: bytes) -> bytes:
+        t = self._tlv
+        return t('7C15', t('7E15', b'Susan') + t('581B', flags))
+
+    def test_flag_set(self) -> None:
+        from openskp import _core
+
+        t = self._tlv
+        flags = t('5B1B', b'\x00') + t('5D1B', b'\x01') + t('5E1B', b'\x01')
+        node = self._def_node(flags)
+        elements = _core.parse_tlv_recursive(
+            node + t('0100', b'\x00'), 0, len(node) + 7)
+        # run the def-collection path via full parse plumbing: emulate by
+        # scanning like collect_defs does — simplest is a synthetic file, but
+        # the flag logic is inline; exercise it through a minimal .skp below.
+        assert elements[0]['tag'] == '7C15'
+
+    def test_flag_via_synthetic_skp(self, tmp_path: pathlib.Path) -> None:
+        import io
+        import zipfile
+        from openskp.model import SkpFile
+
+        t = self._tlv
+        on = t('7C15', (t('7D15', b'\x11' * 16) + t('7E15', b'Susan')
+                        + t('581B', t('5D1B', b'\x01'))
+                        + t('DC05', t('DE05', b'\x05'))))
+        off = t('7C15', (t('7D15', b'\x22' * 16) + t('7E15', b'Silla')
+                         + t('581B', t('5D1B', b'\x00'))
+                         + t('DC05', t('DE05', b'\x06'))))
+        model_dat = t('F901', t('7017', t('7117', on + off)))
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, 'w') as zf:
+            zf.writestr('model.dat', model_dat)
+        path = tmp_path / 's.skp'
+        path.write_bytes(b'\xFF\xFE\xFF\x0E' + b'\x00' * 28 + buf.getvalue())
+
+        model = SkpFile.open(str(path)).parse()
+        by_name = {d.name: d for d in model.definitions.values()}
+        assert by_name['Susan'].always_faces_camera is True
+        assert by_name['Silla'].always_faces_camera is False
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -362,5 +362,88 @@ class TestUtf8EntityNames:
         assert builder.instances[0]['name'] == "Diseño de árbol"
 
 
+class TestMaterialIdJoin:
+    """Tests for the ``Face.material_id`` → :class:`Material` join that
+    :meth:`SkpFile.parse` exposes (``Material.id`` +
+    ``SkpModel.materials_by_id``).
+
+    ``full_parse`` is stubbed out, so no real ``.skp`` file is needed.
+    """
+
+    @staticmethod
+    def _parse_with(monkeypatch, tmp_path: pathlib.Path, parsed: dict):
+        import openskp._core as _core
+        from openskp.model import SkpFile
+
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "model.skp"
+        fake.write_bytes(b"")
+        return SkpFile.open(str(fake)).parse()
+
+    def test_material_id_defaults_to_none(self) -> None:
+        from openskp.model import Material
+
+        assert Material(name="Wood").id is None
+
+    def test_face_material_resolves_through_materials_by_id(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {
+                "Wood": {"name": "Wood",
+                         "color": {"r": 10, "g": 20, "b": 30},
+                         "transparency": 1.0},
+            },
+            "materials_by_folder": {},
+            "material_id_to_name": {29491: "Wood"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert model.materials[0].id == 29491
+        mat = model.materials_by_id[29491]
+        assert mat is model.materials[0]
+        assert mat.color == (10, 20, 30)
+
+    def test_folder_alias_resolves_to_same_material(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        # The TLV name may match the ZIP folder rather than the XML name —
+        # the same name-then-folder fallback the internal exporter uses.
+        wood = {"name": "Wood", "color": {"r": 1, "g": 2, "b": 3},
+                "transparency": 1.0}
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {"Wood": wood},
+            "materials_by_folder": {"m0": wood},
+            "material_id_to_name": {7: "Wood", 8: "m0"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert len(model.materials) == 1
+        assert model.materials_by_id[7] is model.materials_by_id[8]
+        # The first ID seen sticks as the Material's own id; both resolve.
+        assert model.materials[0].id in (7, 8)
+
+    def test_unresolvable_id_is_skipped(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {99: "Ghost"},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert model.materials_by_id == {}
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -533,5 +533,78 @@ class TestStyles:
         assert st.back_color == ((v2 >> 16) & 255, (v2 >> 8) & 255, v2 & 255)
 
 
+# ── Per-face UV transform tests ──────────────────────────────────────────
+
+
+class TestFaceUvTransform:
+    """Tests for positioned-texture mapping extraction (``Face.uv_transform``)."""
+
+    ROT90 = (0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 96.0, -96.0, 1.0)
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def _dc05(self, front=None, back=None) -> bytes:
+        t = self._tlv
+        def side(tag, mat):
+            m1527 = t('1527', struct.pack('<9d', *mat))
+            return t(tag, t('1327', t('1427', b'\x01') + m1527))
+        inner = b''
+        if front is not None:
+            inner += side('1127', front)
+        if back is not None:
+            inner += side('1227', back)
+        t1027 = t('1027', inner)
+        return (t('DE05', b'\x2A')
+                + t('DD05', t('B136', t('B236', t1027))))
+
+    def test_extracts_front_matrix(self) -> None:
+        from openskp._core import _extract_uv_transforms
+
+        front, back = _extract_uv_transforms(self._dc05(front=self.ROT90))
+        assert front == pytest.approx(self.ROT90)
+        assert back is None
+
+    def test_extracts_both_sides(self) -> None:
+        from openskp._core import _extract_uv_transforms
+
+        other = tuple(v * 2 for v in self.ROT90)
+        front, back = _extract_uv_transforms(
+            self._dc05(front=self.ROT90, back=other))
+        assert front == pytest.approx(self.ROT90)
+        assert back == pytest.approx(other)
+
+    def test_untouched_texture_has_no_transform(self) -> None:
+        from openskp._core import _extract_uv_transforms
+        from openskp.model import Face
+
+        t = self._tlv
+        plain = t('DE05', b'\x2A')      # entity id only, no DD05 block
+        assert _extract_uv_transforms(plain) == (None, None)
+        assert Face(id=0).uv_transform is None
+        assert Face(id=0).uv_transform_back is None
+
+    def test_recipe_reproduces_known_uvs(self) -> None:
+        # Ground truth from a controlled SketchUp file: a 1x1 m square on the
+        # ground with the texture rotated 90 deg (48x48 in tile). The stored
+        # matrix maps texture->plane; UV = [x, y, 1] @ inv(M) / tile.
+        import numpy as np
+
+        m = np.array(self.ROT90).reshape(3, 3)
+        minv = np.linalg.inv(m)
+        tile = 48.0
+        for (x, y), (u_t, v_t) in [
+            ((82.64, 0.0), (2.0, 0.2784)),
+            ((122.01, 0.0), (2.0, -0.5418)),
+            ((82.64, 39.37), (2.8202, 0.2784)),
+        ]:
+            uvq = np.array([x, y, 1.0]) @ minv
+            u = uvq[0] / uvq[2] / tile
+            v = uvq[1] / uvq[2] / tile
+            assert u == pytest.approx(u_t, abs=2e-3)
+            assert v == pytest.approx(v_t, abs=2e-3)
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -331,5 +331,65 @@ class TestSkpFile:
             SkpFile.open(str(fake))
 
 
+# ── Image entity tests ───────────────────────────────────────────────────
+
+
+class TestImageEntities:
+    """Image entities: a picture placed in the model wraps a standard 6419
+    instance inside ``9013 → 401F``, and its backing definition carries
+    kind ``8315 == 2``."""
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_image_placement_instance_is_extracted(self) -> None:
+        from openskp import _core
+
+        t = self._tlv
+        inner_6419 = t('6419', t('6719', b'\x07'))       # ref_idx 7
+        node = t('9013', t('401F', inner_6419))
+        elements = _core.parse_tlv_recursive(
+            node + t('0100', b'\x00'), 0, len(node) + 7)
+        builder = _core._GeometryBuilder()
+        _core._extract_geometry_from_nodes(elements, builder)
+
+        assert len(builder.instances) == 1
+        assert builder.instances[0]['ref_idx'] == 7
+
+    def test_definition_kind_2_marks_is_image(self, tmp_path: pathlib.Path,
+                                              monkeypatch) -> None:
+        from openskp.model import Definition, SkpFile
+        import openskp._core as _core
+
+        class _B:
+            vertices = {}
+            edges = {}
+            faces = {}
+            instances = []
+
+        parsed = {
+            "version": "test",
+            "defs_dict": {
+                1: {"guid": "", "name": "imagen#1", "is_image": True,
+                    "builder": _B()},
+                2: {"guid": "", "name": "Grupo", "is_image": False,
+                    "builder": _B()},
+            },
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {},
+        }
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "m.skp"
+        fake.write_bytes(b"")
+        model = SkpFile.open(str(fake)).parse()
+
+        assert model.definitions[1].is_image is True
+        assert model.definitions[2].is_image is False
+        assert Definition().is_image is False
+
+
 # Need pathlib for tmp_path fixture
 import pathlib

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -751,5 +751,144 @@ class TestImageEntities:
         assert Definition().is_image is False
 
 
+# ── Texture extraction tests ─────────────────────────────────────────────
+
+
+_MATERIAL_XML_TEXTURED = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="%s" type="1" colorRed="10" colorGreen="20"
+                colorBlue="30" trans="1" hasTexture="1">
+    <mat:texture textureFilename="%s" xScale="24" yScale="12"/>
+  </mat:material>
+</materialDocument>
+"""
+
+_MATERIAL_XML_PLAIN = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="Plain" type="0" colorRed="1" colorGreen="2"
+                colorBlue="3" trans="1" hasTexture="0"/>
+</materialDocument>
+"""
+
+
+def _write_synthetic_skp(tmp_path: "pathlib.Path",
+                         entries: dict) -> "pathlib.Path":
+    """Build a minimal ``.skp``: the UTF-16 header marker followed by an
+    embedded ZIP with ``model.dat`` plus *entries*."""
+    import io
+    import zipfile
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("model.dat", b"")
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    path = tmp_path / "synthetic.skp"
+    path.write_bytes(b"\xFF\xFE\xFF\x0E" + b"\x00" * 28 + buf.getvalue())
+    return path
+
+
+class TestTextureExtraction:
+    """Tests for material texture extraction (``Material.texture``)."""
+
+    def test_texture_dataclass_save(self, tmp_path: "pathlib.Path") -> None:
+        from openskp.model import Texture
+
+        tex = Texture(filename="wood.jpg", width=24.0, height=12.0,
+                      data=b"\xff\xd8fakejpeg")
+        out = tex.save(tmp_path / "out.jpg")
+        assert out.read_bytes() == b"\xff\xd8fakejpeg"
+
+    def test_texture_save_without_data_raises(self) -> None:
+        from openskp.model import Texture
+
+        with pytest.raises(ValueError, match="no image data"):
+            Texture(filename="missing.jpg").save("/tmp/never-written.jpg")
+
+    def test_textured_material_roundtrip(self, tmp_path: "pathlib.Path") -> None:
+        from openskp.model import SkpFile
+
+        jpeg = b"\xff\xd8syntheticjpegbytes"
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Wood/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Wood", b"wood.jpg"),
+            "materials/Wood/wood.jpg": jpeg,
+            "materials/Plain/material.xml": _MATERIAL_XML_PLAIN,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        by_name = {m.name: m for m in model.materials}
+        wood = by_name["Wood"]
+        assert wood.texture is not None
+        assert wood.texture.filename == "wood.jpg"
+        assert wood.texture.width == 24.0    # inches, from xScale
+        assert wood.texture.height == 12.0
+        assert wood.texture.data == jpeg
+        assert by_name["Plain"].texture is None
+
+    def test_image_name_mismatch_falls_back_to_sibling(
+        self, tmp_path: "pathlib.Path"
+    ) -> None:
+        # Observed in real files: the XML says "..._Safety.jpg" while the
+        # stored image is "..._Saftey.jpg" — the folder sibling must win.
+        from openskp.model import SkpFile
+
+        jpeg = b"\xff\xd8siblingbytes"
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Glass/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Glass", b"glass_safety.jpg"),
+            "materials/Glass/glass_saftey.jpg": jpeg,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        glass = {m.name: m for m in model.materials}["Glass"]
+        assert glass.texture is not None
+        assert glass.texture.data == jpeg
+
+    def test_colorized_copy_shares_source_image(
+        self, tmp_path: "pathlib.Path"
+    ) -> None:
+        # A colourized material ("[Name]1", type="2") stores no image of
+        # its own — its <mat:image path> points into the SOURCE material's
+        # folder. The shared bytes must be resolved, and the colorized
+        # flag exposed so viewers can re-tint.
+        from openskp.model import SkpFile
+
+        png = b"\x89PNGsharedchainlink"
+        colorized_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+<materialDocument xmlns="http://sketchup.google.com/schemas/sketchup/1.0/material"
+                  xmlns:mat="http://sketchup.google.com/schemas/sketchup/1.0/material">
+  <mat:material name="[Fence]1" type="2" colorRed="27" colorGreen="135"
+                colorBlue="59" colorizeType="0" trans="1" hasTexture="1">
+    <mat:texture textureFilename="fence.png" xScale="2.75" yScale="2.75">
+      <mat:images>
+        <mat:image id="1" path="materials/Fence/fence.png"
+                   file_name="fence.png"/>
+      </mat:images>
+    </mat:texture>
+  </mat:material>
+</materialDocument>
+"""
+        skp = _write_synthetic_skp(tmp_path, {
+            "materials/Fence/material.xml":
+                _MATERIAL_XML_TEXTURED % (b"Fence", b"fence.png"),
+            "materials/Fence/fence.png": png,
+            "materials/[Fence]1/material.xml": colorized_xml,
+        })
+        model = SkpFile.open(str(skp)).parse()
+
+        by_name = {m.name: m for m in model.materials}
+        copy = by_name["[Fence]1"]
+        assert copy.texture is not None
+        assert copy.texture.data == png       # borrowed from materials/Fence/
+        assert copy.colorized is True
+        assert copy.colorize_type == 0
+        assert copy.color[:3] == (27, 135, 59)
+        base = by_name["Fence"]
+        assert base.colorized is False
+
+
 # Need pathlib for tmp_path fixture
 import pathlib


### PR DESCRIPTION
## 0.3.0 integration — 10 approved additive PRs

Internal integration PR. Bundles the 10 reviewed-and-approved, **backwards-compatible** additive PRs into one set for `main`. Every change is additive (new defaulted dataclass fields / new modules); no existing field or behaviour is removed or changed in value.

### Included (merged in this branch)

| PR | Summary |
|----|---------|
| #7 | Decode entity names as UTF-8 (was ASCII-with-ignore) — fixes accented names + the material-name join key |
| #3 | `Material.id` + `SkpModel.materials_by_id` — resolve face → material from the public API |
| #5 | `Instance.material_id` — "paint the component" instance-level material |
| #6 | `Face.uv_transform` / `uv_transform_back` — per-face positioned/photo-fitted texture mapping |
| #11 | `Face.back_material_id` — back-side material (`AF0D`) |
| #15 | `Edge.soft` / `smooth` / `hidden` — per-edge display flags (`D307`) |
| #10 | `SkpModel.styles` (`Style`) — style front/back face colours |
| #9 | `Definition.always_faces_camera` — billboard behaviour |
| #8 | Image entities — `9013`/`401F` placement + `Definition.is_image` |
| #13 | Texture extraction (`Material.texture`/`Texture`) + colourized-copy shared-texture resolution + `colorized`/`colorize_type` |

`#13` supersedes `#4` (it contains #4's texture extraction), so **#4 will be closed as superseded** rather than merged.

### Conflict resolution

The source PRs each merged cleanly against `main` individually but overlapped each other; conflicts were resolved by **unioning** every overlapping field — nothing dropped:

- `Face` dict / dataclass (#6 + #11) → one statement carrying `material_id`, `back_material_id`, `uv_transform`, `uv_transform_back`.
- `collect_defs` (#7 + #8 + #9) → UTF-8 decode + `is_image` + `always_faces_camera` branches coexist.
- materials loop (#3 + #13 + #10) → texture-building + material-id join + styles conversion combined.
- CHANGELOG consolidated into one `[Unreleased]` section.

### Verification

- **Test suite: 59 passed** (35 on `main` → 59), stable across repeated runs.
- `ruff check packages/python/src/` — clean.
- Smoke-checked that all 10 new API surfaces coexist on the dataclasses.
- Local run was Windows + Python 3.14 only — **this PR exists to get the full CI matrix (3 OS × Python 3.9–3.12)** it hasn't had yet.

### Explicitly NOT included (held for follow-up)

- **#12** (transparency / `useTrans`) — correct fix, but it changes the *value* of the existing `Material.transparency` field; to be released deliberately with a "Changed" note.
- **#14** (legacy MFC reader) — approved approach, pending a real-file binary fixture test for the decoder.

Releases (PyPI) are a separate later step; merging this only advances `main`.
