### PR TITLE
fix(cpp): SketchUp 2013 instances have no trailing GUID

### DIFF
--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -105,6 +105,7 @@ std::vector<std::pair<std::string, ByteBuffer>> parse_flat(const ByteBuffer&);
 std::string extract_version(const ByteBuffer&);
 bool valid_header(const ByteBuffer&);
 bool is_legacy(const ByteBuffer&);
+bool legacy_instance_has_guid(const std::string&, std::optional<int>);
 RawParsed full_parse(const ByteBuffer&, const ParseOptions&);
 RawParsed parse_legacy(const ByteBuffer&, const ParseOptions&);
 void collect_geometry(const std::vector<TlvNode>&, GeometryBuilder&);

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -6,6 +6,11 @@
 #include "internal.hpp"
 
 namespace openskp {
+bool legacy_instance_has_guid(const std::string& class_name, std::optional<int> schema) {
+  if (!schema) return true;
+  return *schema >= (class_name == "CGroup" ? 1 : 5);
+}
+
 namespace {
 struct R {
   const ByteBuffer& d;
@@ -151,6 +156,7 @@ struct Archive {
   bool in_entity_list{};
   std::unordered_map<uint64_t, Entry> slots;
   std::unordered_map<std::string, uint64_t> class_slot;
+  std::unordered_map<std::string, int> class_schema;
 
   Archive(const ByteBuffer& d, int v) : r{d}, ver(v), pid(v >= 17) {}
 
@@ -177,6 +183,7 @@ struct Archive {
       std::string name(b.begin(), b.end());
       auto cs = alloc({true, name, int(schema), {}});
       class_slot[name] = cs;
+      class_schema[name] = int(schema);
       return new_obj(name);
     }
     if (tag & 0x8000) return new_class_ref(tag & 0x7fff, expect);
@@ -487,18 +494,13 @@ struct Archive {
       v->def = std::get<0>(q);
       v->xf = r.f64s(13);
       v->name = r.utf16();
-      // The trailing instance GUID arrives with CComponentInstance schema 5 /
-      // CGroup schema 1; SketchUp 2013 writes CComponentInstance schema 4,
-      // whose record ends at the name (see openskp#38 / #40). A schema of 0
-      // means the class slot was only ever learned from an `expect` hint
-      // (new_class_ref's premodel fallback), not a real 0xffff registration
-      // - treat that the same as "unknown" and keep today's default of
-      // reading the GUID, matching the other ports' schema==null handling.
-      int min_schema = n == "CGroup" ? 1 : 5;
-      auto cs = class_slot.find(n);
-      int schema = cs != class_slot.end() ? slots[cs->second].schema : 0;
-      bool has_guid = schema == 0 || schema >= min_schema;
-      if (has_guid) r.raw(16);
+      // The trailing GUID was introduced in CComponentInstance schema 5 and
+      // CGroup schema 1. SketchUp 2013 writes component-instance schema 4,
+      // whose record ends at the name.
+      auto schema = class_schema.find(n);
+      std::optional<int> schema_number;
+      if (schema != class_schema.end()) schema_number = schema->second;
+      if (legacy_instance_has_guid(n, schema_number)) r.raw(16);
     } else
       throw std::runtime_error("no legacy reader for " + n);
     return v;

--- a/packages/cpp/tests/lowlevel_test.cpp
+++ b/packages/cpp/tests/lowlevel_test.cpp
@@ -44,6 +44,14 @@ TEST(Legacy, DetectsClassicContainer) {
   EXPECT_FALSE(is_legacy(test::read_fixture("Untitled.skp")));
 }
 
+TEST(Legacy, GatesInstanceGuidByClassSchema) {
+  EXPECT_FALSE(legacy_instance_has_guid("CComponentInstance", 4));
+  EXPECT_TRUE(legacy_instance_has_guid("CComponentInstance", 5));
+  EXPECT_FALSE(legacy_instance_has_guid("CGroup", 0));
+  EXPECT_TRUE(legacy_instance_has_guid("CGroup", 1));
+  EXPECT_TRUE(legacy_instance_has_guid("CComponentInstance", std::nullopt));
+}
+
 TEST(Transforms, Composition) {
   std::vector<double> a{1, 0, 0, 0, 1, 0, 0, 0, 1, 2, 3, 4, 1};
   std::vector<double> b{1, 0, 0, 0, 1, 0, 0, 0, 1, 5, 6, 7, 1};


### PR DESCRIPTION
## Summary
Fix the C++ legacy walker for the SketchUp 2013 instance layout identified in #38 and fixed for Python in #40.

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] New platform implementation

## Changes
- retain each MFC class schema while walking the legacy archive
- read the trailing GUID only for `CComponentInstance` schema 5+ and `CGroup` schema 1+
- preserve the existing GUID read for unknown schemas
- add regression coverage for both schema boundaries and unknown-schema behavior

## Validation
Both files attached to #38 now parse with finite geometry and match the Python fix results:

- `TestSketchup2013.skp`: 3 definitions, 69 faces, 1,617 vertices
- `TestSketchup8.skp`: 15 definitions, 39,274 faces, 26,286 vertices

Local CI-equivalent checks:

- GCC Release build: 44/44 tests passed
- Clang Release build: 44/44 tests passed
- install and downstream consumer builds passed with GCC and Clang
- ASan + UBSan Debug build: 44/44 tests passed
- `openskp-format-check` passed
- `git diff --check` passed

## Checklist
- [x] Code follows the project style guidelines
- [x] Tests pass locally
- [x] Documentation updated (not applicable)
- [x] No breaking changes to the public API