### PR TITLE
Expose layer visibility (Layer.hidden) for legacy files (Dart)

### DIFF
--- a/packages/dart/lib/src/core.dart
+++ b/packages/dart/lib/src/core.dart
@@ -13,6 +13,11 @@ import 'vff.dart';
 class RawParsed {
   String version = 'unknown';
   final Map<String, (int, int, int)> layerColors = {};
+  // Modern (VFF) files derive layers from Layer_<name>-prefixed materials,
+  // which carry no visibility flag of their own - unlike legacy MFC files,
+  // there is currently no known tag exposing a VFF layer's hidden state,
+  // so every VFF layer defaults to visible.
+  final Map<String, bool> layerHidden = {};
   final Map<int, String> layerIdToName = {};
   final Map<int, String> materialIdToName = {};
   final Map<String, RawMaterial> materials = {};
@@ -53,6 +58,7 @@ class Core {
     final zip = Vff.openZip(data, pkPos);
 
     final layerColors = <String, (int, int, int)>{};
+    final layerHidden = <String, bool>{};
     final materials = <String, RawMaterial>{};
     final materialsByFolder = <String, RawMaterial>{};
 
@@ -75,6 +81,7 @@ class Core {
           }
           if (mat.name.startsWith('Layer_')) {
             layerColors[mat.name.substring(6)] = (mat.r, mat.g, mat.b);
+            layerHidden[mat.name.substring(6)] = false;
           }
         }
       }
@@ -150,10 +157,14 @@ class Core {
     if (!layerColors.containsKey('Layer0')) {
       layerColors['Layer0'] = (136, 136, 136);
     }
+    if (!layerHidden.containsKey('Layer0')) {
+      layerHidden['Layer0'] = false;
+    }
 
     return RawParsed()
       ..version = version
       ..layerColors.addAll(layerColors)
+      ..layerHidden.addAll(layerHidden)
       ..layerIdToName.addAll(layerIdToName)
       ..materialIdToName.addAll(materialIdToName)
       ..materials.addAll(materials)

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -1257,15 +1257,20 @@ class Legacy {
     }
 
     final layerColors = <String, (int, int, int)>{};
+    final layerHidden = <String, bool>{};
     final layerIdToName = <int, String>{};
     for (final (s, vObj) in walkResult.layers) {
       final v = vObj as LayerRec;
       final rgba = v.rgba;
       layerColors[v.name] = (rgba[0], rgba[1], rgba[2]);
+      layerHidden[v.name] = v.hidden != 0;
       layerIdToName[s] = v.name;
     }
     if (!layerColors.containsKey('Layer0')) {
       layerColors['Layer0'] = (136, 136, 136);
+    }
+    if (!layerHidden.containsKey('Layer0')) {
+      layerHidden['Layer0'] = false;
     }
 
     final defsDict = <int, RawDefinition>{};
@@ -1313,6 +1318,7 @@ class Legacy {
     return RawParsed()
       ..version = version
       ..layerColors.addAll(layerColors)
+      ..layerHidden.addAll(layerHidden)
       ..layerIdToName.addAll(layerIdToName)
       ..materialIdToName.addAll(materialIdToName)
       ..materials.addAll(materialsMap)

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -64,11 +64,20 @@ class Face {
 class Layer {
   final String name;
   final int colorR, colorG, colorB;
+
+  /// Whether the layer's visibility is switched off. Only populated for
+  /// legacy (pre-2021 MFC) files, where the byte is read directly from the
+  /// layer record - modern (VFF) files derive layers from
+  /// Layer_<name>-prefixed materials, which carry no visibility data, so
+  /// this is always false there.
+  final bool hidden;
+
   Layer(
       {required this.name,
       this.colorR = 200,
       this.colorG = 200,
-      this.colorB = 200});
+      this.colorB = 200,
+      this.hidden = false});
 }
 
 class Style {

--- a/packages/dart/lib/src/parser.dart
+++ b/packages/dart/lib/src/parser.dart
@@ -71,7 +71,8 @@ class SkpFile {
 
     for (final entry in parsed.layerColors.entries) {
       final (r, g, b) = entry.value;
-      model.layers.add(Layer(name: entry.key, colorR: r, colorG: g, colorB: b));
+      final hidden = parsed.layerHidden[entry.key] ?? false;
+      model.layers.add(Layer(name: entry.key, colorR: r, colorG: g, colorB: b, hidden: hidden));
     }
 
     final matForData = <RawMaterial, Material>{};

--- a/packages/dart/test/integration_test.dart
+++ b/packages/dart/test/integration_test.dart
@@ -36,6 +36,10 @@ void main() {
     for (final name in expectedLayers) {
       expect(parsedLayers, contains(name));
     }
+    // VFF files carry no known layer-visibility tag - always false here.
+    for (final layer in model.layers) {
+      expect(layer.hidden, false);
+    }
 
     expect(model.materials.length, 15);
     const expectedMaterials = [

--- a/packages/dart/test/legacy_test.dart
+++ b/packages/dart/test/legacy_test.dart
@@ -75,6 +75,7 @@ void main() {
 
     expect(model.layers.length, 1);
     expect(model.layers[0].name, 'Layer0');
+    expect(model.layers[0].hidden, false);
 
     double minX = double.infinity,
         minY = double.infinity,


### PR DESCRIPTION
## What

Same fix as the Python/TypeScript/.NET PRs (#88-#90): the on/off visibility bit for layers is already read and correctly captured by `legacy.dart`'s `readLayer()` (`LayerRec.hidden`) - it was just never carried one field further onto the public `Layer` class.

## Change

Adds `Layer.hidden` (bool, defaults false). Threaded through as a new `layerHidden` map on `RawParsed` alongside the existing `layerColors`/`layerIdToName` maps (rather than changing `layerColors`' tuple shape) in both parse paths:

- `legacy.dart`: `layerHidden[name] = v.hidden != 0` per layer, Layer0 defaults to visible if absent (matching the existing `layerColors` fallback).
- `core.dart` (VFF/modern format): always `false`. Modern files derive layers from `Layer_<name>`-prefixed materials, which carry no visibility flag at all - no known VFF tag for this exists yet. Documented on `Layer.hidden` itself.

`parser.dart`'s `SkpFile.parse()` reads the new map when constructing `Layer` objects.

## Verification

Real-fixture assertions in both `integration_test.dart` (`Untitled.skp`, VFF - all 14 layers report `hidden=false`) and `legacy_test.dart` (the legacy fixture's one layer reports `hidden=false`), confirming the field is actually populated end-to-end.

A synthetic mock-based unit test (Python/TypeScript's stubbed-parse pattern) isn't practical here without adding a new seam purely for testability - `SkpFile.parse()` has no `RawParsed`-accepting entry point to inject a synthetic `hidden=true` case through, matching the same call this session already made for .NET (#90).

All 9 test files pass individually (per the established display-quirk workaround for `dart test`'s piped/parallel output), `dart analyze` clean.

Part of the ongoing repo-health checklist (Tier 2, item 5) - Python in #88, TypeScript in #89, .NET in #90, C++ follows separately.