### PR TITLE
fix(dart): recognise big-tag CThumbnail class-refs in the definition-tail scan (ports #28)

### DIFF
--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -78,6 +78,19 @@ bool _matchesAscii(Uint8List data, int offset, String str) {
   return true;
 }
 
+/// True when the bytes at [p] are an MFC class-ref to class [slot]. Mirrors
+/// both encodings Archive.readObject decodes: the short 16-bit form
+/// (0x8000|slot) and, for slots past 0x7FFF, the big-tag escape (0x7FFF
+/// followed by a u32 of 0x80000000|slot).
+bool isClassRef(Uint8List data, int p, int slot) {
+  if (slot <= 0x7FFF) {
+    return p + 2 <= data.length && Tlv.readU16(data, p) == (0x8000 | slot);
+  }
+  return p + 6 <= data.length &&
+      Tlv.readU16(data, p) == 0x7FFF &&
+      Tlv.readU32(data, p + 2) == (0x80000000 | slot);
+}
+
 /// Byte cursor, matching Python's _R.
 class LR {
   final Uint8List data;
@@ -853,6 +866,7 @@ class LegacyReaders {
     r.u32();
 
     int? tpos;
+    final thumbSlot = ar.classSlot['CThumbnail'];
     for (int off = 0; off < 96; off++) {
       final p = r.pos + off;
       if (p + 16 <= r.data.length &&
@@ -864,13 +878,9 @@ class LegacyReaders {
         tpos = p;
         break;
       }
-      final thumbSlot = ar.classSlot['CThumbnail'];
-      if (thumbSlot != null) {
-        if (p + 2 <= r.data.length &&
-            Tlv.readU16(r.data, p) == (0x8000 | thumbSlot)) {
-          tpos = p;
-          break;
-        }
+      if (thumbSlot != null && isClassRef(r.data, p, thumbSlot)) {
+        tpos = p;
+        break;
       }
     }
     if (tpos == null) {

--- a/packages/dart/test/legacy_classref_test.dart
+++ b/packages/dart/test/legacy_classref_test.dart
@@ -1,0 +1,44 @@
+import 'dart:typed_data';
+
+import 'package:openskp/src/legacy.dart';
+import 'package:test/test.dart';
+
+/// Both MFC class-ref encodings the definition-tail scanner must match.
+/// Mirrors packages/python/tests/test_parser.py::TestLegacyClassRef
+/// (openskp#28 / #39): once a class slot passes 0x7FFF the short 16-bit
+/// form 0x8000|slot can't fit, so MFC escalates to the big-tag escape
+/// (0x7FFF followed by a u32 of 0x80000000|slot).
+void main() {
+  group('isClassRef', () {
+    test('matches the short form', () {
+      final data = Uint8List(2);
+      ByteData.sublistView(data).setUint16(0, 0x8000 | 278, Endian.little);
+      expect(isClassRef(data, 0, 278), isTrue);
+      expect(isClassRef(data, 0, 279), isFalse);
+    });
+
+    test('matches the big-tag escape', () {
+      // slot 65712 does not fit in 0x8000|slot: MFC writes 0x7FFF + u32
+      final data = Uint8List(6);
+      final view = ByteData.sublistView(data);
+      view.setUint16(0, 0x7FFF, Endian.little);
+      view.setUint32(2, 0x80000000 | 65712, Endian.little);
+      expect(isClassRef(data, 0, 65712), isTrue);
+      expect(isClassRef(data, 0, 65713), isFalse);
+    });
+
+    test('never matches a big slot via the truncated short form', () {
+      // the pre-fix scanner compared a u16 read against 0x8000|65712, which
+      // cannot fit in 16 bits - the truncated value must not match
+      final data = Uint8List(2);
+      ByteData.sublistView(data)
+          .setUint16(0, (0x8000 | 65712) & 0xFFFF, Endian.little);
+      expect(isClassRef(data, 0, 65712), isFalse);
+    });
+
+    test('rejects truncated data', () {
+      final data = Uint8List.fromList([0xFF, 0x7F, 0xB0]);
+      expect(isClassRef(data, 0, 65712), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Ports the fix from #39 (Python) / #42 (.NET) / #45 (TypeScript) to the Dart legacy walker. Same root cause, same fix, different language.

## The bug

The definition-tail scanner only tested the short class-ref form:

```dart
if (thumbSlot != null && Tlv.readU16(r.data, p) == (0x8000 | thumbSlot)) { ... }
```

Once the `CThumbnail` class slot passes `0x7FFF`, `0x8000 | slot` cannot fit in 16 bits, the comparison is dead code, and every definition tail throws `"thumbnail not found"` — while `readObject` had decoded the big-tag escape (`0x7FFF` + u32 of `0x80000000 | slot`) all along.

`CThumbnail`'s slot is the raw global object-slot number where its class was first registered — not a count of distinct class *types* — so any file where the first `CThumbnail` happens to be encountered after ~32,767 other objects have already been allocated hits this, independent of file size.

## The fix

Both encodings now live in one helper, `isClassRef`, mirroring `readObject` exactly (matches Python's `_is_class_ref` in #39). Unit tests cover the short form, the escape form, the truncated-data edge, and the specific pre-fix failure (a big slot must never match the truncated 16-bit comparison).

## Verification

- Swept 9 of the same 11 real production files used for prior regression testing (1.2 MB–109 MB): all parse identically before/after, zero regressions. The 2 #38 repro files correctly still fail with their original symptoms in this isolated build (they need the separate #38/#40 schema-gate fix, not this one).
- Full `dart test` suite: 19 passed (15 existing + 4 new).

Credit to @thomazyujibaba for the original TS report/repro (#28) and @tuxiasumari for confirming and porting to Python (#39).
