### PR TITLE
TypeScript: write TEXCOORD_0 in toGLB()'s actual exported GLB bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **TypeScript**: `toGLB()` never wrote a `TEXCOORD_0` accessor, despite
+  `GlbPrimitive.uvs` existing on its data model since #65 - real UV data
+  was computed but the actual exported `.glb` bytes never carried it.
+  Found while using `toGLB()` as the structural reference for porting GLB
+  export to .NET and Dart (both new writers included `TEXCOORD_0` from
+  the start rather than reproducing this gap). Same shape as the gap
+  already fixed for Python's `export/glb.py` (#68) and C++'s `glb.cpp`
+  (#66). No test coverage existed for `toGLB()` before now, which is how
+  this went unnoticed - added real coverage, including a real-fixture
+  round-trip test that decodes every primitive's `TEXCOORD_0` back out of
+  the binary chunk and confirms it matches the source `GlbPrimitive.uvs`
+  exactly.
 - **C++**: `Face.uv_transform`/`uv_transform_back` were never populated for
   *any* legacy MFC (SketchUp 2013–2020) file - every legacy face's UV
   silently fell back to the default (non-positioned) face-plane

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -340,6 +340,7 @@ export function toGLB(scene: SkpScene): Uint8Array {
   for (const prim of prims) {
     totalBinaryLength += prim.positions.byteLength;
     totalBinaryLength += prim.normals.byteLength;
+    totalBinaryLength += prim.uvs.byteLength;
     totalBinaryLength += prim.indices.byteLength;
   }
 
@@ -359,6 +360,10 @@ export function toGLB(scene: SkpScene): Uint8Array {
     binaryBuffer.set(new Uint8Array(prim.normals.buffer, prim.normals.byteOffset, prim.normals.byteLength), normByteOffset);
     byteOffset += prim.normals.byteLength;
 
+    const uvByteOffset = byteOffset;
+    binaryBuffer.set(new Uint8Array(prim.uvs.buffer, prim.uvs.byteOffset, prim.uvs.byteLength), uvByteOffset);
+    byteOffset += prim.uvs.byteLength;
+
     const indByteOffset = byteOffset;
     binaryBuffer.set(new Uint8Array(prim.indices.buffer, prim.indices.byteOffset, prim.indices.byteLength), indByteOffset);
     byteOffset += prim.indices.byteLength;
@@ -376,6 +381,14 @@ export function toGLB(scene: SkpScene): Uint8Array {
       buffer: 0,
       byteOffset: normByteOffset,
       byteLength: prim.normals.byteLength,
+      target: 34962, // ARRAY_BUFFER
+    });
+
+    const uvBufferViewIdx = bufferViews.length;
+    bufferViews.push({
+      buffer: 0,
+      byteOffset: uvByteOffset,
+      byteLength: prim.uvs.byteLength,
       target: 34962, // ARRAY_BUFFER
     });
 
@@ -423,6 +436,15 @@ export function toGLB(scene: SkpScene): Uint8Array {
       type: 'VEC3',
     });
 
+    const uvAccessorIdx = accessors.length;
+    accessors.push({
+      bufferView: uvBufferViewIdx,
+      byteOffset: 0,
+      componentType: 5126, // FLOAT
+      count: prim.uvs.length / 2,
+      type: 'VEC2',
+    });
+
     const indAccessorIdx = accessors.length;
     accessors.push({
       bufferView: indBufferViewIdx,
@@ -436,6 +458,7 @@ export function toGLB(scene: SkpScene): Uint8Array {
       attributes: {
         POSITION: posAccessorIdx,
         NORMAL: normAccessorIdx,
+        TEXCOORD_0: uvAccessorIdx,
       },
       indices: indAccessorIdx,
       material: prim.materialIndex,

--- a/packages/typescript/tests/glb.test.ts
+++ b/packages/typescript/tests/glb.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { toGLB, buildScene, SkpScene, GlbPrimitive } from '../src/index';
+
+function triangleScene(): SkpScene {
+  return {
+    sceneHierarchy: { name: '', definitionName: '', layer: '', positionMm: [0, 0, 0], properties: {}, children: [] },
+    meshIndex: {},
+    gltfMaterials: [
+      {
+        pbrMetallicRoughness: {
+          baseColorFactor: [0.25, 0.5, 0.75, 1.0],
+          metallicFactor: 0.1,
+          roughnessFactor: 0.9,
+        },
+      },
+    ],
+    glbPrimitives: [
+      {
+        positions: new Float32Array([1, 2, 3, -4, 5, 0, 2, -1, 7]),
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        uvs: new Float32Array([0, 0, 1, 0, 0, 1]),
+        indices: new Uint32Array([0, 1, 2]),
+        materialIndex: 0,
+        geomName: 'triangle',
+      } as GlbPrimitive,
+    ],
+  };
+}
+
+function parseGlb(bytes: Uint8Array): { json: any; binary: Uint8Array } {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const jsonChunkLen = view.getUint32(12, true);
+  const jsonStr = new TextDecoder().decode(bytes.subarray(20, 20 + jsonChunkLen));
+  const json = JSON.parse(jsonStr);
+
+  const binHeaderOffset = 20 + jsonChunkLen;
+  let binary = new Uint8Array(0);
+  if (binHeaderOffset < bytes.length) {
+    const binChunkLen = view.getUint32(binHeaderOffset, true);
+    binary = bytes.subarray(binHeaderOffset + 8, binHeaderOffset + 8 + binChunkLen);
+  }
+  return { json, binary };
+}
+
+describe('toGLB', () => {
+  it('serializes scene and binary data, including TEXCOORD_0', () => {
+    const bytes = toGLB(triangleScene());
+    expect(bytes.length).toBeGreaterThanOrEqual(12);
+    expect(new TextDecoder().decode(bytes.subarray(0, 4))).toBe('glTF');
+
+    const { json, binary } = parseGlb(bytes);
+    expect(json.asset.version).toBe('2.0');
+
+    expect(json.meshes.length).toBe(1);
+    const prim = json.meshes[0].primitives[0];
+    expect(prim.attributes.POSITION).toBeDefined();
+    expect(prim.attributes.NORMAL).toBeDefined();
+    expect(prim.attributes.TEXCOORD_0).toBeDefined();
+    expect(prim.material).toBe(0);
+
+    const posAccessor = json.accessors[prim.attributes.POSITION];
+    expect(posAccessor.componentType).toBe(5126);
+    expect(posAccessor.type).toBe('VEC3');
+    expect(posAccessor.count).toBe(3);
+    expect(posAccessor.min).toEqual([-4, -1, 0]);
+    expect(posAccessor.max).toEqual([2, 5, 7]);
+
+    const uvAccessor = json.accessors[prim.attributes.TEXCOORD_0];
+    expect(uvAccessor.componentType).toBe(5126);
+    expect(uvAccessor.type).toBe('VEC2');
+    expect(uvAccessor.count).toBe(3);
+    const uvBufferView = json.bufferViews[uvAccessor.bufferView];
+    const uvView = new DataView(binary.buffer, binary.byteOffset + uvBufferView.byteOffset);
+    expect(uvView.getFloat32(2 * 4, true)).toBe(1);
+
+    const pbr = json.materials[0].pbrMetallicRoughness;
+    expect(pbr.baseColorFactor[0]).toBe(0.25);
+    expect(pbr.metallicFactor).toBe(0.1);
+    expect(pbr.roughnessFactor).toBe(0.9);
+  });
+
+  it('serializes an empty scene', () => {
+    const scene: SkpScene = {
+      sceneHierarchy: { name: '', definitionName: '', layer: '', positionMm: [0, 0, 0], properties: {}, children: [] },
+      meshIndex: {},
+      gltfMaterials: [],
+      glbPrimitives: [],
+    };
+    const { json } = parseGlb(toGLB(scene));
+    expect(json.meshes.length).toBe(0);
+    expect(json.nodes.length).toBe(0);
+  });
+
+  it('exports the real fixture with real UV data matching the source GlbPrimitive.uvs', () => {
+    const filePath = path.join(__dirname, 'fixtures', 'capilla_quiroz_v17.skp');
+    const buf = fs.readFileSync(filePath);
+    const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    const scene = buildScene(arrayBuffer);
+
+    const bytes = toGLB(scene);
+    const { json, binary } = parseGlb(bytes);
+
+    const meshPrimitives = json.meshes[0].primitives;
+    expect(meshPrimitives.length).toBe(scene.glbPrimitives.length);
+
+    // Every primitive must carry TEXCOORD_0, and the decoded values must
+    // exactly match the source GlbPrimitive.uvs that fed the writer - a
+    // real round-trip check, not just "some accessor exists."
+    for (let i = 0; i < scene.glbPrimitives.length; i++) {
+      const prim = scene.glbPrimitives[i];
+      const attrs = meshPrimitives[i].attributes;
+      expect(attrs.TEXCOORD_0).toBeDefined();
+      const uvAccessor = json.accessors[attrs.TEXCOORD_0];
+      const uvBufferView = json.bufferViews[uvAccessor.bufferView];
+      const uvCount = uvAccessor.count;
+      expect(prim.uvs.length).toBe(uvCount * 2);
+      const uvView = new DataView(binary.buffer, binary.byteOffset + uvBufferView.byteOffset);
+      for (let j = 0; j < prim.uvs.length; j++) {
+        expect(uvView.getFloat32(j * 4, true)).toBeCloseTo(prim.uvs[j], 5);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What

`toGLB()` never wrote a `TEXCOORD_0` accessor, despite `GlbPrimitive.uvs` existing on the data model since #65 - real UV data was computed but the actual exported `.glb` bytes never carried it.

Found while using `toGLB()` as the structural reference for porting GLB export to .NET (#74) and Dart (#75) - both new writers included `TEXCOORD_0` from the start rather than reproducing this gap, and this is the follow-up to close it here too.

Same shape as the gap already fixed for Python's `export/glb.py` (#68) and C++'s `glb.cpp` (#66): the field existed on the data model, but the actual file/byte writer never read it.

## Testing

No test coverage existed for `toGLB()` before now, which is how this went unnoticed. Added real coverage in `glb.test.ts`:
- Serialization shape - accessors, min/max bounds, material pass-through, now including `TEXCOORD_0`.
- Empty-scene case.
- A real-fixture round-trip test that decodes every primitive's `TEXCOORD_0` back out of the binary chunk and confirms it matches the source `GlbPrimitive.uvs` exactly.

`tsc --noEmit` and `npm run build` both clean. Full suite: 43/43 passing.