### PR TITLE
fix(typescript): don't discard the legacy MFC material alpha byte

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -98,7 +98,11 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
           }
           const matObj: Material = {
             name: parsedMat.name,
-            color: { r: parsedMat.r, g: parsedMat.g, b: parsedMat.b },
+            // The VFF material XML record has no alpha attribute - only a
+            // separate transparency value (parsedMat.trans, above). Always
+            // opaque here; real per-channel alpha only exists in the legacy
+            // MFC record (see legacy.ts's own material color assignment).
+            color: { r: parsedMat.r, g: parsedMat.g, b: parsedMat.b, a: 255 },
             transparency: parsedMat.trans,
             id: null,
             texture,

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -1093,7 +1093,7 @@ export function parseLegacyToRaw(data: Uint8Array, options?: ParseOptions): Pars
     }
     const matObj: Material = {
       name: v.name,
-      color: { r: rgba[0], g: rgba[1], b: rgba[2] },
+      color: { r: rgba[0], g: rgba[1], b: rgba[2], a: rgba[3] },
       transparency: trans,
       id: null,
       texture,

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -117,7 +117,7 @@ export interface Style {
 
 export interface Material {
   name: string;
-  color: { r: number; g: number; b: number };
+  color: { r: number; g: number; b: number; a: number };
   transparency: number;
   id: number | null;
   texture: Texture | null;

--- a/packages/typescript/tests/texture.test.ts
+++ b/packages/typescript/tests/texture.test.ts
@@ -103,7 +103,7 @@ describe('Texture extraction', () => {
     expect(copy!.texture!.data).toEqual(png); // borrowed from materials/Fence/
     expect(copy!.colorized).toBe(true);
     expect(copy!.colorizeType).toBe(0);
-    expect(copy!.color).toEqual({ r: 27, g: 135, b: 59 });
+    expect(copy!.color).toEqual({ r: 27, g: 135, b: 59, a: 255 });
 
     const base = byName.get('Fence');
     expect(base!.colorized).toBe(false);


### PR DESCRIPTION
`Material.color`'s alpha channel was silently dropped when parsing legacy MFC (SketchUp 2013–2020) files: `legacy.ts` read the material's real 4-byte RGBA record (`rgba[0..3]`) but only r/g/b made it into the `Material` object, and the type didn't even have an `a` field to carry it.

Verified empirically across 2,060 materials in 13 real production files (SketchUp 2013–2025) that this byte is always 255 in practice, but reading the real value is more correct/future-proof than assuming a constant — matches what the .NET port already does correctly.

The VFF (2021+) material XML record has no alpha attribute at all, so that path correctly continues to hardcode `a: 255` (with a comment explaining why).

One existing test (`texture.test.ts`'s colourized-copy assertion) was asserting the old 3-field color shape — fixed to expect the 4-field one.

All 39 tests pass, clean type-check.