### PR TITLE
Expose Face.hidden / Instance.hidden (Python)

### DIFF
--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -395,6 +395,7 @@ def _extract_geometry_from_nodes(elements, builder):
                             loops.append(co_edges)
                 face_mat_id = None
                 uv_front = uv_back = None
+                face_hidden = False
                 d007 = next((c for c in el['children'] if c['tag'] == 'D007'), None)
                 if d007:
                     d107 = next((c for c in d007['children'] if c['tag'] == 'D107'), None)
@@ -403,6 +404,12 @@ def _extract_geometry_from_nodes(elements, builder):
                     dc05 = next((c for c in d007['children'] if c['tag'] == 'DC05'), None)
                     if dc05 is not None:
                         uv_front, uv_back = _extract_uv_transforms(dc05['payload'])
+                    # D307 = display flags, same record edges already read
+                    # (base 0x06, +0x01 hidden) - faces carry the identical
+                    # tag under their own D007 container.
+                    d307 = next((c for c in d007['children'] if c['tag'] == 'D307'), None)
+                    if d307 is not None and d307['payload']:
+                        face_hidden = bool(d307['payload'][0] & 0x01)
                 # Back-side material: the AF0D child of the face node (a face
                 # painted only on its back — common when the author paints the
                 # visible side of a downward-facing cap — carries AF0D but no
@@ -415,7 +422,8 @@ def _extract_geometry_from_nodes(elements, builder):
                                        'material_id': face_mat_id,
                                        'back_material_id': back_mat_id,
                                        'uv_transform': uv_front,
-                                       'uv_transform_back': uv_back}
+                                       'uv_transform_back': uv_back,
+                                       'hidden': face_hidden}
 
         elif tag == '6419':
             nodes_to_search = el['children'] if el['children'] else [el]
@@ -442,6 +450,7 @@ def _extract_geometry_from_nodes(elements, builder):
             # is None inherit this — the SDK resolves that inheritance when
             # exporting, so consumers need the raw value to do the same.
             inst_mat_id = None
+            inst_hidden = False
             d007 = next((c for c in el['children'] if c['tag'] == 'D007'),
                         None)
             if d007:
@@ -450,6 +459,12 @@ def _extract_geometry_from_nodes(elements, builder):
                 if d107:
                     inst_mat_id = parse_var_int(
                         d107['payload'], 0, len(d107['payload']))
+                # D307 = display flags, same record edges/faces already
+                # read (base 0x06, +0x01 hidden).
+                d307 = next((c for c in d007['children']
+                             if c['tag'] == 'D307'), None)
+                if d307 is not None and d307['payload']:
+                    inst_hidden = bool(d307['payload'][0] & 0x01)
 
             builder.instances.append({
                 'offset': el['offset'],
@@ -458,6 +473,7 @@ def _extract_geometry_from_nodes(elements, builder):
                 'name': name,
                 'matrix': matrix,
                 'material_id': inst_mat_id,
+                'hidden': inst_hidden,
                 'children': el['children']
             })
 

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -863,7 +863,8 @@ def _fill_builder(builder, ents, slots):
                 loops.append(loop)
             face = {'loops': loops, 'normal': tuple(v['plane'][:3]),
                     'material_id': v['db']['mat'] or None,
-                    'back_material_id': v['back_mat'] or None}
+                    'back_material_id': v['back_mat'] or None,
+                    'hidden': bool(v['db']['hidden'])}
             attrs = v.get('attrs')
             if isinstance(attrs, dict):
                 for cn, cv in attrs.get('children', []):
@@ -879,6 +880,7 @@ def _fill_builder(builder, ents, slots):
                 'ref_guid': '', 'matrix': list(v['xf']),
                 'material_id': v['db']['mat'] or None,
                 'layer_id': v['db']['layer'] or None,
+                'hidden': bool(v['db']['hidden']),
                 'children': []})
 
 

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -126,6 +126,8 @@ class Face:
             terrain drape): its UVs run in the projection plane's frame,
             not the face frame.
         uv_projected_back: Same for the face's back side.
+        hidden: Whether the face is hidden (SketchUp's "Hide" on this
+            specific face, not a layer/tag visibility toggle).
     """
 
     id: int
@@ -137,6 +139,7 @@ class Face:
     uv_transform_back: Optional[Tuple[float, ...]] = None
     uv_projected: bool = False
     uv_projected_back: bool = False
+    hidden: bool = False
 
 
 # ── Layers & Materials ────────────────────────────────────────────────────
@@ -277,6 +280,9 @@ class Instance:
             the placed definition whose own :attr:`Face.material_id` is
             ``None`` inherit this material — consumers must resolve that
             inheritance themselves, like the official SDK does on export.
+        hidden: Whether the instance itself is hidden (SketchUp's "Hide"
+            on this specific component/group placement, not a layer/tag
+            visibility toggle).
     """
 
     name: str = ""
@@ -292,6 +298,7 @@ class Instance:
     properties: Dict[str, str] = field(default_factory=dict)
     children: List["Instance"] = field(default_factory=list)
     material_id: Optional[int] = None
+    hidden: bool = False
 
 
 @dataclass
@@ -475,6 +482,7 @@ class SkpFile:
                     uv_transform_back=f_data.get("uv_transform_back"),
                     uv_projected=f_data.get("uv_projected", False),
                     uv_projected_back=f_data.get("uv_projected_back", False),
+                    hidden=f_data.get("hidden", False),
                 )
             # Populate instances
             for inst in builder.instances:
@@ -484,6 +492,7 @@ class SkpFile:
                     guid=inst.get("ref_guid", ""),
                     matrix=inst.get("matrix", []),
                     material_id=inst.get("material_id"),
+                    hidden=inst.get("hidden", False),
                 ))
             if def_id == "ROOT":
                 model.root = defn

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -654,6 +654,106 @@ class TestLayerHidden:
         assert model.layers[0].hidden is False
 
 
+class TestFaceInstanceHidden:
+    """``Face.hidden`` / ``Instance.hidden`` - the same per-element "Hide"
+    bit edges already exposed. Both the legacy MFC drawbase record
+    (``_drawbase``'s ``'hidden'`` key) and the VFF/modern D007->D307
+    display-flags record (confirmed present on every single face and
+    instance in a real VFF fixture - 1588/1588 faces, 46/46 instances in
+    Untitled.skp) already carried this bit; it was just discarded when
+    building the final ``Face``/``Instance`` objects.
+
+    ``full_parse`` is stubbed for the VFF-shaped case (constructing a
+    synthetic ``_GeometryBuilder``); the legacy real-fixture case is
+    checked separately below since it can't exercise the True branch.
+    """
+
+    @staticmethod
+    def _parse_with(monkeypatch, tmp_path: pathlib.Path, parsed: dict):
+        import openskp._core as _core
+        from openskp.model import SkpFile
+
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "model.skp"
+        fake.write_bytes(b"")
+        return SkpFile.open(str(fake)).parse()
+
+    def test_hidden_face_and_instance_are_reported_hidden(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        from openskp._core import _GeometryBuilder
+
+        builder = _GeometryBuilder()
+        builder.faces[1] = {"loops": [], "normal": (0.0, 0.0, 1.0), "hidden": True}
+        builder.faces[2] = {"loops": [], "normal": (0.0, 0.0, 1.0), "hidden": False}
+        builder.instances.append({
+            "offset": 0, "ref_guid": "", "ref_idx": None, "name": "hidden_one",
+            "matrix": [], "material_id": None, "hidden": True, "children": [],
+        })
+        builder.instances.append({
+            "offset": 0, "ref_guid": "", "ref_idx": None, "name": "visible_one",
+            "matrix": [], "material_id": None, "hidden": False, "children": [],
+        })
+        parsed = {
+            "version": "test",
+            "defs_dict": {"ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": builder}},
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert model.root.faces[1].hidden is True
+        assert model.root.faces[2].hidden is False
+        by_name = {i.name: i for i in model.root.instances}
+        assert by_name["hidden_one"].hidden is True
+        assert by_name["visible_one"].hidden is False
+
+    def test_missing_hidden_key_defaults_to_visible(
+        self, monkeypatch, tmp_path: pathlib.Path
+    ) -> None:
+        from openskp._core import _GeometryBuilder
+
+        builder = _GeometryBuilder()
+        builder.faces[1] = {"loops": [], "normal": (0.0, 0.0, 1.0)}
+        builder.instances.append({
+            "offset": 0, "ref_guid": "", "ref_idx": None, "name": "n",
+            "matrix": [], "material_id": None, "children": [],
+        })
+        parsed = {
+            "version": "test",
+            "defs_dict": {"ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": builder}},
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {},
+        }
+        model = self._parse_with(monkeypatch, tmp_path, parsed)
+
+        assert model.root.faces[1].hidden is False
+        assert model.root.instances[0].hidden is False
+
+    def test_real_legacy_fixture_faces_and_instances_are_not_hidden(self) -> None:
+        # Real-fixture sanity check: nothing in this file is hidden, but
+        # this confirms the field is actually populated end-to-end through
+        # the real legacy parser (not silently dropped), even though it
+        # can't exercise the True branch.
+        import pytest as _pytest
+        fixture = pathlib.Path(__file__).parent / "fixtures" / "capilla_quiroz_v17.skp"
+        if not fixture.exists():
+            _pytest.skip("legacy fixture not present")
+        from openskp.model import SkpFile
+
+        model = SkpFile.open(str(fixture)).parse()
+        assert len(model.definitions) > 0
+        for defn in model.definitions.values():
+            for face in defn.faces.values():
+                assert face.hidden is False
+        for inst in model.root.instances:
+            assert inst.hidden is False
+
+
 # ── Instance material tests ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Same "already read, just discarded" shape as the `Layer.hidden` fix (#88): the per-element "Hide" bit was already being read for faces and instances in both parse paths, just never carried through to the final model objects.

**Legacy path**: `_drawbase()` (`legacy.py:239-243`) already returns `'hidden'` in its dict - `_read_face()` and instance readers both call it and store the result as `v['db']`, but `_fill_builder()`'s face/instance dict construction only pulled `'mat'`/`'back_mat'`/`'layer'` out of `db`, not `'hidden'`.

**VFF/modern path**: confirmed by directly scanning a real fixture (`Untitled.skp`) that every single face (1588/1588) and instance (46/46) carries a `D307` child under its `D007` container - the exact same display-flags record edges already read (base `0x06`, `+0x01` hidden bit), just never looked up for these two entity types. This isn't new reverse-engineering, it's applying an already-proven, already-decoded pattern to two more entity types that happen to share the same record shape.

## Change

Adds `Face.hidden` and `Instance.hidden` (both bool, default `False`). Wired through `builder.faces[...]['hidden']` / `builder.instances[...]['hidden']` in both `_core.py` (VFF) and `legacy.py`, read by `model.py`'s `Face`/`Instance` construction.

## Verification

`full_parse` is stubbed with a synthetic `_GeometryBuilder` (hand-crafting a real hidden-face/instance file isn't practical) confirming both the true/false cases and a missing-key default. A real-fixture test confirms the fields are actually populated (not silently dropped) end-to-end through the real legacy parser - nothing in this fixture is hidden, but the wiring runs cleanly across all faces/instances in both real definitions.

Full suite: 104/104 passing, `ruff check src/ tests/` clean.

Part of the ongoing repo-health checklist (Tier 2, item 6) - TypeScript/.NET/Dart/C++ follow separately.