### PR TITLE
fix(dart): don't discard the legacy MFC material alpha byte

### DIFF
--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -49,7 +49,7 @@ class RawTexture {
 
 class RawMaterial {
   String name;
-  int r, g, b;
+  int r, g, b, a;
   double transparency;
   bool colorized;
   int colorizeType;
@@ -59,6 +59,7 @@ class RawMaterial {
     this.r = 128,
     this.g = 128,
     this.b = 128,
+    this.a = 255,
     this.transparency = 1.0,
     this.colorized = false,
     this.colorizeType = 0,

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -1242,6 +1242,7 @@ class Legacy {
         r: rgba[0],
         g: rgba[1],
         b: rgba[2],
+        a: rgba[3],
         transparency: trans,
         colorized: colorized,
         // colourize type is not decoded in the legacy record; tint (1) is

--- a/packages/dart/lib/src/parser.dart
+++ b/packages/dart/lib/src/parser.dart
@@ -87,7 +87,7 @@ class SkpFile {
       }
       final mat = Material(
         name: rawMat.name,
-        color: (rawMat.r, rawMat.g, rawMat.b, 255),
+        color: (rawMat.r, rawMat.g, rawMat.b, rawMat.a),
         transparency: rawMat.transparency,
         texture: texture,
         colorized: rawMat.colorized,


### PR DESCRIPTION
`Material.color`'s alpha channel was silently dropped when parsing legacy MFC (SketchUp 2013–2020) files: `legacy.dart` read the material's real 4-byte RGBA record (`rgba[0..3]`) but the intermediate `RawMaterial` DTO had no `a` field to carry it, and `parser.dart`'s final `Material` construction hardcoded alpha to 255 regardless of what was actually read.

Verified empirically across 2,060 materials in 13 real production files (SketchUp 2013–2025) that this byte is always 255 in practice, but reading the real value is more correct/future-proof than assuming a constant — matches what the .NET port already does correctly.

The VFF (2021+) material XML path (`parseMaterialXml`) never sets `a`, so it correctly continues to fall through to `RawMaterial`'s own default (255) — there's no real alpha data in that record shape.

`dart analyze`: clean. All 19 tests pass.