### PR TITLE
C++: compute real per-vertex UV coordinates in GlbPrimitive and GLB output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **TypeScript**: `GlbPrimitive` gained a `uvs` field, same fix as the
   Python/.NET entries above. Verified numerically identical to both on the
   same real fixture.
+- **C++**: `GlbPrimitive` gained a `uvs` field, same fix as the other three
+  ports. Unlike those, C++'s `to_glb`/`export_glb` write real `.glb` files
+  directly from this struct, so this PR also wires a `TEXCOORD_0` accessor
+  into the actual glTF output - exported files now carry real texture
+  coordinates, not just the in-memory struct. C++ also uniquely models
+  front/back materials as separate primitives; the back-side primitive
+  (when present) uses `uv_transform_back` with the same face-plane basis
+  as the front, per the documented recipe - this path has no cross-language
+  reference to verify against, since no other port models back materials
+  at all.
 
 - **C++**: public `to_glb(const Scene&)` and `export_glb(const Scene&, path)`
   APIs for in-memory and file-based binary glTF 2.0 export. The implementation

--- a/packages/cpp/include/openskp/scene.hpp
+++ b/packages/cpp/include/openskp/scene.hpp
@@ -31,6 +31,17 @@ struct MeshMetadata {
 struct GlbPrimitive {
   std::vector<float> positions;
   std::vector<float> normals;
+  // Flat [u, v, u, v, ...] texture coordinates, matching positions 1:1.
+  // Computed from the source face's uv_transform (or the default
+  // face-plane projection when a face has none): a face-plane basis from
+  // the normal, inverting uv_transform when present, divided by the
+  // material's texture tile size. A vertex shared by two faces that
+  // disagree on UV is split, since indexed glTF meshes need
+  // position/normal/uv aligned per vertex. Faces with a PROJECTED texture
+  // (terrain-drape, e.g. Add Location) still use the face-plane formula
+  // here, since the real projection-plane basis isn't captured in the
+  // parsed data - their UVs will be approximate.
+  std::vector<float> uvs;
   std::vector<std::uint32_t> indices;
   std::size_t material_index{};
   std::string geom_name;

--- a/packages/cpp/src/glb.cpp
+++ b/packages/cpp/src/glb.cpp
@@ -130,6 +130,9 @@ void validate_scene(const Scene& scene) {
     if (primitive.normals.size() != primitive.positions.size()) {
       throw std::invalid_argument(prefix + "normals must match positions");
     }
+    if (primitive.uvs.size() != primitive.positions.size() / 3 * 2) {
+      throw std::invalid_argument(prefix + "uvs must match positions");
+    }
     if (primitive.indices.size() % 3 != 0) {
       throw std::invalid_argument(prefix + "indices must contain complete triangles");
     }
@@ -143,11 +146,12 @@ void validate_scene(const Scene& scene) {
     const auto vertex_count = primitive.positions.size() / 3;
     for (const auto value : primitive.positions) check_finite(value, prefix + "position");
     for (const auto value : primitive.normals) check_finite(value, prefix + "normal");
+    for (const auto value : primitive.uvs) check_finite(value, prefix + "uv");
     for (const auto index : primitive.indices) {
       if (index >= vertex_count) throw std::invalid_argument(prefix + "index is out of range");
     }
 
-    for (const auto* values : {&primitive.positions, &primitive.normals}) {
+    for (const auto* values : {&primitive.positions, &primitive.normals, &primitive.uvs}) {
       estimated_binary_size = (estimated_binary_size + 3) & ~std::size_t{3};
       check_binary_growth(estimated_binary_size, values->size(), sizeof(float));
       estimated_binary_size += values->size() * sizeof(float);
@@ -213,6 +217,13 @@ gltf::Model make_model(const Scene& scene) {
     const auto normal_accessor = add_accessor(model, normal_view, source.normals.size() / 3,
                                               TINYGLTF_COMPONENT_TYPE_FLOAT, TINYGLTF_TYPE_VEC3);
 
+    const auto uv_offset = append_values(
+        binary, source.uvs, [](ByteBuffer& bytes, float value) { append_f32(bytes, value); });
+    const auto uv_view =
+        add_view(model, uv_offset, source.uvs.size() * 4, TINYGLTF_TARGET_ARRAY_BUFFER);
+    const auto uv_accessor = add_accessor(model, uv_view, source.uvs.size() / 2,
+                                          TINYGLTF_COMPONENT_TYPE_FLOAT, TINYGLTF_TYPE_VEC2);
+
     const auto index_offset =
         append_values(binary, source.indices,
                       [](ByteBuffer& bytes, std::uint32_t value) { append_u32(bytes, value); });
@@ -225,6 +236,7 @@ gltf::Model make_model(const Scene& scene) {
     gltf::Primitive primitive;
     primitive.attributes["POSITION"] = position_accessor;
     primitive.attributes["NORMAL"] = normal_accessor;
+    primitive.attributes["TEXCOORD_0"] = uv_accessor;
     primitive.indices = index_accessor;
     primitive.material = static_cast<int>(source.material_index);
     primitive.mode = TINYGLTF_MODE_TRIANGLES;

--- a/packages/cpp/src/scene.cpp
+++ b/packages/cpp/src/scene.cpp
@@ -3,6 +3,7 @@
 #include <set>
 #include <sstream>
 #include <tuple>
+#include <utility>
 
 #include "internal.hpp"
 
@@ -19,28 +20,88 @@ struct GroupKey {
   }
 };
 
+// A vertex is keyed by (source vertex id, u, v): UVs are inherently
+// per-face, so a vertex position shared by two faces that disagree on
+// texture mapping must become two distinct output vertices (glTF requires
+// position/normal/uv aligned per index).
+using VKey = std::tuple<EntityId, double, double>;
+
 struct Group {
   std::vector<Vec3> verts;
+  std::vector<std::array<float, 2>> uvs;
   std::vector<std::array<size_t, 3>> tris;
-  std::map<EntityId, size_t> map;
-  std::map<EntityId, Vec3> normals;
+  std::map<VKey, size_t> map;
+  std::map<VKey, Vec3> normals;
 };
 
-std::optional<Key> material_color(const RawParsed& parsed, std::optional<EntityId> id) {
-  if (!id) return {};
+std::shared_ptr<RawMaterial> find_material(const RawParsed& parsed, std::optional<EntityId> id) {
+  if (!id) return nullptr;
   auto name = parsed.material_id_to_name.find(*id);
-  if (name == parsed.material_id_to_name.end()) return {};
-  std::shared_ptr<RawMaterial> material;
+  if (name == parsed.material_id_to_name.end()) return nullptr;
   auto direct = parsed.materials.find(name->second);
-  if (direct != parsed.materials.end())
-    material = direct->second;
-  else {
-    auto folder = parsed.materials_by_folder.find(name->second);
-    if (folder != parsed.materials_by_folder.end()) material = folder->second;
-  }
+  if (direct != parsed.materials.end()) return direct->second;
+  auto folder = parsed.materials_by_folder.find(name->second);
+  if (folder != parsed.materials_by_folder.end()) return folder->second;
+  return nullptr;
+}
+
+std::optional<Key> material_color(const std::shared_ptr<RawMaterial>& material) {
   if (!material) return {};
   return Key{material->r, material->g, material->b,
              static_cast<int>(std::lround(std::clamp(material->transparency, 0.0, 1.0) * 255.0))};
+}
+
+std::pair<double, double> tile_size(const std::shared_ptr<RawMaterial>& material) {
+  double w = 1.0, h = 1.0;
+  if (material && material->texture) {
+    if (material->texture->x_scale > 1e-9) w = material->texture->x_scale;
+    if (material->texture->y_scale > 1e-9) h = material->texture->y_scale;
+  }
+  return {w, h};
+}
+
+// Inverse of a row-major 3x3 matrix, via the cofactor/adjugate method.
+std::array<double, 9> invert_3x3(const std::array<double, 9>& m) {
+  double a = m[0], b = m[1], c = m[2];
+  double d = m[3], e = m[4], f = m[5];
+  double g = m[6], h = m[7], i = m[8];
+  double det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+  if (std::abs(det) < 1e-12) return {1, 0, 0, 0, 1, 0, 0, 0, 1};
+  double inv_det = 1.0 / det;
+  return {
+      (e * i - f * h) * inv_det, (c * h - b * i) * inv_det, (b * f - c * e) * inv_det,
+      (f * g - d * i) * inv_det, (a * i - c * g) * inv_det, (c * d - a * f) * inv_det,
+      (d * h - e * g) * inv_det, (b * g - a * h) * inv_det, (a * e - b * d) * inv_det,
+  };
+}
+
+// Face-plane basis vectors (xr, yr) for UV projection, from a face normal.
+std::pair<Vec3, Vec3> face_uv_basis(const Vec3& n) {
+  double cx = -n[1], cy = n[0];
+  double clen = std::sqrt(cx * cx + cy * cy);
+  if (clen < 1e-9) {
+    return {Vec3{1, 0, 0}, Vec3{0, n[2] >= 0 ? 1.0 : -1.0, 0}};
+  }
+  Vec3 xr{cx / clen, cy / clen, 0};
+  Vec3 yr{n[1] * xr[2] - n[2] * xr[1], n[2] * xr[0] - n[0] * xr[2], n[0] * xr[1] - n[1] * xr[0]};
+  return {xr, yr};
+}
+
+// UV of point p (inches, local/object space) on a face with the given
+// plane basis, per-face uv_transform (or nullopt for the default
+// projection), and material tile size (inches).
+std::pair<double, double> compute_face_uv(const Vec3& p, const Vec3& xr, const Vec3& yr,
+                                          const std::optional<std::array<double, 9>>& uv_transform,
+                                          double tile_w, double tile_h) {
+  double px = p[0] * xr[0] + p[1] * xr[1] + p[2] * xr[2];
+  double py = p[0] * yr[0] + p[1] * yr[1] + p[2] * yr[2];
+  if (!uv_transform) return {px / tile_w, py / tile_h};
+  auto inv = invert_3x3(*uv_transform);
+  double u = px * inv[0] + py * inv[3] + inv[6];
+  double v = px * inv[1] + py * inv[4] + inv[7];
+  double q = px * inv[2] + py * inv[5] + inv[8];
+  if (std::abs(q) < 1e-12) q = 1.0;
+  return {(u / q) / tile_w, (v / q) / tile_h};
 }
 
 Key default_color(const RawParsed& parsed, const std::string& layer) {
@@ -88,8 +149,10 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
     for (auto& fv : b.faces) {
       auto& f = fv.second;
       const auto fallback = inherited.value_or(default_color(p, layer));
-      const auto front = material_color(p, f.material_id).value_or(fallback);
-      const auto back = material_color(p, f.back_material_id).value_or(fallback);
+      const auto front_mat = find_material(p, f.material_id);
+      const auto back_mat = find_material(p, f.back_material_id);
+      const auto front = material_color(front_mat).value_or(fallback);
+      const auto back = material_color(back_mat).value_or(fallback);
       std::vector<std::vector<EntityId>> loops;
       for (auto& l : f.loops) {
         auto x = loop_vertices(l, b);
@@ -99,20 +162,31 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
       std::map<EntityId, Vertex> vv;
       for (auto& x : b.vertices) vv[x.first] = {x.first, x.second[0], x.second[1], x.second[2]};
       const auto triangles = triangulate_face_3d(vv, loops, f.normal);
-      const auto add_side = [&](const GroupKey& key, bool reverse) {
+      // Not a structured binding: those can't be captured by the nested
+      // add_side lambda below in C++17 (only from C++20 onward).
+      const auto uv_basis = face_uv_basis(f.normal);
+      const Vec3& xr = uv_basis.first;
+      const Vec3& yr = uv_basis.second;
+      const auto add_side = [&](const GroupKey& key, bool reverse,
+                                const std::optional<std::array<double, 9>>& uv_transform,
+                                double tile_w, double tile_h) {
         auto& group = groups[key];
         for (auto triangle : triangles) {
           if (reverse) std::swap(triangle[1], triangle[2]);
           std::array<size_t, 3> indices{};
           for (int vertex = 0; vertex < 3; ++vertex) {
             auto id = triangle[vertex];
-            auto it = group.map.find(id);
+            const auto& pos = b.vertices.at(id);
+            const auto [u, v] = compute_face_uv(pos, xr, yr, uv_transform, tile_w, tile_h);
+            const VKey vkey{id, u, v};
+            auto it = group.map.find(vkey);
             if (it == group.map.end()) {
-              it = group.map.emplace(id, group.verts.size()).first;
-              group.verts.push_back(b.vertices.at(id));
+              it = group.map.emplace(vkey, group.verts.size()).first;
+              group.verts.push_back(pos);
+              group.uvs.push_back({float(u), float(v)});
             }
             indices[vertex] = it->second;
-            auto& normal = group.normals[id];
+            auto& normal = group.normals[vkey];
             for (int axis = 0; axis < 3; ++axis)
               normal[axis] += reverse ? -f.normal[axis] : f.normal[axis];
           }
@@ -120,10 +194,13 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
         }
       };
       if (front == back) {
-        add_side({front, true}, false);
+        const auto [tw, th] = tile_size(front_mat);
+        add_side({front, true}, false, f.uv_transform, tw, th);
       } else {
-        add_side({front, false}, false);
-        add_side({back, false}, true);
+        const auto [ftw, fth] = tile_size(front_mat);
+        add_side({front, false}, false, f.uv_transform, ftw, fth);
+        const auto [btw, bth] = tile_size(back_mat);
+        add_side({back, false}, true, f.uv_transform_back, btw, bth);
       }
     }
     for (auto& kv : groups) {
@@ -155,13 +232,16 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
         prim.indices.push_back(static_cast<uint32_t>(triangle[mirrored ? 1 : 2]));
       }
       for (auto& m : g.map) {
-        auto pt = transform_point(matrix, b.vertices.at(m.first));
+        auto pt = transform_point(matrix, b.vertices.at(std::get<0>(m.first)));
         prim.positions.resize(g.verts.size() * 3);
         prim.normals.resize(g.verts.size() * 3);
+        prim.uvs.resize(g.verts.size() * 2);
         auto i = m.second;
         prim.positions[i * 3] = float(pt[0] * .0254);
         prim.positions[i * 3 + 1] = float(pt[2] * .0254);
         prim.positions[i * 3 + 2] = float(-pt[1] * .0254);
+        prim.uvs[i * 2] = g.uvs[i][0];
+        prim.uvs[i * 2 + 1] = g.uvs[i][1];
         auto n = g.normals[m.first];
         double l = std::sqrt(n[0] * n[0] + n[1] * n[1] + n[2] * n[2]);
         if (l < 1e-6)
@@ -204,7 +284,7 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
         }
       }
       auto child_color = inherited;
-      if (auto color = material_color(p, i.material_id)) child_color = color;
+      if (auto color = material_color(find_material(p, i.material_id))) child_color = color;
       auto nm =
           i.name.empty() ? "Component_" + (i.ref_idx ? std::to_string(*i.ref_idx) : "") : i.name;
       auto child_path = path + " / " + nm;

--- a/packages/cpp/tests/glb_test.cpp
+++ b/packages/cpp/tests/glb_test.cpp
@@ -25,6 +25,7 @@ Scene triangle_scene() {
   scene.glb_primitives.push_back({
       {1.0F, 2.0F, 3.0F, -4.0F, 5.0F, 0.0F, 2.0F, -1.0F, 7.0F},
       {0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F},
+      {0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F},
       {0, 1, 2},
       0,
       "triangle",
@@ -74,6 +75,7 @@ TEST(Glb, SerializesSceneAndBinaryData) {
   EXPECT_EQ(primitive.material, 0);
   ASSERT_TRUE(primitive.attributes.count("POSITION"));
   ASSERT_TRUE(primitive.attributes.count("NORMAL"));
+  ASSERT_TRUE(primitive.attributes.count("TEXCOORD_0"));
 
   const auto& positions = model.accessors.at(primitive.attributes.at("POSITION"));
   EXPECT_EQ(positions.componentType, TINYGLTF_COMPONENT_TYPE_FLOAT);
@@ -87,6 +89,12 @@ TEST(Glb, SerializesSceneAndBinaryData) {
   const auto& normals = model.accessors.at(primitive.attributes.at("NORMAL"));
   EXPECT_EQ(normals.count, 3);
   EXPECT_FLOAT_EQ(buffer_value<float>(model, normals, 8), 1.0F);
+
+  const auto& uvs = model.accessors.at(primitive.attributes.at("TEXCOORD_0"));
+  EXPECT_EQ(uvs.componentType, TINYGLTF_COMPONENT_TYPE_FLOAT);
+  EXPECT_EQ(uvs.type, TINYGLTF_TYPE_VEC2);
+  EXPECT_EQ(uvs.count, 3);
+  EXPECT_FLOAT_EQ(buffer_value<float>(model, uvs, 2), 1.0F);
 
   const auto& indices = model.accessors.at(static_cast<std::size_t>(primitive.indices));
   EXPECT_EQ(indices.componentType, TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT);
@@ -121,6 +129,10 @@ TEST(Glb, RejectsMalformedGeometry) {
   EXPECT_THROW(to_glb(scene), std::invalid_argument);
 
   scene = triangle_scene();
+  scene.glb_primitives[0].uvs.pop_back();
+  EXPECT_THROW(to_glb(scene), std::invalid_argument);
+
+  scene = triangle_scene();
   scene.glb_primitives[0].indices.pop_back();
   EXPECT_THROW(to_glb(scene), std::invalid_argument);
 
@@ -140,6 +152,10 @@ TEST(Glb, RejectsNonFiniteAndInvalidPbrValues) {
 
   scene = triangle_scene();
   scene.glb_primitives[0].normals[0] = std::numeric_limits<float>::quiet_NaN();
+  EXPECT_THROW(to_glb(scene), std::invalid_argument);
+
+  scene = triangle_scene();
+  scene.glb_primitives[0].uvs[0] = std::numeric_limits<float>::quiet_NaN();
   EXPECT_THROW(to_glb(scene), std::invalid_argument);
 
   scene = triangle_scene();

--- a/packages/cpp/tests/parser_test.cpp
+++ b/packages/cpp/tests/parser_test.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <gtest/gtest.h>
 #include <limits>
 #include <set>
@@ -171,6 +172,8 @@ TEST(Parser, LegacyMatchesReference) {
 
   for (const auto& primitive : scene.glb_primitives) {
     EXPECT_EQ(primitive.positions.size(), primitive.normals.size());
+    EXPECT_EQ(primitive.uvs.size(), primitive.positions.size() / 3 * 2);
+    for (auto value : primitive.uvs) EXPECT_TRUE(std::isfinite(value));
     EXPECT_EQ(primitive.indices.size() % 3, 0);
     for (auto index : primitive.indices) EXPECT_LT(index, primitive.positions.size() / 3);
   }


### PR DESCRIPTION
## What

Related to #62 - same gap as #63 (Python), #64 (.NET), #65 (TypeScript), now ported to C++. `GlbPrimitive` exposed `positions`/`normals`/`indices` but no texture coordinates.

C++ is the last of the four languages that already ship GLB export - this closes the loop for #62. (Dart/.NET-file-writer scope is separate/pre-existing, tracked independently.)

## How

Same formula as the other three merged PRs (face-plane basis from the normal, invert `uv_transform` when present, divide by material tile size), with two C++-specific differences from how this repo's C++ port is structured:

1. **`glb.cpp` wiring.** Unlike Python (whose real `.glb` writer is a separate legacy trimesh path not addressed here) and TS/.NET (whose `GlbPrimitive` is consumed by callers, not an internal file writer), C++'s `to_glb`/`export_glb` write real `.glb` files *directly* from `GlbPrimitive`. So this PR also wires a `TEXCOORD_0` accessor into the actual glTF output in `glb.cpp` - exported `.glb` files now carry real texture coordinates, not just the in-memory struct.

2. **Front/back materials.** C++ uniquely models a face's front and back materials as two separate primitives when they differ (`add_side` with a reverse-winding flag) - none of the other four ports do this at all. The back-side primitive, when present, computes UV from `uv_transform_back` using the same face-plane basis as the front, per the documented recipe ("same for the back side"). I want to flag honestly: **this specific path has no cross-language reference to verify against**, since no other port models back materials. It's a literal reading of the documented formula, not an invented heuristic, but it's the one part of this PR I couldn't cross-check numerically against an already-merged implementation the way I could for the front-facing/single-sided case.

Vertex dedup key changed from vertex id alone to `(vertex id, u, v)` - UV is inherently per-face, so a shared vertex has to split wherever two faces disagree on its mapping.

## Verification (please weigh this carefully - see below)

**I cannot compile or run this locally** - there is no C++ toolchain (no cmake, no compiler) in this environment, same constraint as every prior C++ PR in this repo. Given that, and the added complexity here (vertex-key restructuring, a nested lambda, front/back material handling), I did more manual work than usual before opening this:

- Ran `clang-format` locally (pip-installed 22.1.8, vs. CI's clang-format-18) against every changed file - clean except one whitespace diff in a wrapped lambda signature, now fixed.
- Caught and fixed a real C++17 pitfall myself: the face-plane basis (`xr`, `yr`) is computed once per face and then used inside a nested `add_side` lambda - originally written as a structured binding (`const auto [xr, yr] = ...`), which cannot be captured by a lambda before C++20. Rewrote as plain named references.
- Line-by-line compared the vertex-dedup and UV-computation logic against the already-merged, already-cross-verified Python/.NET/TypeScript implementations for structural parity.
- Extended the existing `glb_test.cpp` and `parser_test.cpp` coverage (uvs length/finiteness checks, `TEXCOORD_0` accessor assertions, malformed/non-finite-uv rejection tests, matching the existing test shape for positions/normals) rather than adding a separate, disconnected test file.

I'm relying on CI's 3-OS build+test matrix as the actual compile/correctness gate here, same as prior C++ work - flagging this explicitly rather than overstating confidence.

## Testing

- `clang-format --dry-run --Werror` equivalent: clean locally (see above).
- Test file updates: `glb_test.cpp`'s `triangle_scene()` helper uses aggregate initialization, so adding `uvs` in the middle of the struct required updating it with a placeholder UV array - done, and extended with `TEXCOORD_0` assertions plus malformed/non-finite rejection cases mirroring the existing `positions`/`normals` tests. `parser_test.cpp`'s real-fixture loop now also asserts `uvs` length and finiteness.
- Will confirm CI is fully green before merging.