### PR TITLE
fix(python): expose the projected-texture flag the legacy walker already decodes

### DIFF
--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -122,6 +122,10 @@ class Face:
             ``u = (p·xr)/tile_w``, ``v = (p·yr)/tile_h``.  Distorted
             (4-pin) mappings are projective: ``uvq[2]`` ≠ 1.
         uv_transform_back: Same for the face's back side, or ``None``.
+        uv_projected: The texture is PROJECTED (e.g. the Add Location
+            terrain drape): its UVs run in the projection plane's frame,
+            not the face frame.
+        uv_projected_back: Same for the face's back side.
     """
 
     id: int
@@ -131,6 +135,8 @@ class Face:
     back_material_id: Optional[int] = None
     uv_transform: Optional[Tuple[float, ...]] = None
     uv_transform_back: Optional[Tuple[float, ...]] = None
+    uv_projected: bool = False
+    uv_projected_back: bool = False
 
 
 # ── Layers & Materials ────────────────────────────────────────────────────
@@ -461,6 +467,8 @@ class SkpFile:
                     back_material_id=f_data.get("back_material_id"),
                     uv_transform=f_data.get("uv_transform"),
                     uv_transform_back=f_data.get("uv_transform_back"),
+                    uv_projected=f_data.get("uv_projected", False),
+                    uv_projected_back=f_data.get("uv_projected_back", False),
                 )
             # Populate instances
             for inst in builder.instances:


### PR DESCRIPTION
Small one, and best understood as **completing the legacy-walker port**: when the classic MFC reader landed (946e43b), it brought the `CFaceTextureCoords` flag decode along — `legacy.py` reads the per-side PROJECTED bit (bit 1 of the two trailing flag words) and writes `uv_projected` / `uv_projected_back` into the face dict — but the model-side half didn't make the port: `Face` never gained the fields, so the decoded value is dropped before any consumer can see it.

This adds the two fields (default `False`) and passes them through. That's the whole diff — 8 lines.

## Why it matters

A projected texture (most commonly the **Add Location terrain drape**) stores its UVs in the projection plane's frame, not the face frame. A consumer that applies the regular positioned-texture recipe from the `Face.uv_transform` docs to a projected face gets visibly wrong texturing — and today it can't even know the face is projected.

## Evidence the bit means what the docstring says

- **Original calibration** (July, when the decode was written): geolocated files flag exactly their aerial-draped terrain faces; files with only repositioned textures carry no bit-1 anywhere.
- **Negative control on the corpus**: `pin-one` / `pin-four` — the user-pinned face carries front+back `uv_transform` and **no** projected bit. Positioned ≠ projected.
- **Discrimination within one component**: the bundled *Chris* template figure has six faces with positioned mappings; exactly one (the cutout's back side, face 558) carries the projected bit — the flag is per-face-per-side signal, not per-file noise.
- **Structural cross-check**: the independent Rust implementation reads the same record shape (24×f64 + two pin lists + two per-side u32 flag words at the same position) and preserves both flag words verbatim.

## Verification

- Swept ~50 legacy corpus files: only faces genuinely carrying the flag report it; files whose template ships no figure and no projected content (`blank-template-box`, `instance-scaled`, `nested-3-deep`, `curve`) report zero.
- `pytest`: 85 passed.
- VFF-era files untouched — the projected bit is only decoded on the legacy path today, and the fields default `False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)