### PR TITLE
feat(python): bootstrap the legacy slot base for single- and zero-material files

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -647,27 +647,49 @@ def _walk(data: bytes):
     if not ver_m:
         raise LegacyParseError("no version string in header")
     ver = int(ver_m.group(1))
-    ar = _Archive(data, ver)
-    ar.readers.update(_READERS)
-    r = ar.r
-
     # anchor: the material manager (u32 count right before the first
-    # CMaterial new-class record)
+    # CMaterial new-class record); zero-material files have no CMaterial
+    # record anywhere, so fall back to the first CLayer class record and
+    # start at the layer-list marker just before it
     m = re.search(re.escape(b'\xff\xff') + b'..'
                   + re.escape(struct.pack('<H', 9) + b'CMaterial'),
                   data, re.DOTALL)
-    if not m:
-        raise LegacyParseError("no CMaterial class record found")
-    mat_hdr = m.start()
-    mat_count = struct.unpack_from('<I', data, mat_hdr - 4)[0]
-    if mat_count > 100000:
-        raise LegacyParseError("implausible material count")
+    if m:
+        start = m.start()
+        mat_count = struct.unpack_from('<I', data, start - 4)[0]
+        if mat_count > 100000:
+            raise LegacyParseError("implausible material count")
+    else:
+        lm = re.search(re.escape(b'\xff\xff') + b'..'
+                       + re.escape(struct.pack('<H', 6) + b'CLayer'),
+                       data, re.DOTALL)
+        if not lm:
+            raise LegacyParseError("no CMaterial or CLayer class record found")
+        mat_count = 0
+        start = lm.start() - (9 if ver >= 17 else 8)
 
-    # bootstrap the absolute slot base: parse material 1 with a throwaway
-    # archive; material 2's class-ref tag names CMaterial's true slot
-    if mat_count < 2:
-        raise LegacyParseError(
-            "single-material bootstrap not implemented for this file")
+    if mat_count >= 2:
+        bases = [_bootstrap_two_materials(data, ver, start)]
+    else:
+        # single-material / no-material files: derive the base from the
+        # definition-list anchor, a back-ref to the ACTIVE layer object
+        bases = _probe_layer_anchor_bases(data, ver, start, mat_count)
+
+    last_exc = None
+    for base in bases:
+        try:
+            return _walk_model(data, ver, start, mat_count, base)
+        except (LegacyParseError, struct.error, IndexError,
+                UnicodeDecodeError) as exc:
+            last_exc = exc
+    if last_exc is not None:
+        raise last_exc
+    raise LegacyParseError("no viable slot base candidate")
+
+
+def _bootstrap_two_materials(data: bytes, ver: int, mat_hdr: int) -> int:
+    """Parse material 1 with a throwaway archive; material 2's class-ref
+    tag names CMaterial's true absolute slot."""
     boot = _Archive(data, ver)
     boot.readers.update(_READERS)
     boot.next_slot = 1 << 20
@@ -677,11 +699,57 @@ def _walk(data: bytes):
     tag = boot.r.peek_u16()
     if tag == 0xFFFF or not (tag & 0x8000):
         raise LegacyParseError("cannot bootstrap the slot base")
-    ar.next_slot = tag & 0x7FFF
-    ar.walk_base = ar.next_slot
+    return tag & 0x7FFF
+
+
+def _probe_layer_anchor_bases(data: bytes, ver: int, start: int,
+                              mat_count: int):
+    """Slot-base candidates for files where the two-material trick is
+    unavailable.
+
+    Parse the model prefix (materials, layer list) with a throwaway base;
+    the object right after the layer list is the definition-list anchor —
+    an ABSOLUTE back-ref to the active layer, an object we just allocated
+    relatively.  Each walked layer yields one candidate base; with a single
+    layer (the common case) the answer is exact.
+    """
+    boot = _Archive(data, ver)
+    boot.readers.update(_READERS)
+    b0 = 1 << 20
+    boot.next_slot = b0
+    boot.walk_base = b0
+    boot.r.pos = start
+    for _ in range(mat_count):
+        boot.read_object(boot.r, expect='CMaterial')
+    boot.r.u32()
+    if ver >= 17:
+        boot.r.u8()
+    layer_count = boot.r.u32()
+    if not 1 <= layer_count <= 100000:
+        raise LegacyParseError("implausible layer count in base probe")
+    layer_slots = []
+    for _ in range(layer_count):
+        s, _, _ = boot.read_object(boot.r, expect='CLayer')
+        layer_slots.append(s)
+    s, n, _ = boot.read_object(boot.r)
+    if n != 'premodel':
+        # under the throwaway base every absolute back-ref classifies as
+        # premodel; anything else means the prefix did not parse
+        raise LegacyParseError(f"base probe: anchor resolved to {n}")
+    return [s - (rel - b0) for rel in layer_slots
+            if 0 < s - (rel - b0) < b0]
+
+
+def _walk_model(data: bytes, ver: int, start: int, mat_count: int,
+                base: int):
+    ar = _Archive(data, ver)
+    ar.readers.update(_READERS)
+    ar.next_slot = base
+    ar.walk_base = base
+    r = ar.r
 
     # material manager
-    r.pos = mat_hdr
+    r.pos = start
     materials = []
     for _ in range(mat_count):
         s, _, v = ar.read_object(r, expect='CMaterial')


### PR DESCRIPTION
The legacy walker could only learn the absolute MFC slot base from files with **two or more materials** — material 2's class-ref names `CMaterial`'s true slot. Every other file raised `single-material bootstrap not implemented` (or `no CMaterial class record found` when the file has no materials at all). That is not an exotic case: it covers every template-fresh SketchUp drawing, and 37 of the 62 files in the independent Rust implementation's corpus fail on it today.

## The idea

The file itself names the base a few objects later. Right after the layer list comes the definition-list anchor: an **absolute** back-ref to the active layer — an object the walker just allocated **relatively**. So:

1. Parse the model prefix (materials, layer list) under a throwaway base.
2. Read the anchor's absolute tag `T`.
3. Each walked layer at relative slot `R` yields the candidate base `T − (R − B0)`; with a single layer (the common case) the answer is exact, and with several the full walk is simply retried per candidate.

Zero-material files additionally have no `CMaterial` record to anchor the walk on, so it now falls back to the first `CLayer` class record and starts at the layer-list marker just before it.

The two-material path is untouched and still preferred — and it doubles as the correctness oracle: on the 24 multi-material corpus files, the probe agrees with it **24 / 24**.

## Verification

- All 37 previously-failing corpus files parse, and the corpus names are the spec: `blank-template-box` → exactly 6 faces / 12 edges / 8 vertices; `curve` → 171 edges, 0 faces; `layers` → its 4 layers, through the multi-candidate path; `nested-3-deep` → 4 definitions.
- Wireframe renders of `box`, `cylinder`, `face-with-hole`, `nested-3-deep`, `box-v2013`, `box-v2016` all draw their names.
- The 25 previously-parsing legacy files produce **byte-identical vertex fingerprints** (order-stable SHA-256 over every coordinate) before and after.
- `pytest`: 80 passed on this branch.

Same gap presumably exists in the TS/.NET/Dart ports of the walker; the probe translates directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)