### PR TITLE
fix(python): SketchUp 2013 instances have no trailing GUID — fixes both crashes in #38

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -125,6 +125,8 @@ class _Archive:
         self.r = _R(data)
         self.slots: Dict[int, tuple] = {}    # slot -> ('class'|'obj', name, value)
         self.class_slot: Dict[str, int] = {}
+        self.class_schema: Dict[str, int] = {}
+        self.current_class: Optional[str] = None  # class of the object being read
         self.next_slot = 0
         self.walk_base = 0            # slots below this are unwalked pre-model
         self.readers: Dict[str, Any] = {}
@@ -155,6 +157,7 @@ class _Archive:
             name = r.raw(namelen).decode('ascii')
             self.alloc(('class', name, schema))
             self.class_slot[name] = self.next_slot - 1
+            self.class_schema[name] = schema
             return self._new_obj(r, name)
         if tag & 0x8000:                       # class ref -> new object
             return self._new_of_class(r, tag & 0x7FFF, expect)
@@ -182,7 +185,12 @@ class _Archive:
         reader = self.readers.get(name)
         if reader is None:
             raise LegacyParseError(f"no reader for class {name} {r.ctx()}")
-        value = reader(self, r)
+        prev_class = self.current_class
+        self.current_class = name
+        try:
+            value = reader(self, r)
+        finally:
+            self.current_class = prev_class
         self.slots[slot] = ('obj', name, value)
         return slot, name, value
 
@@ -601,6 +609,7 @@ def _read_definition(ar, r):
 
 
 def _read_instance(ar, r):
+    cls = ar.current_class
     _preamble(ar, r)
     db = _drawbase(ar, r)
     ds, dn, _ = ar.read_object(r, expect='CComponentDefinition')
@@ -608,7 +617,15 @@ def _read_instance(ar, r):
         raise LegacyParseError(f"instance definition ref is {dn} {r.ctx()}")
     xf = r.f64s(13)
     name = r.utf16()
-    guid = r.raw(16)
+    # the trailing instance GUID arrives with CComponentInstance schema 5 /
+    # CGroup schema 1; SketchUp 2013 writes CComponentInstance schema 4,
+    # which ends at the name
+    schema = ar.class_schema.get(cls)
+    min_schema = 1 if cls == 'CGroup' else 5
+    if schema is None or schema >= min_schema:
+        guid = r.raw(16)
+    else:
+        guid = b''
     return {'k': 'instance', 'db': db, 'def': ds, 'xf': xf,
             'name': name, 'guid': guid.hex().upper()}
 


### PR DESCRIPTION
Root cause and fix for **both** failure modes in #38. They are one bug with two faces, and it is not C#-specific — every port that shares the legacy walker has it (verified against the Python one; the walker logic is the same in TS/.NET/Dart).

## The bug

`_read_instance` unconditionally consumes a 16-byte GUID after the instance name:

```python
xf = r.f64s(13)
name = r.utf16()
guid = r.raw(16)
```

That field only exists from **`CComponentInstance` schema 5** (and `CGroup` schema 1) on. **SketchUp 2013 writes `CComponentInstance` schema 4**, whose record ends at the name. So on 2013-era files every in-definition instance overruns the stream by exactly 16 bytes, and the definition tail (`nrel`, guid, name) is read misaligned. Both attached repros are format-version 13 (`TestSketchup8.skp` was re-saved as 2013, so it is v13 too), and both fail at the first definition that contains an instance — the template figure components ("Derrick", "Susan") that every SketchUp template ships:

| file | first in-def instance | symptom |
|---|---|---|
| TestSketchup2013.skp | `Derrick` figure | `definition list misaligned` (Python) / `LegacyParseError @0x1c571` (C#) |
| TestSketchup8.skp | same overrun, corrupts a later back-ref | `back-ref to unwalked slot` (Python) / `Nullable object must have a value` in `ReadEntityList` (C#) |

Worth knowing when triaging: those two signatures are not two bugs.

## The fix

The archive already reads and stores each class's MFC schema number — it just never consulted it. The instance reader now keys the trailing GUID on it: `CComponentInstance` ≥ 5, `CGroup` ≥ 1, unknown schema keeps today's behavior. (These thresholds match the schema ranges the independent Rust implementation pins for the same records.)

## Verification

- Both #38 repros parse with finite geometry: `TestSketchup2013.skp` → 3 definitions, 1 617 vertices; `TestSketchup8.skp` → 15 definitions, 39 274 faces, 26 286 vertices. Definition names come out as expected (`Rodeo#2`, `Derrick`, `Pillar`, `Mall`, `Susan`, …).
- Swept 63 other corpus files (v17 files heavy with instances included: 1 186-instance theater, 143-instance attributes file) with an order-stable SHA-256 fingerprint of every vertex coordinate: **all byte-identical** before and after.
- `pytest`: 80 passed.

The same schema gate should port directly to the TS/.NET/Dart walkers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)