### PR TITLE
Reject implausible ZIP entry sizes before allocating for them (.NET)

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/ZipEntrySizeCapTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/ZipEntrySizeCapTests.cs
@@ -1,0 +1,84 @@
+using System.IO;
+using System.IO.Compression;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// A ZIP entry's declared uncompressed size (ZipArchiveEntry.Length) is
+    /// untrusted central-directory metadata - a maliciously crafted file can
+    /// declare an arbitrary size with almost no real compressed data behind
+    /// it, and code that pre-sizes an allocation off that declared value
+    /// (ChunkedBuffer.FromStream for model.dat) would try to allocate that
+    /// much memory before reading a single byte. These tests exercise
+    /// Vff.ValidateEntrySize's compression-ratio guard against that.
+    /// </summary>
+    public class ZipEntrySizeCapTests
+    {
+        private static ZipArchiveEntry BuildEntry(MemoryStream backing, byte[] content, CompressionLevel level)
+        {
+            using (var archive = new ZipArchive(backing, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                var entry = archive.CreateEntry("payload.dat", level);
+                using var s = entry.Open();
+                s.Write(content, 0, content.Length);
+            }
+            backing.Position = 0;
+            var readArchive = new ZipArchive(backing, ZipArchiveMode.Read, leaveOpen: true);
+            return readArchive.Entries[0];
+        }
+
+        [Fact]
+        public void RejectsAnImplausibleCompressionRatio()
+        {
+            // 8 MB of zeros deflates to a few hundred bytes - a ratio well
+            // past what real (binary geometry) model.dat entries show
+            // (~10x), exactly the shape of a declared-size decompression
+            // bomb: tiny real payload, huge claimed size.
+            var content = new byte[8 * 1024 * 1024];
+            using var backing = new MemoryStream();
+            var entry = BuildEntry(backing, content, CompressionLevel.Optimal);
+
+            Assert.True(entry.CompressedLength > 0);
+            Assert.True(entry.Length / entry.CompressedLength > 1000);
+
+            var ex = Assert.Throws<SkpParseException>(() => Vff.ValidateEntrySize(entry));
+            Assert.Contains("compression ratio", ex.Message);
+        }
+
+        [Fact]
+        public void AllowsARealisticCompressionRatio()
+        {
+            // Pseudo-random content compresses poorly (ratio close to 1x),
+            // comfortably under the safety threshold.
+            var content = new byte[64 * 1024];
+            new System.Random(42).NextBytes(content);
+            using var backing = new MemoryStream();
+            var entry = BuildEntry(backing, content, CompressionLevel.Optimal);
+
+            Vff.ValidateEntrySize(entry); // must not throw
+        }
+
+        [Fact]
+        public void AllowsATinyEntryRegardlessOfRatio()
+        {
+            // Below the 1 MB ratio-check threshold, even a high ratio is
+            // allowed through - the absolute cost is bounded regardless.
+            var content = new byte[1024];
+            using var backing = new MemoryStream();
+            var entry = BuildEntry(backing, content, CompressionLevel.Optimal);
+
+            Vff.ValidateEntrySize(entry); // must not throw
+        }
+
+        [Fact]
+        public void AllowsAnEmptyEntry()
+        {
+            using var backing = new MemoryStream();
+            var entry = BuildEntry(backing, System.Array.Empty<byte>(), CompressionLevel.NoCompression);
+
+            Vff.ValidateEntrySize(entry); // must not throw
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Core.cs
+++ b/packages/dotnet/OpenSkp/Core.cs
@@ -64,6 +64,7 @@ namespace OpenSkp
                 string name = entry.FullName;
                 if (name.EndsWith("material.xml", StringComparison.Ordinal) && name.StartsWith("materials/", StringComparison.Ordinal))
                 {
+                    Vff.ValidateEntrySize(entry);
                     byte[] xmlData;
                     using (var s = entry.Open())
                     using (var ms = new System.IO.MemoryStream())
@@ -105,6 +106,7 @@ namespace OpenSkp
                 {
                     continue;
                 }
+                Vff.ValidateEntrySize(entry);
                 byte[] xmlData;
                 using (var s = entry.Open())
                 using (var ms = new System.IO.MemoryStream())
@@ -126,6 +128,7 @@ namespace OpenSkp
             {
                 throw new SkpParseException("model.dat not found in ZIP container", stage: "zip_extract");
             }
+            Vff.ValidateEntrySize(modelDatEntry);
             // model.dat routinely decompresses to several GB on real
             // production files (SketchUp's binary format has been observed
             // compressing at ~10x) - well past .NET's ~2.1GB single-array

--- a/packages/dotnet/OpenSkp/Geometry.cs
+++ b/packages/dotnet/OpenSkp/Geometry.cs
@@ -603,6 +603,7 @@ namespace OpenSkp
         private static byte[] ReadEntry(ZipArchive zip, string name)
         {
             var entry = zip.GetEntry(name)!;
+            Vff.ValidateEntrySize(entry);
             using var stream = entry.Open();
             using var ms = new System.IO.MemoryStream();
             stream.CopyTo(ms);

--- a/packages/dotnet/OpenSkp/Vff.cs
+++ b/packages/dotnet/OpenSkp/Vff.cs
@@ -101,5 +101,45 @@ namespace OpenSkp
             var stream = new MemoryStream(data, zipOffset, data.Length - zipOffset, writable: false);
             return new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen: false);
         }
+
+        // A ZIP entry's declared uncompressed size (ZipArchiveEntry.Length)
+        // is untrusted central-directory metadata - it does not have to
+        // match what the compressed stream actually decompresses to. Code
+        // that pre-sizes an allocation off it (e.g. ChunkedBuffer.FromStream
+        // for model.dat) can be made to allocate an arbitrary amount of
+        // memory from a tiny malicious file before a single byte is read.
+        // Real production model.dat entries are observed at ~10x
+        // compression, so both limits below leave generous headroom for
+        // legitimate files while rejecting the kind of declared-size lie a
+        // genuine file would never need.
+        private const long MaxUncompressedEntryBytes = 16L * 1024 * 1024 * 1024; // 16 GB
+        private const long MaxCompressionRatio = 1000;
+        private const long RatioCheckThresholdBytes = 1024 * 1024; // 1 MB
+
+        /// <summary>Reject a ZIP entry whose declared uncompressed size is
+        /// implausible, before any code allocates memory sized off it.</summary>
+        public static void ValidateEntrySize(ZipArchiveEntry entry)
+        {
+            long declared = entry.Length;
+            if (declared <= 0) return;
+
+            if (declared > MaxUncompressedEntryBytes)
+            {
+                throw new SkpParseException(
+                    $"ZIP entry '{entry.FullName}' declares {declared} bytes uncompressed, exceeding the {MaxUncompressedEntryBytes}-byte safety ceiling",
+                    stage: "zip_extract");
+            }
+
+            if (declared >= RatioCheckThresholdBytes)
+            {
+                long compressed = entry.CompressedLength;
+                if (compressed <= 0 || declared / compressed > MaxCompressionRatio)
+                {
+                    throw new SkpParseException(
+                        $"ZIP entry '{entry.FullName}' declares an implausible compression ratio ({declared} bytes from {compressed} bytes compressed) - likely a decompression bomb",
+                        stage: "zip_extract");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

A ZIP entry's declared uncompressed size (`ZipArchiveEntry.Length`) is untrusted central-directory metadata - it does not have to match what the compressed stream actually decompresses to. `Core.cs` trusted it directly: `ChunkedBuffer.FromStream(s, modelDatEntry.Length)` pre-allocates the *full declared size*, before reading a single byte. A maliciously crafted `.skp` file barely larger than a few KB could declare `model.dat`'s uncompressed size as e.g. 100GB and trigger an out-of-memory failure immediately, with no real compressed data behind the claim required. Worst of the 5 languages per the audit (`Core.cs:136-140` / `ChunkedBuffer.cs:88-114`).

## Change

Added `Vff.ValidateEntrySize(ZipArchiveEntry)`, called before any code sizes an allocation off an entry's declared length: `model.dat`, each `materials/*/material.xml`, each `styles/*/style.xml`, and (via the shared `ReadEntry` helper in `Geometry.cs`) every texture image read.

Two checks, both generous relative to real production files (`model.dat` is observed at ~10x compression):
- An absolute ceiling (16 GB) as a backstop against overflow-adjacent or otherwise absurd declared sizes.
- A declared-vs-compressed-size ratio ceiling (1000x), only enforced above a 1 MB floor so tiny entries (bounded cost regardless of ratio) are never falsely rejected. **This is the primary defense** - the declared size field can be set to anything independent of the real compressed bytes, so a tiny malicious payload claiming a huge size is caught here regardless of the absolute value chosen.

## Verification

New tests: 8 MB of zeros (deflates to a few hundred bytes, ratio >> 1000) is rejected with a clear error; realistic (~1x, pseudo-random) and tiny (<1MB) content passes through unaffected.

Full suite: 33/33 passing, including all 3 real-fixture integration/scene/legacy tests - confirming the real files' actual materials/styles/textures/model.dat entries all clear the new checks without any false positives.

Part of the ongoing repo-health checklist (item 3, ZIP decompression-bomb size cap - .NET first as the most acute case, Python/TypeScript/Dart/C++ follow separately).