### PR TITLE
fix(dart): SketchUp 2013 instances have no trailing GUID — fixes both crashes in #38

### DIFF
--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -180,6 +180,8 @@ class Archive {
   late final LR r;
   final Map<int, SlotEntry> slots = {};
   final Map<String, int> classSlot = {};
+  final Map<String, int> classSchema = {};
+  String? currentClass;
   int nextSlot = 0;
   int walkBase = 0;
   final Map<String, LegacyReader> readers = {};
@@ -219,6 +221,7 @@ class Archive {
       final name = ascii.decode(nameBytes);
       alloc(SlotEntry(kind: 'class', name: name, value: schema));
       classSlot[name] = nextSlot - 1;
+      classSchema[name] = schema;
       return _newObj(r, name);
     }
     if ((tag & 0x8000) != 0) {
@@ -251,7 +254,14 @@ class Archive {
     if (reader == null) {
       throw LegacyParseError('no reader for class $name ${r.ctx()}');
     }
-    final value = reader(this, r);
+    final prevClass = currentClass;
+    currentClass = name;
+    Object? value;
+    try {
+      value = reader(this, r);
+    } finally {
+      currentClass = prevClass;
+    }
     slots[slot] = SlotEntry(kind: 'obj', name: name, value: value);
     return (slot, name, value);
   }
@@ -888,6 +898,7 @@ class LegacyReaders {
   }
 
   static Object readInstance(Archive ar, LR r) {
+    final cls = ar.currentClass;
     preamble(ar, r);
     final db = drawbase(ar, r);
     final (ds, dn, _) = ar.readObject(r, 'CComponentDefinition');
@@ -896,7 +907,15 @@ class LegacyReaders {
     }
     final xf = r.f64s(13);
     final name = r.utf16();
-    final guid = r.raw(16);
+
+    // The trailing instance GUID arrives with CComponentInstance schema 5 /
+    // CGroup schema 1; SketchUp 2013 writes CComponentInstance schema 4,
+    // whose record ends at the name (see openskp#38 / #40).
+    final minSchema = cls == 'CGroup' ? 1 : 5;
+    final schema = cls != null ? ar.classSchema[cls] : null;
+    final guid =
+        (schema == null || schema >= minSchema) ? r.raw(16) : Uint8List(0);
+
     return InstanceRec(
         db: db, def: ds, xf: xf, name: name, guid: Tlv.toHexUpper(guid));
   }


### PR DESCRIPTION
Ports the schema-gated fix from #40 (Python) / #41 (.NET) / #43 (TypeScript) to the Dart legacy walker. Same root cause, same fix, different language.

## The bug

`readInstance` unconditionally reads a 16-byte GUID after the instance name. That field only exists from **`CComponentInstance` schema 5** (and `CGroup` schema 1) on. **SketchUp 2013 writes `CComponentInstance` schema 4**, whose record ends at the name. On 2013-era files every in-definition instance overruns the stream by exactly 16 bytes.

Credit to @tuxiasumari for root-causing this in #38 / #40.

## The fix

The archive already tracked each class's registration slot (`classSlot`); this adds tracking of the schema number itself (`Archive.classSchema`) and which class is currently being read (`Archive.currentClass`), so `readInstance` can key the trailing GUID read on the actual schema — mirroring #40's Python approach field-for-field.

## Verification

- Both #38 repro files parse (isolated build, this fix alone, without the separate #28/#39 class-ref fix), matching the same definition counts as the other ports.
- The full combined-fix build (both this and the class-ref fix together) was separately swept against 10 of the 11 real production files used for prior regression testing (1.2 MB–374.5 MB, plus a 280.7 MB file): all parse identically before/after, zero regressions. The one excluded file (591.7 MB) hits a pre-existing out-of-memory failure in the unrelated VFF/TLV path (`stage=tlv_walk`, not the legacy walker this change touches) — reproduces identically on unmodified main.
- Full `dart test` suite: 15 passed.
