### PR TITLE
Guard scene-baking against recursive component definitions (Dart)

### DIFF
--- a/packages/dart/lib/src/scene.dart
+++ b/packages/dart/lib/src/scene.dart
@@ -198,6 +198,13 @@ class SceneBuilder {
     final colorToMaterialIndex = <(int, int, int), int>{};
     final gltfMaterials = <Map<String, dynamic>>[];
 
+    // Definitions currently being instantiated on the active recursion path
+    // (not "ever visited" - the same definition legitimately reused by
+    // sibling instances is fine). Guards against a component that directly
+    // or transitively instances itself, which would otherwise recurse until
+    // the stack overflows.
+    final activeDefinitions = <int>{};
+
     (int, int, int) getLayerColor(String name) => layerColors[name] ?? (136, 136, 136);
 
     int getMaterialIndex((int, int, int) color) {
@@ -460,9 +467,23 @@ class SceneBuilder {
           emitLog(options, SkpLogLevel.debug, 'Processed $instanceCounter placed instances');
         }
         final childDef = refIdx != null ? defsDict[refIdx] : null;
-        final childNodes = (refIdx != null && childDef != null)
-            ? instantiateBuilder(childDef.builder, childDef.name ?? '', refIdx, newMatrix, lName, fullPathName, instColor)
-            : <InstanceNode>[];
+        List<InstanceNode> childNodes;
+        if (refIdx != null && childDef != null) {
+          if (!activeDefinitions.add(refIdx)) {
+            throw SkpParseException(
+              'Recursive component definition',
+              stage: 'build_scene', definitionId: refIdx,
+            );
+          }
+          try {
+            childNodes = instantiateBuilder(
+                childDef.builder, childDef.name ?? '', refIdx, newMatrix, lName, fullPathName, instColor);
+          } finally {
+            activeDefinitions.remove(refIdx);
+          }
+        } else {
+          childNodes = <InstanceNode>[];
+        }
 
         final itx = newMatrix.length > 9 ? newMatrix[9] * _inchesToMm : 0.0;
         final ity = newMatrix.length > 10 ? newMatrix[10] * _inchesToMm : 0.0;

--- a/packages/dart/test/scene_recursion_guard_test.dart
+++ b/packages/dart/test/scene_recursion_guard_test.dart
@@ -1,0 +1,69 @@
+import 'package:openskp/src/core.dart';
+import 'package:openskp/src/geometry.dart';
+import 'package:openskp/src/scene.dart';
+import 'package:openskp/openskp.dart';
+import 'package:test/test.dart';
+
+/// A component definition that (directly or transitively) instances itself
+/// must throw, not recurse until the stack overflows. Real .skp files can't
+/// easily be hand-crafted to exercise this, so these tests build a
+/// synthetic RawParsed directly using the same GeometryBuilder shape
+/// geometry.dart produces.
+
+GeometryBuilderInstance _instance(int refIdx, [String name = 'child']) {
+  return GeometryBuilderInstance()
+    ..offset = 0
+    ..refGuid = ''
+    ..refIdx = refIdx
+    ..name = name
+    ..matrix = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0]
+    ..materialId = null
+    ..children = [];
+}
+
+void main() {
+  test('self-referencing definition throws', () {
+    final builder = GeometryBuilder()..instances.add(_instance(1));
+    final rootBuilder = GeometryBuilder()..instances.add(_instance(1));
+
+    final parsed = RawParsed()
+      ..defsDict[1] = RawDefinition(guid: 'g1', name: 'self_ref', builder: builder)
+      ..root = RawDefinition(guid: 'ROOT', name: 'ROOT_MODEL', builder: rootBuilder);
+
+    expect(
+      () => SceneBuilder.build(parsed),
+      throwsA(isA<SkpParseException>().having(
+        (e) => e.message,
+        'message',
+        contains('Recursive component definition'),
+      )),
+    );
+  });
+
+  test('indirect cycle throws', () {
+    final builderA = GeometryBuilder()..instances.add(_instance(2));
+    final builderB = GeometryBuilder()..instances.add(_instance(1));
+    final rootBuilder = GeometryBuilder()..instances.add(_instance(1));
+
+    final parsed = RawParsed()
+      ..defsDict[1] = RawDefinition(guid: 'g1', name: 'a', builder: builderA)
+      ..defsDict[2] = RawDefinition(guid: 'g2', name: 'b', builder: builderB)
+      ..root = RawDefinition(guid: 'ROOT', name: 'ROOT_MODEL', builder: rootBuilder);
+
+    expect(() => SceneBuilder.build(parsed), throwsA(isA<SkpParseException>()));
+  });
+
+  test('legitimate sibling reuse does not throw', () {
+    final shared = GeometryBuilder();
+    final rootBuilder = GeometryBuilder()
+      ..instances.add(_instance(1, 'child_a'))
+      ..instances.add(_instance(1, 'child_b'));
+
+    final parsed = RawParsed()
+      ..defsDict[1] = RawDefinition(guid: 'g1', name: 'shared', builder: shared)
+      ..root = RawDefinition(guid: 'ROOT', name: 'ROOT_MODEL', builder: rootBuilder);
+
+    final scene = SceneBuilder.build(parsed);
+    expect(scene.sceneHierarchy.children.length, 2);
+  });
+}


### PR DESCRIPTION
## What

Same fix as the Python/TypeScript/.NET PRs (#78, #79, #80): a component definition that directly or transitively instances itself would recurse in `instantiateBuilder()` (`scene.dart`) until the call stack overflows - a cheap, real DoS from a maliciously crafted `.skp` file. Ports the same active-definitions-set guard shape C++'s `scene.cpp` already uses (`scene.cpp:295-304`). **All 5 languages now have this guard.**

## Change

- Added `activeDefinitions = <int>{}` alongside the other closure-local scene-baking state in `SceneBuilder.build()`.
- Before recursing into a child instance's definition, uses `Set.add`'s bool return for an atomic check-and-insert; throws `SkpParseException('Recursive component definition', stage: 'build_scene', definitionId: refIdx)` on a hit - matching the existing error convention elsewhere in the file.
- Removes the definition id in a `finally` block so legitimate reuse of the same definition by sibling instances (not nested inside itself) still works correctly.

## Verification

Hand-crafting a self-referencing component in a real `.skp` file isn't practical, so added synthetic tests built directly on `GeometryBuilder`/`RawParsed` (both accessible via `package:openskp/src/...` even though not re-exported from the public `openskp.dart` barrel file):
- A direct self-reference throws `SkpParseException`.
- An indirect two-definition cycle throws.
- Legitimate sibling reuse - the same definition instanced twice as siblings, not nested - does *not* throw.

All 8 test files pass (verified each individually - `dart test`'s default multi-file run has a display quirk with piped/parallel output that can misleadingly truncate the visible per-file test list, so I confirmed one file at a time rather than trusting the aggregate run). `dart analyze` clean.

Part of the ongoing repo-health checklist (item 2, recursion/cycle guard across all languages) - Python in #78, TypeScript in #79, .NET in #80. This closes out the item.