### PR TITLE
Dart: add binary glTF (GLB) export - toGlb/exportGlb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dart**: `toGlb(Scene)`/`exportGlb(Scene, path)` - binary glTF 2.0
+  (GLB) export, matching Python's and C++'s `to_glb`/`export_glb` pair
+  (same scope as the .NET entry below). A from-scratch writer with no new
+  dependency - `dart:convert`'s built-in `jsonEncode` covers the JSON
+  chunk directly, no custom serializer needed (simpler than .NET's port,
+  which had to hand-roll one since `netstandard2.0` has no built-in JSON
+  support). Same TEXCOORD_0 correction as .NET's port relative to the
+  TypeScript reference. `exportGlb` doesn't create missing parent
+  directories, matching C++/.NET's `export_glb`/`ExportGlb`. One
+  Dart-specific wrinkle: `GlbPrimitive`'s fields are `List<double>`
+  (64-bit) here, but the binary accessor data is float32 - min/max
+  bounds are now read back from the already-written float32 buffer
+  rather than computed from the raw doubles, so they match what's
+  actually in the accessor. Verified against the real fixture: chunk
+  headers, mesh/material counts, and decoded UV values all confirmed
+  correct, byte-for-byte identical (after accounting for float32
+  rounding) to the already cross-verified Python/TypeScript/C#/.NET
+  output on the same file.
 - **.NET**: `GlbExport.ToGlb(Scene)`/`GlbExport.ExportGlb(Scene, path)` -
   binary glTF 2.0 (GLB) export, matching Python's and C++'s
   `to_glb`/`export_glb` pair (TypeScript only has the bytes-returning

--- a/packages/dart/lib/openskp.dart
+++ b/packages/dart/lib/openskp.dart
@@ -5,5 +5,6 @@ library openskp;
 export 'src/model.dart';
 export 'src/parser.dart' show SkpFile;
 export 'src/scene.dart' show Scene, InstanceNode, MeshMetadata, GlbPrimitive;
+export 'src/glb.dart' show toGlb, exportGlb;
 export 'src/errors.dart' show SkpParseException;
 export 'src/observability.dart' show SkpLogLevel, ParseProgress, ParseOptions;

--- a/packages/dart/lib/src/glb.dart
+++ b/packages/dart/lib/src/glb.dart
@@ -1,0 +1,289 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'scene.dart';
+
+/// glTF's chunk-length fields are uint32 - a GLB file's total size (and
+/// each individual chunk) is hard-capped at 4GB by the format itself, not
+/// an arbitrary choice here.
+const int _glbSizeLimit = 0xFFFFFFFF;
+
+/// Serializes a baked [Scene] to binary glTF 2.0 (GLB) bytes.
+///
+/// A from-scratch writer with no external dependency, matching how this
+/// project has stayed dependency-light everywhere except C++'s bundled
+/// TinyGLTF - `dart:convert`'s built-in [jsonEncode] covers the JSON
+/// chunk directly, no custom serializer needed. Structurally ported from
+/// the TypeScript reference implementation's `toGLB()`, with one
+/// correction: TS's own `toGLB()` doesn't write `TEXCOORD_0` despite
+/// `GlbPrimitive.uvs` existing there too (tracked as a separate
+/// follow-up) - this writer includes it from the start.
+Uint8List toGlb(Scene scene) {
+  final prims = scene.glbPrimitives;
+  final materials = scene.gltfMaterials;
+
+  _validateScene(prims, materials);
+
+  var totalBinaryLength = 0;
+  for (final prim in prims) {
+    totalBinaryLength += prim.positions.length * 4;
+    totalBinaryLength += prim.normals.length * 4;
+    totalBinaryLength += prim.uvs.length * 4;
+    totalBinaryLength += prim.indices.length * 4;
+  }
+  if (totalBinaryLength > _glbSizeLimit) {
+    throw StateError("scene geometry exceeds GLB's 32-bit binary-buffer limit");
+  }
+
+  final binaryBuffer = ByteData(totalBinaryLength);
+  final bufferViews = <Map<String, dynamic>>[];
+  final accessors = <Map<String, dynamic>>[];
+  final gltfPrimitives = <Map<String, dynamic>>[];
+
+  var byteOffset = 0;
+  for (final prim in prims) {
+    final posByteOffset = byteOffset;
+    for (final v in prim.positions) {
+      binaryBuffer.setFloat32(byteOffset, v, Endian.little);
+      byteOffset += 4;
+    }
+
+    final normByteOffset = byteOffset;
+    for (final v in prim.normals) {
+      binaryBuffer.setFloat32(byteOffset, v, Endian.little);
+      byteOffset += 4;
+    }
+
+    final uvByteOffset = byteOffset;
+    for (final v in prim.uvs) {
+      binaryBuffer.setFloat32(byteOffset, v, Endian.little);
+      byteOffset += 4;
+    }
+
+    final indByteOffset = byteOffset;
+    for (final idx in prim.indices) {
+      binaryBuffer.setUint32(byteOffset, idx, Endian.little);
+      byteOffset += 4;
+    }
+
+    final posBufferViewIdx = bufferViews.length;
+    bufferViews.add({
+      'buffer': 0,
+      'byteOffset': posByteOffset,
+      'byteLength': prim.positions.length * 4,
+      'target': 34962, // ARRAY_BUFFER
+    });
+
+    final normBufferViewIdx = bufferViews.length;
+    bufferViews.add({
+      'buffer': 0,
+      'byteOffset': normByteOffset,
+      'byteLength': prim.normals.length * 4,
+      'target': 34962,
+    });
+
+    final uvBufferViewIdx = bufferViews.length;
+    bufferViews.add({
+      'buffer': 0,
+      'byteOffset': uvByteOffset,
+      'byteLength': prim.uvs.length * 4,
+      'target': 34962,
+    });
+
+    final indBufferViewIdx = bufferViews.length;
+    bufferViews.add({
+      'buffer': 0,
+      'byteOffset': indByteOffset,
+      'byteLength': prim.indices.length * 4,
+      'target': 34963, // ELEMENT_ARRAY_BUFFER
+    });
+
+    // Read back through binaryBuffer (already written above) rather than
+    // prim.positions directly: positions are List<double> (64-bit) here,
+    // but the accessor's actual binary data is float32, so min/max must
+    // reflect the same rounded values that are actually in the buffer -
+    // otherwise a strict glTF validator could see min/max bounds that
+    // don't match what the POSITION accessor's own data contains.
+    var minX = double.infinity, minY = double.infinity, minZ = double.infinity;
+    var maxX = double.negativeInfinity, maxY = double.negativeInfinity, maxZ = double.negativeInfinity;
+    for (var i = 0; i < prim.positions.length; i += 3) {
+      final x = binaryBuffer.getFloat32(posByteOffset + i * 4, Endian.little);
+      final y = binaryBuffer.getFloat32(posByteOffset + (i + 1) * 4, Endian.little);
+      final z = binaryBuffer.getFloat32(posByteOffset + (i + 2) * 4, Endian.little);
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+      if (z < minZ) minZ = z;
+      if (z > maxZ) maxZ = z;
+    }
+
+    final posAccessorIdx = accessors.length;
+    accessors.add({
+      'bufferView': posBufferViewIdx,
+      'byteOffset': 0,
+      'componentType': 5126, // FLOAT
+      'count': prim.positions.length ~/ 3,
+      'type': 'VEC3',
+      'min': [minX, minY, minZ],
+      'max': [maxX, maxY, maxZ],
+    });
+
+    final normAccessorIdx = accessors.length;
+    accessors.add({
+      'bufferView': normBufferViewIdx,
+      'byteOffset': 0,
+      'componentType': 5126,
+      'count': prim.normals.length ~/ 3,
+      'type': 'VEC3',
+    });
+
+    final uvAccessorIdx = accessors.length;
+    accessors.add({
+      'bufferView': uvBufferViewIdx,
+      'byteOffset': 0,
+      'componentType': 5126,
+      'count': prim.uvs.length ~/ 2,
+      'type': 'VEC2',
+    });
+
+    final indAccessorIdx = accessors.length;
+    accessors.add({
+      'bufferView': indBufferViewIdx,
+      'byteOffset': 0,
+      'componentType': 5125, // UNSIGNED_INT
+      'count': prim.indices.length,
+      'type': 'SCALAR',
+    });
+
+    gltfPrimitives.add({
+      'attributes': {
+        'POSITION': posAccessorIdx,
+        'NORMAL': normAccessorIdx,
+        'TEXCOORD_0': uvAccessorIdx,
+      },
+      'indices': indAccessorIdx,
+      'material': prim.materialIndex,
+    });
+  }
+
+  final gltfMeshes = <Map<String, dynamic>>[];
+  if (gltfPrimitives.isNotEmpty) {
+    gltfMeshes.add({'primitives': gltfPrimitives});
+  }
+
+  final gltfJson = {
+    'asset': {'version': '2.0', 'generator': 'OpenSKP Dart Exporter'},
+    'scene': 0,
+    'scenes': [
+      {'nodes': gltfMeshes.isNotEmpty ? [0] : <int>[]},
+    ],
+    'nodes': gltfMeshes.isNotEmpty ? [
+      {'mesh': 0},
+    ] : <Map<String, dynamic>>[],
+    'meshes': gltfMeshes,
+    'materials': materials,
+    'buffers': [
+      {'byteLength': totalBinaryLength},
+    ],
+    'bufferViews': bufferViews,
+    'accessors': accessors,
+  };
+
+  return _createGlb(gltfJson, binaryBuffer.buffer.asUint8List());
+}
+
+/// Serializes a baked [Scene] to GLB and writes it to [path]. Does not
+/// create missing parent directories - matching the C++ and .NET ports'
+/// export_glb/ExportGlb.
+void exportGlb(Scene scene, String path) {
+  File(path).writeAsBytesSync(toGlb(scene));
+}
+
+void _validateScene(List<GlbPrimitive> prims, List<Map<String, dynamic>> materials) {
+  for (var i = 0; i < prims.length; i++) {
+    final prim = prims[i];
+    final prefix = 'primitive $i ';
+    if (prim.positions.isEmpty) throw ArgumentError('${prefix}positions must not be empty');
+    if (prim.positions.length % 3 != 0) throw ArgumentError('${prefix}positions must contain complete vec3 values');
+    if (prim.normals.length != prim.positions.length) throw ArgumentError('${prefix}normals must match positions');
+    if (prim.uvs.length != prim.positions.length ~/ 3 * 2) throw ArgumentError('${prefix}uvs must match positions');
+    if (prim.indices.isEmpty) throw ArgumentError('${prefix}indices must not be empty');
+    if (prim.indices.length % 3 != 0) throw ArgumentError('${prefix}indices must contain complete triangles');
+    if (prim.materialIndex < 0 || prim.materialIndex >= materials.length) {
+      throw ArgumentError('${prefix}references an invalid material');
+    }
+
+    final vertexCount = prim.positions.length ~/ 3;
+    for (final v in prim.positions) {
+      _checkFinite(v, '${prefix}position');
+    }
+    for (final v in prim.normals) {
+      _checkFinite(v, '${prefix}normal');
+    }
+    for (final v in prim.uvs) {
+      _checkFinite(v, '${prefix}uv');
+    }
+    for (final idx in prim.indices) {
+      if (idx >= vertexCount) throw ArgumentError('${prefix}index is out of range');
+    }
+  }
+}
+
+void _checkFinite(double value, String field) {
+  if (value.isNaN || value.isInfinite) {
+    throw ArgumentError('$field must be finite');
+  }
+}
+
+Uint8List _createGlb(Map<String, dynamic> json, Uint8List binaryBuffer) {
+  var jsonBytes = Uint8List.fromList(utf8.encode(jsonEncode(json)));
+  final jsonPad = (4 - jsonBytes.length % 4) % 4;
+  if (jsonPad > 0) {
+    final padded = Uint8List(jsonBytes.length + jsonPad);
+    padded.setRange(0, jsonBytes.length, jsonBytes);
+    for (var i = jsonBytes.length; i < padded.length; i++) {
+      padded[i] = 0x20; // space
+    }
+    jsonBytes = padded;
+  }
+
+  final binPad = (4 - binaryBuffer.length % 4) % 4;
+  var paddedBinary = binaryBuffer;
+  if (binPad > 0) {
+    paddedBinary = Uint8List(binaryBuffer.length + binPad);
+    paddedBinary.setRange(0, binaryBuffer.length, binaryBuffer);
+  }
+
+  final totalLength = 12 + 8 + jsonBytes.length + 8 + paddedBinary.length;
+  if (totalLength > _glbSizeLimit) {
+    throw StateError("serialized GLB exceeds its 32-bit file-size limit");
+  }
+
+  final glbBytes = Uint8List(totalLength);
+  final view = ByteData.sublistView(glbBytes);
+  var p = 0;
+  view.setUint32(p, 0x46546C67, Endian.little); // magic 'glTF'
+  p += 4;
+  view.setUint32(p, 2, Endian.little); // version
+  p += 4;
+  view.setUint32(p, totalLength, Endian.little);
+  p += 4;
+
+  view.setUint32(p, jsonBytes.length, Endian.little);
+  p += 4;
+  view.setUint32(p, 0x4E4F534A, Endian.little); // 'JSON'
+  p += 4;
+  glbBytes.setRange(p, p + jsonBytes.length, jsonBytes);
+  p += jsonBytes.length;
+
+  view.setUint32(p, paddedBinary.length, Endian.little);
+  p += 4;
+  view.setUint32(p, 0x004E4942, Endian.little); // 'BIN\0'
+  p += 4;
+  glbBytes.setRange(p, p + paddedBinary.length, paddedBinary);
+  p += paddedBinary.length;
+
+  return glbBytes;
+}

--- a/packages/dart/test/glb_test.dart
+++ b/packages/dart/test/glb_test.dart
@@ -1,0 +1,203 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:openskp/openskp.dart';
+import 'package:test/test.dart';
+
+Scene _triangleScene() {
+  return Scene(
+    sceneHierarchy: InstanceNode(),
+    meshIndex: {},
+    gltfMaterials: [
+      {
+        'pbrMetallicRoughness': {
+          'baseColorFactor': [0.25, 0.5, 0.75, 1.0],
+          'metallicFactor': 0.1,
+          'roughnessFactor': 0.9,
+        },
+      },
+    ],
+    glbPrimitives: [
+      GlbPrimitive(
+        positions: [1, 2, 3, -4, 5, 0, 2, -1, 7],
+        normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+        uvs: [0, 0, 1, 0, 0, 1],
+        indices: [0, 1, 2],
+        materialIndex: 0,
+        geomName: 'triangle',
+      ),
+    ],
+  );
+}
+
+({Map<String, dynamic> json, Uint8List binary}) _parseGlb(Uint8List bytes) {
+  final bd = ByteData.sublistView(bytes);
+  final jsonChunkLen = bd.getUint32(12, Endian.little);
+  final jsonStr = utf8.decode(bytes.sublist(20, 20 + jsonChunkLen));
+  final json = jsonDecode(jsonStr) as Map<String, dynamic>;
+
+  final binHeaderOffset = 20 + jsonChunkLen;
+  var binary = Uint8List(0);
+  if (binHeaderOffset < bytes.length) {
+    final binChunkLen = bd.getUint32(binHeaderOffset, Endian.little);
+    binary = bytes.sublist(binHeaderOffset + 8, binHeaderOffset + 8 + binChunkLen);
+  }
+  return (json: json, binary: binary);
+}
+
+void main() {
+  group('GLB export', () {
+    test('serializes scene and binary data', () {
+      final bytes = toGlb(_triangleScene());
+      expect(bytes.length, greaterThanOrEqualTo(12));
+      expect(utf8.decode(bytes.sublist(0, 4)), 'glTF');
+
+      final parsed = _parseGlb(bytes);
+      final json = parsed.json;
+      expect(json['asset']['version'], '2.0');
+
+      final meshes = json['meshes'] as List;
+      expect(meshes.length, 1);
+      final prim = (meshes[0]['primitives'] as List)[0] as Map<String, dynamic>;
+      final attrs = prim['attributes'] as Map<String, dynamic>;
+      expect(attrs.containsKey('POSITION'), true);
+      expect(attrs.containsKey('NORMAL'), true);
+      expect(attrs.containsKey('TEXCOORD_0'), true);
+      expect(prim['material'], 0);
+
+      final accessors = json['accessors'] as List;
+      final posAccessor = accessors[attrs['POSITION'] as int] as Map<String, dynamic>;
+      expect(posAccessor['componentType'], 5126);
+      expect(posAccessor['type'], 'VEC3');
+      expect(posAccessor['count'], 3);
+      expect(posAccessor['min'], [-4.0, -1.0, 0.0]);
+      expect(posAccessor['max'], [2.0, 5.0, 7.0]);
+
+      final uvAccessor = accessors[attrs['TEXCOORD_0'] as int] as Map<String, dynamic>;
+      expect(uvAccessor['componentType'], 5126);
+      expect(uvAccessor['type'], 'VEC2');
+      expect(uvAccessor['count'], 3);
+      final uvBufferView = (json['bufferViews'] as List)[uvAccessor['bufferView'] as int] as Map<String, dynamic>;
+      final uvOffset = uvBufferView['byteOffset'] as int;
+      final bd = ByteData.sublistView(parsed.binary);
+      expect(bd.getFloat32(uvOffset + 2 * 4, Endian.little), 1.0);
+
+      final materials = json['materials'] as List;
+      final pbr = materials[0]['pbrMetallicRoughness'] as Map<String, dynamic>;
+      expect(pbr['baseColorFactor'][0], 0.25);
+      expect(pbr['metallicFactor'], 0.1);
+      expect(pbr['roughnessFactor'], 0.9);
+    });
+
+    test('serializes an empty scene', () {
+      final bytes = toGlb(Scene(
+        sceneHierarchy: InstanceNode(),
+        meshIndex: {},
+        gltfMaterials: [],
+        glbPrimitives: [],
+      ));
+      final json = _parseGlb(bytes).json;
+      expect((json['meshes'] as List).length, 0);
+      expect((json['nodes'] as List).length, 0);
+    });
+
+    test('rejects malformed geometry', () {
+      var scene = _triangleScene();
+      scene.glbPrimitives[0].positions.removeLast();
+      expect(() => toGlb(scene), throwsArgumentError);
+
+      scene = _triangleScene();
+      scene.glbPrimitives[0].normals.clear();
+      expect(() => toGlb(scene), throwsArgumentError);
+
+      scene = _triangleScene();
+      scene.glbPrimitives[0].uvs.removeLast();
+      expect(() => toGlb(scene), throwsArgumentError);
+
+      scene = _triangleScene();
+      scene.glbPrimitives[0].indices.clear();
+      expect(() => toGlb(scene), throwsArgumentError);
+
+      scene = _triangleScene();
+      scene.glbPrimitives[0].indices[2] = 5;
+      expect(() => toGlb(scene), throwsArgumentError);
+
+      scene = _triangleScene();
+      scene.glbPrimitives[0] = GlbPrimitive(
+        positions: scene.glbPrimitives[0].positions,
+        normals: scene.glbPrimitives[0].normals,
+        uvs: scene.glbPrimitives[0].uvs,
+        indices: scene.glbPrimitives[0].indices,
+        materialIndex: 1,
+        geomName: scene.glbPrimitives[0].geomName,
+      );
+      expect(() => toGlb(scene), throwsArgumentError);
+    });
+
+    test('rejects non-finite values', () {
+      var scene = _triangleScene();
+      scene.glbPrimitives[0].positions[0] = double.nan;
+      expect(() => toGlb(scene), throwsArgumentError);
+
+      scene = _triangleScene();
+      scene.glbPrimitives[0].normals[0] = double.infinity;
+      expect(() => toGlb(scene), throwsArgumentError);
+
+      scene = _triangleScene();
+      scene.glbPrimitives[0].uvs[0] = double.negativeInfinity;
+      expect(() => toGlb(scene), throwsArgumentError);
+    });
+
+    test('exports real fixture matching toGlb and buildScene', () {
+      final fixturePath = '${Directory.current.path}/test/fixtures/capilla_quiroz_v17.skp';
+      final scene = SkpFile.open(fixturePath).buildScene();
+      final expected = toGlb(scene);
+
+      final output = '${Directory.systemTemp.path}/openskp-dart-glb-test-${DateTime.now().microsecondsSinceEpoch}.glb';
+      exportGlb(scene, output);
+      final file = File(output);
+      try {
+        final actual = file.readAsBytesSync();
+        expect(actual, expected);
+
+        final parsed = _parseGlb(Uint8List.fromList(actual));
+        final meshes = (parsed.json['meshes'] as List)[0]['primitives'] as List;
+        expect(meshes.length, scene.glbPrimitives.length);
+
+        // Every primitive must carry TEXCOORD_0, and the decoded values
+        // must exactly match the source GlbPrimitive.uvs that fed the
+        // writer - a real round-trip check, not just "some accessor
+        // exists."
+        final bd = ByteData.sublistView(parsed.binary);
+        for (var i = 0; i < scene.glbPrimitives.length; i++) {
+          final prim = scene.glbPrimitives[i];
+          final attrs = (meshes[i] as Map<String, dynamic>)['attributes'] as Map<String, dynamic>;
+          expect(attrs.containsKey('TEXCOORD_0'), true);
+          final uvAccessor = (parsed.json['accessors'] as List)[attrs['TEXCOORD_0'] as int] as Map<String, dynamic>;
+          final uvBufferView = (parsed.json['bufferViews'] as List)[uvAccessor['bufferView'] as int] as Map<String, dynamic>;
+          final uvOffset = uvBufferView['byteOffset'] as int;
+          final uvCount = uvAccessor['count'] as int;
+          expect(prim.uvs.length, uvCount * 2);
+          for (var j = 0; j < prim.uvs.length; j++) {
+            final decoded = bd.getFloat32(uvOffset + j * 4, Endian.little);
+            // prim.uvs is double (64-bit); the accessor stores float32,
+            // so compare against the same round-trip precision.
+            final expectedRounded = (ByteData(4)
+                  ..setFloat32(0, prim.uvs[j], Endian.little))
+                .getFloat32(0, Endian.little);
+            expect(decoded, expectedRounded);
+          }
+        }
+      } finally {
+        if (file.existsSync()) file.deleteSync();
+      }
+    });
+
+    test('reports file failures without creating directories', () {
+      final output = '${Directory.systemTemp.path}/openskp-missing-parent-${DateTime.now().microsecondsSinceEpoch}/asset.glb';
+      expect(() => exportGlb(_triangleScene(), output), throwsA(anything));
+      expect(Directory(output).parent.existsSync(), false);
+    });
+  });
+}


### PR DESCRIPTION
## What

Same gap as #74 (.NET, merged): ports a way to actually export a baked `Scene` as a `.glb` file, not just the intermediate `Scene`/`GlbPrimitive` data. Matches Python's and C++'s `to_glb`/`export_glb` pair.

## How

A from-scratch writer, no new dependency. `dart:convert`'s built-in `jsonEncode` covers the JSON chunk directly - no custom serializer needed, simpler than the .NET port, which had to hand-roll one since `netstandard2.0` has no built-in JSON support.

Structurally ported from the TypeScript reference implementation's `toGLB()`, with the same `TEXCOORD_0` correction as the .NET port: TS's own `toGLB()` doesn't write it despite `GlbPrimitive.uvs` existing on its data model too (tracked as a separate follow-up, not part of this PR). This writer includes it from the start.

`exportGlb` doesn't create missing parent directories, matching C++/.NET's `export_glb`/`ExportGlb` - Dart's `File.writeAsBytesSync` already behaves this way by default, nothing extra needed.

One Dart-specific wrinkle worth flagging: `GlbPrimitive`'s `positions`/`normals`/`uvs` are `List<double>` (64-bit) here, unlike TS's `Float32Array` or C#'s `float[]` - but the binary accessor data is float32. Computing min/max bounds from the raw doubles would have produced values that don't match what's actually stored in the POSITION accessor's own binary data. Fixed by reading the bounds back from the already-written float32 buffer instead of the source doubles.

## Testing

- `dart analyze --fatal-infos`: clean.
- `dart test`: all 7 test files pass individually (same local-quirk workaround as prior Dart PRs - bare `dart test` only auto-discovers one file in this environment; CI's invocation doesn't have this problem, confirmed on #70/#71).
- New `glb_test.dart` (6 tests) mirrors the C++/.NET GLB test coverage: serialization shape, empty scenes, malformed-geometry and non-finite-value rejection, and a real-fixture round-trip test that decodes every primitive's `TEXCOORD_0` back out of the binary chunk and asserts it matches the source `GlbPrimitive.uvs` (accounting for float32 rounding, made explicit in the test itself).
- Verified end to end against the real fixture via a throwaway script: chunk headers correct, 13 meshes/9 materials matching every other language, `TEXCOORD_0` on all primitives, decoded UV values matching the already cross-verified Python/TypeScript/C#/.NET output on the same file.