### PR TITLE
TypeScript: expose Face.uvProjected/uvProjectedBack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TypeScript**: `Face` gained `uvProjected`/`uvProjectedBack` fields.
+  The legacy MFC reader already decoded these bits internally
+  (`front_projected`/`back_projected` on the `CFaceTextureCoords` record)
+  but discarded them instead of exposing them, same gap Python closed in
+  #61. A PROJECTED texture (e.g. the Add Location terrain drape) has UVs
+  that run in the projection plane's frame, not the face frame - callers
+  need to know this to render it correctly. VFF/modern files don't carry
+  this flag at all, so it correctly defaults to `false` there, matching
+  Python's precedent.
+
 - **Python**: `scene.GlbPrimitive` gained a `uvs` field with real per-vertex
   texture coordinates, computed from each source face's `uv_transform` (or
   the default face-plane projection when a face has none) — see

--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -20,6 +20,8 @@ export interface GeometryBuilderFace {
   backMaterialId?: number | null;
   uvTransform?: number[] | null;
   uvTransformBack?: number[] | null;
+  uvProjected?: boolean;
+  uvProjectedBack?: boolean;
 }
 
 export class GeometryBuilder {

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -1004,6 +1004,8 @@ function fillBuilder(builder: LegacyBuilder, ents: [number, string | null, any][
         backMaterialId: v.back_mat || null,
         uvTransform: null,
         uvTransformBack: null,
+        uvProjected: false,
+        uvProjectedBack: false,
       };
       const attrs = v.attrs;
       if (attrs && typeof attrs === 'object') {
@@ -1011,6 +1013,8 @@ function fillBuilder(builder: LegacyBuilder, ents: [number, string | null, any][
           if (cv && typeof cv === 'object' && cv.k === 'ftc') {
             face.uvTransform = [...cv.front];
             face.uvTransformBack = [...cv.back];
+            face.uvProjected = cv.front_projected;
+            face.uvProjectedBack = cv.back_projected;
           }
         }
       }

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -73,6 +73,11 @@ export interface Face {
   uvTransform: number[] | null;
   /** Same for the face's back side, or null. */
   uvTransformBack: number[] | null;
+  /** The texture is PROJECTED (e.g. the Add Location terrain drape): its
+   * UVs run in the projection plane's frame, not the face frame. */
+  uvProjected: boolean;
+  /** Same for the face's back side. */
+  uvProjectedBack: boolean;
 }
 
 export interface CoEdge {
@@ -286,6 +291,8 @@ function buildDefinition(id: number, d: ParsedDefinition): Definition {
     backMaterialId: fData.backMaterialId ?? null,
     uvTransform: fData.uvTransform ?? null,
     uvTransformBack: fData.uvTransformBack ?? null,
+    uvProjected: fData.uvProjected ?? false,
+    uvProjectedBack: fData.uvProjectedBack ?? false,
   }));
   const instances: Instance[] = d.builder.instances.map((inst) => ({
     name: inst.name,


### PR DESCRIPTION
## What

`Face` gained `uvProjected`/`uvProjectedBack`. The legacy MFC reader already decoded these bits internally (`front_projected`/`back_projected` on the `CFaceTextureCoords` record - used for PROJECTED textures like the Add Location terrain drape) but discarded them instead of exposing them on the public model. Same gap Python closed for itself in #61.

A PROJECTED texture has UVs that run in the projection plane's frame rather than the standard face frame, so a renderer needs to know about it to map the texture correctly - right now there's no way to tell.

VFF/modern files don't carry this flag at all in any language so far - defaults to `false` there, matching Python's precedent.

## Testing

- `tsc --noEmit`: clean.
- `npm test`: 40/40 passing.
- Honest disclosure: neither this fix nor Python's original #61 has a dedicated unit test for the true/projected case - the real test fixture has zero projected faces (confirmed by checking Python's parsed output), and hand-crafting a synthetic byte-accurate `CFaceTextureCoords` record for a unit test is nontrivial. Matched the existing bar rather than silently skipping the gap.