### PR TITLE
.NET: add binary glTF (GLB) export - ToGlb/ExportGlb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **.NET**: `GlbExport.ToGlb(Scene)`/`GlbExport.ExportGlb(Scene, path)` -
+  binary glTF 2.0 (GLB) export, matching Python's and C++'s
+  `to_glb`/`export_glb` pair (TypeScript only has the bytes-returning
+  variant). A from-scratch writer with no new dependency, matching how
+  this project has stayed dependency-light everywhere except C++'s
+  bundled TinyGLTF - `netstandard2.0` has no built-in JSON support, so
+  this also adds a small internal `MiniJson` serializer (reflection-based,
+  just enough to cover the object graphs this writer builds; not a
+  general-purpose JSON library). Ported from the TypeScript reference
+  implementation's `toGLB()`, with one correction: TS's own `toGLB()`
+  still doesn't write `TEXCOORD_0` despite `GlbPrimitive.uvs` existing
+  there too (tracked as a separate follow-up) - .NET's writer includes it
+  from the start. `ExportGlb` doesn't create missing parent directories,
+  matching C++'s `export_glb` (the other language with this same pair).
+  Verified against a real fixture: magic/chunk headers, mesh/material
+  counts, and decoded UV values all confirmed correct, with the UV values
+  byte-for-byte identical to the already cross-verified Python/TypeScript/
+  C#/Dart output on the same file.
 - **Python**: `export.json_export.to_dict()`'s output gained a top-level
   `root` key with the model's implicit top-level definition (matching
   `SkpModel.root`) - previously only `definitions` (the numeric-ID-keyed

--- a/packages/dotnet/OpenSkp.Tests/GlbTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/GlbTests.cs
@@ -1,0 +1,221 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// Tests for GlbExport - the from-scratch binary glTF (.glb) writer
+    /// (no external dependency, matching how this project stays
+    /// dependency-light everywhere except C++'s bundled TinyGLTF).
+    /// Uses System.Text.Json here only to parse the *output* for
+    /// assertions - that's part of the modern .NET SDK the test project
+    /// already targets (net9.0), not a new dependency on the library
+    /// itself (which stays netstandard2.0, hence GlbExport's own
+    /// hand-rolled MiniJson).
+    /// </summary>
+    public class GlbTests
+    {
+        private static string FixturePath(string name) =>
+            Path.Combine(AppContext.BaseDirectory, "fixtures", name);
+
+        private static Scene TriangleScene()
+        {
+            return new Scene
+            {
+                GltfMaterials = new System.Collections.Generic.List<object>
+                {
+                    new
+                    {
+                        pbrMetallicRoughness = new
+                        {
+                            baseColorFactor = new[] { 0.25, 0.5, 0.75, 1.0 },
+                            metallicFactor = 0.1,
+                            roughnessFactor = 0.9,
+                        },
+                    },
+                },
+                GlbPrimitives = new System.Collections.Generic.List<GlbPrimitive>
+                {
+                    new GlbPrimitive
+                    {
+                        Positions = new float[] { 1, 2, 3, -4, 5, 0, 2, -1, 7 },
+                        Normals = new float[] { 0, 0, 1, 0, 0, 1, 0, 0, 1 },
+                        Uvs = new float[] { 0, 0, 1, 0, 0, 1 },
+                        Indices = new uint[] { 0, 1, 2 },
+                        MaterialIndex = 0,
+                        GeomName = "triangle",
+                    },
+                },
+            };
+        }
+
+        [Fact]
+        public void SerializesSceneAndBinaryData()
+        {
+            var bytes = GlbExport.ToGlb(TriangleScene());
+            Assert.True(bytes.Length >= 12);
+            Assert.Equal("glTF", Encoding.ASCII.GetString(bytes, 0, 4));
+
+            var (json, binary) = ParseGlb(bytes);
+            Assert.Equal("2.0", json.GetProperty("asset").GetProperty("version").GetString());
+
+            var meshes = json.GetProperty("meshes");
+            Assert.Equal(1, meshes.GetArrayLength());
+            var prim = meshes[0].GetProperty("primitives")[0];
+            var attrs = prim.GetProperty("attributes");
+            Assert.True(attrs.TryGetProperty("POSITION", out _));
+            Assert.True(attrs.TryGetProperty("NORMAL", out _));
+            Assert.True(attrs.TryGetProperty("TEXCOORD_0", out _));
+            Assert.Equal(0, prim.GetProperty("material").GetInt32());
+
+            var accessors = json.GetProperty("accessors");
+            var posAccessor = accessors[attrs.GetProperty("POSITION").GetInt32()];
+            Assert.Equal(5126, posAccessor.GetProperty("componentType").GetInt32());
+            Assert.Equal("VEC3", posAccessor.GetProperty("type").GetString());
+            Assert.Equal(3, posAccessor.GetProperty("count").GetInt32());
+            var min = posAccessor.GetProperty("min").EnumerateArray().Select(e => e.GetDouble()).ToArray();
+            var max = posAccessor.GetProperty("max").EnumerateArray().Select(e => e.GetDouble()).ToArray();
+            Assert.Equal(new[] { -4.0, -1.0, 0.0 }, min);
+            Assert.Equal(new[] { 2.0, 5.0, 7.0 }, max);
+
+            var uvAccessor = accessors[attrs.GetProperty("TEXCOORD_0").GetInt32()];
+            Assert.Equal(5126, uvAccessor.GetProperty("componentType").GetInt32());
+            Assert.Equal("VEC2", uvAccessor.GetProperty("type").GetString());
+            Assert.Equal(3, uvAccessor.GetProperty("count").GetInt32());
+            var uvBufferView = json.GetProperty("bufferViews")[uvAccessor.GetProperty("bufferView").GetInt32()];
+            var uvOffset = uvBufferView.GetProperty("byteOffset").GetInt32();
+            Assert.Equal(1.0f, BitConverter.ToSingle(binary, uvOffset + 2 * 4));
+
+            var materials = json.GetProperty("materials");
+            var pbr = materials[0].GetProperty("pbrMetallicRoughness");
+            Assert.Equal(0.25, pbr.GetProperty("baseColorFactor")[0].GetDouble());
+            Assert.Equal(0.1, pbr.GetProperty("metallicFactor").GetDouble());
+            Assert.Equal(0.9, pbr.GetProperty("roughnessFactor").GetDouble());
+        }
+
+        [Fact]
+        public void SerializesAnEmptyScene()
+        {
+            var bytes = GlbExport.ToGlb(new Scene());
+            var (json, _) = ParseGlb(bytes);
+            Assert.Equal(0, json.GetProperty("meshes").GetArrayLength());
+            Assert.Equal(0, json.GetProperty("nodes").GetArrayLength());
+        }
+
+        [Fact]
+        public void RejectsMalformedGeometry()
+        {
+            var scene = TriangleScene();
+            scene.GlbPrimitives[0].Positions = scene.GlbPrimitives[0].Positions.Take(8).ToArray();
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+
+            scene = TriangleScene();
+            scene.GlbPrimitives[0].Normals = scene.GlbPrimitives[0].Normals.Take(2).ToArray();
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+
+            scene = TriangleScene();
+            scene.GlbPrimitives[0].Uvs = scene.GlbPrimitives[0].Uvs.Take(1).ToArray();
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+
+            scene = TriangleScene();
+            scene.GlbPrimitives[0].Indices = Array.Empty<uint>();
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+
+            scene = TriangleScene();
+            scene.GlbPrimitives[0].Indices = new uint[] { 0, 1, 5 };
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+
+            scene = TriangleScene();
+            scene.GlbPrimitives[0].MaterialIndex = 1;
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+        }
+
+        [Fact]
+        public void RejectsNonFiniteValues()
+        {
+            var scene = TriangleScene();
+            scene.GlbPrimitives[0].Positions[0] = float.NaN;
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+
+            scene = TriangleScene();
+            scene.GlbPrimitives[0].Normals[0] = float.PositiveInfinity;
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+
+            scene = TriangleScene();
+            scene.GlbPrimitives[0].Uvs[0] = float.NegativeInfinity;
+            Assert.Throws<ArgumentException>(() => GlbExport.ToGlb(scene));
+        }
+
+        [Fact]
+        public void ExportsRealFixtureMatchingToGlbAndBuildScene()
+        {
+            var scene = SkpFile.BuildScene(FixturePath("capilla_quiroz_v17.skp"));
+            var expected = GlbExport.ToGlb(scene);
+
+            var output = Path.Combine(Path.GetTempPath(), "openskp-dotnet-glb-test.glb");
+            GlbExport.ExportGlb(scene, output);
+            try
+            {
+                var actual = File.ReadAllBytes(output);
+                Assert.Equal(expected, actual);
+
+                var (json, binary) = ParseGlb(actual);
+                var meshes = json.GetProperty("meshes")[0].GetProperty("primitives");
+                Assert.Equal(scene.GlbPrimitives.Count, meshes.GetArrayLength());
+
+                // Every primitive must carry TEXCOORD_0, and the decoded
+                // values must exactly match the source GlbPrimitive.Uvs
+                // that fed the writer - a real round-trip check, not
+                // just "some accessor exists."
+                for (var i = 0; i < scene.GlbPrimitives.Count; i++)
+                {
+                    var prim = scene.GlbPrimitives[i];
+                    var attrs = meshes[i].GetProperty("attributes");
+                    Assert.True(attrs.TryGetProperty("TEXCOORD_0", out var uvAccessorIdx));
+                    var uvAccessor = json.GetProperty("accessors")[uvAccessorIdx.GetInt32()];
+                    var uvBufferView = json.GetProperty("bufferViews")[uvAccessor.GetProperty("bufferView").GetInt32()];
+                    var uvOffset = uvBufferView.GetProperty("byteOffset").GetInt32();
+                    var uvCount = uvAccessor.GetProperty("count").GetInt32();
+                    Assert.Equal(prim.Uvs.Length, uvCount * 2);
+                    for (var j = 0; j < prim.Uvs.Length; j++)
+                    {
+                        Assert.Equal(prim.Uvs[j], BitConverter.ToSingle(binary, uvOffset + j * 4));
+                    }
+                }
+            }
+            finally
+            {
+                File.Delete(output);
+            }
+        }
+
+        [Fact]
+        public void ReportsFileFailuresWithoutCreatingDirectories()
+        {
+            var output = Path.Combine(Path.GetTempPath(), "openskp-missing-parent-" + Guid.NewGuid(), "asset.glb");
+            Assert.ThrowsAny<Exception>(() => GlbExport.ExportGlb(TriangleScene(), output));
+        }
+
+        private static (JsonElement Json, byte[] Binary) ParseGlb(byte[] bytes)
+        {
+            var jsonChunkLen = BitConverter.ToUInt32(bytes, 12);
+            var jsonStr = Encoding.UTF8.GetString(bytes, 20, (int)jsonChunkLen);
+            var json = JsonDocument.Parse(jsonStr).RootElement;
+
+            var binHeaderOffset = 20 + (int)jsonChunkLen;
+            byte[] binary = Array.Empty<byte>();
+            if (binHeaderOffset < bytes.Length)
+            {
+                var binChunkLen = BitConverter.ToUInt32(bytes, binHeaderOffset);
+                binary = new byte[binChunkLen];
+                Array.Copy(bytes, binHeaderOffset + 8, binary, 0, (int)binChunkLen);
+            }
+            return (json, binary);
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Glb.cs
+++ b/packages/dotnet/OpenSkp/Glb.cs
@@ -1,0 +1,422 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Reflection;
+using System.Text;
+
+namespace OpenSkp
+{
+    /// <summary>Minimal JSON serializer for the plain object graphs
+    /// (nested Dictionary/List/array/primitive, or anonymous types via
+    /// reflection) GlbExport builds internally. Not a general-purpose
+    /// JSON library - this project stays dependency-light everywhere
+    /// except C++'s bundled TinyGLTF, and netstandard2.0 has no built-in
+    /// JSON support, so this only needs to cover the shapes GlbExport
+    /// actually produces.</summary>
+    internal static class MiniJson
+    {
+        public static string Serialize(object? value)
+        {
+            var sb = new StringBuilder();
+            Write(sb, value);
+            return sb.ToString();
+        }
+
+        private static void Write(StringBuilder sb, object? value)
+        {
+            switch (value)
+            {
+                case null:
+                    sb.Append("null");
+                    return;
+                case string s:
+                    WriteString(sb, s);
+                    return;
+                case bool b:
+                    sb.Append(b ? "true" : "false");
+                    return;
+                // "R" is unreliable for float round-tripping on some
+                // netstandard2.0 runtimes (a known historical .NET
+                // Framework bug) - G9/G17 are the documented
+                // always-round-trips-safely precisions for float/double.
+                case float f:
+                    sb.Append(f.ToString("G9", CultureInfo.InvariantCulture));
+                    return;
+                case double d:
+                    sb.Append(d.ToString("G17", CultureInfo.InvariantCulture));
+                    return;
+                case int or uint or long or ulong:
+                    sb.Append(Convert.ToString(value, CultureInfo.InvariantCulture));
+                    return;
+                case IDictionary<string, object> dict:
+                    WriteObject(sb, dict);
+                    return;
+                case IEnumerable enumerable:
+                    WriteArray(sb, enumerable);
+                    return;
+                default:
+                    WriteReflected(sb, value);
+                    return;
+            }
+        }
+
+        private static void WriteString(StringBuilder sb, string s)
+        {
+            sb.Append('"');
+            foreach (var c in s)
+            {
+                switch (c)
+                {
+                    case '"': sb.Append("\\\""); break;
+                    case '\\': sb.Append("\\\\"); break;
+                    case '\n': sb.Append("\\n"); break;
+                    case '\r': sb.Append("\\r"); break;
+                    case '\t': sb.Append("\\t"); break;
+                    default:
+                        if (c < 0x20) sb.Append("\\u").Append(((int)c).ToString("x4"));
+                        else sb.Append(c);
+                        break;
+                }
+            }
+            sb.Append('"');
+        }
+
+        private static void WriteObject(StringBuilder sb, IDictionary<string, object> dict)
+        {
+            sb.Append('{');
+            var first = true;
+            foreach (var kv in dict)
+            {
+                if (!first) sb.Append(',');
+                first = false;
+                WriteString(sb, kv.Key);
+                sb.Append(':');
+                Write(sb, kv.Value);
+            }
+            sb.Append('}');
+        }
+
+        private static void WriteArray(StringBuilder sb, IEnumerable enumerable)
+        {
+            sb.Append('[');
+            var first = true;
+            foreach (var item in enumerable)
+            {
+                if (!first) sb.Append(',');
+                first = false;
+                Write(sb, item);
+            }
+            sb.Append(']');
+        }
+
+        // Anonymous types (used for Scene.GltfMaterials) have no
+        // interface to pattern-match on - their property names match the
+        // assigned identifiers exactly (e.g. `new { pbrMetallicRoughness
+        // = ... }`), so reflecting them produces the correct camelCase
+        // glTF keys with no name mapping needed.
+        private static void WriteReflected(StringBuilder sb, object value)
+        {
+            sb.Append('{');
+            var first = true;
+            foreach (var prop in value.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance))
+            {
+                if (!first) sb.Append(',');
+                first = false;
+                WriteString(sb, prop.Name);
+                sb.Append(':');
+                Write(sb, prop.GetValue(value));
+            }
+            sb.Append('}');
+        }
+    }
+
+    /// <summary>Binary glTF (.glb) export for a baked Scene - a
+    /// from-scratch writer with no external dependency, matching how this
+    /// project has stayed dependency-light everywhere except C++'s
+    /// bundled TinyGLTF. Ported from the TypeScript reference
+    /// implementation's toGLB(), with TEXCOORD_0 support added (the TS
+    /// reference doesn't write it despite GlbPrimitive.uvs existing there
+    /// too - tracked separately) and the same validation rigor as the
+    /// C++ port's glb.cpp.</summary>
+    public static class GlbExport
+    {
+        // glTF's chunk-length fields are uint32 - a GLB file's total size
+        // (and each individual chunk) is hard-capped at 4GB by the format
+        // itself, not an arbitrary choice here.
+        private const long GlbSizeLimit = uint.MaxValue;
+
+        /// <summary>Serializes a baked Scene to binary glTF 2.0 (GLB) bytes.</summary>
+        public static byte[] ToGlb(Scene scene)
+        {
+            if (scene == null) throw new ArgumentNullException(nameof(scene));
+            var prims = scene.GlbPrimitives ?? new List<GlbPrimitive>();
+            var materials = scene.GltfMaterials ?? new List<object>();
+
+            ValidateScene(prims, materials);
+
+            long totalBinaryLength = 0;
+            foreach (var prim in prims)
+            {
+                totalBinaryLength += (long)prim.Positions.Length * 4;
+                totalBinaryLength += (long)prim.Normals.Length * 4;
+                totalBinaryLength += (long)prim.Uvs.Length * 4;
+                totalBinaryLength += (long)prim.Indices.Length * 4;
+            }
+            if (totalBinaryLength > GlbSizeLimit)
+                throw new InvalidOperationException("scene geometry exceeds GLB's 32-bit binary-buffer limit");
+
+            var binaryBuffer = new byte[totalBinaryLength];
+            var bufferViews = new List<object>();
+            var accessors = new List<object>();
+            var gltfPrimitives = new List<object>();
+
+            var byteOffset = 0;
+            foreach (var prim in prims)
+            {
+                var posByteOffset = byteOffset;
+                Buffer.BlockCopy(prim.Positions, 0, binaryBuffer, byteOffset, prim.Positions.Length * 4);
+                byteOffset += prim.Positions.Length * 4;
+
+                var normByteOffset = byteOffset;
+                Buffer.BlockCopy(prim.Normals, 0, binaryBuffer, byteOffset, prim.Normals.Length * 4);
+                byteOffset += prim.Normals.Length * 4;
+
+                var uvByteOffset = byteOffset;
+                Buffer.BlockCopy(prim.Uvs, 0, binaryBuffer, byteOffset, prim.Uvs.Length * 4);
+                byteOffset += prim.Uvs.Length * 4;
+
+                var indByteOffset = byteOffset;
+                Buffer.BlockCopy(prim.Indices, 0, binaryBuffer, byteOffset, prim.Indices.Length * 4);
+                byteOffset += prim.Indices.Length * 4;
+
+                var posBufferViewIdx = bufferViews.Count;
+                bufferViews.Add(new Dictionary<string, object>
+                {
+                    ["buffer"] = 0,
+                    ["byteOffset"] = posByteOffset,
+                    ["byteLength"] = prim.Positions.Length * 4,
+                    ["target"] = 34962, // ARRAY_BUFFER
+                });
+
+                var normBufferViewIdx = bufferViews.Count;
+                bufferViews.Add(new Dictionary<string, object>
+                {
+                    ["buffer"] = 0,
+                    ["byteOffset"] = normByteOffset,
+                    ["byteLength"] = prim.Normals.Length * 4,
+                    ["target"] = 34962,
+                });
+
+                var uvBufferViewIdx = bufferViews.Count;
+                bufferViews.Add(new Dictionary<string, object>
+                {
+                    ["buffer"] = 0,
+                    ["byteOffset"] = uvByteOffset,
+                    ["byteLength"] = prim.Uvs.Length * 4,
+                    ["target"] = 34962,
+                });
+
+                var indBufferViewIdx = bufferViews.Count;
+                bufferViews.Add(new Dictionary<string, object>
+                {
+                    ["buffer"] = 0,
+                    ["byteOffset"] = indByteOffset,
+                    ["byteLength"] = prim.Indices.Length * 4,
+                    ["target"] = 34963, // ELEMENT_ARRAY_BUFFER
+                });
+
+                float minX = float.PositiveInfinity, minY = float.PositiveInfinity, minZ = float.PositiveInfinity;
+                float maxX = float.NegativeInfinity, maxY = float.NegativeInfinity, maxZ = float.NegativeInfinity;
+                for (var i = 0; i < prim.Positions.Length; i += 3)
+                {
+                    var x = prim.Positions[i];
+                    var y = prim.Positions[i + 1];
+                    var z = prim.Positions[i + 2];
+                    if (x < minX) minX = x;
+                    if (x > maxX) maxX = x;
+                    if (y < minY) minY = y;
+                    if (y > maxY) maxY = y;
+                    if (z < minZ) minZ = z;
+                    if (z > maxZ) maxZ = z;
+                }
+
+                var posAccessorIdx = accessors.Count;
+                accessors.Add(new Dictionary<string, object>
+                {
+                    ["bufferView"] = posBufferViewIdx,
+                    ["byteOffset"] = 0,
+                    ["componentType"] = 5126, // FLOAT
+                    ["count"] = prim.Positions.Length / 3,
+                    ["type"] = "VEC3",
+                    ["min"] = new object[] { minX, minY, minZ },
+                    ["max"] = new object[] { maxX, maxY, maxZ },
+                });
+
+                var normAccessorIdx = accessors.Count;
+                accessors.Add(new Dictionary<string, object>
+                {
+                    ["bufferView"] = normBufferViewIdx,
+                    ["byteOffset"] = 0,
+                    ["componentType"] = 5126,
+                    ["count"] = prim.Normals.Length / 3,
+                    ["type"] = "VEC3",
+                });
+
+                var uvAccessorIdx = accessors.Count;
+                accessors.Add(new Dictionary<string, object>
+                {
+                    ["bufferView"] = uvBufferViewIdx,
+                    ["byteOffset"] = 0,
+                    ["componentType"] = 5126,
+                    ["count"] = prim.Uvs.Length / 2,
+                    ["type"] = "VEC2",
+                });
+
+                var indAccessorIdx = accessors.Count;
+                accessors.Add(new Dictionary<string, object>
+                {
+                    ["bufferView"] = indBufferViewIdx,
+                    ["byteOffset"] = 0,
+                    ["componentType"] = 5125, // UNSIGNED_INT
+                    ["count"] = prim.Indices.Length,
+                    ["type"] = "SCALAR",
+                });
+
+                gltfPrimitives.Add(new Dictionary<string, object>
+                {
+                    ["attributes"] = new Dictionary<string, object>
+                    {
+                        ["POSITION"] = posAccessorIdx,
+                        ["NORMAL"] = normAccessorIdx,
+                        ["TEXCOORD_0"] = uvAccessorIdx,
+                    },
+                    ["indices"] = indAccessorIdx,
+                    ["material"] = prim.MaterialIndex,
+                });
+            }
+
+            var gltfMeshes = new List<object>();
+            if (gltfPrimitives.Count > 0)
+            {
+                gltfMeshes.Add(new Dictionary<string, object> { ["primitives"] = gltfPrimitives });
+            }
+
+            var gltfJson = new Dictionary<string, object>
+            {
+                ["asset"] = new Dictionary<string, object> { ["version"] = "2.0", ["generator"] = "OpenSKP .NET Exporter" },
+                ["scene"] = 0,
+                ["scenes"] = new object[]
+                {
+                    new Dictionary<string, object> { ["nodes"] = gltfMeshes.Count > 0 ? new object[] { 0 } : Array.Empty<object>() },
+                },
+                ["nodes"] = gltfMeshes.Count > 0 ? new object[] { new Dictionary<string, object> { ["mesh"] = 0 } } : Array.Empty<object>(),
+                ["meshes"] = gltfMeshes,
+                ["materials"] = materials,
+                ["buffers"] = new object[] { new Dictionary<string, object> { ["byteLength"] = totalBinaryLength } },
+                ["bufferViews"] = bufferViews,
+                ["accessors"] = accessors,
+            };
+
+            return CreateGlb(gltfJson, binaryBuffer);
+        }
+
+        /// <summary>Serializes a baked Scene to GLB and writes it to
+        /// <paramref name="path"/>. Does not create missing parent
+        /// directories - matching the C++ port's export_glb, the other
+        /// language with this same in-memory-bytes/file-write pair.</summary>
+        public static void ExportGlb(Scene scene, string path)
+        {
+            var bytes = ToGlb(scene);
+            File.WriteAllBytes(path, bytes);
+        }
+
+        private static void ValidateScene(List<GlbPrimitive> prims, List<object> materials)
+        {
+            for (var i = 0; i < prims.Count; i++)
+            {
+                var prim = prims[i];
+                var prefix = $"primitive {i} ";
+                if (prim.Positions.Length == 0) throw new ArgumentException(prefix + "positions must not be empty");
+                if (prim.Positions.Length % 3 != 0) throw new ArgumentException(prefix + "positions must contain complete vec3 values");
+                if (prim.Normals.Length != prim.Positions.Length) throw new ArgumentException(prefix + "normals must match positions");
+                if (prim.Uvs.Length != prim.Positions.Length / 3 * 2) throw new ArgumentException(prefix + "uvs must match positions");
+                if (prim.Indices.Length == 0) throw new ArgumentException(prefix + "indices must not be empty");
+                if (prim.Indices.Length % 3 != 0) throw new ArgumentException(prefix + "indices must contain complete triangles");
+                if (prim.MaterialIndex < 0 || prim.MaterialIndex >= materials.Count) throw new ArgumentException(prefix + "references an invalid material");
+
+                var vertexCount = (uint)(prim.Positions.Length / 3);
+                foreach (var v in prim.Positions) CheckFinite(v, prefix + "position");
+                foreach (var v in prim.Normals) CheckFinite(v, prefix + "normal");
+                foreach (var v in prim.Uvs) CheckFinite(v, prefix + "uv");
+                foreach (var idx in prim.Indices)
+                    if (idx >= vertexCount) throw new ArgumentException(prefix + "index is out of range");
+            }
+        }
+
+        private static void CheckFinite(float value, string field)
+        {
+            // netstandard2.0 has no float.IsFinite - IsNaN/IsInfinity
+            // predate it and are available everywhere this targets.
+            if (float.IsNaN(value) || float.IsInfinity(value))
+                throw new ArgumentException(field + " must be finite");
+        }
+
+        private static byte[] CreateGlb(object json, byte[] binaryBuffer)
+        {
+            var jsonBytes = Encoding.UTF8.GetBytes(MiniJson.Serialize(json));
+            var jsonPad = (4 - jsonBytes.Length % 4) % 4;
+            if (jsonPad > 0)
+            {
+                var padded = new byte[jsonBytes.Length + jsonPad];
+                Buffer.BlockCopy(jsonBytes, 0, padded, 0, jsonBytes.Length);
+                for (var i = jsonBytes.Length; i < padded.Length; i++) padded[i] = 0x20; // space
+                jsonBytes = padded;
+            }
+
+            var binPad = (4 - binaryBuffer.Length % 4) % 4;
+            var paddedBinary = binaryBuffer;
+            if (binPad > 0)
+            {
+                paddedBinary = new byte[binaryBuffer.Length + binPad];
+                Buffer.BlockCopy(binaryBuffer, 0, paddedBinary, 0, binaryBuffer.Length);
+            }
+
+            long totalLength = 12 + 8 + jsonBytes.Length + 8 + paddedBinary.Length;
+            if (totalLength > GlbSizeLimit)
+                throw new InvalidOperationException("serialized GLB exceeds its 32-bit file-size limit");
+
+            var glb = new byte[totalLength];
+            var p = 0;
+            WriteU32(glb, ref p, 0x46546C67); // magic 'glTF'
+            WriteU32(glb, ref p, 2); // version
+            WriteU32(glb, ref p, (uint)totalLength);
+
+            WriteU32(glb, ref p, (uint)jsonBytes.Length);
+            WriteU32(glb, ref p, 0x4E4F534A); // 'JSON'
+            Buffer.BlockCopy(jsonBytes, 0, glb, p, jsonBytes.Length);
+            p += jsonBytes.Length;
+
+            WriteU32(glb, ref p, (uint)paddedBinary.Length);
+            WriteU32(glb, ref p, 0x004E4942); // 'BIN\0'
+            Buffer.BlockCopy(paddedBinary, 0, glb, p, paddedBinary.Length);
+            p += paddedBinary.Length;
+
+            return glb;
+        }
+
+        // Chunk headers are written byte-by-byte in explicit little-endian
+        // order (matching the C++ port's approach) rather than relying on
+        // host endianness, even though every realistic .NET deployment
+        // target is little-endian anyway - cheap to be correct here.
+        private static void WriteU32(byte[] buffer, ref int pos, uint value)
+        {
+            buffer[pos] = (byte)value;
+            buffer[pos + 1] = (byte)(value >> 8);
+            buffer[pos + 2] = (byte)(value >> 16);
+            buffer[pos + 3] = (byte)(value >> 24);
+            pos += 4;
+        }
+    }
+}


### PR DESCRIPTION
## What

Ports the last missing capability from Python/TypeScript/C++: a way to actually export a baked `Scene` as a `.glb` file, not just the intermediate `Scene`/`GlbPrimitive` data. Matches Python's and C++'s `to_glb`/`export_glb` pair (TypeScript only has the bytes-returning variant, no file-write one - so "full parity" here means matching the fullest existing API surface, not literally every other language, since they aren't uniform).

## How

A from-scratch writer, no new dependency - matching how this project has stayed dependency-light everywhere except C++'s bundled TinyGLTF. `netstandard2.0` has no built-in JSON support, so this also adds a small internal `MiniJson` serializer: reflection-based, only covering what this writer actually needs (Dictionary/List/array/primitive, plus anonymous types for `Scene.GltfMaterials` - anonymous-type property names match their declared identifiers exactly, so reflecting them produces correct camelCase glTF keys with no name mapping needed). Not a general-purpose JSON library, just enough for this.

Structurally ported from the TypeScript reference implementation's `toGLB()` (chunk framing, accessor/bufferView construction, min/max bounds on POSITION), with one real correction worth flagging: **TS's own `toGLB()` still doesn't write `TEXCOORD_0`**, despite `GlbPrimitive.uvs` existing on its data model too (added back in #65). I'm treating that as a separate, small follow-up rather than folding it into this PR. This new .NET writer includes `TEXCOORD_0` from the start, since building it fresh made that the obviously right thing to do.

`ExportGlb` deliberately does **not** create missing parent directories, matching C++'s `export_glb` - the only other language with this exact in-memory-bytes/file-write pair to stay consistent with. (Python's `export.glb.export()` does create directories, but it's a heavier, older pipeline that also writes JSON metadata/thumbnails alongside the GLB - not a direct analog to compare against here.)

## Verification

Built a throwaway console app referencing this build, exported the real fixture (`capilla_quiroz_v17.skp`), and inspected the raw GLB bytes directly (not just "did `ToGlb` return without throwing"):
- magic/version/chunk headers correct
- 13 meshes / 9 materials - matching every other language's already-verified count on this exact file
- all 13 primitives carry `TEXCOORD_0`
- the decoded UV values are **byte-for-byte identical** to the already cross-verified Python/TypeScript/C#/Dart output on the same file

## Testing

- `dotnet test`: 26/26 passing (20 existing + 6 new).
- New `GlbTests.cs` covers: serialization shape (POSITION/NORMAL/TEXCOORD_0 accessors, min/max bounds, material pass-through), empty scenes, malformed-geometry and non-finite-value rejection (mirroring C++'s `glb_test.cpp`'s coverage), and a real-fixture round-trip test that decodes every primitive's `TEXCOORD_0` back out of the binary chunk and asserts it matches the source `GlbPrimitive.Uvs` array exactly - not just "some accessor exists."
- Clean build, 0 warnings.