### PR TITLE
Guard scene-baking against recursive component definitions (TypeScript)

### DIFF
--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -404,6 +404,13 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
   const colorToMaterialIndex = new Map<string, number>();
   const gltfMaterials: any[] = [];
 
+  // Definitions currently being instantiated on the active recursion path
+  // (not "ever visited" - the same definition legitimately reused by
+  // sibling instances is fine). Guards against a component that directly
+  // or transitively instances itself, which would otherwise recurse until
+  // the stack overflows.
+  const activeDefinitions = new Set<number | string>();
+
   function getMaterialIndex(color: { r: number; g: number; b: number }) {
     const key = `${color.r},${color.g},${color.b}`;
     if (colorToMaterialIndex.has(key)) {
@@ -667,7 +674,15 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         emitProgress(options, 'build_scene', instanceCounter.count, instanceCounter.count);
         emitLog(options, 'debug', `Processed ${instanceCounter.count} placed instances`);
       }
+      if (activeDefinitions.has(refIdx)) {
+        throw new SkpParseError('Recursive component definition', {
+          stage: 'build_scene',
+          definitionId: refIdx,
+        });
+      }
+      activeDefinitions.add(refIdx);
       const childNodes = instantiate(refIdx, newMatrix, lName, fullPathName, instColor);
+      activeDefinitions.delete(refIdx);
 
       const tx = (newMatrix[9] ?? 0) * 25.4;
       const ty = (newMatrix[10] ?? 0) * 25.4;

--- a/packages/typescript/tests/recursion-guard.test.ts
+++ b/packages/typescript/tests/recursion-guard.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { buildSceneFromParsed, ParsedRawData } from '../src/index';
+import { GeometryBuilder, GeometryBuilderInstance } from '../src/geometry';
+import { SkpParseError } from '../src/errors';
+
+/**
+ * A component definition that (directly or transitively) instances itself
+ * must raise, not recurse until the stack overflows. Real .skp files can't
+ * easily be hand-crafted to exercise this, so these tests build a synthetic
+ * ParsedRawData directly using the same GeometryBuilder shape geometry.ts
+ * produces.
+ */
+
+function instance(refIdx: number | string, name = 'child'): GeometryBuilderInstance {
+  return {
+    offset: 0,
+    refGuid: '',
+    refIdx: refIdx as number,
+    name,
+    matrix: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0],
+    materialId: null,
+    children: [],
+  };
+}
+
+function parsed(defsDict: Map<number | string, any>): ParsedRawData {
+  return {
+    layerColors: new Map(),
+    layerIdToName: new Map(),
+    materialIdToName: new Map(),
+    materialsMap: new Map(),
+    materialsByFolder: new Map(),
+    defsDict,
+  } as ParsedRawData;
+}
+
+describe('buildSceneFromParsed recursion guard', () => {
+  it('throws on a self-referencing definition', () => {
+    const builder = new GeometryBuilder();
+    builder.instances.push(instance(1));
+    const rootBuilder = new GeometryBuilder();
+    rootBuilder.instances.push(instance(1));
+
+    const defsDict = new Map<number | string, any>([
+      [1, { guid: 'g1', name: 'self_ref', isImage: false, alwaysFacesCamera: false, builder }],
+      ['ROOT', { guid: 'ROOT', name: 'ROOT_MODEL', isImage: false, alwaysFacesCamera: false, builder: rootBuilder }],
+    ]);
+
+    expect(() => buildSceneFromParsed(parsed(defsDict))).toThrow('Recursive component definition');
+  });
+
+  it('throws on an indirect cycle', () => {
+    const builderA = new GeometryBuilder();
+    builderA.instances.push(instance(2));
+    const builderB = new GeometryBuilder();
+    builderB.instances.push(instance(1));
+    const rootBuilder = new GeometryBuilder();
+    rootBuilder.instances.push(instance(1));
+
+    const defsDict = new Map<number | string, any>([
+      [1, { guid: 'g1', name: 'a', isImage: false, alwaysFacesCamera: false, builder: builderA }],
+      [2, { guid: 'g2', name: 'b', isImage: false, alwaysFacesCamera: false, builder: builderB }],
+      ['ROOT', { guid: 'ROOT', name: 'ROOT_MODEL', isImage: false, alwaysFacesCamera: false, builder: rootBuilder }],
+    ]);
+
+    expect(() => buildSceneFromParsed(parsed(defsDict))).toThrow(SkpParseError);
+  });
+
+  it('does not throw on legitimate sibling reuse of the same definition', () => {
+    const shared = new GeometryBuilder();
+    const rootBuilder = new GeometryBuilder();
+    rootBuilder.instances.push(instance(1, 'child_a'));
+    rootBuilder.instances.push(instance(1, 'child_b'));
+
+    const defsDict = new Map<number | string, any>([
+      [1, { guid: 'g1', name: 'shared', isImage: false, alwaysFacesCamera: false, builder: shared }],
+      ['ROOT', { guid: 'ROOT', name: 'ROOT_MODEL', isImage: false, alwaysFacesCamera: false, builder: rootBuilder }],
+    ]);
+
+    const scene = buildSceneFromParsed(parsed(defsDict));
+    expect(scene.sceneHierarchy.children.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## What

Same fix as the Python PR (#78): a component definition that directly or transitively instances itself would recurse in `instantiate()` (`model.ts`) until the call stack overflows - a cheap, real DoS from a maliciously crafted `.skp` file. Ports the same active-definitions-set guard shape C++'s `scene.cpp` already uses (`scene.cpp:295-304`).

## Change

- Added `activeDefinitions: Set<number | string>` alongside the other closure-local scene-baking state in `buildSceneFromParsed()`.
- Before recursing into a child instance's definition, checks membership and throws `SkpParseError('Recursive component definition', { stage: 'build_scene', definitionId: refIdx })` on a hit - matching the existing triangulation-failure error convention in the same function.
- Adds the definition id before recursing, deletes it after the call returns - so legitimate reuse of the same definition by sibling instances (not nested inside itself) still works correctly.

## Verification

Hand-crafting a self-referencing component in a real `.skp` file isn't practical, so added synthetic tests built directly on `GeometryBuilder` (the same class `geometry.ts` produces):
- A direct self-reference throws `SkpParseError`.
- An indirect two-definition cycle throws.
- Legitimate sibling reuse - the same definition instanced twice as siblings, not nested - does *not* throw.

Full suite: 46/46 passing, `tsc --noEmit` clean. (`eslint` isn't installed in this local environment - pre-existing gap, unrelated to this change; typecheck covers the same ground.)

Part of the ongoing repo-health checklist (item 2, recursion/cycle guard across all languages - Python in #78, .NET/Dart follow separately).