### PR TITLE
Reject implausible ZIP entry sizes before decompressing them (Dart)

### DIFF
--- a/packages/dart/lib/src/core.dart
+++ b/packages/dart/lib/src/core.dart
@@ -59,6 +59,7 @@ class Core {
     for (final entry in zip.files) {
       final name = entry.name;
       if (name.endsWith('material.xml') && name.startsWith('materials/')) {
+        Vff.validateEntrySize(entry);
         RawMaterial? mat;
         try {
           mat = Geometry.parseMaterialXml(zip, name, entry.content);
@@ -85,6 +86,7 @@ class Core {
       if (!(name.startsWith('styles/') && name.endsWith('style.xml'))) {
         continue;
       }
+      Vff.validateEntrySize(entry);
       final style = Geometry.parseStyleXml(entry.content);
       if (style != null) {
         styles.add(style);
@@ -97,6 +99,7 @@ class Core {
     if (modelDatEntry == null) {
       throw SkpParseException('model.dat not found in ZIP container', stage: 'zip_extract');
     }
+    Vff.validateEntrySize(modelDatEntry);
     final modelDat = modelDatEntry.content;
     emitLog(options, SkpLogLevel.debug, 'Read model.dat: ${modelDat.length} bytes');
 

--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -5,6 +5,7 @@ import 'package:archive/archive.dart';
 import 'package:xml/xml.dart';
 
 import 'tlv.dart';
+import 'vff.dart';
 
 class GeometryBuilderFace {
   List<List<(int edgeId, int orientation)>> loops = [];
@@ -499,12 +500,17 @@ class Geometry {
 
     final candidate = filename.isNotEmpty ? '$folder/$filename' : null;
     if (candidate != null && entryNames.contains(candidate)) {
-      data = zip.findFile(candidate)?.content;
+      final candEntry = zip.findFile(candidate);
+      if (candEntry != null) {
+        Vff.validateEntrySize(candEntry);
+        data = candEntry.content;
+      }
     } else {
       for (final entry in zip.files) {
         if (entry.name.startsWith('$folder/') &&
             entry.name != xmlName &&
             !entry.name.toLowerCase().endsWith('.xml')) {
+          Vff.validateEntrySize(entry);
           data = entry.content;
           if (filename.isEmpty) {
             final s = entry.name.lastIndexOf('/');
@@ -523,7 +529,11 @@ class Geometry {
       imgPath = _lstripChars(imgPath, './');
       for (final cand in [imgPath, '$folder/$imgPath']) {
         if (cand.isNotEmpty && entryNames.contains(cand)) {
-          data = zip.findFile(cand)?.content;
+          final candEntry = zip.findFile(cand);
+          if (candEntry != null) {
+            Vff.validateEntrySize(candEntry);
+            data = candEntry.content;
+          }
           if (filename.isEmpty) {
             final s = cand.lastIndexOf('/');
             filename = s >= 0 ? cand.substring(s + 1) : cand;

--- a/packages/dart/lib/src/vff.dart
+++ b/packages/dart/lib/src/vff.dart
@@ -2,6 +2,8 @@ import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 
+import 'errors.dart';
+
 /// Container-level helpers for the modern (2021+) VFF/ZIP .skp format:
 /// header validation, version-string extraction, and locating the embedded
 /// ZIP payload. Ported from the steps in Python's _core.full_parse() that
@@ -76,5 +78,48 @@ class Vff {
   static Archive openZip(Uint8List data, int zipOffset) {
     final zipBytes = Uint8List.sublistView(data, zipOffset);
     return ZipDecoder().decodeBytes(zipBytes);
+  }
+
+  // A ZIP entry's declared uncompressed size (ArchiveFile.size) is
+  // untrusted central-directory metadata - it can be set independently of
+  // what the compressed stream actually decompresses to, and even when
+  // genuine, DEFLATE can expand highly compressible data by three orders
+  // of magnitude. ArchiveFile.content decompresses (and so allocates) up
+  // to that declared size with no ceiling of its own - decodeBytes() only
+  // reads the central directory, so this check runs before any real
+  // decompression happens. Real production model.dat entries are observed
+  // at ~10x compression, so both limits below leave generous headroom for
+  // legitimate files.
+  static const int _maxUncompressedEntryBytes = 16 * 1024 * 1024 * 1024; // 16 GB
+  static const int _maxCompressionRatio = 1000;
+  static const int _ratioCheckThresholdBytes = 1024 * 1024; // 1 MB
+
+  /// Reject a ZIP entry whose declared uncompressed size is implausible,
+  /// before any code reads (and so decompresses/allocates for) its
+  /// content.
+  static void validateEntrySize(ArchiveFile entry) {
+    final declared = entry.size;
+    if (declared <= 0) return;
+
+    if (declared > _maxUncompressedEntryBytes) {
+      throw SkpParseException(
+        "ZIP entry '${entry.name}' declares $declared bytes uncompressed, "
+        'exceeding the $_maxUncompressedEntryBytes-byte safety ceiling',
+        stage: 'zip_extract',
+      );
+    }
+
+    if (declared >= _ratioCheckThresholdBytes) {
+      final raw = entry.rawContent;
+      final compressed = raw is ZipFile ? raw.compressedSize : 0;
+      if (compressed <= 0 || declared / compressed > _maxCompressionRatio) {
+        throw SkpParseException(
+          "ZIP entry '${entry.name}' declares an implausible compression "
+          "ratio ($declared bytes from $compressed bytes compressed) - "
+          'likely a decompression bomb',
+          stage: 'zip_extract',
+        );
+      }
+    }
   }
 }

--- a/packages/dart/test/zip_entry_size_cap_test.dart
+++ b/packages/dart/test/zip_entry_size_cap_test.dart
@@ -1,0 +1,66 @@
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:archive/archive.dart';
+import 'package:openskp/src/errors.dart';
+import 'package:openskp/src/vff.dart';
+import 'package:test/test.dart';
+
+/// A ZIP entry's declared uncompressed size (ArchiveFile.size) is
+/// untrusted central-directory metadata - it can be set independently of
+/// what the compressed stream actually decompresses to, and even when
+/// genuine, DEFLATE can expand highly compressible data by three orders of
+/// magnitude. ArchiveFile.content decompresses (and so allocates) up to
+/// that declared size with no ceiling of its own, so these tests exercise
+/// Vff.validateEntrySize's compression-ratio guard against that.
+
+ArchiveFile _buildEntry(Uint8List content) {
+  final archive = Archive();
+  archive.add(ArchiveFile.bytes('payload.dat', content));
+  final zipBytes = ZipEncoder().encodeBytes(archive, level: DeflateLevel.bestCompression);
+  final decoded = ZipDecoder().decodeBytes(zipBytes);
+  return decoded.findFile('payload.dat')!;
+}
+
+void main() {
+  test('rejects an implausible compression ratio', () {
+    // 8 MB of zeros deflates to a few hundred bytes - a ratio well past
+    // what real (binary geometry) model.dat entries show (~10x), the
+    // shape of a declared-size decompression bomb: tiny real payload,
+    // huge claimed size.
+    final entry = _buildEntry(Uint8List(8 * 1024 * 1024));
+
+    expect(
+      () => Vff.validateEntrySize(entry),
+      throwsA(isA<SkpParseException>().having(
+        (e) => e.message,
+        'message',
+        contains('compression ratio'),
+      )),
+    );
+  });
+
+  test('allows a realistic compression ratio', () {
+    // Pseudo-random content compresses poorly (ratio close to 1x),
+    // comfortably under the safety threshold.
+    final rng = Random(42);
+    final random = Uint8List.fromList(List<int>.generate(64 * 1024, (_) => rng.nextInt(256)));
+    final entry = _buildEntry(random);
+
+    Vff.validateEntrySize(entry); // must not throw
+  });
+
+  test('allows a tiny entry regardless of ratio', () {
+    // Below the 1 MB ratio-check threshold, even a high ratio is allowed
+    // through - the absolute cost is bounded regardless.
+    final entry = _buildEntry(Uint8List(1024));
+
+    Vff.validateEntrySize(entry); // must not throw
+  });
+
+  test('allows an empty entry', () {
+    final entry = _buildEntry(Uint8List(0));
+
+    Vff.validateEntrySize(entry); // must not throw
+  });
+}


### PR DESCRIPTION
## What

A ZIP entry's declared uncompressed size (`ArchiveFile.size`) is untrusted central-directory metadata - it can be set independently of what the compressed stream actually decompresses to, and even when genuine, DEFLATE can expand highly compressible data by three orders of magnitude. `package:archive`'s `ZipDecoder.decodeBytes()` only reads the central directory (confirmed by reading its source - it never touches entry content up front), but `ArchiveFile.content` decompresses (and so allocates) up to the declared size the first time it's accessed, with no ceiling of its own.

## Change

Added `Vff.validateEntrySize(ArchiveFile)`, called before every `.content` access: `model.dat`, each `materials/*/material.xml`, each `styles/*/style.xml` (all in `core.dart`), and every texture image path `Geometry._extractTexture()` tries.

Two checks, both generous relative to real production files (`model.dat` is observed at ~10x compression) - same shape as the Python/.NET/TypeScript fixes in #82/#83/#84:
- An absolute ceiling (16 GB) as a backstop against absurd declared sizes.
- A declared-vs-compressed-size ratio ceiling (1000x), only enforced above a 1 MB floor so tiny entries (bounded cost regardless of ratio) are never falsely rejected. The compressed size comes from `ArchiveFile.rawContent` cast to `ZipFile` (`package:archive`'s own internal record for a not-yet-decompressed entry), which exposes `compressedSize` alongside the already-used `uncompressedSize`.

## Verification

New tests build real ZIP archives via `package:archive`'s own `ZipEncoder` (no hand-crafted bytes needed): 8 MB of zeros (deflates to a few hundred bytes, ratio >> 1000) is rejected with a clear `SkpParseException`; realistic (~1x, seeded PRNG) and tiny (<1MB) content pass through unaffected.

All 9 test files pass (verified individually, per the display quirk with `dart test`'s piped/parallel output noted in the recursion-guard PR), `dart analyze` clean - including the real-fixture integration and GLB export tests, confirming actual production materials/styles/textures/model.dat entries all clear the new checks without any false positives.

Part of the ongoing repo-health checklist (item 3, ZIP decompression-bomb size cap) - .NET in #82, Python in #83, TypeScript in #84, C++ follows separately.