### PR TITLE
Guard scene-baking against recursive component definitions (.NET)

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/SceneRecursionGuardTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/SceneRecursionGuardTests.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// A component definition that (directly or transitively) instances
+    /// itself must throw, not recurse until the stack overflows. Real .skp
+    /// files can't easily be hand-crafted to exercise this, so these tests
+    /// build a synthetic Core.RawParsed directly using the same
+    /// GeometryBuilder shape Geometry.cs produces.
+    /// </summary>
+    public class SceneRecursionGuardTests
+    {
+        private static GeometryBuilderInstance Instance(long refIdx, string name = "child") =>
+            new GeometryBuilderInstance
+            {
+                Offset = 0,
+                RefGuid = "",
+                RefIdx = refIdx,
+                Name = name,
+                Matrix = new List<double> { 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0 },
+                MaterialId = null,
+                Children = new List<TlvNode>(),
+            };
+
+        [Fact]
+        public void SelfReferencingDefinitionThrows()
+        {
+            var builder = new GeometryBuilder();
+            builder.Instances.Add(Instance(1));
+            var rootBuilder = new GeometryBuilder();
+            rootBuilder.Instances.Add(Instance(1));
+
+            var parsed = new Core.RawParsed
+            {
+                DefsDict = new Dictionary<long, Geometry.RawDefinition>
+                {
+                    [1] = new Geometry.RawDefinition { Guid = "g1", Name = "self_ref", Builder = builder },
+                },
+                Root = new Geometry.RawDefinition { Guid = "ROOT", Name = "ROOT_MODEL", Builder = rootBuilder },
+            };
+
+            var ex = Assert.Throws<SkpParseException>(() => SceneBuilder.Build(parsed));
+            Assert.Contains("Recursive component definition", ex.Message);
+        }
+
+        [Fact]
+        public void IndirectCycleThrows()
+        {
+            var builderA = new GeometryBuilder();
+            builderA.Instances.Add(Instance(2));
+            var builderB = new GeometryBuilder();
+            builderB.Instances.Add(Instance(1));
+            var rootBuilder = new GeometryBuilder();
+            rootBuilder.Instances.Add(Instance(1));
+
+            var parsed = new Core.RawParsed
+            {
+                DefsDict = new Dictionary<long, Geometry.RawDefinition>
+                {
+                    [1] = new Geometry.RawDefinition { Guid = "g1", Name = "a", Builder = builderA },
+                    [2] = new Geometry.RawDefinition { Guid = "g2", Name = "b", Builder = builderB },
+                },
+                Root = new Geometry.RawDefinition { Guid = "ROOT", Name = "ROOT_MODEL", Builder = rootBuilder },
+            };
+
+            Assert.Throws<SkpParseException>(() => SceneBuilder.Build(parsed));
+        }
+
+        [Fact]
+        public void LegitimateSiblingReuseDoesNotThrow()
+        {
+            var shared = new GeometryBuilder();
+            var rootBuilder = new GeometryBuilder();
+            rootBuilder.Instances.Add(Instance(1, "child_a"));
+            rootBuilder.Instances.Add(Instance(1, "child_b"));
+
+            var parsed = new Core.RawParsed
+            {
+                DefsDict = new Dictionary<long, Geometry.RawDefinition>
+                {
+                    [1] = new Geometry.RawDefinition { Guid = "g1", Name = "shared", Builder = shared },
+                },
+                Root = new Geometry.RawDefinition { Guid = "ROOT", Name = "ROOT_MODEL", Builder = rootBuilder },
+            };
+
+            var scene = SceneBuilder.Build(parsed);
+            Assert.Equal(2, scene.SceneHierarchy.Children.Count);
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Scene.cs
+++ b/packages/dotnet/OpenSkp/Scene.cs
@@ -187,6 +187,14 @@ namespace OpenSkp
             var colorToMaterialIndex = new Dictionary<(int, int, int), int>();
             var gltfMaterials = new List<object>();
 
+            // Definitions currently being instantiated on the active
+            // recursion path (not "ever visited" - the same definition
+            // legitimately reused by sibling instances is fine). Guards
+            // against a component that directly or transitively instances
+            // itself, which would otherwise recurse until the stack
+            // overflows.
+            var activeDefinitions = new HashSet<long>();
+
             (int R, int G, int B) GetLayerColor(string name)
             {
                 return layerColors.TryGetValue(name, out var c) ? c : (136, 136, 136);
@@ -217,7 +225,20 @@ namespace OpenSkp
                 {
                     return new List<InstanceNode>();
                 }
-                return InstantiateBuilder(d.Builder, d.Name ?? "", defId, currentMatrix, parentLayer, pathName, inheritedColor);
+                if (!activeDefinitions.Add(defId))
+                {
+                    throw new SkpParseException(
+                        "Recursive component definition",
+                        stage: "build_scene", definitionId: defId);
+                }
+                try
+                {
+                    return InstantiateBuilder(d.Builder, d.Name ?? "", defId, currentMatrix, parentLayer, pathName, inheritedColor);
+                }
+                finally
+                {
+                    activeDefinitions.Remove(defId);
+                }
             }
 
             List<InstanceNode> InstantiateRoot(GeometryBuilder rootBuilder, List<double> currentMatrix)


### PR DESCRIPTION
## What

Same fix as the Python/TypeScript PRs (#78, #79): a component definition that directly or transitively instances itself would recurse in `Instantiate()` (`Scene.cs`) until the call stack overflows - a cheap, real DoS from a maliciously crafted `.skp` file. Ports the same active-definitions-set guard shape C++'s `scene.cpp` already uses (`scene.cpp:295-304`).

## Change

- Added `activeDefinitions: HashSet<long>` alongside the other closure-local scene-baking state in `SceneBuilder.Build()`.
- `Instantiate()` uses `HashSet<T>.Add`'s bool return for an atomic check-and-insert before recursing into `InstantiateBuilder` for a child instance's definition; throws `SkpParseException("Recursive component definition", stage: "build_scene", definitionId: defId)` on a hit - matching the existing triangulation-failure error convention in the same file.
- Removes the definition id in a `finally` block so legitimate reuse of the same definition by sibling instances (not nested inside itself) still works correctly.

## Verification

Hand-crafting a self-referencing component in a real `.skp` file isn't practical, so added synthetic tests built directly on `GeometryBuilder`/`Core.RawParsed` (both `internal`, visible to the test project via the existing `InternalsVisibleTo`):
- A direct self-reference throws `SkpParseException`.
- An indirect two-definition cycle throws.
- Legitimate sibling reuse - the same definition instanced twice as siblings, not nested - does *not* throw.

Full suite: 29/29 passing.

Part of the ongoing repo-health checklist (item 2, recursion/cycle guard across all languages - Python in #78, TypeScript in #79, Dart follows separately).