### PR TITLE
Expose layer visibility (Layer.hidden) for legacy files (TypeScript)

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -69,6 +69,11 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
 
   // 2. Parse XML materials to populate layer colors and materials
   const layerColors = new Map<string, [number, number, number]>();
+  // Modern (VFF) files derive layers from Layer_<name>-prefixed materials,
+  // which carry no visibility flag of their own - unlike legacy MFC files,
+  // there is currently no known tag exposing a VFF layer's hidden state,
+  // so every VFF layer defaults to visible here.
+  const layerHidden = new Map<string, boolean>();
   const materialsMap = new Map<string, Material>();
   const materialsByFolder = new Map<string, Material>();
 
@@ -115,6 +120,7 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
           }
           if (parsedMat.name.startsWith('Layer_')) {
             layerColors.set(parsedMat.name.slice(6), [parsedMat.r, parsedMat.g, parsedMat.b]);
+            layerHidden.set(parsedMat.name.slice(6), false);
           }
         }
       } catch (e) {
@@ -227,6 +233,9 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
   if (!layerColors.has('Layer0')) {
     layerColors.set('Layer0', [136, 136, 136]);
   }
+  if (!layerHidden.has('Layer0')) {
+    layerHidden.set('Layer0', false);
+  }
 
   defsDict.set('ROOT', {
     guid: 'ROOT',
@@ -239,6 +248,7 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
   return {
     version,
     layerColors,
+    layerHidden,
     layerIdToName,
     materialIdToName,
     materialsMap,

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -1112,14 +1112,19 @@ export function parseLegacyToRaw(data: Uint8Array, options?: ParseOptions): Pars
 
   // layers
   const layerColors = new Map<string, [number, number, number]>();
+  const layerHidden = new Map<string, boolean>();
   const layerIdToName = new Map<number, string>();
   for (const [s, v] of layers) {
     const rgba: number[] = v.rgba || [136, 136, 136, 255];
     layerColors.set(v.name, [rgba[0], rgba[1], rgba[2]]);
+    layerHidden.set(v.name, Boolean(v.hidden));
     layerIdToName.set(s, v.name);
   }
   if (!layerColors.has('Layer0')) {
     layerColors.set('Layer0', [136, 136, 136]);
+  }
+  if (!layerHidden.has('Layer0')) {
+    layerHidden.set('Layer0', false);
   }
 
   // definitions
@@ -1174,6 +1179,7 @@ export function parseLegacyToRaw(data: Uint8Array, options?: ParseOptions): Pars
   return {
     version,
     layerColors,
+    layerHidden,
     layerIdToName,
     materialIdToName,
     materialsMap,

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -103,6 +103,12 @@ export interface Instance {
 export interface Layer {
   name: string;
   color: { r: number; g: number; b: number };
+  /** Whether the layer's visibility is switched off. Only populated for
+   * legacy (pre-2021 MFC) files, where the byte is read directly from the
+   * layer record - modern (VFF) files derive layers from
+   * `Layer_<name>`-prefixed materials, which carry no visibility data, so
+   * this is always `false` there. */
+  hidden: boolean;
 }
 
 /** A material's texture image, extracted from the SKP container. */
@@ -206,6 +212,7 @@ export interface SkpScene {
 export interface ParsedRawData {
   version: string;
   layerColors: Map<string, [number, number, number]>;
+  layerHidden: Map<string, boolean>;
   layerIdToName: Map<number, string>;
   materialIdToName: Map<number, string>;
   materialsMap: Map<string, Material>;
@@ -215,7 +222,8 @@ export interface ParsedRawData {
 }
 
 export function buildModelFromParsed(parsed: ParsedRawData): SkpModel {
-  const { version, layerColors, materialIdToName, materialsMap, materialsByFolder, styles, defsDict } = parsed;
+  const { version, layerColors, layerHidden, materialIdToName, materialsMap, materialsByFolder, styles, defsDict } =
+    parsed;
 
   // Join the TLV material IDs (what Face.materialId references) onto the
   // parsed materials, so callers can resolve face -> material.
@@ -234,6 +242,7 @@ export function buildModelFromParsed(parsed: ParsedRawData): SkpModel {
   const finalLayersList: Layer[] = Array.from(layerColors.entries()).map(([name, c]) => ({
     name,
     color: { r: c[0], g: c[1], b: c[2] },
+    hidden: layerHidden.get(name) ?? false,
   }));
 
   const finalMaterialsList: Material[] = Array.from(materialsMap.values());

--- a/packages/typescript/tests/integration.test.ts
+++ b/packages/typescript/tests/integration.test.ts
@@ -28,6 +28,10 @@ describe('SketchUp Parser Integration Test', () => {
     expect(typeof firstLayer!.color.r).toBe('number');
     expect(typeof firstLayer!.color.g).toBe('number');
     expect(typeof firstLayer!.color.b).toBe('number');
+    // VFF files carry no known layer-visibility tag - always false here.
+    for (const layer of model.layers) {
+      expect(layer.hidden).toBe(false);
+    }
 
     // 3. Assert Materials
     expect(model.materials.length).toBe(15);

--- a/packages/typescript/tests/layer-hidden.test.ts
+++ b/packages/typescript/tests/layer-hidden.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { buildModelFromParsed, ParsedRawData } from '../src/model';
+
+/**
+ * Layer.hidden - the on/off visibility bit. Already correctly extracted
+ * from legacy MFC files (legacy.ts's readLayer) but previously discarded
+ * before reaching the public model; now wired through a layerHidden map
+ * alongside the existing layerColors/layerIdToName maps. VFF files carry
+ * no known visibility tag, so they always default to false.
+ */
+
+function parsed(layerColors: Map<string, [number, number, number]>, layerHidden: Map<string, boolean>): ParsedRawData {
+  return {
+    version: 'test',
+    layerColors,
+    layerHidden,
+    layerIdToName: new Map(),
+    materialIdToName: new Map(),
+    materialsMap: new Map(),
+    materialsByFolder: new Map(),
+    styles: [],
+    defsDict: new Map(),
+  };
+}
+
+describe('buildModelFromParsed layer hidden', () => {
+  it('reports a hidden layer as hidden', () => {
+    const layerColors = new Map<string, [number, number, number]>([
+      ['Layer0', [136, 136, 136]],
+      ['Furniture', [200, 50, 50]],
+    ]);
+    const layerHidden = new Map<string, boolean>([
+      ['Layer0', false],
+      ['Furniture', true],
+    ]);
+
+    const model = buildModelFromParsed(parsed(layerColors, layerHidden));
+    const byName = new Map(model.layers.map((l) => [l.name, l]));
+
+    expect(byName.get('Layer0')?.hidden).toBe(false);
+    expect(byName.get('Furniture')?.hidden).toBe(true);
+  });
+
+  it('defaults to visible when the layerHidden map has no entry', () => {
+    const layerColors = new Map<string, [number, number, number]>([['Layer0', [136, 136, 136]]]);
+    const layerHidden = new Map<string, boolean>();
+
+    const model = buildModelFromParsed(parsed(layerColors, layerHidden));
+
+    expect(model.layers[0].hidden).toBe(false);
+  });
+});

--- a/packages/typescript/tests/legacy.test.ts
+++ b/packages/typescript/tests/legacy.test.ts
@@ -84,6 +84,7 @@ describe('Legacy MFC reader (classic pre-2021 .skp)', () => {
 
     // 4. Layers
     expect(model.layers.map((l) => l.name)).toEqual(['Layer0']);
+    expect(model.layers[0].hidden).toBe(false);
 
     // 5. Bounding box across the (ROOT-excluded) definitions, matching
     // Python's bbox computed the same way.


### PR DESCRIPTION
## What

Same fix as the Python PR (#88): the on/off visibility bit for layers is already read and correctly labeled by `legacy.ts`'s `readLayer()` (`'hidden'` key on the raw record) - it was just never carried one field further onto the public `Layer` interface.

## Change

Adds `Layer.hidden: boolean`. Threaded through as a new `layerHidden` map alongside the existing `layerColors`/`layerIdToName` maps (rather than changing `layerColors`' tuple shape, which `buildSceneFromParsed` also depends on) in both parse paths:

- `legacy.ts`'s `parseLegacyToRaw()`: `layerHidden.set(name, Boolean(raw 'hidden' value))` per layer, Layer0 defaults to visible if absent (matching the existing `layerColors` fallback).
- `index.ts`'s `parseToRaw()` (VFF/modern format): always `false`. Modern files derive layers from `Layer_<name>`-prefixed materials, which carry no visibility flag at all - no known VFF tag for this exists yet (would need a real fixture with a hidden layer to locate it). Documented on `Layer.hidden` itself.

`model.ts`'s `buildModelFromParsed()` reads the new map when constructing `Layer` objects.

## Verification

2 new tests call `buildModelFromParsed` directly with a synthetic `ParsedRawData` (hand-crafting a real hidden-layer legacy file isn't practical) confirming both the true/false cases and a missing-key default. Real-fixture assertions added to both `integration.test.ts` (`Untitled.skp`, VFF - all 14 layers report `hidden=false`) and `legacy.test.ts` (the legacy fixture's one layer reports `hidden=false`), confirming the field is actually populated end-to-end.

Full suite: 51/51 passing, `tsc --noEmit` clean.

Part of the ongoing repo-health checklist (Tier 2, item 5) - Python in #88, .NET/Dart/C++ follow separately.