### PR TITLE
cleanup(python): remove dead SkpModel.scene_hierarchy/mesh_index fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that path correctly continues to default to 255, since there's no real
   data to read there.
 
+### Removed
+
+- **Python**: `SkpModel.scene_hierarchy` and `SkpModel.mesh_index` —
+  dead fields that `parse()` never populated (always empty). Leftover
+  from an earlier design; the real, populated versions of both concepts
+  live on the separate `Scene` class returned by `build_scene()`, which
+  is the pattern this project uses consistently everywhere else (a plain
+  `parse()` stays light; a scene bake is opt-in and heavier). Any code
+  reading these two fields was always seeing an empty list/dict — this
+  removal cannot change observed behavior for a correctly-written
+  caller, only surface a clear `AttributeError` instead of silently
+  succeeding with fake-empty data for one that assumed they were real.
+
 ## [0.3.0] — C++ only — 2026-08-07
 
 ### Added

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import pathlib
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from . import scene
@@ -331,10 +331,14 @@ class SkpModel:
         materials_by_id: Mapping of TLV material ID → :class:`Material`,
             the join table for :attr:`Face.material_id`.  Several IDs may
             alias the same :class:`Material` object.
-        scene_hierarchy: Top-level :class:`Instance` list forming the
-            scene graph.
-        mesh_index: Pre-built index mapping definition IDs to triangulated
-            mesh data for fast export.
+        styles: List of :class:`Style` objects found in the file.
+
+    Note:
+        The resolved, world-space scene graph (with baked instance
+        transforms and a mesh index for fast export) is a separate,
+        heavier computation — see :meth:`SkpFile.build_scene` and the
+        :class:`~openskp.scene.Scene` class it returns, rather than a
+        field on this class. ``parse()`` stays light on purpose.
     """
 
     version: str = "unknown"
@@ -342,9 +346,7 @@ class SkpModel:
     layers: List[Layer] = field(default_factory=list)
     materials: List[Material] = field(default_factory=list)
     materials_by_id: Dict[int, Material] = field(default_factory=dict)
-    scene_hierarchy: List[Instance] = field(default_factory=list)
     styles: List[Style] = field(default_factory=list)
-    mesh_index: Dict[int, Any] = field(default_factory=dict)
 
 
 # ── SkpFile entry-point ──────────────────────────────────────────────────


### PR DESCRIPTION
Both were declared on `SkpModel` but never populated anywhere in the source — always empty. The real, populated versions of both concepts already exist on the separate `Scene` class returned by `build_scene()`, which is the pattern this project uses consistently everywhere else (`parse()` stays light; a scene bake is opt-in). Leftover from an earlier design.

Confirmed via full-repo grep: no assignment to `model.scene_hierarchy` or `model.mesh_index` exists anywhere, and the one stale README-style reference to `model.scene_hierarchy` was only in a gitignored, locally-generated `egg-info` build artifact — the real README already correctly references `scene.scene_hierarchy` (the `Scene` class), not this field.

Also drops the now-unused `Any` import.

Technically a breaking change for anyone directly accessing these two always-empty fields — flagged under a `### Removed` heading in the changelog. Since they were always empty, no correctly-written caller's *observed behavior* changes; a caller that assumed they were real would now get a clear `AttributeError` instead of silently working with fake-empty data.

All 84 tests pass, clean ruff lint.