### PR TITLE
.NET: expose Face.UvProjected/UvProjectedBack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Python's precedent.
 - **Dart**: `Face` gained `uvProjected`/`uvProjectedBack` fields, same fix
   and same rationale as the TypeScript entry above.
+- **.NET**: `Face` gained `UvProjected`/`UvProjectedBack` properties, same
+  fix and same rationale as the TypeScript/Dart entries above.
 
 - **Python**: `scene.GlbPrimitive` gained a `uvs` field with real per-vertex
   texture coordinates, computed from each source face's `uv_transform` (or

--- a/packages/dotnet/OpenSkp/Geometry.cs
+++ b/packages/dotnet/OpenSkp/Geometry.cs
@@ -15,6 +15,8 @@ namespace OpenSkp
         public long? BackMaterialId;
         public double[]? UvTransform;
         public double[]? UvTransformBack;
+        public bool UvProjected;
+        public bool UvProjectedBack;
     }
 
     internal sealed class GeometryBuilderInstance

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -1222,6 +1222,8 @@ namespace OpenSkp
                             {
                                 face.UvTransform = (double[])ftc.Front.Clone();
                                 face.UvTransformBack = (double[])ftc.Back.Clone();
+                                face.UvProjected = ftc.FrontProjected;
+                                face.UvProjectedBack = ftc.BackProjected;
                             }
                         }
                     }

--- a/packages/dotnet/OpenSkp/Model.cs
+++ b/packages/dotnet/OpenSkp/Model.cs
@@ -39,6 +39,14 @@ namespace OpenSkp
         /// the face plane.</summary>
         public double[]? UvTransform { get; set; }
         public double[]? UvTransformBack { get; set; }
+
+        /// <summary>The texture is PROJECTED (e.g. the Add Location terrain
+        /// drape): its UVs run in the projection plane's frame, not the face
+        /// frame.</summary>
+        public bool UvProjected { get; set; }
+
+        /// <summary>Same for the face's back side.</summary>
+        public bool UvProjectedBack { get; set; }
     }
 
     public sealed class Layer

--- a/packages/dotnet/OpenSkp/Parser.cs
+++ b/packages/dotnet/OpenSkp/Parser.cs
@@ -122,6 +122,8 @@ namespace OpenSkp
                     BackMaterialId = f.BackMaterialId,
                     UvTransform = f.UvTransform,
                     UvTransformBack = f.UvTransformBack,
+                    UvProjected = f.UvProjected,
+                    UvProjectedBack = f.UvProjectedBack,
                 };
             }
 


### PR DESCRIPTION
## What

Same gap as #69 (TypeScript) and #70 (Dart), both merged: `Face` gained `UvProjected`/`UvProjectedBack`. The legacy MFC reader already decoded these bits (`FrontProjected`/`BackProjected` on the `CFaceTextureCoords` record) but discarded them instead of exposing them - same gap Python closed for itself in #61.

VFF/modern files don't carry this flag - defaults to `false` there, matching Python's precedent. This is the last of the four remaining languages (C++ needs a separate, bigger fix - see follow-up).

## Testing

- `dotnet test`: 20/20 passing.
- Same honest disclosure as #69/#70: no dedicated unit test for the true/projected case - the real fixture has zero projected faces in any language checked so far.