### PR TITLE
Dart: expose Face.uvProjected/uvProjectedBack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   need to know this to render it correctly. VFF/modern files don't carry
   this flag at all, so it correctly defaults to `false` there, matching
   Python's precedent.
+- **Dart**: `Face` gained `uvProjected`/`uvProjectedBack` fields, same fix
+  and same rationale as the TypeScript entry above.
 
 - **Python**: `scene.GlbPrimitive` gained a `uvs` field with real per-vertex
   texture coordinates, computed from each source face's `uv_transform` (or

--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -13,6 +13,8 @@ class GeometryBuilderFace {
   int? backMaterialId;
   List<double>? uvTransform;
   List<double>? uvTransformBack;
+  bool uvProjected = false;
+  bool uvProjectedBack = false;
 }
 
 class GeometryBuilderInstance {

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -1152,6 +1152,8 @@ class Legacy {
             if (cv is FtcRec) {
               face.uvTransform = List<double>.from(cv.front);
               face.uvTransformBack = List<double>.from(cv.back);
+              face.uvProjected = cv.frontProjected;
+              face.uvProjectedBack = cv.backProjected;
             }
           }
         }

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -41,6 +41,13 @@ class Face {
   final List<double>? uvTransform;
   final List<double>? uvTransformBack;
 
+  /// The texture is PROJECTED (e.g. the Add Location terrain drape): its
+  /// UVs run in the projection plane's frame, not the face frame.
+  final bool uvProjected;
+
+  /// Same for the face's back side.
+  final bool uvProjectedBack;
+
   Face({
     required this.id,
     this.loops = const [],
@@ -49,6 +56,8 @@ class Face {
     this.backMaterialId,
     this.uvTransform,
     this.uvTransformBack,
+    this.uvProjected = false,
+    this.uvProjectedBack = false,
   });
 }
 

--- a/packages/dart/lib/src/parser.dart
+++ b/packages/dart/lib/src/parser.dart
@@ -153,6 +153,8 @@ class SkpFile {
         backMaterialId: f.backMaterialId,
         uvTransform: f.uvTransform,
         uvTransformBack: f.uvTransformBack,
+        uvProjected: f.uvProjected,
+        uvProjectedBack: f.uvProjectedBack,
       );
     }
 


### PR DESCRIPTION
## What

Same gap as #69 (TypeScript, merged): `Face` gained `uvProjected`/`uvProjectedBack`. The legacy MFC reader already decoded these bits (`frontProjected`/`backProjected` on the `CFaceTextureCoords` record) but discarded them instead of exposing them - same gap Python closed for itself in #61.

VFF/modern files don't carry this flag - defaults to `false` there, matching Python's precedent.

## Testing

- `dart analyze --fatal-infos`: clean.
- `dart test`: all 6 test files pass individually.
- Same honest disclosure as #69: no dedicated unit test for the true/projected case in this PR or Python's original - the real fixture has zero projected faces, and hand-crafting a synthetic legacy record for one is nontrivial. Matching the existing bar rather than silently skipping the gap.