### PR TITLE
Raise on unsupported coordinate_system/units instead of ignoring them (Python)

### DIFF
--- a/packages/python/src/openskp/export/glb.py
+++ b/packages/python/src/openskp/export/glb.py
@@ -45,12 +45,29 @@ def export(
 
     Raises:
         RuntimeError: If *skp_file* has not been parsed yet.
+        NotImplementedError: If *coordinate_system* or *units* request
+            anything other than the only values currently implemented
+            (``"y-up"`` / ``"mm"``). The underlying conversion (glTF
+            y-up, millimetres) is hardcoded in the scene builder, so a
+            caller requesting e.g. ``units="inches"`` would otherwise
+            silently get millimetre output with no indication anything
+            was ignored.
     """
     from .._core import build_scene
 
     if not hasattr(skp_file, '_parsed') or skp_file._parsed is None:
         raise RuntimeError(
             "SkpFile must be parsed before exporting. Call skp_file.parse() first."
+        )
+
+    if coordinate_system != "y-up":
+        raise NotImplementedError(
+            f"coordinate_system={coordinate_system!r} is not implemented; "
+            "only 'y-up' (glTF standard) is currently supported."
+        )
+    if units != "mm":
+        raise NotImplementedError(
+            f"units={units!r} is not implemented; only 'mm' is currently supported."
         )
 
     output_dir = os.path.dirname(os.path.abspath(output_path))

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -1358,6 +1358,33 @@ class TestGlbExport:
         assert "definition_id" in first_child
         assert "matrix_3x4" in first_child
 
+    def test_export_rejects_unsupported_coordinate_system(self, tmp_path) -> None:
+        # The underlying conversion is hardcoded to y-up/mm - passing
+        # anything else must raise, not silently produce y-up/mm output
+        # while claiming to have honored the request.
+        import pytest as _pytest
+        if not self.FIXTURE.exists():
+            _pytest.skip("legacy fixture not present")
+        from openskp.export import glb as glb_export
+        from openskp.model import SkpFile
+
+        skp = SkpFile.open(str(self.FIXTURE))
+        skp.parse()
+        with pytest.raises(NotImplementedError, match="coordinate_system"):
+            glb_export.export(skp, str(tmp_path / "out.glb"), coordinate_system="z-up")
+
+    def test_export_rejects_unsupported_units(self, tmp_path) -> None:
+        import pytest as _pytest
+        if not self.FIXTURE.exists():
+            _pytest.skip("legacy fixture not present")
+        from openskp.export import glb as glb_export
+        from openskp.model import SkpFile
+
+        skp = SkpFile.open(str(self.FIXTURE))
+        skp.parse()
+        with pytest.raises(NotImplementedError, match="units"):
+            glb_export.export(skp, str(tmp_path / "out.glb"), units="inches")
+
 
 # ── Observability: progress logging + structured error context ──────────
 


### PR DESCRIPTION
## What

`export.glb.export()`'s `coordinate_system` and `units` keyword args were accepted into the signature but never read anywhere in the function body, and never passed down into the underlying `_core.build_scene()` call either - the actual conversion (y-up, millimetres) is hardcoded via a literal `*25.4` in `_core.py`. A caller passing e.g. `units="inches"` got silent wrong (mm) output with no indication the request was ignored.

## Change

This doesn't implement real unit/coordinate-system conversion - that would mean threading new parameters through `build_scene()` and writing conversion math for multiple systems, a real feature addition rather than a bug fix, and this legacy trimesh-based export path isn't the actively maintained one (`scene.py`'s `build_scene()` is, used by every other export path in this project).

Instead, `export()` now validates both parameters and raises `NotImplementedError` for anything other than the only values actually implemented (`"y-up"` / `"mm"`), turning a silent correctness bug into an immediate, clear failure.

## Verification

Two new tests confirm both parameters raise for an unsupported value; existing tests (which use the defaults) continue to pass unchanged.

Full suite: 97/97 passing, `ruff check src/ tests/` clean.

Part of the ongoing repo-health checklist - this closes out Tier 1 (items 1-4).