### PR TITLE
feat(ts): Face.uvTransform / uvTransformBack (ports #6)

### DIFF
--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -14,6 +14,8 @@ export interface GeometryBuilderFace {
   loops: { edgeId: number; orientation: number }[][];
   normal: [number, number, number];
   materialId?: number | null;
+  uvTransform?: number[] | null;
+  uvTransformBack?: number[] | null;
 }
 
 export class GeometryBuilder {
@@ -69,6 +71,77 @@ export function extractEntityId(node: TlvNode): number | null {
     if (res !== null) return res;
   }
   return null;
+}
+
+/** Walk a raw payload as a flat TLV sequence; returns [tag, body] pairs. */
+function tlvFlat(payload: Uint8Array): [string, Uint8Array][] {
+  let pos = 0;
+  const out: [string, Uint8Array][] = [];
+  while (pos <= payload.length - 6) {
+    const tagBytes = payload.subarray(pos, pos + 2);
+    let tagHex = '';
+    for (let i = 0; i < 2; i++) {
+      const h = tagBytes[i].toString(16).toUpperCase();
+      tagHex += h.length === 1 ? '0' + h : h;
+    }
+    const size = readU32(payload, pos + 2);
+    if (pos + 6 + size > payload.length) break;
+    out.push([tagHex, payload.subarray(pos + 6, pos + 6 + size)]);
+    pos += 6 + size;
+  }
+  return out;
+}
+
+function findFlat(seq: [string, Uint8Array][], tag: string): Uint8Array | null {
+  for (const [t, body] of seq) {
+    if (t === tag) return body;
+  }
+  return null;
+}
+
+/**
+ * Per-face texture-mapping matrices from a face's DC05 entity-info blob.
+ *
+ * A positioned / photo-fitted texture stores its mapping per face under
+ * DC05 -> DD05 -> B136 -> B236 -> 1027 -> 1127 (front) / 1227 (back)
+ * -> 1327 -> 1527: a 3x3 row-major matrix of f64 that maps
+ * texture space -> face plane; consumers invert it to get UVs
+ * (see the Face.uvTransform docs in index.ts for the exact recipe).
+ *
+ * Returns [front, back] - each a 9-element array of numbers, or null when
+ * the face carries no positioned mapping on that side.
+ */
+export function extractUvTransforms(
+  dc05Payload: Uint8Array
+): [number[] | null, number[] | null] {
+  const dd05 = findFlat(tlvFlat(dc05Payload), 'DD05');
+  if (dd05 === null) return [null, null];
+  const b136 = findFlat(tlvFlat(dd05), 'B136');
+  if (b136 === null) return [null, null];
+  const b236 = findFlat(tlvFlat(b136), 'B236');
+  if (b236 === null) return [null, null];
+  const t1027 = findFlat(tlvFlat(b236), '1027');
+  if (t1027 === null) return [null, null];
+  const sides = tlvFlat(t1027);
+  const result: (number[] | null)[] = [];
+  for (const sideTag of ['1127', '1227']) {
+    const side = findFlat(sides, sideTag);
+    let mat: number[] | null = null;
+    if (side !== null) {
+      const t1327 = findFlat(tlvFlat(side), '1327');
+      if (t1327 !== null) {
+        const t1527 = findFlat(tlvFlat(t1327), '1527');
+        if (t1527 !== null && t1527.length === 72) {
+          mat = [];
+          for (let i = 0; i < 9; i++) {
+            mat.push(readF64(t1527, i * 8));
+          }
+        }
+      }
+    }
+    result.push(mat);
+  }
+  return [result[0], result[1]];
 }
 
 export function extractGeometryFromNodes(
@@ -144,14 +217,26 @@ export function extractGeometryFromNodes(
           }
         }
         let faceMatId: number | null = null;
+        let uvFront: number[] | null = null;
+        let uvBack: number[] | null = null;
         const d007 = el.children.find((c) => c.tag === 'D007');
         if (d007) {
           const d107 = d007.children.find((c) => c.tag === 'D107');
           if (d107) {
             faceMatId = parseVarInt(d107.payload, 0, d107.payload.length);
           }
+          const dc05 = d007.children.find((c) => c.tag === 'DC05');
+          if (dc05) {
+            [uvFront, uvBack] = extractUvTransforms(dc05.payload);
+          }
         }
-        builder.faces.set(fId, { loops, normal, materialId: faceMatId });
+        builder.faces.set(fId, {
+          loops,
+          normal,
+          materialId: faceMatId,
+          uvTransform: uvFront,
+          uvTransformBack: uvBack,
+        });
       }
     } else if (tag === '6419') {
       const nodesToSearch = el.children.length > 0 ? el.children : [el];

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -59,9 +59,28 @@ export interface Face {
   id: number;
   loops: CoEdge[][];
   normal: [number, number, number];
+  /** Material of the face's FRONT side, or null. */
   materialId: number | null;
+  /** Material of the face's BACK side, or null. */
   backMaterialId: number | null;
+  /**
+   * Per-face texture mapping for a positioned / photo-fitted texture
+   * (SketchUp's pins), or null when the texture is untouched (default
+   * projection applies). A 9-element array: a 3x3 row-major matrix mapping
+   * texture space -> face plane. To compute the UV of a point p (inches):
+   *
+   * 1. Plane basis from the face normal n: xr = normalize(Z x n),
+   *    yr = n x xr (for a vertical n: xr = X, yr = +-Y by the sign of n.Z).
+   * 2. uvq = [p.xr, p.yr, 1] @ inv(M) (row-vector convention).
+   * 3. u = uvq[0]/uvq[2] / tileW, v = uvq[1]/uvq[2] / tileH with the
+   *    material texture's tile size in inches.
+   *
+   * When the texture is untouched (null), the default is
+   * u = (p.xr)/tileW, v = (p.yr)/tileH. Distorted (4-pin) mappings are
+   * projective: uvq[2] != 1.
+   */
   uvTransform: number[] | null;
+  /** Same for the face's back side, or null. */
   uvTransformBack: number[] | null;
 }
 
@@ -612,10 +631,10 @@ export function parseSkp(buffer: ArrayBuffer): SkpModel {
         id: fId,
         loops: fData.loops,
         normal: fData.normal,
-        materialId: (fData as any).materialId ?? null,
+        materialId: fData.materialId ?? null,
         backMaterialId: null,
-        uvTransform: null,
-        uvTransformBack: null,
+        uvTransform: fData.uvTransform ?? null,
+        uvTransformBack: fData.uvTransformBack ?? null,
       }));
       const instances: Instance[] = d.builder.instances.map((inst) => ({
         name: inst.name,

--- a/packages/typescript/tests/parser.test.ts
+++ b/packages/typescript/tests/parser.test.ts
@@ -3,7 +3,7 @@ import { validateHeader, readVersion } from '../src/vff';
 import { readU32, readF64, parseVarInt, parseTlvRecursive } from '../src/parser';
 import { transformPoint, multiplyMatrices, isIdentity } from '../src/transforms';
 import { computeFaceNormal, triangulateFace3D } from '../src/triangulator';
-import { GeometryBuilder, extractGeometryFromNodes } from '../src/geometry';
+import { GeometryBuilder, extractGeometryFromNodes, extractUvTransforms } from '../src/geometry';
 
 /** Build a single TLV element: 2-byte tag (hex) + 4-byte LE size + payload. */
 function tlv(tagHex: string, payload: Uint8Array): Uint8Array {
@@ -192,5 +192,55 @@ describe('Instance material (paint the component)', () => {
 
     expect(builder.instances.length).toBe(1);
     expect(builder.instances[0].materialId).toBeNull();
+  });
+});
+
+describe('Face UV transform (positioned texture mapping)', () => {
+  const ROT90 = [0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 96.0, -96.0, 1.0];
+
+  function packF64Array(values: number[]): Uint8Array {
+    const buf = new Uint8Array(values.length * 8);
+    const view = new DataView(buf.buffer);
+    values.forEach((v, i) => view.setFloat64(i * 8, v, true));
+    return buf;
+  }
+
+  function dc05(front: number[] | null, back: number[] | null): Uint8Array {
+    const side = (tag: string, mat: number[]) => {
+      const m1527 = tlv('1527', packF64Array(mat));
+      const inner1327 = tlv('1327', concatBytes(tlv('1427', new Uint8Array([0x01])), m1527));
+      return tlv(tag, inner1327);
+    };
+    let inner = new Uint8Array(0);
+    if (front !== null) inner = concatBytes(inner, side('1127', front));
+    if (back !== null) inner = concatBytes(inner, side('1227', back));
+    const t1027 = tlv('1027', inner);
+    return concatBytes(
+      tlv('DE05', new Uint8Array([0x2a])),
+      tlv('DD05', tlv('B136', tlv('B236', t1027)))
+    );
+  }
+
+  it('extracts the front matrix', () => {
+    const [front, back] = extractUvTransforms(dc05(ROT90, null));
+    expect(front).not.toBeNull();
+    front!.forEach((v, i) => expect(v).toBeCloseTo(ROT90[i]));
+    expect(back).toBeNull();
+  });
+
+  it('extracts both sides', () => {
+    const other = ROT90.map((v) => v * 2);
+    const [front, back] = extractUvTransforms(dc05(ROT90, other));
+    expect(front).not.toBeNull();
+    expect(back).not.toBeNull();
+    front!.forEach((v, i) => expect(v).toBeCloseTo(ROT90[i]));
+    back!.forEach((v, i) => expect(v).toBeCloseTo(other[i]));
+  });
+
+  it('returns null for an untouched texture (no DD05 block)', () => {
+    const plain = tlv('DE05', new Uint8Array([0x2a])); // entity id only
+    const [front, back] = extractUvTransforms(plain);
+    expect(front).toBeNull();
+    expect(back).toBeNull();
   });
 });


### PR DESCRIPTION
Fourth step of the TypeScript fidelity port — ports Python's #6, the math-heavy one.

## What
`Face.uvTransform` / `Face.uvTransformBack` - the 3x3 matrix a positioned/photo-fitted texture stores per face (SketchUp's texture pins). Located under `DC05 -> DD05 -> B136 -> B236 -> 1027 -> 1127 (front) / 1227 (back) -> 1327 -> 1527`. The documented UV-recovery recipe is included on the public interface (plane basis from the normal, then `[x,y,1] @ inv(M) / tile`), matching Python's docstring, so consumers don't have to re-derive the convention.

## Verification
- Real fixture has no positioned textures - genuinely nothing to exercise there, so verified with a synthetic byte-built test using the exact same `ROT90` ground-truth matrix as the Python PR: front-only extraction, both-sides extraction, and the untouched-texture (no `DD05`) case.
- Caught and fixed a real bug in my own first attempt at the test-builder helper while doing this: I'd omitted the intermediate `1327` wrapper (structure is `tag -> 1327 -> (1427 + 1527)`, not `tag -> (1427 + 1527)` directly) - traced it with an isolated debug script against the real `extractUvTransforms` function before fixing the test, not the extraction code (which was correct throughout).
- `tsc --noEmit` — clean
- `vitest run` — 17/17 pass (14 existing + 3 new)
- `tsup` build — CJS/ESM/DTS succeed