### PR TITLE
fix(python): recognise big-tag CThumbnail class-refs in the definition-tail scan (ports #28)

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -201,6 +201,21 @@ class _Archive:
 
 # ── shared record blocks ─────────────────────────────────────────────────
 
+def _is_class_ref(data: bytes, p: int, slot: int) -> bool:
+    """True when the bytes at *p* are an MFC class-ref to class *slot*.
+
+    Mirrors both encodings that ``_Archive.read_object`` decodes: the short
+    16-bit form ``0x8000|slot`` and, for slots past 0x7FFF, the big-tag
+    escape ``0x7FFF`` followed by a u32 of ``0x80000000|slot``.
+    """
+    if slot <= 0x7FFF:
+        return (p + 2 <= len(data)
+                and struct.unpack_from('<H', data, p)[0] == 0x8000 | slot)
+    return (p + 6 <= len(data)
+            and struct.unpack_from('<H', data, p)[0] == 0x7FFF
+            and struct.unpack_from('<I', data, p + 2)[0] == 0x80000000 | slot)
+
+
 def _preamble(ar, r):
     """Entity preamble: attribute pointer (+ pid mask/bytes on 2017+)."""
     slot, name, attrs = ar.read_object(r, expect='CAttributeContainer')
@@ -578,17 +593,16 @@ def _read_definition(ar, r):
     r.u32()                                   # timestamp
     # undecoded block (~39-47 bytes), then the CThumbnail object
     tpos = None
+    thumb_slot = ar.class_slot.get('CThumbnail')
     for off in range(0, 96):
         p = r.pos + off
         if (r.data[p:p + 2] == b'\xff\xff' and r.data[p + 4:p + 6] == b'\x0a\x00'
                 and r.data[p + 6:p + 16] == b'CThumbnail'):
             tpos = p
             break
-        if 'CThumbnail' in ar.class_slot:
-            if struct.unpack_from('<H', r.data, p)[0] == \
-                    0x8000 | ar.class_slot['CThumbnail']:
-                tpos = p
-                break
+        if thumb_slot is not None and _is_class_ref(r.data, p, thumb_slot):
+            tpos = p
+            break
     if tpos is None:
         raise LegacyParseError(f"definition tail: thumbnail not found {r.ctx()}")
     gap = r.raw(tpos - r.pos)

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -1196,3 +1196,35 @@ class TestObservability:
                 raise SkpParseError("wrapped", stage="tlv_walk") from e
         except SkpParseError as wrapped:
             assert wrapped.__cause__ is original
+
+
+class TestLegacyClassRef:
+    """Both MFC class-ref encodings the definition-tail scanner must match."""
+
+    def test_short_form(self) -> None:
+        from openskp.legacy import _is_class_ref
+
+        data = struct.pack("<H", 0x8000 | 278)
+        assert _is_class_ref(data, 0, 278)
+        assert not _is_class_ref(data, 0, 279)
+
+    def test_big_tag_escape(self) -> None:
+        from openskp.legacy import _is_class_ref
+
+        # slot 65712 does not fit in 0x8000|slot: MFC writes 0x7FFF + u32
+        data = struct.pack("<HI", 0x7FFF, 0x80000000 | 65712)
+        assert _is_class_ref(data, 0, 65712)
+        assert not _is_class_ref(data, 0, 65713)
+
+    def test_big_slot_never_matches_short_form(self) -> None:
+        from openskp.legacy import _is_class_ref
+
+        # the pre-fix scanner compared a u16 read against 0x8000|65712,
+        # which cannot fit in 16 bits — the truncated value must not match
+        data = struct.pack("<H", (0x8000 | 65712) & 0xFFFF)
+        assert not _is_class_ref(data, 0, 65712)
+
+    def test_truncated_data(self) -> None:
+        from openskp.legacy import _is_class_ref
+
+        assert not _is_class_ref(b"\xff\x7f\xb0", 0, 65712)


### PR DESCRIPTION
This is the Python side of #28 — the same 16-bit-only check @thomazyujibaba found in the TypeScript scanner exists in `legacy.py`, as you noted in that issue. Rather than wait for the TS PR to land and port it over, here it is ready.

## The bug

The definition-tail scanner only tested the short class-ref form:

```python
if struct.unpack_from('<H', r.data, p)[0] == 0x8000 | ar.class_slot['CThumbnail']:
```

Once the `CThumbnail` class slot passes 0x7FFF, `0x8000 | slot` cannot fit in 16 bits, the comparison is dead code, and every definition tail throws `thumbnail not found` — while `read_object` had decoded the big-tag escape (`0x7FFF` + u32 of `0x80000000 | slot`) all along.

## The fix

Both encodings now live in one helper, `_is_class_ref`, mirroring `read_object` exactly. Unit tests cover the short form, the escape form, the truncated-data edge, and the specific pre-fix failure (a big slot must never match the truncated 16-bit comparison).

## Verification

- The 36 MB repro from #28 (the office chair posted there) now parses: **7 definitions, 145 353 faces, 0 non-finite coordinates** — face count matching the TS fix's GLB triangle count exactly.
- Swept **64 other corpus files** with an order-stable SHA-256 fingerprint of every vertex coordinate: **all byte-identical** before and after the fix.
- `pytest`: 84 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)