### PR TITLE
Reject implausible ZIP entry sizes before reading them (Python)

### DIFF
--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -532,6 +532,46 @@ def extract_dynamic_properties(d007):
     return properties
 
 
+# ── ZIP entry size validation ────────────────────────────────────────────
+
+# A ZIP entry's declared uncompressed size (ZipInfo.file_size) is
+# untrusted central-directory metadata: it can be set independently of
+# what the compressed stream actually decompresses to, and even when
+# genuine, DEFLATE can expand highly compressible data by three orders of
+# magnitude. zipfile.ZipFile.read() decompresses (and so allocates) up to
+# that declared size with no ceiling of its own. Real production
+# model.dat entries are observed at ~10x compression, so both limits below
+# leave generous headroom for legitimate files while rejecting the kind
+# of declared-size lie or extreme ratio a genuine file would never need.
+_MAX_UNCOMPRESSED_ENTRY_BYTES = 16 * 1024 ** 3  # 16 GB
+_MAX_COMPRESSION_RATIO = 1000
+_RATIO_CHECK_THRESHOLD_BYTES = 1024 ** 2  # 1 MB
+
+
+def _validate_zip_entry_size(zf: "zipfile.ZipFile", name: str) -> None:
+    """Reject a ZIP entry whose declared uncompressed size is implausible,
+    before any code reads (and so decompresses/allocates for) it."""
+    info = zf.getinfo(name)
+    declared = info.file_size
+    if declared <= 0:
+        return
+    if declared > _MAX_UNCOMPRESSED_ENTRY_BYTES:
+        raise SkpParseError(
+            f"ZIP entry '{name}' declares {declared} bytes uncompressed, "
+            f"exceeding the {_MAX_UNCOMPRESSED_ENTRY_BYTES}-byte safety ceiling",
+            stage="zip_extract",
+        )
+    if declared >= _RATIO_CHECK_THRESHOLD_BYTES:
+        compressed = info.compress_size
+        if compressed <= 0 or declared / compressed > _MAX_COMPRESSION_RATIO:
+            raise SkpParseError(
+                f"ZIP entry '{name}' declares an implausible compression ratio "
+                f"({declared} bytes from {compressed} bytes compressed) - "
+                "likely a decompression bomb",
+                stage="zip_extract",
+            )
+
+
 # ── Texture extraction ───────────────────────────────────────────────────
 
 def _extract_texture(zf, xml_name, mat_elem, ns):
@@ -571,6 +611,7 @@ def _extract_texture(zf, xml_name, mat_elem, ns):
     candidate = folder + '/' + filename if filename else None
     names = zf.namelist()
     if candidate and candidate in names:
+        _validate_zip_entry_size(zf, candidate)
         data = zf.read(candidate)
     else:
         # Image name may differ from textureFilename (observed: e.g.
@@ -578,6 +619,7 @@ def _extract_texture(zf, xml_name, mat_elem, ns):
         for entry in names:
             if (entry.startswith(folder + '/') and entry != xml_name
                     and not entry.lower().endswith('.xml')):
+                _validate_zip_entry_size(zf, entry)
                 data = zf.read(entry)
                 if not filename:
                     filename = entry.rsplit('/', 1)[-1]
@@ -591,6 +633,7 @@ def _extract_texture(zf, xml_name, mat_elem, ns):
         img_path = img_path.lstrip('./')
         for cand in (img_path, folder + '/' + img_path):
             if cand and cand in names:
+                _validate_zip_entry_size(zf, cand)
                 data = zf.read(cand)
                 if not filename:
                     filename = cand.rsplit('/', 1)[-1]
@@ -666,6 +709,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
     MAT_NS = {'mat': 'http://sketchup.google.com/schemas/sketchup/1.0/material'}
     for name in zf.namelist():
         if name.endswith('material.xml') and name.startswith('materials/'):
+            _validate_zip_entry_size(zf, name)
             xml_data = zf.read(name)
             try:
                 root = ET.fromstring(xml_data)
@@ -714,6 +758,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
     # Thumbnail
     thumbnail_data = None
     if 'meta/model_thumbnail.png' in zf.namelist():
+        _validate_zip_entry_size(zf, 'meta/model_thumbnail.png')
         thumbnail_data = zf.read('meta/model_thumbnail.png')
 
     # Styles: face colors live in styles/*/style.xml as signed-int32 ARGB
@@ -726,6 +771,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
         if not (name.startswith('styles/') and name.endswith('style.xml')):
             continue
         try:
+            _validate_zip_entry_size(zf, name)
             sroot = ET.fromstring(zf.read(name))
         except ET.ParseError:
             continue
@@ -750,6 +796,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
 
     logger.debug("Parsed %d materials, %d styles", len(materials), len(styles))
 
+    _validate_zip_entry_size(zf, 'model.dat')
     model_dat = zf.read('model.dat')
     zf.close()
     logger.debug("Read model.dat: %d bytes", len(model_dat))

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -266,6 +266,73 @@ class TestVff:
         assert validate_header(b"\xFF\xFE") is False
 
 
+class TestZipEntrySizeCap:
+    """A ZIP entry's declared uncompressed size (ZipInfo.file_size) is
+    untrusted central-directory metadata - it can be set independently of
+    what the compressed stream actually decompresses to, or (even when
+    genuine) DEFLATE can still expand highly compressible data by three
+    orders of magnitude. ``zipfile.ZipFile.read()`` decompresses up to
+    that declared size with no ceiling of its own, so
+    ``_core._validate_zip_entry_size`` is called before every ``zf.read()``
+    in the real full_parse() pipeline (not :mod:`openskp.vff`, whose own
+    ``extract_skp_contents`` turned out to be dead code - nothing in the
+    real parsing path imports it - so the fix lives where ZIP entries are
+    actually read).
+    """
+
+    @staticmethod
+    def _make_zip(name: str, content: bytes, compress: bool = True):
+        import io
+        import zipfile
+
+        buf = io.BytesIO()
+        method = zipfile.ZIP_DEFLATED if compress else zipfile.ZIP_STORED
+        with zipfile.ZipFile(buf, "w", method) as zf:
+            zf.writestr(name, content)
+        buf.seek(0)
+        return zipfile.ZipFile(buf, "r")
+
+    def test_rejects_an_implausible_compression_ratio(self) -> None:
+        from openskp._core import _validate_zip_entry_size
+        from openskp.errors import SkpParseError
+
+        # 8 MB of zeros deflates to a few hundred bytes - a ratio well past
+        # what real (binary geometry) model.dat entries show (~10x), the
+        # shape of a declared-size decompression bomb: tiny real payload,
+        # huge claimed size.
+        zf = self._make_zip("payload.dat", b"\x00" * (8 * 1024 * 1024))
+        info = zf.getinfo("payload.dat")
+        assert info.compress_size > 0
+        assert info.file_size / info.compress_size > 1000
+
+        with pytest.raises(SkpParseError, match="compression ratio"):
+            _validate_zip_entry_size(zf, "payload.dat")
+
+    def test_allows_a_realistic_compression_ratio(self) -> None:
+        import os
+
+        from openskp._core import _validate_zip_entry_size
+
+        # Pseudo-random content compresses poorly (ratio close to 1x),
+        # comfortably under the safety threshold.
+        zf = self._make_zip("payload.dat", os.urandom(64 * 1024))
+        _validate_zip_entry_size(zf, "payload.dat")  # must not raise
+
+    def test_allows_a_tiny_entry_regardless_of_ratio(self) -> None:
+        from openskp._core import _validate_zip_entry_size
+
+        # Below the 1 MB ratio-check threshold, even a high ratio is
+        # allowed through - the absolute cost is bounded regardless.
+        zf = self._make_zip("payload.dat", b"\x00" * 1024)
+        _validate_zip_entry_size(zf, "payload.dat")  # must not raise
+
+    def test_allows_an_empty_entry(self) -> None:
+        from openskp._core import _validate_zip_entry_size
+
+        zf = self._make_zip("payload.dat", b"", compress=False)
+        _validate_zip_entry_size(zf, "payload.dat")  # must not raise
+
+
 # ── Materials tests ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

A ZIP entry's declared uncompressed size (`ZipInfo.file_size`) is untrusted central-directory metadata - it can be set independently of what the compressed stream actually decompresses to, and even when genuine, DEFLATE can expand highly compressible data by three orders of magnitude. `zipfile.ZipFile.read()` decompresses (and so allocates) up to that declared size with no ceiling of its own.

**Correction to the audit checklist's file reference:** the audit pointed at `vff.py`'s `extract_skp_contents()`, but that turned out to be dead code - grepping the whole package and test suite confirms nothing in the real parsing path imports it (only `validate_header()` is actually used). The real ZIP reads all happen in `_core.py`'s `full_parse()` and its `_extract_texture()` helper, so that's where this fix lives.

## Change

Added `_validate_zip_entry_size(zf, name)` in `_core.py`, called before every `zf.read()` in the real pipeline: `material.xml` entries, the thumbnail, `style.xml` entries, `model.dat`, and every texture image path `_extract_texture()` tries.

Two checks, both generous relative to real production files (`model.dat` is observed at ~10x compression) - same shape as the .NET fix in #82:
- An absolute ceiling (16 GB) as a backstop against absurd declared sizes.
- A declared-vs-compressed-size ratio ceiling (1000x), only enforced above a 1 MB floor so tiny entries (bounded cost regardless of ratio) are never falsely rejected.

## Verification

New tests: 8 MB of zeros (deflates to a few hundred bytes, ratio >> 1000) is rejected with a clear `SkpParseError`; realistic (~1x, `os.urandom`) and tiny (<1MB) content passes through unaffected.

Full suite: 95/95 passing (91 existing + 4 new), `ruff check src/ tests/` clean - including the real-fixture parse/build_scene/legacy tests, confirming actual production materials/styles/textures/model.dat entries all clear the new checks without any false positives.

Part of the ongoing repo-health checklist (item 3, ZIP decompression-bomb size cap) - .NET in #82, TypeScript/Dart/C++ follow separately.