### PR TITLE
fix(typescript): recognise big-tag CThumbnail class-refs in the definition-tail scan (ports #28)

### DIFF
--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -78,6 +78,24 @@ function toHex(data: Uint8Array): string {
   return s;
 }
 
+/**
+ * True when the bytes at `p` are an MFC class-ref to class `slot`. Mirrors
+ * both encodings Archive.readObject decodes: the short 16-bit form
+ * (0x8000|slot) and, for slots past 0x7fff, the big-tag escape (0x7fff
+ * followed by a u32 of 0x80000000|slot).
+ */
+export function isClassRef(data: Uint8Array, p: number, slot: number): boolean {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  if (slot <= 0x7fff) {
+    return p + 2 <= data.length && view.getUint16(p, true) === (0x8000 | slot);
+  }
+  return (
+    p + 6 <= data.length &&
+    view.getUint16(p, true) === 0x7fff &&
+    view.getUint32(p + 2, true) === (0x80000000 | slot) >>> 0
+  );
+}
+
 /** Byte cursor, matching Python's `_R`. */
 class R {
   data: Uint8Array;
@@ -699,7 +717,7 @@ function readDefinition(ar: Archive, r: R): any {
 
   // undecoded block (~39-47 bytes), then the CThumbnail object
   let tpos: number | null = null;
-  const view = new DataView(r.data.buffer, r.data.byteOffset, r.data.byteLength);
+  const thumbSlot = ar.classSlot.get('CThumbnail');
   for (let off = 0; off < 96; off++) {
     const p = r.pos + off;
     if (
@@ -710,12 +728,9 @@ function readDefinition(ar: Archive, r: R): any {
       tpos = p;
       break;
     }
-    const thumbSlot = ar.classSlot.get('CThumbnail');
-    if (thumbSlot !== undefined) {
-      if (view.getUint16(p, true) === (0x8000 | thumbSlot)) {
-        tpos = p;
-        break;
-      }
+    if (thumbSlot !== undefined && isClassRef(r.data, p, thumbSlot)) {
+      tpos = p;
+      break;
     }
   }
   if (tpos === null) {

--- a/packages/typescript/tests/legacy-classref.test.ts
+++ b/packages/typescript/tests/legacy-classref.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { isClassRef } from '../src/legacy';
+
+/**
+ * Both MFC class-ref encodings the definition-tail scanner must match.
+ * Mirrors packages/python/tests/test_parser.py::TestLegacyClassRef
+ * (openskp#28 / #39): once a class slot passes 0x7fff the short 16-bit
+ * form 0x8000|slot can't fit, so MFC escalates to the big-tag escape
+ * (0x7fff followed by a u32 of 0x80000000|slot).
+ */
+describe('isClassRef', () => {
+  it('matches the short form', () => {
+    const data = new Uint8Array(2);
+    new DataView(data.buffer).setUint16(0, 0x8000 | 278, true);
+    expect(isClassRef(data, 0, 278)).toBe(true);
+    expect(isClassRef(data, 0, 279)).toBe(false);
+  });
+
+  it('matches the big-tag escape', () => {
+    // slot 65712 does not fit in 0x8000|slot: MFC writes 0x7fff + u32
+    const data = new Uint8Array(6);
+    const view = new DataView(data.buffer);
+    view.setUint16(0, 0x7fff, true);
+    view.setUint32(2, (0x80000000 | 65712) >>> 0, true);
+    expect(isClassRef(data, 0, 65712)).toBe(true);
+    expect(isClassRef(data, 0, 65713)).toBe(false);
+  });
+
+  it('never matches a big slot via the truncated short form', () => {
+    // the pre-fix scanner compared a u16 read against 0x8000|65712, which
+    // cannot fit in 16 bits - the truncated value must not match
+    const data = new Uint8Array(2);
+    new DataView(data.buffer).setUint16(0, (0x8000 | 65712) & 0xffff, true);
+    expect(isClassRef(data, 0, 65712)).toBe(false);
+  });
+
+  it('rejects truncated data', () => {
+    const data = new Uint8Array([0xff, 0x7f, 0xb0]);
+    expect(isClassRef(data, 0, 65712)).toBe(false);
+  });
+});


### PR DESCRIPTION
Ports the fix from #39 (Python) / #42 (.NET) to the TypeScript legacy walker — this is the same bug the original TS report on #28 found, but it never actually landed here in TS; only Python got fixed. Same root cause, same fix.

## The bug

The definition-tail scanner only tested the short class-ref form:

```ts
if (view.getUint16(p, true) === (0x8000 | thumbSlot)) { ... }
```

Once the `CThumbnail` class slot passes `0x7fff`, `0x8000 | slot` cannot fit in 16 bits, the comparison is dead code, and every definition tail throws `"thumbnail not found"` — while `readObject` had decoded the big-tag escape (`0x7fff` + u32 of `0x80000000 | slot`) all along.

`CThumbnail`'s slot is the raw global object-slot number where its class was first registered — not a count of distinct class *types* — so any file where the first `CThumbnail` happens to be encountered after ~32,767 other objects have already been allocated hits this, independent of file size.

## The fix

Both encodings now live in one helper, `isClassRef`, mirroring `readObject` exactly (matches Python's `_is_class_ref` in #39). Unit tests cover the short form, the escape form, the truncated-data edge, and the specific pre-fix failure (a big slot must never match the truncated 16-bit comparison).

## Verification

- Swept 9 of the same 11 real production files used for prior regression testing (1.2 MB–109 MB): all parse identically before/after, zero regressions. The 2 #38 repro files correctly still fail with their original symptoms in this isolated build (they need the separate #38/#40 schema-gate fix, not this one).
- Full `vitest` suite: 39 passed (35 existing + 4 new).

Credit to @thomazyujibaba for the original TS report/repro (#28) and @tuxiasumari for confirming and porting to Python (#39).
