### PR TITLE
feat(ts): Material.id + materialsById join (ports #3)

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -229,6 +229,21 @@ export function parseSkp(buffer: ArrayBuffer): SkpModel {
   }
   collectMaterialIds(elements);
 
+  // 4c. Join the TLV material IDs (what Face.materialId references) onto the
+  // parsed materials, so callers can resolve face -> material. Same
+  // name-then-folder resolution used for face/instance colouring below.
+  // materialsMap/materialsByFolder may share the same Material object
+  // reference for an alias, so setting `.id` here is visible through both.
+  const materialsById = new Map<number, Material>();
+  for (const [mId, mName] of materialIdToName.entries()) {
+    const mat = materialsMap.get(mName) || materialsByFolder.get(mName);
+    if (!mat) continue;
+    if (mat.id === null) {
+      mat.id = mId;
+    }
+    materialsById.set(mId, mat);
+  }
+
   // 5. Collect component definitions
   const defsDict = collectDefs(elements);
 
@@ -618,7 +633,6 @@ export function parseSkp(buffer: ArrayBuffer): SkpModel {
     }
   }
 
-  const materialsById = new Map<number, Material>();
   const styles: Style[] = [];
 
   const model: SkpModel = {

--- a/packages/typescript/tests/integration.test.ts
+++ b/packages/typescript/tests/integration.test.ts
@@ -111,6 +111,13 @@ describe('SketchUp Parser Integration Test', () => {
     expect(matLayer0!.colorizeType).toBe(0);
 
     expect(model.materialsById).toBeInstanceOf(Map);
+    // Real join: TLV material ID 26180 in this fixture resolves to the
+    // default "*" material, and the resolved object is the SAME instance
+    // held in model.materials (not a copy) - the join shares identity.
+    expect(model.materialsById.get(26180)).toBeDefined();
+    expect(model.materialsById.get(26180)!.name).toBe('*');
+    expect(model.materials).toContain(model.materialsById.get(26180));
+    expect(model.materialsById.get(26180)!.id).toBe(26180);
     expect(Array.isArray(model.styles)).toBe(true);
 
     // 8. Assert Scene Hierarchy


### PR DESCRIPTION
Second step of the TypeScript fidelity port — ports Python's #3.

## What
Joins the TLV material IDs (`materialIdToName`, already collected) onto the parsed materials via the same name-then-folder resolution used elsewhere for face/instance colouring, populating `Material.id` and `SkpModel.materialsById`.

## How
Since `materialsMap`/`materialsByFolder` already share the same object reference for a name/folder alias (set at material-parse time), setting `.id` in place on the shared object is visible through both maps and through `model.materials` — no need for Python's `id(dict)` object-identity workaround.

## Verification
- `tsc --noEmit` — clean
- `vitest run` — 12/12 pass. Added a real assertion against the `Untitled.skp` fixture: TLV material ID `26180` resolves to the `"*"` material, confirmed to be the **same object instance** as the entry in `model.materials` (not a copy) — proving the join shares identity correctly.
- `tsup` build — CJS/ESM/DTS succeed