### PR TITLE
Python: real UV coordinates + fix crash in export.glb.export()'s writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the same real fixture. Dart has no `.glb` file writer yet (tracked
   separately), so this reaches the `GlbPrimitive` data shape only, same as
   the Python/.NET/TypeScript entries above.
+- **Python**: `export.glb.export()` - the actual `.glb` file writer, a
+  separate legacy pipeline from `scene.py`'s `build_scene()` - now writes
+  real per-vertex UV coordinates too, closing the same gap as above for
+  Python's literal exported files (matching what C++'s PR already did for
+  its own file writer). Faces are now grouped into one mesh per resolved
+  color per definition, same as `scene.py`, since a single trimesh mesh
+  can only carry one material - previously this pipeline put every face
+  of a definition into one mesh with a flat per-face color array,
+  regardless of how many distinct materials were mixed in (confirmed on a
+  real fixture: 2 of 3 definitions mix colors). Verified numerically
+  identical UV output to `scene.py`'s on three real files (both legacy
+  MFC and modern VFF format).
 
 - **C++**: public `to_glb(const Scene&)` and `export_glb(const Scene&, path)`
   APIs for in-memory and file-based binary glTF 2.0 export. The implementation
@@ -51,6 +63,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Python**: `export.glb.export()` crashed on any file with a textured
+  material - the metadata JSON sidecar it writes tried to embed each
+  material's raw texture image bytes directly, which was never
+  JSON-serializable, so `json.dump` raised `TypeError`. There was no
+  existing test coverage for this function, which is how this went
+  uncaught. Now stripped before serialization - the `.glb` file itself
+  carries the actual texture data, a JSON metadata file was never the
+  right place for it.
 - **Python, TypeScript, Dart, C++**: `Material.color`'s alpha channel was
   silently discarded when parsing legacy MFC (SketchUp 2013–2020) files —
   each language read the material's real 4-byte RGBA record but only kept

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -900,6 +900,8 @@ def build_scene(parsed: Dict[str, Any], output_dir: str, filename_stem: str) -> 
     Returns:
         Dict with glb_path, json_path, metadata, mesh_count
     """
+    from . import scene as _scene
+
     defs_dict = parsed['defs_dict']
     layer_colors = parsed['layer_colors']
     layer_id_to_name = parsed['layer_id_to_name']
@@ -918,26 +920,32 @@ def build_scene(parsed: Dict[str, Any], output_dir: str, filename_stem: str) -> 
         builder = d['builder']
 
         if builder.faces:
-            local_verts = []
-            local_faces = []
-            local_v_map = {}
-            face_colors_list = []
+            # Faces are grouped by resolved color into one mesh each -
+            # same grouping scene.py's build_scene() uses. A single
+            # definition can legitimately mix faces of different colors
+            # (verified: 2 of 3 definitions do, in a real test fixture), so
+            # one Trimesh per color is required to give each its own
+            # material - trimesh's TextureVisuals carries one material per
+            # mesh, so a single flat-colored mesh can't represent that.
+            face_groups: Dict[Any, Dict[str, Any]] = {}
+
             for f_id, f_data in builder.faces.items():
-                # Resolve color for this face
-                face_color = None
+                face_color = inherited_color
                 face_mat_id = f_data.get('material_id')
+                mat = None
                 if face_mat_id is not None:
                     mat_name = material_id_to_name.get(face_mat_id)
                     mat = materials.get(mat_name) or materials_by_folder.get(mat_name)
                     if mat:
                         c = mat['color']
                         face_color = (c['r'], c['g'], c['b'])
-
-                if face_color is None and inherited_color is not None:
-                    face_color = inherited_color
-
                 if face_color is None:
                     face_color = layer_colors.get(parent_layer, (136, 136, 136))
+
+                group = face_groups.get(face_color)
+                if group is None:
+                    group = {'local_verts': [], 'local_uvs': [], 'local_faces': [], 'local_v_map': {}}
+                    face_groups[face_color] = group
 
                 loops = []
                 for loop in f_data['loops']:
@@ -955,30 +963,66 @@ def build_scene(parsed: Dict[str, Any], output_dir: str, filename_stem: str) -> 
                 if not loops:
                     continue
                 triangles = triangulate_face_3d(builder.vertices, loops, f_data['normal'])
+
+                tex = mat.get('texture') if mat else None
+                tile_w = tex.get('x_scale') if tex else None
+                tile_h = tex.get('y_scale') if tex else None
+                tile_w = tile_w if tile_w and tile_w > 1e-9 else 1.0
+                tile_h = tile_h if tile_h and tile_h > 1e-9 else 1.0
+                xr, yr = _scene._face_uv_basis(f_data['normal'])
+                uv_transform = f_data.get('uv_transform')
+
+                # Vertices are deduped per (v_id, uv) rather than just
+                # v_id - see scene.py's build_scene() for why: UV is
+                # inherently per-face, so a shared vertex position must
+                # split wherever two faces disagree on its texture mapping.
+                face_local_map: Dict[Any, int] = {}
                 for tri in triangles:
                     face_indices = []
                     for v_id in tri:
-                        if v_id in builder.vertices:
-                            if v_id not in local_v_map:
-                                local_verts.append(builder.vertices[v_id])
-                                local_v_map[v_id] = len(local_verts) - 1
-                            face_indices.append(local_v_map[v_id])
+                        if v_id not in builder.vertices:
+                            continue
+                        idx = face_local_map.get(v_id)
+                        if idx is None:
+                            p = builder.vertices[v_id]
+                            u, v = _scene._compute_face_uv(p, xr, yr, uv_transform, tile_w, tile_h)
+                            key = (v_id, u, v)
+                            idx = group['local_v_map'].get(key)
+                            if idx is None:
+                                group['local_verts'].append(p)
+                                group['local_uvs'].append((u, v))
+                                idx = len(group['local_verts']) - 1
+                                group['local_v_map'][key] = idx
+                            face_local_map[v_id] = idx
+                        face_indices.append(idx)
                     if len(face_indices) == 3:
-                        local_faces.append(face_indices)
-                        face_colors_list.append(list(face_color) + [255])
+                        group['local_faces'].append(face_indices)
 
-            if local_faces:
+            for face_color, group in face_groups.items():
+                if not group['local_faces']:
+                    continue
                 v_trans = []
-                for v in local_verts:
+                for v in group['local_verts']:
                     pt = transform_point(v, current_matrix)
                     ox = pt[0] * 25.4
                     oy = pt[2] * 25.4
                     oz = -pt[1] * 25.4
                     v_trans.append((ox, oy, oz))
-                mesh = trimesh.Trimesh(vertices=v_trans, faces=local_faces)
-                mesh.visual.face_colors = face_colors_list
+                # process=False: trimesh's default post-construction cleanup
+                # merges/drops vertices by position alone, which would both
+                # misalign the UV array below (built 1:1 against v_trans)
+                # and silently undo the UV-based vertex splitting above.
+                mesh = trimesh.Trimesh(
+                    vertices=v_trans, faces=group['local_faces'], process=False,
+                )
+                r, g, b = face_color
+                mesh.visual = trimesh.visual.TextureVisuals(
+                    uv=group['local_uvs'],
+                    material=trimesh.visual.material.SimpleMaterial(diffuse=(r, g, b, 255)),
+                )
                 safe_path = path_name.replace(' / ', '__').replace(' ', '_')[:80]
-                geom_name = f"mesh_{mesh_counter[0]}_{safe_path}_{parent_layer}"
+                color_suffix = f"_{r}_{g}_{b}" if len(face_groups) > 1 else ""
+                geom_name = f"mesh_{mesh_counter[0]}_{safe_path}_{parent_layer}{color_suffix}"
                 mesh_counter[0] += 1
                 scene.add_geometry(mesh, geom_name=geom_name)
 
@@ -1071,6 +1115,18 @@ def build_scene(parsed: Dict[str, Any], output_dir: str, filename_stem: str) -> 
     layers_list = [{'name': n, 'color': {'r': c[0], 'g': c[1], 'b': c[2]}}
                    for n, c in layer_colors.items()]
 
+    def json_safe_material(mat):
+        # Raw texture image bytes aren't JSON-serializable and don't
+        # belong in a text metadata sidecar anyway - the .glb file itself
+        # carries the actual texture data.
+        safe = dict(mat)
+        tex = safe.get('texture')
+        if tex is not None:
+            safe_tex = dict(tex)
+            safe_tex.pop('data', None)
+            safe['texture'] = safe_tex
+        return safe
+
     metadata = {
         'format_version': '1.0',
         'source_file': filename_stem,
@@ -1080,7 +1136,7 @@ def build_scene(parsed: Dict[str, Any], output_dir: str, filename_stem: str) -> 
         'total_meshes': len(scene.geometry),
         'total_layers': len(layers_list),
         'layers': layers_list,
-        'materials': list(materials.values()),
+        'materials': [json_safe_material(m) for m in materials.values()],
         'mesh_index': mesh_index,
         'scene_hierarchy': {
             'name': 'ROOT', 'layer': 'Layer0',

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -1133,6 +1133,71 @@ class TestBuildScene:
         assert len(scene.glb_primitives) == 13
 
 
+class TestGlbExport:
+    """``export.glb.export()`` writes a real ``.glb`` file via a separate,
+    trimesh-based pipeline (not ``scene.py``'s ``build_scene()``) - so its
+    UV/material/JSON-metadata handling needs its own coverage rather than
+    inheriting ``TestBuildScene``'s.
+
+    Before this was tested, ``export()`` crashed on any file with a
+    textured material (the metadata JSON writer tried to serialize the raw
+    texture image bytes), and no mesh actually carried real UV coordinates
+    at all - both fixed together, verified here.
+    """
+
+    import pathlib as _pathlib
+
+    FIXTURE = _pathlib.Path(__file__).parent / "fixtures" / "capilla_quiroz_v17.skp"
+
+    def _export(self, tmp_path):
+        import pytest as _pytest
+        if not self.FIXTURE.exists():
+            _pytest.skip("legacy fixture not present")
+        from openskp.export import glb as glb_export
+        from openskp.model import SkpFile
+
+        skp = SkpFile.open(str(self.FIXTURE))
+        skp.parse()
+        out_path = tmp_path / "capilla_quiroz_v17.glb"
+        return skp, glb_export.export(skp, str(out_path))
+
+    def test_export_writes_a_glb_with_real_uv_per_mesh(self, tmp_path) -> None:
+        import trimesh
+
+        skp, glb_path = self._export(tmp_path)
+        loaded = trimesh.load(glb_path, file_type="glb")
+
+        scene = skp.build_scene()
+        assert len(loaded.geometry) == len(scene.glb_primitives)
+
+        for name, geom in loaded.geometry.items():
+            assert geom.visual.kind == "texture", f"{name} has no UV/material"
+            uv = geom.visual.uv
+            assert uv is not None and len(uv) == len(geom.vertices)
+            assert not any(v != v or v in (float("inf"), float("-inf")) for row in uv for v in row)
+
+    def test_metadata_json_is_written_and_json_safe(self, tmp_path) -> None:
+        import json
+
+        _skp, glb_path = self._export(tmp_path)
+        meta_path = str(glb_path).replace(".glb", "_metadata.json")
+        with open(meta_path, encoding="utf-8") as f:
+            metadata = json.load(f)
+
+        assert metadata["total_meshes"] == 13
+        # Regression: materials carry texture data as raw bytes internally,
+        # which isn't JSON-serializable - export() must strip it before
+        # writing, not embed it (or crash).
+        for mat in metadata["materials"]:
+            tex = mat.get("texture")
+            if tex is not None:
+                assert "data" not in tex
+
+        first_child = metadata["scene_hierarchy"]["children"][0]
+        assert "definition_id" in first_child
+        assert "matrix_3x4" in first_child
+
+
 # ── Observability: progress logging + structured error context ──────────
 
 


### PR DESCRIPTION
## What

Follow-up to #62 (Python's part already merged in #63, fixing the `scene.GlbPrimitive` data shape). This PR fixes the *other* Python GLB pipeline: `export.glb.export()` - the actual `.glb` file writer, a separate legacy trimesh-based implementation, not `scene.py`'s `build_scene()`. It had two real, previously-undetected bugs, found while verifying it end to end for the first time (there was no existing test coverage for this function at all).

## Bug 1: crash on any textured file

The metadata JSON sidecar this function writes tried to embed each material's raw texture image bytes directly - never valid JSON. `export()` crashed with `TypeError` on any real file with a textured material. Fixed by stripping the binary `data` field before serialization (the `.glb` file itself carries the actual texture bytes; a JSON metadata file was never the right place for them). Everything else in the metadata schema - `mesh_index`, `scene_hierarchy` (including `definition_id`/`matrix_3x4`), `layers` - is untouched.

## Bug 2: no UV coordinates at all, and a real color-fidelity constraint underneath it

Every face of a definition went into a single trimesh mesh with a flat *per-face* color array, regardless of how many distinct materials were mixed into that definition - confirmed on the real fixture, 2 of 3 definitions mix colors. trimesh's UV/texture visual (`TextureVisuals`) carries one material per mesh, so before UV could be added at all, faces needed to be grouped into one mesh per resolved color per definition - the same grouping `scene.py`'s `build_scene()` already uses. UV itself is computed via the identical face-plane formula (reusing `scene.py`'s `_face_uv_basis`/`_compute_face_uv` via a local import inside the function, to avoid a circular import between `_core.py` and `scene.py`).

One more thing this surfaced: trimesh's `Trimesh` constructor does automatic post-construction vertex processing (merging/dropping vertices by position) unless you pass `process=False`. Since the UV computation splits vertices by `(vertex, uv)` rather than position alone, that default processing was silently misaligning - and for several meshes, entirely dropping - the UV array trimesh's glTF exporter has a `len(uv) == len(vertices)` check and *silently* omits `TEXCOORD_0` when it fails, no error or warning. Caught this by actually inspecting the raw glTF JSON in the exported file, not just checking "did it run without an exception."

## Testing

- Full test suite: 87/87 (added 2 new tests for `export.glb.export()` - previously zero coverage).
- Verified end to end on three real files (two legacy MFC, one modern VFF format, up to 43 meshes / ~14,800 vertices): every exported mesh has real UV data (checked the raw glTF JSON directly, not just a reloaded/round-tripped object), mesh counts and computed UV values match `scene.py`'s already-verified `build_scene()` output exactly on the same files, and the metadata JSON's existing schema is unchanged (`definition_id`/`matrix_3x4` still present).