### PR TITLE
Expose layer visibility (Layer.Hidden) for legacy files (.NET)

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
@@ -39,6 +39,9 @@ namespace OpenSkp.Tests
             var layer0 = model.Layers.FirstOrDefault(l => l.Name == "Layer0");
             Assert.NotNull(layer0);
 
+            // VFF files carry no known layer-visibility tag - always false here.
+            Assert.All(model.Layers, l => Assert.False(l.Hidden));
+
             Assert.Equal(15, model.Materials.Count);
             var expectedMaterials = new[]
             {

--- a/packages/dotnet/OpenSkp.Tests/LegacyTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/LegacyTests.cs
@@ -73,6 +73,7 @@ namespace OpenSkp.Tests
 
             Assert.Single(model.Layers);
             Assert.Equal("Layer0", model.Layers[0].Name);
+            Assert.False(model.Layers[0].Hidden);
 
             double minX = double.PositiveInfinity, minY = double.PositiveInfinity, minZ = double.PositiveInfinity;
             double maxX = double.NegativeInfinity, maxY = double.NegativeInfinity, maxZ = double.NegativeInfinity;

--- a/packages/dotnet/OpenSkp/Core.cs
+++ b/packages/dotnet/OpenSkp/Core.cs
@@ -15,6 +15,12 @@ namespace OpenSkp
         {
             public string Version = "unknown";
             public Dictionary<string, (int R, int G, int B)> LayerColors = new Dictionary<string, (int, int, int)>();
+            // Modern (VFF) files derive layers from Layer_<name>-prefixed
+            // materials, which carry no visibility flag of their own -
+            // unlike legacy MFC files, there is currently no known tag
+            // exposing a VFF layer's hidden state, so every VFF layer
+            // defaults to visible.
+            public Dictionary<string, bool> LayerHidden = new Dictionary<string, bool>();
             public Dictionary<long, string> LayerIdToName = new Dictionary<long, string>();
             public Dictionary<long, string> MaterialIdToName = new Dictionary<long, string>();
             public Dictionary<string, Geometry.RawMaterial> Materials = new Dictionary<string, Geometry.RawMaterial>();
@@ -56,6 +62,7 @@ namespace OpenSkp
             using var zip = Vff.OpenZip(data, pkPos);
 
             var layerColors = new Dictionary<string, (int, int, int)>();
+            var layerHidden = new Dictionary<string, bool>();
             var materials = new Dictionary<string, Geometry.RawMaterial>();
             var materialsByFolder = new Dictionary<string, Geometry.RawMaterial>();
 
@@ -93,6 +100,7 @@ namespace OpenSkp
                         if (mat.Name.StartsWith("Layer_", StringComparison.Ordinal))
                         {
                             layerColors[mat.Name.Substring(6)] = (mat.R, mat.G, mat.B);
+                            layerHidden[mat.Name.Substring(6)] = false;
                         }
                     }
                 }
@@ -200,11 +208,16 @@ namespace OpenSkp
             {
                 layerColors["Layer0"] = (136, 136, 136);
             }
+            if (!layerHidden.ContainsKey("Layer0"))
+            {
+                layerHidden["Layer0"] = false;
+            }
 
             return new RawParsed
             {
                 Version = version,
                 LayerColors = layerColors,
+                LayerHidden = layerHidden,
                 LayerIdToName = layerIdToName,
                 MaterialIdToName = materialIdToName,
                 Materials = materials,

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -1326,17 +1326,23 @@ namespace OpenSkp
             }
 
             var layerColors = new Dictionary<string, (int, int, int)>();
+            var layerHidden = new Dictionary<string, bool>();
             var layerIdToName = new Dictionary<long, string>();
             foreach (var (s, vObj) in walkResult.Layers)
             {
                 var v = (LayerRec)vObj!;
                 byte[] rgba = v.Rgba;
                 layerColors[v.Name] = (rgba[0], rgba[1], rgba[2]);
+                layerHidden[v.Name] = v.Hidden != 0;
                 layerIdToName[s] = v.Name;
             }
             if (!layerColors.ContainsKey("Layer0"))
             {
                 layerColors["Layer0"] = (136, 136, 136);
+            }
+            if (!layerHidden.ContainsKey("Layer0"))
+            {
+                layerHidden["Layer0"] = false;
             }
 
             var defsDict = new Dictionary<long, Geometry.RawDefinition>();
@@ -1387,6 +1393,7 @@ namespace OpenSkp
             {
                 Version = version,
                 LayerColors = layerColors,
+                LayerHidden = layerHidden,
                 LayerIdToName = layerIdToName,
                 MaterialIdToName = materialIdToName,
                 Materials = materialsMap,

--- a/packages/dotnet/OpenSkp/Model.cs
+++ b/packages/dotnet/OpenSkp/Model.cs
@@ -55,6 +55,13 @@ namespace OpenSkp
         public int ColorR { get; set; } = 200;
         public int ColorG { get; set; } = 200;
         public int ColorB { get; set; } = 200;
+
+        /// <summary>Whether the layer's visibility is switched off. Only
+        /// populated for legacy (pre-2021 MFC) files, where the byte is read
+        /// directly from the layer record - modern (VFF) files derive layers
+        /// from Layer_&lt;name&gt;-prefixed materials, which carry no
+        /// visibility data, so this is always false there.</summary>
+        public bool Hidden { get; set; }
     }
 
     public sealed class Style

--- a/packages/dotnet/OpenSkp/Parser.cs
+++ b/packages/dotnet/OpenSkp/Parser.cs
@@ -29,7 +29,8 @@ namespace OpenSkp
 
             foreach (var kv in parsed.LayerColors)
             {
-                model.Layers.Add(new Layer { Name = kv.Key, ColorR = kv.Value.R, ColorG = kv.Value.G, ColorB = kv.Value.B });
+                bool hidden = parsed.LayerHidden.TryGetValue(kv.Key, out var h) && h;
+                model.Layers.Add(new Layer { Name = kv.Key, ColorR = kv.Value.R, ColorG = kv.Value.G, ColorB = kv.Value.B, Hidden = hidden });
             }
 
             var matForData = new Dictionary<Geometry.RawMaterial, Material>(ReferenceEqualityComparer.Instance);


### PR DESCRIPTION
## What

Same fix as the Python/TypeScript PRs (#88, #89): the on/off visibility bit for layers is already read and correctly captured by `Legacy.cs`'s `ReadLayer()` (`LayerRec.Hidden`) - it was just never carried one field further onto the public `Layer` type.

## Change

Adds `Layer.Hidden` (bool). Threaded through as a new `LayerHidden` dictionary alongside the existing `LayerColors`/`LayerIdToName` dictionaries (rather than changing `LayerColors`' tuple shape) in both parse paths:

- `Legacy.cs`: `LayerHidden[name] = v.Hidden != 0` per layer, Layer0 defaults to visible if absent (matching the existing `LayerColors` fallback).
- `Core.cs` (VFF/modern format): always `false`. Modern files derive layers from `Layer_<name>`-prefixed materials, which carry no visibility flag at all - no known VFF tag for this exists yet. Documented on `Layer.Hidden` itself.

`Parser.cs`'s `SkpFile.Parse()` reads the new dictionary when constructing `Layer` objects.

## Verification

Real-fixture assertions in both `IntegrationTests.cs` (`Untitled.skp`, VFF - all 14 layers report `Hidden=false`) and `LegacyTests.cs` (the legacy fixture's one layer reports `Hidden=false`), confirming the field is actually populated end-to-end.

A synthetic mock-based unit test (matching Python/TypeScript's stubbed-parse pattern) isn't practical here without adding a new internal-only seam purely for testability - `SkpFile.Parse(byte[])` is the only entry point, with no `RawParsed`-accepting overload to inject a synthetic `hidden=true` case through - so this relies on real-fixture coverage plus the fact that the change itself is a straightforward, low-risk dictionary lookup mirroring the already-tested Python/TypeScript wiring.

Full suite: 33/33 passing.

Part of the ongoing repo-health checklist (Tier 2, item 5) - Python in #88, TypeScript in #89, Dart/C++ follow separately.