### PR TITLE
Expose layer visibility (Layer::hidden) for legacy files (C++)

### DIFF
--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -60,6 +60,12 @@ struct Face {
 struct Layer {
   std::string name;
   Color3 color{200, 200, 200};
+  // Whether the layer's visibility is switched off. Only populated for
+  // legacy (pre-2021 MFC) files, where the byte is read directly from the
+  // layer record - modern (VFF) files derive layers from
+  // Layer_<name>-prefixed materials, which carry no visibility data, so
+  // this is always false there.
+  bool hidden{};
 };
 
 struct Texture {

--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -235,9 +235,11 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
           auto folder = n.substr(10, slash == std::string::npos ? std::string::npos : slash - 10);
           p.materials[m->name] = m;
           p.materials_by_folder[folder] = m;
-          if (m->name.rfind("Layer_", 0) == 0)
+          if (m->name.rfind("Layer_", 0) == 0) {
             p.layer_colors[m->name.substr(6)] = {std::uint8_t(m->r), std::uint8_t(m->g),
                                                  std::uint8_t(m->b)};
+            p.layer_hidden[m->name.substr(6)] = false;
+          }
         }
     }
   for (auto& n : zip.names)
@@ -271,6 +273,7 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
   }
   if (!p.layer_id_to_name.count(1)) p.layer_id_to_name[1] = "Layer0";
   if (!p.layer_colors.count("Layer0")) p.layer_colors["Layer0"] = {136, 136, 136};
+  if (!p.layer_hidden.count("Layer0")) p.layer_hidden["Layer0"] = false;
   emit_log(o, LogLevel::information,
            "Parse complete: " + std::to_string(p.definitions.size()) + " defs");
   return p;

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -89,6 +89,11 @@ struct RawStyle {
 struct RawParsed {
   std::string version{"unknown"};
   std::map<std::string, Color3> layer_colors;
+  // Modern (VFF) files derive layers from Layer_<name>-prefixed materials,
+  // which carry no visibility flag of their own - unlike legacy MFC files,
+  // there is currently no known tag exposing a VFF layer's hidden state,
+  // so every VFF layer defaults to visible.
+  std::map<std::string, bool> layer_hidden;
   std::map<EntityId, std::string> layer_id_to_name;
   std::map<EntityId, std::string> material_id_to_name;
   std::map<std::string, std::shared_ptr<RawMaterial>> materials;

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -328,6 +328,7 @@ struct Archive {
       v->name = r.utf16();
       ByteBuffer mid;
       while (mid.size() < 8 && !r.marker()) mid.push_back(r.u8());
+      v->hidden = mid.empty() ? 0 : mid[0];
       r.utf16();
       r.u16();
       auto c = r.raw(4);
@@ -745,8 +746,10 @@ RawParsed parse_legacy(const ByteBuffer& data, const ParseOptions& o) {
       out.layer_id_to_name[l.first] = l.second->name;
       out.layer_colors[l.second->name] = {uint8_t(l.second->r), uint8_t(l.second->g),
                                           uint8_t(l.second->b)};
+      out.layer_hidden[l.second->name] = l.second->hidden != 0;
     }
     if (!out.layer_colors.count("Layer0")) out.layer_colors["Layer0"] = {136, 136, 136};
+    if (!out.layer_hidden.count("Layer0")) out.layer_hidden["Layer0"] = false;
     for (auto& s : ar.slots)
       if (!s.second.cls && s.second.name == "CComponentDefinition" && s.second.v) {
         RawDefinition d;

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -82,7 +82,11 @@ SkpModel build_model(RawParsed&& p) {
   }
   resolve_layers(p.root);
   m.root_ = definition(0, std::move(p.root));
-  for (auto& l : p.layer_colors) m.layers.push_back({l.first, l.second});
+  for (auto& l : p.layer_colors) {
+    auto hidden_it = p.layer_hidden.find(l.first);
+    bool hidden = hidden_it != p.layer_hidden.end() && hidden_it->second;
+    m.layers.push_back({l.first, l.second, hidden});
+  }
   std::map<const RawMaterial*, std::size_t> raw_index;
   for (auto& v : p.materials) {
     auto& r = *v.second;

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(
   openskp_tests
   geometry_test.cpp
   glb_test.cpp
+  layer_hidden_test.cpp
   lowlevel_test.cpp
   observability_test.cpp
   parser_test.cpp

--- a/packages/cpp/tests/layer_hidden_test.cpp
+++ b/packages/cpp/tests/layer_hidden_test.cpp
@@ -1,0 +1,56 @@
+#include <gtest/gtest.h>
+
+#include <openskp/openskp.hpp>
+
+#include "internal.hpp"
+
+// Layer::hidden - the on/off visibility bit. Already correctly extracted
+// from legacy MFC files (legacy.cpp's CLayer branch, via V::hidden) but
+// previously discarded before reaching the public model; now wired through
+// RawParsed::layer_hidden alongside the existing layer_colors/
+// layer_id_to_name maps. VFF files carry no known visibility tag, so they
+// always default to false.
+//
+// build_model() is called directly with a synthetic RawParsed (hand-crafting
+// a real hidden-layer legacy binary stream isn't practical), matching the
+// TypeScript port's buildModelFromParsed-based test.
+
+namespace openskp::test {
+namespace {
+
+TEST(LayerHidden, ReportsHiddenLayerAsHidden) {
+  RawParsed parsed;
+  parsed.layer_colors["Layer0"] = {136, 136, 136};
+  parsed.layer_colors["Furniture"] = {200, 50, 50};
+  parsed.layer_hidden["Layer0"] = false;
+  parsed.layer_hidden["Furniture"] = true;
+
+  auto model = build_model(std::move(parsed));
+
+  bool found_layer0 = false, found_furniture = false;
+  for (const auto& layer : model.layers) {
+    if (layer.name == "Layer0") {
+      found_layer0 = true;
+      EXPECT_FALSE(layer.hidden);
+    } else if (layer.name == "Furniture") {
+      found_furniture = true;
+      EXPECT_TRUE(layer.hidden);
+    }
+  }
+  EXPECT_TRUE(found_layer0);
+  EXPECT_TRUE(found_furniture);
+}
+
+TEST(LayerHidden, DefaultsToVisibleWhenMissingFromMap) {
+  RawParsed parsed;
+  parsed.layer_colors["Layer0"] = {136, 136, 136};
+  // layer_hidden deliberately left empty.
+
+  auto model = build_model(std::move(parsed));
+
+  ASSERT_EQ(model.layers.size(), 1);
+  EXPECT_FALSE(model.layers[0].hidden);
+}
+
+}  // namespace
+}  // namespace openskp::test

--- a/packages/cpp/tests/parser_test.cpp
+++ b/packages/cpp/tests/parser_test.cpp
@@ -24,7 +24,11 @@ TEST(Parser, ModernUntitled) {
       "HeaderPlate2", "SillPlate1",   "VerticalHeaderStud", "generic_frame",
       "dimension",    "Hat Sections",
   };
-  for (const auto& layer : model.layers) EXPECT_TRUE(expected_layers.count(layer.name));
+  for (const auto& layer : model.layers) {
+    EXPECT_TRUE(expected_layers.count(layer.name));
+    // VFF files carry no known layer-visibility tag - always false here.
+    EXPECT_FALSE(layer.hidden);
+  }
 
   const auto& definition = model.definitions.at(66);
   EXPECT_EQ(definition.name, "Group200#2");
@@ -135,6 +139,10 @@ TEST(Parser, LegacyMatchesReference) {
   for (const auto& material : model.materials) {
     EXPECT_TRUE(expected_materials.count(material.name));
   }
+
+  ASSERT_EQ(model.layers.size(), 1);
+  EXPECT_EQ(model.layers[0].name, "Layer0");
+  EXPECT_FALSE(model.layers[0].hidden);
 
   Vec3 minimum{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(),
                std::numeric_limits<double>::infinity()};


### PR DESCRIPTION
## What

Same fix as the Python/TypeScript/.NET/Dart PRs (#88-#91): C++ was the one language that didn't even capture the layer visibility byte at all (unlike the other four, which read it but discarded it before reaching the public model). `legacy.cpp`'s `CLayer` branch read the flag bytes into a local `mid` buffer but never copied `mid[0]` into `V::hidden` (a field the shared `V` record struct already has, reused here from the edge/face drawbase records that do wire it through).

## Change

Adds `Layer::hidden` (bool). Threaded through as a new `RawParsed::layer_hidden` map alongside the existing `layer_colors`/`layer_id_to_name` maps in both parse paths:

- `legacy.cpp`: `layer_hidden[name] = (v.hidden != 0)` per layer, Layer0 defaults to visible if absent (matching the existing `layer_colors` fallback). Also fixes the underlying capture bug: `v->hidden = mid[0]` is now set in the `CLayer` branch, matching `V::hidden`'s existing use elsewhere in this same struct.
- `core.cpp` (VFF/modern format): always `false`. Modern files derive layers from `Layer_<name>`-prefixed materials, which carry no visibility flag at all - no known VFF tag for this exists yet. Documented on `Layer::hidden` itself.

`model.cpp`'s `build_model()` reads the new map when constructing `Layer` objects.

## Verification

**No C++ toolchain is available in this environment** - the standing caveat for every C++ change in this project.

Added 2 new tests calling `build_model()` directly with a synthetic `RawParsed` (hand-crafting a real hidden-layer legacy binary stream isn't practical - `build_model()` is a genuinely public, directly-callable seam, matching the TypeScript port's `buildModelFromParsed`-based test) confirming both the true/false cases and a missing-key default. Also added real-fixture assertions to the existing legacy and VFF parser tests.

Ran `clang-format` locally on every changed file to avoid the CI format-check round-trip from the ZIP-cap PR (#86). Relies entirely on CI (GCC/Clang/MSVC + sanitizers) as the actual correctness gate.

Part of the ongoing repo-health checklist (Tier 2, item 5) - Python in #88, TypeScript in #89, .NET in #90, Dart in #91. **This closes out the item across all 5 languages.**