### PR TITLE
fix(typescript): SketchUp 2013 instances have no trailing GUID — fixes both crashes in #38

### DIFF
--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -174,6 +174,8 @@ class Archive {
   r: R;
   slots = new Map<number, SlotEntry>();
   classSlot = new Map<string, number>();
+  classSchema = new Map<string, number>();
+  currentClass: string | null = null;
   nextSlot = 0;
   walkBase = 0;
   readers: Record<string, (ar: Archive, r: R) => any> = {};
@@ -216,6 +218,7 @@ class Archive {
       const name = new TextDecoder('utf-8').decode(nameBytes);
       this.alloc(['class', name, schema]);
       this.classSlot.set(name, this.nextSlot - 1);
+      this.classSchema.set(name, schema);
       return this.newObj(r, name);
     }
     if (tag & 0x8000) {
@@ -248,7 +251,14 @@ class Archive {
     if (reader === undefined) {
       throw new LegacyParseError(`no reader for class ${name} ${r.ctx()}`);
     }
-    const value = reader(this, r);
+    const prevClass = this.currentClass;
+    this.currentClass = name;
+    let value: any;
+    try {
+      value = reader(this, r);
+    } finally {
+      this.currentClass = prevClass;
+    }
     this.slots.set(slot, ['obj', name, value]);
     return [slot, name, value];
   }
@@ -736,6 +746,7 @@ function readDefinition(ar: Archive, r: R): any {
 }
 
 function readInstance(ar: Archive, r: R): any {
+  const cls = ar.currentClass;
   preamble(ar, r);
   const db = drawbase(ar, r);
   const [ds, dn] = ar.readObject(r, 'CComponentDefinition');
@@ -744,7 +755,14 @@ function readInstance(ar: Archive, r: R): any {
   }
   const xf = r.f64s(13);
   const name = r.utf16();
-  const guid = r.raw(16);
+
+  // The trailing instance GUID arrives with CComponentInstance schema 5 /
+  // CGroup schema 1; SketchUp 2013 writes CComponentInstance schema 4,
+  // whose record ends at the name (see openskp#38 / #40).
+  const minSchema = cls === 'CGroup' ? 1 : 5;
+  const schema = cls !== null ? ar.classSchema.get(cls) : undefined;
+  const guid = schema === undefined || schema >= minSchema ? r.raw(16) : new Uint8Array(0);
+
   return { k: 'instance', db, def: ds, xf, name, guid: toHex(guid) };
 }
 


### PR DESCRIPTION
Ports the schema-gated fix from #40 (Python) / #41 (.NET) to the TypeScript legacy walker. Same root cause, same fix, different language.

## The bug

`readInstance` unconditionally reads a 16-byte GUID after the instance name:

```ts
const xf = r.f64s(13);
const name = r.utf16();
const guid = r.raw(16);
```

That field only exists from **`CComponentInstance` schema 5** (and `CGroup` schema 1) on. **SketchUp 2013 writes `CComponentInstance` schema 4**, whose record ends at the name. On 2013-era files every in-definition instance overruns the stream by exactly 16 bytes.

Credit to @tuxiasumari for root-causing this in #38 / #40.

## The fix

The archive already tracked each class's registration slot (`classSlot`); this adds tracking of the schema number itself (`Archive.classSchema`) and which class is currently being read (`Archive.currentClass`), so `readInstance` can key the trailing GUID read on the actual schema — mirroring #40's Python approach field-for-field.

## Verification

- Both #38 repro files parse (isolated build, this fix alone, without the separate #28/#39 class-ref fix): `TestSketchup2013.skp` → 2 definitions, `TestSketchup8.skp` → 14 definitions — matching #41's (.NET) numbers.
- Swept 9 of the same 11 real production files used for prior regression testing (1.2 MB–109 MB): all parse identically before/after, zero regressions. The remaining 2 files (280–592 MB) hit a pre-existing Node/V8 heap limit in this package's in-memory model representation, independent of this change — reproduces identically on unmodified main.
- Full `vitest` suite: 35 passed.
