### PR TITLE
fix(cpp): recognise big-tag CThumbnail class-refs in the definition-tail scan (ports #28)

### DIFF
--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -129,6 +129,18 @@ struct Entry {
   std::shared_ptr<V> v;
 };
 
+// True when the bytes at p are an MFC class-ref to class `slot`. Mirrors both
+// encodings Archive::object() decodes: the short 16-bit form (0x8000|slot)
+// and, for slots past 0x7fff, the big-tag escape (0x7fff followed by a u32
+// of 0x80000000|slot).
+bool is_class_ref(const ByteBuffer& d, size_t p, uint64_t slot) {
+  if (slot <= 0x7fff) {
+    return p + 2 <= d.size() && read_u16(d, p) == (0x8000 | slot);
+  }
+  return p + 6 <= d.size() && read_u16(d, p) == 0x7fff &&
+         read_u32(d, p + 2) == (0x80000000u | uint32_t(slot));
+}
+
 struct Archive {
   R r;
   int ver;
@@ -450,6 +462,7 @@ struct Archive {
       r.utf16();
       r.u32();
       size_t tpos = std::string::npos;
+      auto thumb_cs = class_slot.find("CThumbnail");
       for (size_t off = 0; off < 96 && r.p + off + 26 <= r.d.size(); ++off) {
         auto p = r.p + off;
         if (r.d[p] == 255 && r.d[p + 1] == 255 && r.d[p + 4] == 10 && r.d[p + 5] == 0 &&
@@ -457,8 +470,7 @@ struct Archive {
           tpos = p;
           break;
         }
-        auto cs = class_slot.find("CThumbnail");
-        if (cs != class_slot.end() && read_u16(r.d, p) == (0x8000 | cs->second)) {
+        if (thumb_cs != class_slot.end() && is_class_ref(r.d, p, thumb_cs->second)) {
           tpos = p;
           break;
         }


### PR DESCRIPTION
Ports the fix from #39 (Python) / #42 (.NET) / #45 (TS) / #46 (Dart) to the C++ legacy walker. Same root cause, same fix, different language.

## ⚠️ Not locally verified

Unlike the other four ports, **this build was not compiled or tested locally** — this environment has no `cmake`, no C++ compiler (`g++`/`clang`/MSVC), and no Visual Studio install available. The diff is small and was reviewed carefully by hand, mirroring the already-verified C#/TS/Dart ports field-for-field, but please build and run the existing C++ test suite locally (or confirm CI is green) before merging.

## The bug

The definition-tail scanner only tested the short class-ref form:

```cpp
auto cs = class_slot.find("CThumbnail");
if (cs != class_slot.end() && read_u16(r.d, p) == (0x8000 | cs->second)) { ... }
```

Once the `CThumbnail` class slot passes `0x7fff`, `0x8000 | slot` cannot fit in 16 bits, the comparison is dead code, and every definition tail fails — while `Archive::object()` had decoded the big-tag escape (`0x7fff` + u32 of `0x80000000 | slot`) all along.

`CThumbnail`'s slot is the raw global object-slot number where its class was first registered — not a count of distinct class *types* — so any file where the first `CThumbnail` happens to be encountered after ~32,767 other objects have already been allocated hits this, independent of file size.

## The fix

Both encodings now live in one free function, `is_class_ref`, mirroring `Archive::object()` exactly (matches Python's `_is_class_ref` in #39).

`is_class_ref` lives in `legacy.cpp`'s anonymous namespace (internal linkage), matching the existing helper style already in that scope — it isn't reachable from a separate test translation unit the way the other ports' equivalents are, so no dedicated unit test was added here, matching #40's own precedent (the schema-gate fix also shipped without one).

## Verification

Manual code review only (see note above).
