### PR TITLE
fix(cpp): SketchUp 2013 instances have no trailing GUID — fixes both crashes in #38

### DIFF
--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -475,7 +475,18 @@ struct Archive {
       v->def = std::get<0>(q);
       v->xf = r.f64s(13);
       v->name = r.utf16();
-      r.raw(16);
+      // The trailing instance GUID arrives with CComponentInstance schema 5 /
+      // CGroup schema 1; SketchUp 2013 writes CComponentInstance schema 4,
+      // whose record ends at the name (see openskp#38 / #40). A schema of 0
+      // means the class slot was only ever learned from an `expect` hint
+      // (new_class_ref's premodel fallback), not a real 0xffff registration
+      // - treat that the same as "unknown" and keep today's default of
+      // reading the GUID, matching the other ports' schema==null handling.
+      int min_schema = n == "CGroup" ? 1 : 5;
+      auto cs = class_slot.find(n);
+      int schema = cs != class_slot.end() ? slots[cs->second].schema : 0;
+      bool has_guid = schema == 0 || schema >= min_schema;
+      if (has_guid) r.raw(16);
     } else
       throw std::runtime_error("no legacy reader for " + n);
     return v;


### PR DESCRIPTION
Ports the schema-gated fix from #40 (Python) / #41 (.NET) / #43 (TS) / #44 (Dart) to the C++ legacy walker. Same root cause, same fix, different language.

## ⚠️ Not locally verified

Unlike the other four ports, **this build was not compiled or tested locally** — this environment has no `cmake`, no C++ compiler (`g++`/`clang`/MSVC), and no Visual Studio install available. The diff is small and was reviewed carefully by hand against `Archive`'s exact tag-dispatch/registration semantics, and mirrors the already-verified C#/TS/Dart ports field-for-field, but please build and run the existing C++ test suite locally (or confirm CI is green) before merging.

## The bug

`CComponentInstance`/`CGroup` unconditionally read (and discard) a 16-byte trailing GUID after the instance name:

```cpp
v->xf = r.f64s(13);
v->name = r.utf16();
r.raw(16);
```

That field only exists from **`CComponentInstance` schema 5** (and `CGroup` schema 1) on. **SketchUp 2013 writes `CComponentInstance` schema 4**, whose record ends at the name. On 2013-era files every in-definition instance overruns the stream by exactly 16 bytes.

Credit to @tuxiasumari for root-causing this in #38 / #40.

## The fix

`Archive::Entry` already stored each class's registration schema (`Entry::schema`); this consults it via `class_slot` before deciding whether to consume the trailing 16 bytes, keyed on the class name `n` — which is already directly available as `read()`'s own parameter, so no separate "current class" tracking is needed here (unlike the other ports, which had to add that).

One extra subtlety handled explicitly: `new_class_ref`'s "learned from an `expect` hint" fallback path (for premodel-only class refs) defaults `schema` to `0`, which is not a real registration. That's treated the same as "unknown" — keeping today's default of reading the GUID — matching the other ports' `schema == null` handling.

## Verification

Manual code review only (see note above). No dedicated unit test was added for the schema logic itself, matching #40's own precedent (the Python schema-gate fix also shipped without one, relying on corpus-level verification that isn't reproducible here without a working toolchain).
