### PR TITLE
Guard scene-baking against recursive component definitions (Python)

### DIFF
--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -216,6 +216,13 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
     color_to_material_index: Dict[Tuple[int, int, int], int] = {}
     gltf_materials: List[Dict[str, Any]] = []
 
+    # Definitions currently being instantiated on the active recursion
+    # path (not "ever visited" - the same definition legitimately reused
+    # by sibling instances is fine). Guards against a component that
+    # directly or transitively instances itself, which would otherwise
+    # recurse until the stack overflows.
+    active_definitions: set = set()
+
     def get_layer_color(name: str) -> Tuple[int, int, int]:
         return layer_colors.get(name, (136, 136, 136))
 
@@ -452,7 +459,15 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             instance_counter[0] += 1
             if instance_counter[0] % _PROGRESS_INTERVAL == 0:
                 logger.debug("Processed %d placed instances", instance_counter[0])
+
+            if ref_idx in active_definitions:
+                raise SkpParseError(
+                    "Recursive component definition",
+                    stage="build_scene", definition_id=ref_idx,
+                )
+            active_definitions.add(ref_idx)
             child_nodes = instantiate(ref_idx, new_matrix, l_name, full_path_name, inst_color)
+            active_definitions.discard(ref_idx)
 
             tx = new_matrix[9] * INCHES_TO_MM if len(new_matrix) > 9 else 0.0
             ty = new_matrix[10] * INCHES_TO_MM if len(new_matrix) > 10 else 0.0

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -1144,6 +1144,89 @@ class TestBuildScene:
         assert len(scene.glb_primitives) == 13
 
 
+class TestBuildSceneRecursionGuard:
+    """A component definition that (directly or transitively) instances
+    itself must raise, not recurse until the stack overflows. Real .skp
+    files can't easily be hand-crafted to exercise this, so these tests
+    build a synthetic ``defs_dict`` directly using the same
+    ``_GeometryBuilder`` shape ``_core.py`` produces.
+    """
+
+    @staticmethod
+    def _instance(ref_idx, name="child"):
+        return {
+            "offset": 0, "ref_guid": "", "ref_idx": ref_idx, "name": name,
+            "matrix": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0],
+            "material_id": None, "children": [],
+        }
+
+    @staticmethod
+    def _parsed(defs_dict):
+        return {
+            "defs_dict": defs_dict,
+            "layer_colors": {},
+            "layer_id_to_name": {},
+            "material_id_to_name": {},
+            "materials": {},
+            "materials_by_folder": {},
+        }
+
+    def test_self_referencing_definition_raises(self) -> None:
+        from openskp._core import _GeometryBuilder
+        from openskp.errors import SkpParseError
+        from openskp.scene import build_scene
+
+        builder = _GeometryBuilder()
+        builder.instances.append(self._instance(1))
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1))
+        defs_dict = {
+            1: {"guid": "g1", "name": "self_ref", "builder": builder},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        with pytest.raises(SkpParseError, match="Recursive component definition"):
+            build_scene(self._parsed(defs_dict))
+
+    def test_indirect_cycle_raises(self) -> None:
+        from openskp._core import _GeometryBuilder
+        from openskp.errors import SkpParseError
+        from openskp.scene import build_scene
+
+        builder_a = _GeometryBuilder()
+        builder_a.instances.append(self._instance(2))
+        builder_b = _GeometryBuilder()
+        builder_b.instances.append(self._instance(1))
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1))
+        defs_dict = {
+            1: {"guid": "g1", "name": "a", "builder": builder_a},
+            2: {"guid": "g2", "name": "b", "builder": builder_b},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        with pytest.raises(SkpParseError, match="Recursive component definition"):
+            build_scene(self._parsed(defs_dict))
+
+    def test_legitimate_sibling_reuse_does_not_raise(self) -> None:
+        """The same definition instanced twice as siblings (not nested
+        inside itself) is normal and must not trip the guard."""
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        shared = _GeometryBuilder()
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, "child_a"))
+        root_builder.instances.append(self._instance(1, "child_b"))
+        defs_dict = {
+            1: {"guid": "g1", "name": "shared", "builder": shared},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        scene = build_scene(self._parsed(defs_dict))
+        assert len(scene.scene_hierarchy.children) == 2
+
+
 class TestGlbExport:
     """``export.glb.export()`` writes a real ``.glb`` file via a separate,
     trimesh-based pipeline (not ``scene.py``'s ``build_scene()``) - so its


### PR DESCRIPTION
## What

A component definition that directly or transitively instances itself would recurse in `instantiate()` (`scene.py`) until the call stack overflows - a cheap, real DoS from a maliciously crafted `.skp` file. C++'s `scene.cpp` already tracks an active-definitions set during the bake recursion and raises a structured error on a cycle (`scene.cpp:295-304`); this ports the same guard shape to Python.

## Change

- Added `active_definitions: set` alongside the other closure-local scene-baking state in `build_scene()`.
- Before recursing into a child instance's definition, checks membership and raises `SkpParseError("Recursive component definition", stage="build_scene", definition_id=ref_idx)` on a hit - matching the existing triangulation-failure error convention in the same function.
- Adds the definition id before recursing, discards it after the call returns - so legitimate reuse of the same definition by sibling instances (not nested inside itself) still works correctly. Only a genuine cycle on the *active* recursion path trips the guard.

## Verification

Hand-crafting a self-referencing component in a real `.skp` file isn't practical, so added synthetic tests built directly on `_GeometryBuilder` (the same plain-Python class `_core.py` produces):
- A direct self-reference (definition instances itself) raises `SkpParseError`.
- An indirect two-definition cycle (A instances B, B instances A) raises.
- Legitimate sibling reuse - the same definition instanced twice as siblings, not nested - does *not* raise.

Full suite: 91/91 passing, `ruff check src/ tests/` clean.

Part of the ongoing repo-health checklist (item 2, recursion/cycle guard across all languages - TypeScript/.NET/Dart follow in separate PRs).