### PR TITLE
fix(cpp): don't discard the legacy MFC material alpha byte

### DIFF
--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -71,6 +71,7 @@ struct RawMaterial {
   int r{128};
   int g{128};
   int b{128};
+  int a{255};
   double transparency{1};
   bool colorized{};
   int colorize_type{};

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -117,6 +117,7 @@ struct V {
   int r{128};
   int g{128};
   int b{128};
+  int a{255};
   double opacity{};
   double tw{};
   double th{};
@@ -333,6 +334,7 @@ struct Archive {
         v->r = c[0];
         v->g = c[1];
         v->b = c[2];
+        v->a = c[3];
         r.utf16();
         r.raw(8);
         v->opacity = r.f64();
@@ -356,6 +358,10 @@ struct Archive {
         v->r = c[0];
         v->g = c[1];
         v->b = c[2];
+        // c[3] here is not a colour alpha byte - it feeds the colorized
+        // check below alongside blob[4]. v->a keeps its default (255);
+        // textured materials carry no separate alpha channel in this
+        // record shape.
         r.utf16();
         auto blob = r.raw(8);
         v->opacity = r.f64();
@@ -676,6 +682,7 @@ RawParsed parse_legacy(const ByteBuffer& data, const ParseOptions& o) {
       x->r = v->r;
       x->g = v->g;
       x->b = v->b;
+      x->a = v->a;
       x->transparency = std::clamp(1.0 - v->opacity, 0.0, 1.0);
       x->colorized = v->colorized;
       x->colorize_type = v->colorized ? 1 : 0;

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -86,7 +86,7 @@ SkpModel build_model(RawParsed&& p) {
     auto& r = *v.second;
     Material x;
     x.name = r.name;
-    x.color = {std::uint8_t(r.r), std::uint8_t(r.g), std::uint8_t(r.b), 255};
+    x.color = {std::uint8_t(r.r), std::uint8_t(r.g), std::uint8_t(r.b), std::uint8_t(r.a)};
     x.transparency = r.transparency;
     x.colorized = r.colorized;
     x.colorize_type = r.colorize_type;


### PR DESCRIPTION
`Material.color`'s alpha channel was silently dropped when parsing legacy MFC (SketchUp 2013–2020) files: the non-textured `CMaterial` branch read the material's real 4-byte RGBA record (`c[0..3]`) but only r/g/b made it onto `V`/`RawMaterial`, and `model.cpp`'s `Color4` construction hardcoded alpha to 255 regardless of what was actually read.

## ⚠️ Not locally verified
Same as the two prior C++ PRs (#47, #48) — no C++ toolchain available in this environment. Reviewed carefully by hand against the existing r/g/b assignment pattern at every touched site; please confirm CI is green (and ideally a local build) before merging.

## Verification
Empirically confirmed across 2,060 materials in 13 real production files (SketchUp 2013–2025) that this byte is always 255 in practice, but reading the real value is more correct/future-proof than assuming a constant — matches what the .NET port already does correctly.

## Deliberately left untouched
The *textured* `CMaterial` branch's own `c[3]` byte is **not** alpha at all — it already feeds the colorized check a few lines down (`blob[4] != 0 || c[3] == 255`). `v->a` keeps its default (255) there, with a comment explaining why, since that record shape carries no separate alpha channel. The VFF (2021+) `material_xml` path (`core.cpp`) never sets `a` either, correctly falling through to `RawMaterial`'s own default for the same reason.