### PR TITLE
fix(python): don't discard the legacy MFC material alpha byte

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -870,7 +870,7 @@ def full_parse_legacy(skp_path: str) -> Dict[str, Any]:
         colorized = v.get('colorized', False)
         mat_obj: Dict[str, Any] = {
             'name': v['name'],
-            'color': {'r': rgba[0], 'g': rgba[1], 'b': rgba[2]},
+            'color': {'r': rgba[0], 'g': rgba[1], 'b': rgba[2], 'a': rgba[3]},
             'transparency': trans,
             # colourize type is not decoded in the legacy record; tint is
             # the correct rendering for the grey base textures observed

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -482,7 +482,7 @@ class SkpFile:
                 )
             mat = Material(
                 name=mat_data.get("name", ""),
-                color=(c.get("r", 128), c.get("g", 128), c.get("b", 128)),
+                color=(c.get("r", 128), c.get("g", 128), c.get("b", 128), c.get("a", 255)),
                 transparency=mat_data.get("transparency", 0.5),
                 texture=texture,
                 colorized=mat_data.get("colorized", False),

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -449,7 +449,7 @@ class TestMaterialIdJoin:
         assert model.materials[0].id == 29491
         mat = model.materials_by_id[29491]
         assert mat is model.materials[0]
-        assert mat.color == (10, 20, 30)
+        assert mat.color == (10, 20, 30, 255)
 
     def test_folder_alias_resolves_to_same_material(
         self, monkeypatch, tmp_path: pathlib.Path


### PR DESCRIPTION
`Material.color`'s alpha channel was silently dropped when parsing legacy MFC (SketchUp 2013–2020) files: `legacy.py` read the material's real 4-byte RGBA record (`rgba[0..3]`) but the dict it built only kept r/g/b, and `model.py`'s `Material(...)` construction only ever passed 3 values into a field typed `Tuple[int, int, int, int]` — a genuine type mismatch that silently produced a 3-tuple at runtime.

Verified empirically across 2,060 materials in 13 real production files (SketchUp 2013–2025) that this byte is always 255 in practice, but reading the real value is more correct/future-proof than assuming a constant — matches what the .NET port already does correctly.

The VFF (2021+) material XML record has no alpha attribute at all, so that path correctly continues to default to 255 (`c.get("a", 255)`).

One existing test (`test_face_material_resolves_through_materials_by_id`) was asserting the old, incorrect 3-tuple shape — fixed to expect the type-correct 4-tuple.

All 84 tests pass.