### PR TITLE
Reject implausible ZIP entry sizes before decompressing them (TypeScript)

### DIFF
--- a/packages/typescript/src/vff.ts
+++ b/packages/typescript/src/vff.ts
@@ -70,6 +70,41 @@ function findZipOffset(data: Uint8Array): number {
   return offset;
 }
 
+// A ZIP entry's declared uncompressed size (UnzipFileInfo.originalSize) is
+// untrusted central-directory metadata - it can be set independently of
+// what the compressed stream actually decompresses to, and even when
+// genuine, DEFLATE can expand highly compressible data by three orders of
+// magnitude. fflate's unzipSync decompresses (and so allocates) up to that
+// declared size with no ceiling of its own. Real production model.dat
+// entries are observed at ~10x compression, so both limits below leave
+// generous headroom for legitimate files while rejecting the kind of
+// declared-size lie or extreme ratio a genuine file would never need.
+const MAX_UNCOMPRESSED_ENTRY_BYTES = 16 * 1024 * 1024 * 1024; // 16 GB
+const MAX_COMPRESSION_RATIO = 1000;
+const RATIO_CHECK_THRESHOLD_BYTES = 1024 * 1024; // 1 MB
+
+/** Reject a ZIP entry whose declared uncompressed size is implausible,
+ * before unzipSync decompresses (and so allocates for) it. */
+function validateEntrySize(file: UnzipFileInfo): void {
+  const declared = file.originalSize;
+  if (declared <= 0) return;
+
+  if (declared > MAX_UNCOMPRESSED_ENTRY_BYTES) {
+    throw new Error(
+      `ZIP entry '${file.name}' declares ${declared} bytes uncompressed, exceeding the ${MAX_UNCOMPRESSED_ENTRY_BYTES}-byte safety ceiling`
+    );
+  }
+
+  if (declared >= RATIO_CHECK_THRESHOLD_BYTES) {
+    const compressed = file.size;
+    if (compressed <= 0 || declared / compressed > MAX_COMPRESSION_RATIO) {
+      throw new Error(
+        `ZIP entry '${file.name}' declares an implausible compression ratio (${declared} bytes from ${compressed} bytes compressed) - likely a decompression bomb`
+      );
+    }
+  }
+}
+
 export function extractSkpContents(data: Uint8Array): SkpContents {
   // Allow both VFF-wrapped and bare ZIP (some exporters omit the header)
   if (!validateHeader(data)) {
@@ -88,7 +123,7 @@ export function extractSkpContents(data: Uint8Array): SkpContents {
   // fully inflated into memory alongside model.dat for nothing.
   const wanted = (file: UnzipFileInfo): boolean => {
     const lower = file.name.toLowerCase();
-    return (
+    const isWanted = (
       lower === 'model.dat' ||
       lower.endsWith('/model.dat') ||
       lower.endsWith('.xml') ||
@@ -97,6 +132,8 @@ export function extractSkpContents(data: Uint8Array): SkpContents {
       lower.endsWith('.jpeg') ||
       lower.includes('material')
     );
+    if (isWanted) validateEntrySize(file);
+    return isWanted;
   };
 
   let unzipped: Record<string, Uint8Array>;

--- a/packages/typescript/tests/zip-entry-size-cap.test.ts
+++ b/packages/typescript/tests/zip-entry-size-cap.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { zipSync } from 'fflate';
+import { randomBytes } from 'node:crypto';
+import { extractSkpContents } from '../src/vff';
+
+/**
+ * A ZIP entry's declared uncompressed size is untrusted central-directory
+ * metadata - it can be set independently of what the compressed stream
+ * actually decompresses to, and even when genuine, DEFLATE can expand
+ * highly compressible data by three orders of magnitude. fflate's
+ * unzipSync decompresses (and so allocates) up to that declared size with
+ * no ceiling of its own, so vff.ts's `wanted` filter validates every
+ * entry's size before letting unzipSync touch it.
+ */
+
+function buildSkpBytes(zipBytes: Uint8Array): Uint8Array {
+  const header = new Uint8Array(16); // VFF magic + padding
+  header.set([0xff, 0xfe, 0xff, 0x0e], 0);
+  const combined = new Uint8Array(header.length + zipBytes.length);
+  combined.set(header, 0);
+  combined.set(zipBytes, header.length);
+  return combined;
+}
+
+describe('extractSkpContents ZIP entry size cap', () => {
+  it('rejects an implausible compression ratio in model.dat', () => {
+    // 8 MB of zeros deflates to a few hundred bytes - a ratio well past
+    // what real (binary geometry) model.dat entries show (~10x), the
+    // shape of a declared-size decompression bomb: tiny real payload,
+    // huge claimed size.
+    const zeros = new Uint8Array(8 * 1024 * 1024);
+    const zipBytes = zipSync({ 'model.dat': zeros }, { level: 9 });
+    const skpBytes = buildSkpBytes(zipBytes);
+
+    expect(() => extractSkpContents(skpBytes)).toThrow(/compression ratio/);
+  });
+
+  it('allows a realistic compression ratio', () => {
+    // Random content compresses poorly (ratio close to 1x), comfortably
+    // under the safety threshold.
+    const random = new Uint8Array(randomBytes(64 * 1024));
+    const zipBytes = zipSync({ 'model.dat': random }, { level: 9 });
+    const skpBytes = buildSkpBytes(zipBytes);
+
+    const contents = extractSkpContents(skpBytes);
+    expect(contents.modelData.length).toBe(random.length);
+  });
+
+  it('allows a tiny entry regardless of ratio', () => {
+    // Below the 1 MB ratio-check threshold, even a high ratio is allowed
+    // through - the absolute cost is bounded regardless.
+    const zeros = new Uint8Array(1024);
+    const zipBytes = zipSync({ 'model.dat': zeros }, { level: 9 });
+    const skpBytes = buildSkpBytes(zipBytes);
+
+    const contents = extractSkpContents(skpBytes);
+    expect(contents.modelData.length).toBe(zeros.length);
+  });
+});


### PR DESCRIPTION
## What

A ZIP entry's declared uncompressed size (`UnzipFileInfo.originalSize`) is untrusted central-directory metadata - it can be set independently of what the compressed stream actually decompresses to, and even when genuine, DEFLATE can expand highly compressible data by three orders of magnitude. `fflate`'s `unzipSync` decompresses (and so allocates) up to that declared size with no ceiling of its own.

Unlike Python's `vff.py` (see #83), TypeScript's `vff.ts` is the real, actually-used ZIP extraction path - `index.ts`'s `parseToRaw()` calls `extractSkpContents()` directly. Its existing `wanted` filter already runs once per entry *before* `unzipSync` decompresses anything (it decides which entries even get inflated), which is the ideal place to add a size check with no restructuring needed.

## Change

Added `validateEntrySize(file: UnzipFileInfo)`, called from the `wanted` filter for every entry that passes the existing name-based filter (`model.dat`, XML, image, and material-named entries).

Two checks, both generous relative to real production files (`model.dat` is observed at ~10x compression) - same shape as the Python/.NET fixes in #82/#83:
- An absolute ceiling (16 GB) as a backstop against absurd declared sizes.
- A declared-vs-compressed-size ratio ceiling (1000x), only enforced above a 1 MB floor so tiny entries (bounded cost regardless of ratio) are never falsely rejected.

## Verification

New tests build real ZIP archives via `fflate`'s own `zipSync` (no hand-crafted bytes needed): 8 MB of zeros (deflates to a few hundred bytes, ratio >> 1000) is rejected with a clear error; realistic (~1x, random) and tiny (<1MB) content pass through unaffected.

Full suite: 49/49 passing (46 existing + 3 new), `tsc --noEmit` clean - including the real-fixture integration test, confirming actual production ZIP entries clear the new checks without any false positives.

Part of the ongoing repo-health checklist (item 3, ZIP decompression-bomb size cap) - .NET in #82, Python in #83, Dart/C++ follow separately.