### PR TITLE
Reject implausible ZIP entry sizes before extracting them (C++)

### DIFF
--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -59,19 +59,20 @@ struct Zip {
 
     if (declared > kMaxUncompressedEntryBytes) {
       throw SkpParseError("ZIP entry '" + std::string(s.m_filename) + "' declares " +
-                               std::to_string(declared) + " bytes uncompressed, exceeding the " +
-                               std::to_string(kMaxUncompressedEntryBytes) + "-byte safety ceiling",
-                           ParseStage::zip_extract);
+                              std::to_string(declared) + " bytes uncompressed, exceeding the " +
+                              std::to_string(kMaxUncompressedEntryBytes) + "-byte safety ceiling",
+                          ParseStage::zip_extract);
     }
 
     if (declared >= kRatioCheckThresholdBytes) {
       auto compressed = s.m_comp_size;
       if (compressed == 0 || declared / compressed > kMaxCompressionRatio) {
         throw SkpParseError("ZIP entry '" + std::string(s.m_filename) +
-                                 "' declares an implausible compression ratio (" +
-                                 std::to_string(declared) + " bytes from " + std::to_string(compressed) +
-                                 " bytes compressed) - likely a decompression bomb",
-                             ParseStage::zip_extract);
+                                "' declares an implausible compression ratio (" +
+                                std::to_string(declared) + " bytes from " +
+                                std::to_string(compressed) +
+                                " bytes compressed) - likely a decompression bomb",
+                            ParseStage::zip_extract);
       }
     }
   }

--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -28,12 +28,52 @@ struct Zip {
   std::optional<ByteBuffer> get(const std::string& name) {
     int i = mz_zip_reader_locate_file(&z, name.c_str(), nullptr, 0);
     if (i < 0) return {};
+    mz_zip_archive_file_stat s{};
+    if (!mz_zip_reader_file_stat(&z, i, &s)) return {};
+    validate_entry_size(s);
     size_t n = 0;
     void* p = mz_zip_reader_extract_to_heap(&z, i, &n, 0);
     if (!p) return {};
     ByteBuffer b(static_cast<std::uint8_t*>(p), static_cast<std::uint8_t*>(p) + n);
     mz_free(p);
     return b;
+  }
+
+ private:
+  // A ZIP entry's declared uncompressed size (m_uncomp_size) is untrusted
+  // central-directory metadata - it can be set independently of what the
+  // compressed stream actually decompresses to, and even when genuine,
+  // DEFLATE can expand highly compressible data by three orders of
+  // magnitude. mz_zip_reader_extract_to_heap allocates up to that declared
+  // size with no ceiling of its own. Real production model.dat entries are
+  // observed at ~10x compression, so both limits below leave generous
+  // headroom for legitimate files while rejecting the kind of declared-size
+  // lie or extreme ratio a genuine file would never need.
+  static constexpr std::uint64_t kMaxUncompressedEntryBytes = 16ull * 1024 * 1024 * 1024;  // 16 GB
+  static constexpr std::uint64_t kMaxCompressionRatio = 1000;
+  static constexpr std::uint64_t kRatioCheckThresholdBytes = 1024ull * 1024;  // 1 MB
+
+  static void validate_entry_size(const mz_zip_archive_file_stat& s) {
+    auto declared = s.m_uncomp_size;
+    if (declared == 0) return;
+
+    if (declared > kMaxUncompressedEntryBytes) {
+      throw SkpParseError("ZIP entry '" + std::string(s.m_filename) + "' declares " +
+                               std::to_string(declared) + " bytes uncompressed, exceeding the " +
+                               std::to_string(kMaxUncompressedEntryBytes) + "-byte safety ceiling",
+                           ParseStage::zip_extract);
+    }
+
+    if (declared >= kRatioCheckThresholdBytes) {
+      auto compressed = s.m_comp_size;
+      if (compressed == 0 || declared / compressed > kMaxCompressionRatio) {
+        throw SkpParseError("ZIP entry '" + std::string(s.m_filename) +
+                                 "' declares an implausible compression ratio (" +
+                                 std::to_string(declared) + " bytes from " + std::to_string(compressed) +
+                                 " bytes compressed) - likely a decompression bomb",
+                             ParseStage::zip_extract);
+      }
+    }
   }
 };
 

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(
   scene_test.cpp
   texture_test.cpp
   triangulator_test.cpp
+  zip_entry_size_cap_test.cpp
 )
 
 target_link_libraries(openskp_tests PRIVATE OpenSkp::OpenSkp GTest::gtest_main)

--- a/packages/cpp/tests/zip_entry_size_cap_test.cpp
+++ b/packages/cpp/tests/zip_entry_size_cap_test.cpp
@@ -30,10 +30,12 @@ namespace {
 
 ByteBuffer build_zip_with_entry(const std::string& name, const ByteBuffer& content, int level) {
   mz_zip_archive zip{};
-  if (!mz_zip_writer_init_heap(&zip, 0, 0)) throw std::runtime_error("mz_zip_writer_init_heap failed");
+  if (!mz_zip_writer_init_heap(&zip, 0, 0))
+    throw std::runtime_error("mz_zip_writer_init_heap failed");
 
   const void* data_ptr = content.empty() ? static_cast<const void*>("") : content.data();
-  if (!mz_zip_writer_add_mem(&zip, name.c_str(), data_ptr, content.size(), static_cast<mz_uint>(level))) {
+  if (!mz_zip_writer_add_mem(&zip, name.c_str(), data_ptr, content.size(),
+                             static_cast<mz_uint>(level))) {
     mz_zip_writer_end(&zip);
     throw std::runtime_error("mz_zip_writer_add_mem failed");
   }

--- a/packages/cpp/tests/zip_entry_size_cap_test.cpp
+++ b/packages/cpp/tests/zip_entry_size_cap_test.cpp
@@ -1,0 +1,103 @@
+#include <cstring>
+#include <gtest/gtest.h>
+#include <miniz.h>
+#include <random>
+#include <stdexcept>
+
+#include <openskp/openskp.hpp>
+
+#include "internal.hpp"
+#include "test_helpers.hpp"
+
+// A ZIP entry's declared uncompressed size is untrusted central-directory
+// metadata - it can be set independently of what the compressed stream
+// actually decompresses to, and even when genuine, DEFLATE can expand
+// highly compressible data by three orders of magnitude.
+// mz_zip_reader_extract_to_heap allocates up to that declared size with no
+// ceiling of its own, so core.cpp's Zip::get() validates every entry's
+// size before extracting. These tests build real ZIP archives via miniz's
+// own writer API (no hand-crafted bytes needed) to exercise that guard
+// end-to-end through the public full_parse() entry point, since Zip and
+// validate_entry_size are implementation details in an anonymous
+// namespace with no separately-testable surface.
+//
+// Not verified locally - no C++ toolchain is available in this
+// environment. Relies on CI (GCC/Clang/MSVC) as the actual correctness
+// gate; reviewed carefully against miniz's documented writer API instead.
+
+namespace openskp::test {
+namespace {
+
+ByteBuffer build_zip_with_entry(const std::string& name, const ByteBuffer& content, int level) {
+  mz_zip_archive zip{};
+  if (!mz_zip_writer_init_heap(&zip, 0, 0)) throw std::runtime_error("mz_zip_writer_init_heap failed");
+
+  const void* data_ptr = content.empty() ? static_cast<const void*>("") : content.data();
+  if (!mz_zip_writer_add_mem(&zip, name.c_str(), data_ptr, content.size(), static_cast<mz_uint>(level))) {
+    mz_zip_writer_end(&zip);
+    throw std::runtime_error("mz_zip_writer_add_mem failed");
+  }
+
+  void* buf = nullptr;
+  size_t size = 0;
+  if (!mz_zip_writer_finalize_heap_archive(&zip, &buf, &size)) {
+    mz_zip_writer_end(&zip);
+    throw std::runtime_error("mz_zip_writer_finalize_heap_archive failed");
+  }
+
+  ByteBuffer result(static_cast<std::uint8_t*>(buf), static_cast<std::uint8_t*>(buf) + size);
+  mz_free(buf);
+  mz_zip_writer_end(&zip);
+  return result;
+}
+
+ByteBuffer wrap_vff(const ByteBuffer& zip_bytes) {
+  ByteBuffer header(16, 0);
+  header[0] = 0xFF;
+  header[1] = 0xFE;
+  header[2] = 0xFF;
+  header[3] = 0x0E;
+  return concat({header, zip_bytes});
+}
+
+}  // namespace
+
+TEST(ZipEntrySizeCap, RejectsAnImplausibleCompressionRatio) {
+  // 8 MB of zeros deflates to a few hundred bytes - a ratio well past what
+  // real (binary geometry) model.dat entries show (~10x), the shape of a
+  // declared-size decompression bomb: tiny real payload, huge claimed size.
+  ByteBuffer zeros(8 * 1024 * 1024, 0);
+  auto skp_bytes = wrap_vff(build_zip_with_entry("model.dat", zeros, MZ_BEST_COMPRESSION));
+
+  bool threw = false;
+  try {
+    full_parse(skp_bytes, ParseOptions{});
+  } catch (const SkpParseError& e) {
+    threw = true;
+    EXPECT_NE(std::string(e.what()).find("compression ratio"), std::string::npos) << e.what();
+  }
+  EXPECT_TRUE(threw);
+}
+
+TEST(ZipEntrySizeCap, AllowsARealisticCompressionRatio) {
+  // Pseudo-random content compresses poorly (ratio close to 1x),
+  // comfortably under the safety threshold.
+  ByteBuffer random(64 * 1024);
+  std::mt19937 rng(42);
+  std::uniform_int_distribution<int> dist(0, 255);
+  for (auto& b : random) b = static_cast<std::uint8_t>(dist(rng));
+  auto skp_bytes = wrap_vff(build_zip_with_entry("model.dat", random, MZ_BEST_COMPRESSION));
+
+  EXPECT_NO_THROW(full_parse(skp_bytes, ParseOptions{}));
+}
+
+TEST(ZipEntrySizeCap, AllowsATinyEntryRegardlessOfRatio) {
+  // Below the 1 MB ratio-check threshold, even a high ratio is allowed
+  // through - the absolute cost is bounded regardless.
+  ByteBuffer zeros(1024, 0);
+  auto skp_bytes = wrap_vff(build_zip_with_entry("model.dat", zeros, MZ_BEST_COMPRESSION));
+
+  EXPECT_NO_THROW(full_parse(skp_bytes, ParseOptions{}));
+}
+
+}  // namespace openskp::test


### PR DESCRIPTION
## What

A ZIP entry's declared uncompressed size (`m_uncomp_size`, from miniz's `mz_zip_archive_file_stat`) is untrusted central-directory metadata - it can be set independently of what the compressed stream actually decompresses to, and even when genuine, DEFLATE can expand highly compressible data by three orders of magnitude. `mz_zip_reader_extract_to_heap` allocates up to that declared size with no ceiling of its own.

## Change

`core.cpp`'s internal `Zip::get()` is the single choke point every ZIP read in this file goes through (model.dat, materials, styles, textures), so the check lives there: after locating an entry, stat it first and validate before calling `mz_zip_reader_extract_to_heap`.

Two checks, both generous relative to real production files (`model.dat` is observed at ~10x compression) - same shape as the Python/.NET/TypeScript/Dart fixes in #82-#85:
- An absolute ceiling (16 GB) as a backstop against absurd declared sizes.
- A declared-vs-compressed-size ratio ceiling (1000x, using `m_comp_size`), only enforced above a 1 MB floor so tiny entries (bounded cost regardless of ratio) are never falsely rejected.

## Verification

**No C++ toolchain is available in this environment** (no cmake, no compiler) - this is unverified locally, the standing caveat for every C++ change in this project.

Added 3 new tests building real ZIP archives via miniz's own writer API (`mz_zip_writer_add_mem`) and running them through the public `full_parse()` entry point (`Zip` and `validate_entry_size` are anonymous-namespace implementation details with no separately-testable surface): 8 MB of zeros (deflates to a few hundred bytes, ratio >> 1000) is rejected with `SkpParseError`; realistic (~1x, seeded PRNG) and tiny (<1MB) content parse without throwing.

Reviewed carefully against miniz's documented reader/writer API (`mz_zip_archive_file_stat`'s `m_uncomp_size`/`m_comp_size`/`m_filename` fields, `mz_zip_writer_init_heap`/`add_mem`/`finalize_heap_archive`) since I can't compile to confirm. Relies entirely on CI (GCC/Clang/MSVC + sanitizers) as the actual correctness gate.

Part of the ongoing repo-health checklist (item 3, ZIP decompression-bomb size cap) - .NET in #82, Python in #83, TypeScript in #84, Dart in #85. **This closes out the item across all 5 languages.**