### PR TITLE
feat(ts): Definition.alwaysFacesCamera (ports #9)

### DIFF
--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -29,6 +29,7 @@ export interface ParsedDefinition {
   guid: string;
   name: string;
   isImage: boolean;
+  alwaysFacesCamera: boolean;
   builder: GeometryBuilder;
 }
 
@@ -353,6 +354,7 @@ export function collectDefs(
       let guid: string | null = null;
       let name: string | null = null;
       let isImage = false;
+      let facesCamera = false;
       for (const child of el.children) {
         if (child.tag === '7D15' && child.payload.length === 16) {
           let hex = '';
@@ -372,6 +374,20 @@ export function collectDefs(
           // Definition kind: observed 0/1 for ordinary component/group
           // definitions, 2 for the quad definition backing an Image entity.
           isImage = parseVarInt(child.payload, 0, child.payload.length) === 2;
+        } else if (child.tag === '581B') {
+          // Component behavior flags: sub-TLV 5D1B == 1 marks "always
+          // faces camera" (2D people/tree cut-outs); its companion 5E1B
+          // is "shadows face sun".
+          let pos = 0;
+          const pl = child.payload;
+          while (pos <= pl.length - 6) {
+            const subSize = readU32(pl, pos + 2);
+            if (pos + 6 + subSize > pl.length) break;
+            if (pl[pos] === 0x5d && pl[pos + 1] === 0x1b && subSize >= 1) {
+              facesCamera = parseVarInt(pl, pos + 6, subSize) === 1;
+            }
+            pos += 6 + subSize;
+          }
         }
       }
       const entId = extractEntityId(el);
@@ -382,6 +398,7 @@ export function collectDefs(
           guid: guid || '',
           name: name || '',
           isImage,
+          alwaysFacesCamera: facesCamera,
           builder,
         });
       }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -283,6 +283,7 @@ export function parseSkp(buffer: ArrayBuffer): SkpModel {
     guid: 'ROOT',
     name: 'ROOT_MODEL',
     isImage: false,
+    alwaysFacesCamera: false,
     builder: rootBuilder,
   });
 
@@ -654,7 +655,7 @@ export function parseSkp(buffer: ArrayBuffer): SkpModel {
         faces,
         instances,
         isImage: d.isImage,
-        alwaysFacesCamera: false,
+        alwaysFacesCamera: d.alwaysFacesCamera,
       });
     }
   }

--- a/packages/typescript/tests/parser.test.ts
+++ b/packages/typescript/tests/parser.test.ts
@@ -287,3 +287,27 @@ describe('Image entities', () => {
     expect(names).toContainEqual(['Grupo', false]);
   });
 });
+
+describe('Always faces camera (component behavior flags)', () => {
+  it('marks Definition.alwaysFacesCamera when 581B carries 5D1B == 1', () => {
+    const behaviorOn = tlv('581B', tlv('5D1B', new Uint8Array([0x01])));
+    const behaviorOff = tlv('581B', tlv('5D1B', new Uint8Array([0x00])));
+
+    const susan = tlv(
+      '7C15',
+      concatBytes(tlv('DE05', new Uint8Array([0x01])), tlv('7E15', new TextEncoder().encode('Susan')), behaviorOn)
+    );
+    const chair = tlv(
+      '7C15',
+      concatBytes(tlv('DE05', new Uint8Array([0x02])), tlv('7E15', new TextEncoder().encode('Chair')), behaviorOff)
+    );
+    const buf = concatBytes(susan, chair);
+
+    const elements = parseTlvRecursive(buf, 0, buf.length);
+    const defsDict = collectDefs(elements);
+
+    const names = Array.from(defsDict.values()).map((d) => [d.name, d.alwaysFacesCamera]);
+    expect(names).toContainEqual(['Susan', true]);
+    expect(names).toContainEqual(['Chair', false]);
+  });
+});


### PR DESCRIPTION
Sixth step of the TypeScript fidelity port — ports Python's #9.

## What
`Definition.alwaysFacesCamera` — SketchUp's "always face camera" component behavior (2D people / tree cut-outs), decoded from the definition's behavior block (`581B` -> sub-TLV `5D1B == 1`; its companion `5E1B` is "shadows face sun").

## Verification
- Real fixture has no camera-facing components (a framing/structural model) — verified with a synthetic test: two `7C15` definitions, one with `581B/5D1B=1` ("Susan"), one with `581B/5D1B=0` ("Chair"), correctly resolving `true`/`false`.
- `tsc --noEmit` — clean
- `vitest run` — 20/20 pass (19 existing + 1 new)
- `tsup` build — CJS/ESM/DTS succeed