### PR TITLE
ci: add workflow_dispatch to the new .NET/Dart CI workflows

### DIFF
--- a/.github/workflows/ci-dart.yml
+++ b/.github/workflows/ci-dart.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [main]
     paths: ['packages/dart/**']
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [main]
     paths: ['packages/dotnet/**']
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Lets these be re-run manually from the Actions tab (or via `gh workflow run`) without needing a matching push/PR — useful for verifying a workflow itself works, and for re-running after an unrelated infrastructure fix without touching package code.