### PR TITLE
ci: add real test workflows for .NET and Dart

### DIFF
--- a/.github/workflows/ci-dart.yml
+++ b/.github/workflows/ci-dart.yml
@@ -1,0 +1,37 @@
+name: Dart CI
+
+on:
+  push:
+    branches: [main]
+    paths: ['packages/dart/**']
+  pull_request:
+    branches: [main]
+    paths: ['packages/dart/**']
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Install dependencies
+        run: |
+          cd packages/dart
+          dart pub get
+
+      - name: Analyze
+        run: |
+          cd packages/dart
+          dart analyze --fatal-infos
+
+      - name: Test
+        run: |
+          cd packages/dart
+          dart test

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -1,0 +1,33 @@
+name: .NET CI
+
+on:
+  push:
+    branches: [main]
+    paths: ['packages/dotnet/**']
+  pull_request:
+    branches: [main]
+    paths: ['packages/dotnet/**']
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0'
+
+      - name: Restore
+        run: dotnet restore packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj
+
+      - name: Build
+        run: dotnet build packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj --no-build --configuration Release


### PR DESCRIPTION
Neither language had any automated verification on push/PR:

- **.NET** only had `release-nuget.yml`, which builds/packs on every push but never runs the `OpenSkp.Tests` suite.
- **Dart** had nothing at all — `release-dart.yml` only verifies package structure and publishes on a version tag; it never runs `dart test` or `dart analyze`, on any trigger.

Both new workflows mirror `ci-python.yml`'s cross-platform matrix (ubuntu/windows/macos) and only trigger on changes under their own package directory, matching `ci-typescript.yml`/`ci-python.yml`'s path-filtered pattern.

Verified locally before committing:
- `dotnet restore`/`build`/`test` → 20/20 passing
- `dart pub get`/`analyze --fatal-infos`/`test` → 19/19 passing, 0 analyzer issues

This PR itself will be the first real test of both workflows — check the Actions tab once it's opened.