### PR TITLE
fix(python): give the implicit root model its own field, not a fake dict key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that path correctly continues to default to 255, since there's no real
   data to read there.
 
+### Changed
+
+- **Python**: `SkpModel.definitions` no longer contains an entry keyed by
+  the string `"ROOT"`. The implicit top-level model (the file's directly
+  placed, non-componentized geometry and instances) now has its own
+  dedicated `SkpModel.root` field, matching TypeScript/.NET/Dart/C++'s
+  `root`/`Root` exactly. Previously `definitions` was typed
+  `Dict[int, Definition]` but silently held one non-`int` key at
+  runtime — any code iterating `model.definitions.values()` to sum
+  geometry across the whole file (not just named components) needs to
+  also include `model.root` now, the same way the other four languages'
+  own callers already do. `len(model.definitions)` is now the count of
+  real named component/group definitions only, one lower than before.
+
 ### Removed
 
 - **Python**: `SkpModel.scene_hierarchy` and `SkpModel.mesh_index` —

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -325,7 +325,14 @@ class SkpModel:
 
     Attributes:
         version: SketchUp file-format version number.
-        definitions: Mapping of definition index → :class:`Definition`.
+        definitions: Mapping of definition index → :class:`Definition`,
+            for named component/group definitions only. The implicit
+            top-level model is a separate field — see :attr:`root`.
+        root: The implicit top-level model definition: its ``instances``
+            are the entities placed directly in the model (not inside
+            any component/group), and its ``vertices``/``edges``/``faces``
+            are geometry drawn directly at the top level. Corresponds to
+            TypeScript/.NET/Dart/C++'s ``root``/``Root``.
         layers: List of :class:`Layer` objects found in the file.
         materials: List of :class:`Material` objects found in the file.
         materials_by_id: Mapping of TLV material ID → :class:`Material`,
@@ -343,6 +350,7 @@ class SkpModel:
 
     version: str = "unknown"
     definitions: Dict[int, Definition] = field(default_factory=dict)
+    root: Definition = field(default_factory=Definition)
     layers: List[Layer] = field(default_factory=list)
     materials: List[Material] = field(default_factory=list)
     materials_by_id: Dict[int, Material] = field(default_factory=dict)
@@ -463,7 +471,10 @@ class SkpFile:
                     matrix=inst.get("matrix", []),
                     material_id=inst.get("material_id"),
                 ))
-            model.definitions[def_id] = defn
+            if def_id == "ROOT":
+                model.root = defn
+            else:
+                model.definitions[def_id] = defn
 
         # Convert layers
         for name, (r, g, b) in parsed["layer_colors"].items():

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -1026,9 +1026,12 @@ class TestLegacyRealFile:
     def test_version_and_counts(self) -> None:
         model = self._model()
         assert model.version == "{17.0.18899}"
-        n_faces = sum(len(d.faces) for d in model.definitions.values())
-        n_edges = sum(len(d.edges) for d in model.definitions.values())
-        n_verts = sum(len(d.vertices) for d in model.definitions.values())
+        # root carries its own top-level geometry alongside the named
+        # component definitions - both must be counted for the full totals.
+        all_defs = list(model.definitions.values()) + [model.root]
+        n_faces = sum(len(d.faces) for d in all_defs)
+        n_edges = sum(len(d.edges) for d in all_defs)
+        n_verts = sum(len(d.vertices) for d in all_defs)
         assert n_faces == 181
         assert n_edges == 515
         assert n_verts == 335
@@ -1038,7 +1041,7 @@ class TestLegacyRealFile:
         model = self._model()
         lo = [float("inf")] * 3
         hi = [float("-inf")] * 3
-        for d in model.definitions.values():
+        for d in list(model.definitions.values()) + [model.root]:
             for v in d.vertices.values():
                 for i, c in enumerate((v.x, v.y, v.z)):
                     lo[i] = min(lo[i], c)
@@ -1049,14 +1052,26 @@ class TestLegacyRealFile:
 
     def test_has_instances_and_geometry(self) -> None:
         model = self._model()
-        # 3 definitions (root + 2 components), and the root places instances.
-        assert len(model.definitions) == 3
-        placed = sum(len(d.instances) for d in model.definitions.values())
+        # 2 named component definitions; the implicit root (which places
+        # the instances) is its own separate field, not a 3rd entry here.
+        assert len(model.definitions) == 2
+        all_defs = list(model.definitions.values()) + [model.root]
+        placed = sum(len(d.instances) for d in all_defs)
         assert placed >= 2
         # Every face resolves a real ring of vertices.
-        a_face = next(f for d in model.definitions.values()
+        a_face = next(f for d in all_defs
                       for f in d.faces.values() if f.loops)
         assert len(a_face.loops[0]) >= 3
+
+    def test_root_is_a_separate_field_not_a_definitions_entry(self) -> None:
+        model = self._model()
+        assert model.root.name == "ROOT_MODEL"
+        assert model.root.guid == "ROOT"
+        assert len(model.root.instances) >= 2
+        # The implicit root must never leak into the definitions map under
+        # its internal "ROOT" sentinel key - it has its own field.
+        assert "ROOT" not in model.definitions
+        assert all(isinstance(k, int) for k in model.definitions)
 
 
 # ── Scene baking (opt-in build_scene(), separate from parse()) ──────────


### PR DESCRIPTION
`SkpModel.definitions` was typed `Dict[int, Definition]` but silently held one entry keyed by the string `"ROOT"` — the implicit top-level model (directly placed, non-componentized geometry and instances). Every other language (TypeScript, .NET, Dart, C++) already exposes this as its own dedicated `root`/`Root` field, kept separate from the numeric-ID definitions map; Python was the only one smuggling it into the same dict under a non-int key.

Adds `SkpModel.root: Definition`, matching the other four languages exactly. `parse()` now routes the `"ROOT"` entry there instead of into `definitions`.

## Breaking change (narrow)

`model.definitions` no longer contains a `"ROOT"` entry, and `len(model.definitions)` drops by one. Any code aggregating geometry across the whole file (not just named components) needs to also include `model.root` now — exactly what the other four languages' own callers already do.

Updated the three `TestLegacyRealFile` tests that were relying on the old count/aggregate behavior, and added a new dedicated test (`test_root_is_a_separate_field_not_a_definitions_entry`) confirming `"ROOT"` never leaks into `definitions` and every remaining key is a real `int`.

All 85 tests pass, clean ruff lint on the touched source file.