### PR TITLE
feat(ts): Instance.materialId (ports #5)

### DIFF
--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -6,6 +6,7 @@ export interface GeometryBuilderInstance {
   refIdx: number;
   name: string;
   matrix: number[];
+  materialId: number | null;
   children: TlvNode[];
 }
 
@@ -191,12 +192,26 @@ export function extractGeometryFromNodes(
         }
       }
 
+      // Instance-level material (SketchUp "paint the component"): same
+      // D007/D107 structure faces use. Faces whose own materialId is null
+      // inherit this - the SDK resolves that inheritance when exporting,
+      // so consumers need the raw value to do the same.
+      let instMatId: number | null = null;
+      const d007 = el.children.find((c) => c.tag === 'D007');
+      if (d007) {
+        const d107 = d007.children.find((c) => c.tag === 'D107');
+        if (d107) {
+          instMatId = parseVarInt(d107.payload, 0, d107.payload.length);
+        }
+      }
+
       builder.instances.push({
         offset: el.offset,
         refGuid: guid || '',
         refIdx: defIdx !== null ? defIdx : -1,
         name: name || '',
         matrix: matrix,
+        materialId: instMatId,
         children: el.children,
       });
     } else if (el.children && el.children.length > 0) {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -76,6 +76,12 @@ export interface Instance {
   refIdx: number;
   guid: string;
   matrix: number[];
+  /**
+   * Material painted onto the instance itself (SketchUp's "paint the
+   * component"), or null. Faces inside the placed definition whose own
+   * Face.materialId is null inherit this material - consumers must resolve
+   * that inheritance themselves, like the official SDK does on export.
+   */
   materialId: number | null;
 }
 
@@ -616,7 +622,7 @@ export function parseSkp(buffer: ArrayBuffer): SkpModel {
         refIdx: inst.refIdx,
         guid: inst.refGuid,
         matrix: inst.matrix,
-        materialId: null,
+        materialId: inst.materialId,
       }));
 
       finalDefinitions.set(id, {

--- a/packages/typescript/tests/parser.test.ts
+++ b/packages/typescript/tests/parser.test.ts
@@ -3,6 +3,30 @@ import { validateHeader, readVersion } from '../src/vff';
 import { readU32, readF64, parseVarInt, parseTlvRecursive } from '../src/parser';
 import { transformPoint, multiplyMatrices, isIdentity } from '../src/transforms';
 import { computeFaceNormal, triangulateFace3D } from '../src/triangulator';
+import { GeometryBuilder, extractGeometryFromNodes } from '../src/geometry';
+
+/** Build a single TLV element: 2-byte tag (hex) + 4-byte LE size + payload. */
+function tlv(tagHex: string, payload: Uint8Array): Uint8Array {
+  const tagBytes = new Uint8Array(tagHex.match(/.{2}/g)!.map((h) => parseInt(h, 16)));
+  const sizeBytes = new Uint8Array(4);
+  new DataView(sizeBytes.buffer).setUint32(0, payload.length, true);
+  const result = new Uint8Array(2 + 4 + payload.length);
+  result.set(tagBytes, 0);
+  result.set(sizeBytes, 2);
+  result.set(payload, 6);
+  return result;
+}
+
+function concatBytes(...arrays: Uint8Array[]): Uint8Array {
+  const total = arrays.reduce((sum, a) => sum + a.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    result.set(a, offset);
+    offset += a.length;
+  }
+  return result;
+}
 
 describe('VFF Header and Version Parsing', () => {
   it('should validate VFF header', () => {
@@ -139,5 +163,34 @@ describe('Triangulation', () => {
     expect(triangles.length).toBe(2); // Two triangles for a quad
     expect(triangles[0]).toEqual([0, 1, 2]);
     expect(triangles[1]).toEqual([0, 2, 3]);
+  });
+});
+
+describe('Instance material (paint the component)', () => {
+  it('reads the D007/D107 material id from a 6419 instance node', () => {
+    const d107 = tlv('D107', new Uint8Array([0x33, 0x73])); // id 0x7333
+    const d007 = tlv('D007', d107);
+    const ref = tlv('6719', new Uint8Array([0x05])); // refIdx 5
+    const node = tlv('6419', concatBytes(ref, d007));
+
+    const elements = parseTlvRecursive(node, 0, node.length);
+    const builder = new GeometryBuilder();
+    extractGeometryFromNodes(elements, builder);
+
+    expect(builder.instances.length).toBe(1);
+    expect(builder.instances[0].refIdx).toBe(5);
+    expect(builder.instances[0].materialId).toBe(0x7333);
+  });
+
+  it('defaults materialId to null when the instance has no D007/D107', () => {
+    const ref = tlv('6719', new Uint8Array([0x05]));
+    const node = tlv('6419', ref);
+
+    const elements = parseTlvRecursive(node, 0, node.length);
+    const builder = new GeometryBuilder();
+    extractGeometryFromNodes(elements, builder);
+
+    expect(builder.instances.length).toBe(1);
+    expect(builder.instances[0].materialId).toBeNull();
   });
 });


### PR DESCRIPTION
Third step of the TypeScript fidelity port — ports Python's #5.

## What
`Instance.materialId` — the material painted onto a component instance itself (SketchUp's "paint the component"), read from the same `D007`/`D107` structure faces use, under the `6419` instance node.

## Verification
- Real fixture (`Untitled.skp`) has 0/43 instances with a painted material — genuinely no data to exercise here, not a bug (this workflow is less common in SketchUp).
- Added a synthetic byte-built unit test instead (mirrors the Python PR's own synthetic-TLV test approach): a hand-built `6419` node carrying `D007/D107`, run through the real `parseTlvRecursive` + `extractGeometryFromNodes`, asserting `materialId` resolves correctly, plus a defaults-to-null case when absent.
- `tsc --noEmit` — clean
- `vitest run` — 14/14 pass (12 existing + 2 new)
- `tsup` build — CJS/ESM/DTS succeed