### PR TITLE
feat(ts): Image entities (ports #8)

### DIFF
--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -28,6 +28,7 @@ export class GeometryBuilder {
 export interface ParsedDefinition {
   guid: string;
   name: string;
+  isImage: boolean;
   builder: GeometryBuilder;
 }
 
@@ -351,6 +352,7 @@ export function collectDefs(
     if (el.tag === '7C15') {
       let guid: string | null = null;
       let name: string | null = null;
+      let isImage = false;
       for (const child of el.children) {
         if (child.tag === '7D15' && child.payload.length === 16) {
           let hex = '';
@@ -366,6 +368,10 @@ export function collectDefs(
           } catch (e) {
             name = '';
           }
+        } else if (child.tag === '8315' && child.payload.length > 0) {
+          // Definition kind: observed 0/1 for ordinary component/group
+          // definitions, 2 for the quad definition backing an Image entity.
+          isImage = parseVarInt(child.payload, 0, child.payload.length) === 2;
         }
       }
       const entId = extractEntityId(el);
@@ -375,6 +381,7 @@ export function collectDefs(
         defsDict.set(entId, {
           guid: guid || '',
           name: name || '',
+          isImage,
           builder,
         });
       }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -282,6 +282,7 @@ export function parseSkp(buffer: ArrayBuffer): SkpModel {
   defsDict.set('ROOT', {
     guid: 'ROOT',
     name: 'ROOT_MODEL',
+    isImage: false,
     builder: rootBuilder,
   });
 
@@ -652,7 +653,7 @@ export function parseSkp(buffer: ArrayBuffer): SkpModel {
         edges,
         faces,
         instances,
-        isImage: false,
+        isImage: d.isImage,
         alwaysFacesCamera: false,
       });
     }

--- a/packages/typescript/src/parser.ts
+++ b/packages/typescript/src/parser.ts
@@ -12,6 +12,11 @@ export const CONTAINER_TAGS = new Set<string>([
   'F901', '7017', '7117', 'D007', 'C409', '9411', '9511', '0F01',
   '384A', 'B80B', '9713', '2C4C', 'AC0D', 'AE0D', 'F601', 'F801',
   '983A', '993A', '8C3C', '8D3C',
+  // Image-entity placement: an Image placed in the model wraps a standard
+  // 6419 instance node inside 9013 -> 401F. Without these two containers,
+  // that inner instance stays buried in an opaque payload and the image
+  // definition looks "never placed".
+  '9013', '401F',
 ]);
 
 export function readU32(data: Uint8Array, offset: number): number {

--- a/packages/typescript/tests/parser.test.ts
+++ b/packages/typescript/tests/parser.test.ts
@@ -3,7 +3,7 @@ import { validateHeader, readVersion } from '../src/vff';
 import { readU32, readF64, parseVarInt, parseTlvRecursive } from '../src/parser';
 import { transformPoint, multiplyMatrices, isIdentity } from '../src/transforms';
 import { computeFaceNormal, triangulateFace3D } from '../src/triangulator';
-import { GeometryBuilder, extractGeometryFromNodes, extractUvTransforms } from '../src/geometry';
+import { GeometryBuilder, extractGeometryFromNodes, extractUvTransforms, collectDefs } from '../src/geometry';
 
 /** Build a single TLV element: 2-byte tag (hex) + 4-byte LE size + payload. */
 function tlv(tagHex: string, payload: Uint8Array): Uint8Array {
@@ -242,5 +242,48 @@ describe('Face UV transform (positioned texture mapping)', () => {
     const [front, back] = extractUvTransforms(plain);
     expect(front).toBeNull();
     expect(back).toBeNull();
+  });
+});
+
+describe('Image entities', () => {
+  it('extracts the instance wrapped in 9013 -> 401F placement containers', () => {
+    const inner6419 = tlv('6419', tlv('6719', new Uint8Array([0x07]))); // refIdx 7
+    const node = tlv('9013', tlv('401F', inner6419));
+
+    const elements = parseTlvRecursive(node, 0, node.length);
+    const builder = new GeometryBuilder();
+    extractGeometryFromNodes(elements, builder);
+
+    expect(builder.instances.length).toBe(1);
+    expect(builder.instances[0].refIdx).toBe(7);
+  });
+
+  it('marks Definition.isImage when the 8315 kind byte is 2', () => {
+    const defOn = tlv(
+      '7C15',
+      concatBytes(
+        tlv('DE05', new Uint8Array([0x01])),
+        tlv('7D15', new Uint8Array(16).fill(0x11)),
+        tlv('7E15', new TextEncoder().encode('imagen#1')),
+        tlv('8315', new Uint8Array([0x02]))
+      )
+    );
+    const defOff = tlv(
+      '7C15',
+      concatBytes(
+        tlv('DE05', new Uint8Array([0x02])),
+        tlv('7D15', new Uint8Array(16).fill(0x22)),
+        tlv('7E15', new TextEncoder().encode('Grupo')),
+        tlv('8315', new Uint8Array([0x00]))
+      )
+    );
+    const buf = concatBytes(defOn, defOff);
+
+    const elements = parseTlvRecursive(buf, 0, buf.length);
+    const defsDict = collectDefs(elements);
+
+    const names = Array.from(defsDict.values()).map((d) => [d.name, d.isImage]);
+    expect(names).toContainEqual(['imagen#1', true]);
+    expect(names).toContainEqual(['Grupo', false]);
   });
 });


### PR DESCRIPTION
Fifth step of the TypeScript fidelity port — ports Python's #8.

## What
- `CONTAINER_TAGS += {'9013', '401F'}` — an Image placed in the model wraps a standard `6419` instance node inside these two image-specific containers; without them the inner instance stayed buried in an opaque leaf payload and the image looked "never placed". Confirmed neither tag was consumed as raw payload anywhere else in the TS codebase before this change (safe to promote to container status).
- `Definition.isImage` — the definition backing an image carries TLV kind `8315 == 2` (ordinary definitions carry 0/1).

## Verification
- Real fixtures have no Image entities — verified with synthetic byte-built tests instead: a `9013 -> 401F -> 6419` node correctly yields an extracted instance, and a pair of `7C15` definitions with `8315` kind bytes 2 / 0 correctly resolve to `isImage: true` / `false`.
- `tsc --noEmit` — clean
- `vitest run` — 19/19 pass (17 existing + 2 new)
- `tsup` build — CJS/ESM/DTS succeed