### PR TITLE
fix(dotnet): recognise big-tag CThumbnail class-refs in the definition-tail scan (ports #28)

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/LegacyTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/LegacyTests.cs
@@ -114,4 +114,49 @@ namespace OpenSkp.Tests
             Assert.True(Legacy.IsLegacy(bytes));
         }
     }
+
+    /// <summary>
+    /// Both MFC class-ref encodings the definition-tail scanner must match.
+    /// Mirrors packages/python/tests/test_parser.py::TestLegacyClassRef
+    /// (openskp#28 / #39): once a class slot passes 0x7FFF the short 16-bit
+    /// form 0x8000|slot can't fit, so MFC escalates to the big-tag escape
+    /// (0x7FFF followed by a u32 of 0x80000000|slot).
+    /// </summary>
+    public class LegacyClassRefTests
+    {
+        [Fact]
+        public void ShortForm()
+        {
+            var data = BitConverter.GetBytes((ushort)(0x8000 | 278));
+            Assert.True(LegacyBytes.IsClassRef(data, 0, 278));
+            Assert.False(LegacyBytes.IsClassRef(data, 0, 279));
+        }
+
+        [Fact]
+        public void BigTagEscape()
+        {
+            // slot 65712 does not fit in 0x8000|slot: MFC writes 0x7FFF + u32
+            var data = new byte[6];
+            BitConverter.GetBytes((ushort)0x7FFF).CopyTo(data, 0);
+            BitConverter.GetBytes(0x80000000u | 65712).CopyTo(data, 2);
+            Assert.True(LegacyBytes.IsClassRef(data, 0, 65712));
+            Assert.False(LegacyBytes.IsClassRef(data, 0, 65713));
+        }
+
+        [Fact]
+        public void BigSlotNeverMatchesShortForm()
+        {
+            // the pre-fix scanner compared a u16 read against 0x8000|65712,
+            // which cannot fit in 16 bits - the truncated value must not match
+            var data = BitConverter.GetBytes(unchecked((ushort)(0x8000 | 65712)));
+            Assert.False(LegacyBytes.IsClassRef(data, 0, 65712));
+        }
+
+        [Fact]
+        public void TruncatedData()
+        {
+            var data = new byte[] { 0xFF, 0x7F, 0xB0 };
+            Assert.False(LegacyBytes.IsClassRef(data, 0, 65712));
+        }
+    }
 }

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -72,6 +72,21 @@ namespace OpenSkp
             return -1;
         }
 
+        /// <summary>True when the bytes at <paramref name="p"/> are an MFC class-ref
+        /// to class <paramref name="slot"/>. Mirrors both encodings Archive.ReadObject
+        /// decodes: the short 16-bit form (0x8000|slot) and, for slots past 0x7FFF,
+        /// the big-tag escape (0x7FFF followed by a u32 of 0x80000000|slot).</summary>
+        public static bool IsClassRef(byte[] data, int p, int slot)
+        {
+            if (slot <= 0x7FFF)
+            {
+                return p + 2 <= data.Length && Tlv.ReadU16(data, p) == (0x8000 | slot);
+            }
+            return p + 6 <= data.Length
+                && Tlv.ReadU16(data, p) == 0x7FFF
+                && Tlv.ReadU32(data, p + 2) == (0x80000000u | (uint)slot);
+        }
+
         public static int[] AsciiCodes(string s) => s.Select(c => (int)c).ToArray();
 
         public static bool MatchesAscii(byte[] data, int offset, string str)
@@ -879,6 +894,7 @@ namespace OpenSkp
             r.U32();
 
             int? tpos = null;
+            bool haveThumbSlot = ar.ClassSlot.TryGetValue("CThumbnail", out int thumbSlot);
             for (int off = 0; off < 96; off++)
             {
                 int p = r.Pos + off;
@@ -890,13 +906,10 @@ namespace OpenSkp
                     tpos = p;
                     break;
                 }
-                if (ar.ClassSlot.TryGetValue("CThumbnail", out int thumbSlot))
+                if (haveThumbSlot && LegacyBytes.IsClassRef(r.Data, p, thumbSlot))
                 {
-                    if (p + 2 <= r.Data.Length && Tlv.ReadU16(r.Data, p) == (0x8000 | thumbSlot))
-                    {
-                        tpos = p;
-                        break;
-                    }
+                    tpos = p;
+                    break;
                 }
             }
             if (tpos == null)


### PR DESCRIPTION
Ports the fix from #39 (Python) / the original TS fix on #28 to the C# legacy walker. Same root cause, same fix, different language.

## The bug

The definition-tail scanner only tested the short class-ref form:

```csharp
if (p + 2 <= r.Data.Length && Tlv.ReadU16(r.Data, p) == (0x8000 | thumbSlot))
```

Once the `CThumbnail` class slot passes `0x7FFF`, `0x8000 | slot` cannot fit in 16 bits, the comparison is dead code, and every definition tail throws `"thumbnail not found"` — while `ReadObject` had decoded the big-tag escape (`0x7FFF` + u32 of `0x80000000 | slot`) all along.

`CThumbnail`'s slot is the raw global object-slot number where its class was first registered — not a count of distinct class *types* — so any file where the first `CThumbnail` happens to be encountered after ~32,767 other objects have already been allocated hits this, independent of file size or complexity in any simple sense.

## The fix

Both encodings now live in one helper, `LegacyBytes.IsClassRef`, mirroring `ReadObject` exactly (matches Python's `_is_class_ref` in #39). Unit tests cover the short form, the escape form, the truncated-data edge, and the specific pre-fix failure (a big slot must never match the truncated 16-bit comparison).

## Verification

- Swept the same 11-file real-world corpus used for prior regression testing (1.2 MB–591.7 MB): all parse identically before/after, zero regressions.
- Full `dotnet test` suite: 20 passed (16 existing + 4 new).

Credit to @thomazyujibaba for the original TS report/repro (#28) and @tuxiasumari for confirming and porting to Python (#39).
