### PR TITLE
fix(dotnet): SketchUp 2013 instances have no trailing GUID — fixes both crashes in #38

### DIFF
--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -214,6 +214,8 @@ namespace OpenSkp
         public LR R;
         public Dictionary<int, SlotEntry> Slots = new Dictionary<int, SlotEntry>();
         public Dictionary<string, int> ClassSlot = new Dictionary<string, int>();
+        public Dictionary<string, int> ClassSchema = new Dictionary<string, int>();
+        public string? CurrentClass;
         public int NextSlot;
         public int WalkBase;
         public Dictionary<string, LegacyReader> Readers = new Dictionary<string, LegacyReader>();
@@ -264,6 +266,7 @@ namespace OpenSkp
                 string name = Encoding.ASCII.GetString(nameBytes);
                 Alloc(new SlotEntry { Kind = "class", Name = name, Value = (int)schema });
                 ClassSlot[name] = NextSlot - 1;
+                ClassSchema[name] = schema;
                 return NewObj(r, name);
             }
             if ((tag & 0x8000) != 0)
@@ -300,7 +303,17 @@ namespace OpenSkp
             {
                 throw new LegacyParseError($"no reader for class {name} {r.Ctx()}");
             }
-            object? value = reader(this, r);
+            string? prevClass = CurrentClass;
+            CurrentClass = name;
+            object? value;
+            try
+            {
+                value = reader(this, r);
+            }
+            finally
+            {
+                CurrentClass = prevClass;
+            }
             Slots[slot] = new SlotEntry { Kind = "obj", Name = name, Value = value };
             return (slot, name, value);
         }
@@ -917,6 +930,7 @@ namespace OpenSkp
 
         public static object ReadInstance(Archive ar, LR r)
         {
+            string? cls = ar.CurrentClass;
             Preamble(ar, r);
             var db = Drawbase(ar, r);
             var (ds, dn, _) = ar.ReadObject(r, "CComponentDefinition");
@@ -926,7 +940,14 @@ namespace OpenSkp
             }
             var xf = r.F64s(13);
             string name = r.Utf16();
-            var guid = r.Raw(16);
+
+            // The trailing instance GUID arrives with CComponentInstance schema 5 /
+            // CGroup schema 1; SketchUp 2013 writes CComponentInstance schema 4,
+            // whose record ends at the name (see openskp#38 / #40).
+            int minSchema = cls == "CGroup" ? 1 : 5;
+            int? schema = (cls != null && ar.ClassSchema.TryGetValue(cls, out int s)) ? s : (int?)null;
+            byte[] guid = (schema == null || schema >= minSchema) ? r.Raw(16) : Array.Empty<byte>();
+
             return new InstanceRec { Db = db, Def = ds, Xf = xf, Name = name, Guid = LegacyBytes.ToHex(guid) };
         }
 


### PR DESCRIPTION
Ports the schema-gated fix from #40 (Python) to the C# legacy walker. Same root cause, same fix — different language.

## The bug

`ReadInstance` unconditionally reads a 16-byte GUID after the instance name:

```csharp
var xf = r.F64s(13);
string name = r.Utf16();
var guid = r.Raw(16);
```

That field only exists from **`CComponentInstance` schema 5** (and `CGroup` schema 1) on. **SketchUp 2013 writes `CComponentInstance` schema 4**, whose record ends at the name. On 2013-era files every in-definition instance overruns the stream by exactly 16 bytes, and everything after it (the definition tail, subsequent backrefs) reads misaligned.

Credit to @tuxiasumari for root-causing this in #38 / #40.

## The fix

The archive already tracked each class's registration slot (`ClassSlot`); this adds tracking of the schema number itself (`Archive.ClassSchema`) and which class is currently being read (`Archive.CurrentClass`), so `ReadInstance` can key the trailing GUID read on the actual schema instead of assuming it's always present — mirroring `#40`'s Python approach field-for-field.

## Verification

- Both #38 repro files parse with finite geometry:
  - `TestSketchup2013.skp` → 3 definitions (incl. root), 1,617 vertices
  - `TestSketchup8.skp` → 15 definitions (incl. root), 39,274 faces, 26,286 vertices
  - Both numbers match #40's reported Python results exactly, including component names (`Derrick`, `Rodeo#2`, `Pillar`, `Mall`, `Susan`, ...).
- Swept 11 real production files (1.2 MB–591.7 MB) with the existing regression harness: all parse identically before/after, zero regressions.
- Full `dotnet test` suite: 16 passed.
