### PR TITLE
docs: fix stale claims about Dart/.NET GLB export and other drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ OpenSKP is the **first and only** open-source, cross-platform parser for SketchU
 | **3D Geometry Extraction** | ✅ | Vertices, edges, faces, normals, and UV coordinates |
 | **Component Hierarchy** | ✅ | Nested component definitions and instance transforms |
 | **Scene Baking / Triangulation** | ✅ | Opt-in scene baking: full placed scene graph resolved to world-space, triangulated, GLB-ready — in all five languages |
-| **Layers / Tags** | ✅ | Layer definitions with colors and visibility state |
+| **Layers / Tags** | ⚠️ | Layer definitions with colors — on/off visibility state is read from the file internally but not yet exposed on the public model in any language |
 | **Materials & Textures** | ✅ | Material properties, colors, transparency, colorized materials, and embedded texture images |
 | **Styles** | ✅ | Front/back face colors for unpainted faces |
-| **Dynamic Components** | ✅ | Extract dynamic component attribute key-value pairs |
+| **Dynamic Components** | ⚠️ | Extracts dynamic component attribute key-value pairs for modern (2021+) files in Python, TypeScript, and C++ — not yet supported for legacy (2013–2020) files in any language, or for modern files in Dart/.NET |
 | **Observability** | ✅ | Opt-in progress reporting + structured, location-carrying parse errors — see [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
-| **Export to GLB / OBJ / JSON** | ⚠️ | Full GLB/OBJ/JSON exporters in Python; GLB export in TypeScript and C++; .NET and Dart expose scene data only — see [Export capabilities](docs/DEVELOPER_GUIDE.md#export-capabilities) |
+| **Export to GLB / OBJ / JSON** | ⚠️ | GLB export is available in all five languages; OBJ and JSON metadata export are currently Python-only (JSON also in TypeScript) — see [Export capabilities](docs/DEVELOPER_GUIDE.md#export-capabilities) |
 | **Streaming / low-memory parsing** | ✅ | Peak memory bounded by the largest single definition, not the whole file — see [Memory architecture](docs/ARCHITECTURE.md#memory-architecture) |
 | **Pure Implementation** | ✅ | No SketchUp SDK, no native dependencies, no license required |
 | **Cross-Platform** | ✅ | Works on Linux, macOS, and Windows |
@@ -74,7 +74,7 @@ Using OpenSKP in your own project? [Open an issue](https://github.com/iamahsanme
 | Platform | Version | Status | Install | Package Link |
 |:---------|:--------|:------:|:--------|:-------------|
 | 🐍 **Python** | `v0.3.0` | ✅ Available | `pip install openskp` | [PyPI](https://pypi.org/project/openskp/) |
-| 📘 **TypeScript / JS** | `v0.3.0` | ✅ Available | `npm install openskp` | [npm](https://www.npmjs.com/package/openskp) |
+| 📘 **TypeScript / JS** | `v0.3.1` | ✅ Available | `npm install openskp` | [npm](https://www.npmjs.com/package/openskp) |
 | 🚀 **.NET / C#** | `v0.3.0` | ✅ Available | `dotnet add package OpenSkp` | [NuGet](https://www.nuget.org/packages/OpenSkp) |
 | 🎯 **Dart / Flutter** | `v0.3.0` | ✅ Available | `dart pub add openskp` | [pub.dev](https://pub.dev/packages/openskp) |
 | ⚙️ **C++17** | `v0.3.0` | ✅ Source package | `find_package(OpenSkp CONFIG REQUIRED)` | [`packages/cpp`](packages/cpp) |
@@ -110,8 +110,6 @@ print(f"SketchUp version: {model.version}")
 print(f"Layers: {[l.name for l in model.layers]}")
 
 for def_id, defn in model.definitions.items():
-    if not isinstance(def_id, int):
-        continue  # skip the implicit 'ROOT' entry
     print(f"{defn.name}: {len(defn.vertices)} verts, {len(defn.faces)} faces")
 
 for material in model.materials:
@@ -160,6 +158,9 @@ Console.WriteLine($"{model.Version} - {model.Layers.Count} layers");
 // Opt-in: full placed scene graph, triangulated, world-space, GLB-ready
 var scene = SkpFile.BuildScene("my_model.skp");
 Console.WriteLine($"{scene.GlbPrimitives.Count} renderable mesh primitives");
+
+var glb = GlbExport.ToGlb(scene);       // ready to write to a .glb file
+GlbExport.ExportGlb(scene, "my_model.glb");
 ```
 
 ### 🎯 Dart / Flutter
@@ -177,6 +178,9 @@ print('${model.version} - ${model.layers.length} layers');
 // Opt-in: full placed scene graph, triangulated, world-space, GLB-ready
 final scene = SkpFile.open('my_model.skp').buildScene();
 print('${scene.glbPrimitives.length} renderable mesh primitives');
+
+final glb = toGlb(scene);               // ready to write to a .glb file
+exportGlb(scene, 'my_model.glb');
 ```
 
 ### ⚙️ C++17 / CMake
@@ -211,7 +215,7 @@ graph TB
     WALK --> RAW["Raw parsed data<br/>defs · layers · materials · styles"]
     RAW --> PARSE["parse() -> SkpModel<br/>per-definition geometry,<br/>no scene resolution"]
     RAW --> SCENE["buildScene() -> Scene<br/>full placed instance tree,<br/>triangulated, world-space"]
-    SCENE --> GLB["GLB export<br/>(Python + TypeScript + C++)"]
+    SCENE --> GLB["GLB export<br/>(all five languages)"]
 
     style SKP fill:#f59e0b,color:#000,stroke:#d97706
     style RAW fill:#8b5cf6,color:#fff,stroke:#7c3aed
@@ -307,13 +311,19 @@ Some tags are *containers* — their payload is a sequence of nested TLV element
 OpenSKP maps known tags to geometry primitives, component hierarchies, layers, and materials to build a structured, queryable model object.
 
 ### 5. Coordinate Conversion
-SketchUp uses a **Z-up, inches** coordinate system. When exporting to glTF (which uses Y-up, meters), OpenSKP applies:
+SketchUp uses a **Z-up, inches** coordinate system. The same Y-up axis swap
+applies everywhere in OpenSKP's output; only the unit scale differs by
+context. For GLB vertex positions (Y-up, **meters**, per the glTF spec):
 
 ```
-x_mm =  x_inches × 25.4
-y_mm =  z_inches × 25.4
-z_mm = -y_inches × 25.4
+x_m =  x_inches × 0.0254
+y_m =  z_inches × 0.0254
+z_m = -y_inches × 0.0254
 ```
+
+The scene graph's `position_mm` fields (`InstanceNode`/`MeshMetadata`) use
+the same axis swap but **millimeters** (`× 25.4`) instead, since they're
+metadata for placement/inspection rather than renderer-facing vertex data.
 
 > 📖 The above covers the modern VFF (2021+) container. Pre-2021 files use a
 > completely different container (a classic MFC `CArchive` object-graph

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -316,9 +316,9 @@ ships file-writing exporters on top of that data:
 | Language | Scene data (`buildScene()`) | GLB | OBJ | JSON metadata |
 |---|---|---|---|---|
 | Python | ✅ | ✅ `openskp.export.glb` | ✅ `openskp.export.obj` | ✅ `openskp.export.json_export` |
-| TypeScript | ✅ | ✅ `toGLB(scene)` in `index.ts` | ❌ not yet ported | ❌ not yet ported |
-| .NET | ✅ | ❌ not yet ported | ❌ not yet ported | ❌ not yet ported |
-| Dart | ✅ | ❌ not yet ported | ❌ not yet ported | ❌ not yet ported |
+| TypeScript | ✅ | ✅ `toGLB(scene)` in `index.ts` | ❌ not yet ported | ✅ `toJSON(model, scene?)` in `index.ts` |
+| .NET | ✅ | ✅ `GlbExport.ToGlb(scene)` / `GlbExport.ExportGlb(scene, path)` | ❌ not yet ported | ❌ not yet ported |
+| Dart | ✅ | ✅ `toGlb(scene)` / `exportGlb(scene, path)` | ❌ not yet ported | ❌ not yet ported |
 | C++ | ✅ | ✅ `to_glb(scene)` / `export_glb(scene, path)` | ❌ not included | ❌ not included |
 
 Python is the only port with a full set of disk-writing exporters today,
@@ -354,14 +354,22 @@ Notes on each:
   `None` unless a built `Scene` is passed via `scene=`, in which case it's
   the real, resolved, world-space instance tree.
 
-TypeScript's `toGLB(scene)` and C++'s `to_glb(scene)` provide complete,
-public, in-memory-to-`.glb` bytes; C++ also provides `export_glb(scene,
-path)` for direct file output. The C++ writer uses a private, pinned
-TinyGLTF dependency that does not appear in installed consumer interfaces.
-.NET and Dart consumers who need a `.glb`/`.obj`/JSON file today need to serialize
-`Scene`'s `GlbPrimitive`s themselves (the format is simple — see the glTF
-2.0 spec, or read TypeScript's `toGLB()` or Python's `openskp.export.obj`
-for reference implementations of exactly this data shape).
+TypeScript's `toGLB(scene)` provides complete, public, in-memory-to-`.glb`
+bytes only (no file-write variant). C++, .NET, and Dart all provide both:
+in-memory bytes (`to_glb`/`ToGlb`/`toGlb`) and direct file output
+(`export_glb`/`ExportGlb`/`exportGlb`). All three of the newer writers
+(C++, .NET, Dart) are from-scratch implementations with no new
+dependency — .NET added a small internal JSON serializer since
+`netstandard2.0` has none built in; C++'s writer uses a private, pinned
+TinyGLTF dependency that does not appear in installed consumer
+interfaces; Dart's uses `dart:convert`'s built-in JSON support directly.
+None of the five GLB writers include OBJ or JSON-metadata export except
+Python (both) and TypeScript (JSON metadata only) — .NET and Dart
+consumers who need an `.obj`/JSON file today still need to serialize
+`Scene`'s `GlbPrimitive`s themselves for those two formats specifically
+(the OBJ format in particular is simple — see Python's
+`openskp.export.obj` for a reference implementation of exactly this data
+shape).
 
 ## The web viewer
 
@@ -397,26 +405,23 @@ directly to another's without adjustment.
 
 ### Root-level definition access
 
-- **Python**: `model.definitions` is a single dict that includes a
-  `'ROOT'` **string key** alongside the integer definition IDs. There is
-  no separate `.root` attribute. Consumers must check
-  `isinstance(key, int)` to distinguish real definitions from the root.
-- **TypeScript, .NET, Dart, C++**: `model.definitions`/`model.Definitions` is
-  strictly numeric-keyed (no root entry mixed in); the root is a separate
-  `model.root` / `model.Root` / `model.root()` property with the same `Definition` shape.
-
-(TypeScript used to drop root-level data from `parse()` entirely — fixed
-this session to add `model.root`, matching .NET/Dart. Python's differing
-shape predates this session and is tracked as a follow-up, not yet
-changed, since Python's `.definitions` shape may have existing consumers
-relying on the string-keyed `'ROOT'` entry.)
+Resolved as of this session — all five languages now agree.
+`model.definitions`/`model.Definitions` is strictly numeric-keyed (no
+root entry mixed in) in every language; the implicit top-level
+definition is always a separate `model.root` / `model.Root` /
+`model.root()` property with the same `Definition` shape. (Python
+previously mixed a string `'ROOT'` key into `model.definitions`, requiring
+consumers to `isinstance(key, int)`-check every key — fixed to match the
+other four; TypeScript previously dropped root-level data from `parse()`
+entirely — also fixed, earlier in the same session.)
 
 ### GLB/OBJ/JSON export
 
-Covered above under [Export capabilities](#export-capabilities) — Python
-has a full set of disk-writing exporters (GLB/OBJ/JSON); TypeScript has a
-public in-memory `.glb` serializer; C++ has in-memory and disk GLB export but
-no OBJ/JSON writer; .NET and Dart have only the raw `Scene` data.
+Covered above under [Export capabilities](#export-capabilities) — GLB
+export is now available in all five languages. Python has the fullest set
+of disk-writing exporters (GLB/OBJ/JSON); TypeScript also has JSON
+metadata export alongside its in-memory `.glb` serializer; C++, .NET, and
+Dart all have in-memory and disk GLB export but no OBJ/JSON writer yet.
 
 ### Progress/logging mechanism
 


### PR DESCRIPTION
## What

Item 1 (and a few closely-related bonus fixes found while touching the same sections) from a full-repository audit conducted earlier today. This one was time-sensitive: `README.md` and `docs/DEVELOPER_GUIDE.md` said Dart and .NET "expose scene data only" / GLB export is "not yet ported" - both shipped complete, tested GLB writers earlier the same day. Actively wrong, not just stale.

## Changes

- **GLB export claims** - feature matrix, export-capabilities table, architecture diagram, and Quick Start snippets for .NET/Dart now correctly show GLB export. Verified the exact snippet shown for both languages actually runs against a real file (not just written and assumed).
- **Two more Feature Matrix overclaims** caught while in the same table: "Layers / Tags" claimed visibility (on/off) state that isn't exposed on the public model in any language yet (verified directly against `model.py`'s `Layer` dataclass); "Dynamic Components" claimed universal support when it's VFF-only in 3 of 5 languages and absent entirely in Dart/.NET.
- **Dead code in the Python README snippet** - an `isinstance` check with a comment describing pre-fix root-key behavior. Removed and re-verified the snippet still works (`model.definitions` is unconditionally int-keyed now).
- **`DEVELOPER_GUIDE`'s stale root-key description** - still described Python's old string-keyed `'ROOT'` behavior as current; that was fixed earlier this same session. Rewritten as a resolved difference.
- **TypeScript version mismatch** - README said v0.3.0, `package.json` says 0.3.1.
- **Mislabeled coordinate-conversion formula** - was showing the inches→millimeters formula (used for the separate `position_mm` scene-graph fields) while claiming it was the meters conversion GLB export actually uses. Split into both, correctly labeled.
- **DEVELOPER_GUIDE's export table** also had TypeScript's real, working `toJSON()` marked as not ported.

## Testing

Docs-only change, no code touched. Every corrected claim was checked against source before editing (not just taken from the audit report at face value):
- `Glb.cs`/`glb.dart` for the .NET/Dart GLB API surface
- `model.py`'s `Layer` dataclass, directly, for the visibility-state claim
- `package.json` for the version number
- Ran the exact Python, .NET, and Dart Quick Start snippets shown in the README against a real fixture file to confirm they work as written