### PR TITLE
Python: add model.root to JSON export; fix 5 lint issues in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Python**: `export.json_export.to_dict()`'s output gained a top-level
+  `root` key with the model's implicit top-level definition (matching
+  `SkpModel.root`) - previously only `definitions` (the numeric-ID-keyed
+  component/group definitions) was included, so the JSON export silently
+  omitted any geometry/instances placed directly in the model rather than
+  inside a component.
+
 - **TypeScript**: `Face` gained `uvProjected`/`uvProjectedBack` fields.
   The legacy MFC reader already decoded these bits internally
   (`front_projected`/`back_projected` on the `CFaceTextureCoords` record)

--- a/packages/python/src/openskp/export/json_export.py
+++ b/packages/python/src/openskp/export/json_export.py
@@ -102,10 +102,15 @@ def to_dict(model: SkpModel, scene: Optional[Scene] = None) -> Dict[str, Any]:
             pays for the heavier scene bake unless asked).
 
     Returns:
-        A nested dict containing all metadata.
+        A nested dict containing all metadata, including ``root`` (the
+        model's implicit top-level definition - non-componentized geometry
+        and instances placed directly in the model, matching
+        :attr:`SkpModel.root`) alongside ``definitions`` (numeric-ID-keyed
+        component/group definitions).
     """
     return {
         "version": model.version,
+        "root": _definition_to_dict(model.root),
         "definitions": {
             str(k): _definition_to_dict(v)
             for k, v in model.definitions.items()

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -6,8 +6,8 @@ construction, and transform maths without requiring a real ``.skp`` file.
 
 from __future__ import annotations
 
+import pathlib
 import struct
-from typing import List
 
 import pytest
 
@@ -303,10 +303,28 @@ class TestJsonExport:
         model = SkpModel()
         d = to_dict(model)
         assert d["version"] == "unknown"
+        assert d["root"] == {
+            "id": 0, "guid": "", "name": "", "vertex_count": 0,
+            "edge_count": 0, "face_count": 0, "vertices": [], "instances": [],
+        }
         assert d["definitions"] == {}
         assert d["layers"] == []
         assert d["materials"] == []
         assert d["scene_hierarchy"] is None
+
+    def test_root_is_included_alongside_definitions(self) -> None:
+        from openskp.model import Definition, SkpModel
+        from openskp.export.json_export import to_dict
+
+        model = SkpModel()
+        model.root = Definition(id=0, guid="ROOT", name="ROOT_MODEL")
+        d = to_dict(model)
+        # root is its own top-level key, not folded into "definitions" -
+        # matching SkpModel.root being a separate field, not a
+        # definitions[...] entry (see TestDataModel's root tests).
+        assert d["root"]["guid"] == "ROOT"
+        assert d["root"]["name"] == "ROOT_MODEL"
+        assert "ROOT" not in d["definitions"]
 
 
 # ── SkpFile tests ────────────────────────────────────────────────────────
@@ -322,7 +340,6 @@ class TestSkpFile:
             SkpFile.open("/nonexistent/path/model.skp")
 
     def test_open_wrong_extension(self, tmp_path: pathlib.Path) -> None:
-        import pathlib
         from openskp.model import SkpFile
 
         fake = tmp_path / "test.txt"
@@ -339,7 +356,6 @@ class TestUseTrans:
 
     def _skp_with(self, tmp_path, mat_xml: bytes):
         import io
-        import struct as _struct
         import zipfile
         buf = io.BytesIO()
         with zipfile.ZipFile(buf, "w") as zf:
@@ -546,7 +562,6 @@ class TestStyles:
 
     def test_style_colors_via_synthetic_skp(self, tmp_path: pathlib.Path) -> None:
         import io
-        import struct as _struct
         import zipfile
         from openskp.model import SkpFile
 
@@ -932,10 +947,6 @@ class TestTextureExtraction:
         assert copy.color[:3] == (27, 135, 59)
         base = by_name["Fence"]
         assert base.colorized is False
-
-
-# Need pathlib for tmp_path fixture
-import pathlib
 
 
 # ── Legacy (classic MFC) container tests ─────────────────────────────────


### PR DESCRIPTION
## What

Two small, related cleanup items from the repo-health checklist:

1. **`export.json_export.to_dict()` was missing `root`.** Its output only included `definitions` (the numeric-ID-keyed component/group definitions), silently omitting any geometry/instances placed directly in the model rather than inside a component. `model.root` has been its own dataclass field since #59, but the JSON exporter was never updated to include it.

2. **5 pre-existing ruff issues in `test_parser.py`**, invisible to CI since `ci-python.yml`'s lint step only checks `src/`, not `tests/`: 4 unused imports (`typing.List`, and three local `pathlib`/`struct` imports genuinely never referenced in their function bodies - all the `pathlib.Path` usages elsewhere are type annotations, which `from __future__ import annotations` makes lazy strings that never need a runtime import) and one `import pathlib` statement misplaced mid-file instead of at the top (moved up rather than removed, since `pathlib` is genuinely used throughout the file's annotations - ruff correctly recognized it as used, just badly placed).

## Testing

- Full test suite: 88/88 passing (added a real test for the `root` JSON key, and extended the existing empty-model test to check it too).
- `ruff check src/ tests/`: fully clean now (previously only `src/` was clean).