### PR TITLE
Expose Face.hidden / Instance.hidden (TypeScript)

### DIFF
--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -10,6 +10,7 @@ export interface GeometryBuilderInstance {
   /** Layer ID this instance belongs to (D007 -> D207), or null. Internal -
    * used for scene-graph layer inheritance, not part of the public API. */
   layerId?: number | null;
+  hidden?: boolean;
   children: TlvNode[];
 }
 
@@ -22,6 +23,7 @@ export interface GeometryBuilderFace {
   uvTransformBack?: number[] | null;
   uvProjected?: boolean;
   uvProjectedBack?: boolean;
+  hidden?: boolean;
 }
 
 export class GeometryBuilder {
@@ -238,6 +240,7 @@ export function extractGeometryFromNodes(
         let faceMatId: number | null = null;
         let uvFront: number[] | null = null;
         let uvBack: number[] | null = null;
+        let faceHidden = false;
         const d007 = el.children.find((c) => c.tag === 'D007');
         if (d007) {
           const d107 = d007.children.find((c) => c.tag === 'D107');
@@ -247,6 +250,13 @@ export function extractGeometryFromNodes(
           const dc05 = d007.children.find((c) => c.tag === 'DC05');
           if (dc05) {
             [uvFront, uvBack] = extractUvTransforms(dc05.payload);
+          }
+          // D307 = display flags, same record edges already read (base
+          // 0x06, +0x01 hidden) - faces carry the identical tag under
+          // their own D007 container.
+          const d307 = d007.children.find((c) => c.tag === 'D307');
+          if (d307 && d307.payload.length > 0) {
+            faceHidden = (d307.payload[0] & 0x01) !== 0;
           }
         }
         // Back-side material: the AF0D child of the face node (a face
@@ -265,6 +275,7 @@ export function extractGeometryFromNodes(
           backMaterialId: backMatId,
           uvTransform: uvFront,
           uvTransformBack: uvBack,
+          hidden: faceHidden,
         });
       }
     } else if (tag === '6419') {
@@ -312,6 +323,7 @@ export function extractGeometryFromNodes(
       // so consumers need the raw value to do the same.
       let instMatId: number | null = null;
       let instLayerId: number | null = null;
+      let instHidden = false;
       const d007 = el.children.find((c) => c.tag === 'D007');
       if (d007) {
         const d107 = d007.children.find((c) => c.tag === 'D107');
@@ -323,6 +335,12 @@ export function extractGeometryFromNodes(
           const p = d207.payload;
           instLayerId = p.length === 1 ? p[0] : parseVarInt(p, 0, p.length);
         }
+        // D307 = display flags, same record edges/faces already read
+        // (base 0x06, +0x01 hidden).
+        const d307 = d007.children.find((c) => c.tag === 'D307');
+        if (d307 && d307.payload.length > 0) {
+          instHidden = (d307.payload[0] & 0x01) !== 0;
+        }
       }
 
       builder.instances.push({
@@ -333,6 +351,7 @@ export function extractGeometryFromNodes(
         matrix: matrix,
         materialId: instMatId,
         layerId: instLayerId,
+        hidden: instHidden,
         children: el.children,
       });
     } else if (el.children && el.children.length > 0) {

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -1006,6 +1006,7 @@ function fillBuilder(builder: LegacyBuilder, ents: [number, string | null, any][
         uvTransformBack: null,
         uvProjected: false,
         uvProjectedBack: false,
+        hidden: Boolean(v.db.hidden),
       };
       const attrs = v.attrs;
       if (attrs && typeof attrs === 'object') {
@@ -1028,6 +1029,7 @@ function fillBuilder(builder: LegacyBuilder, ents: [number, string | null, any][
         matrix: [...v.xf],
         materialId: v.db.mat || null,
         layerId: v.db.layer || null,
+        hidden: Boolean(v.db.hidden),
         children: [],
       });
     }

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -78,6 +78,9 @@ export interface Face {
   uvProjected: boolean;
   /** Same for the face's back side. */
   uvProjectedBack: boolean;
+  /** Whether the face is hidden (SketchUp's "Hide" on this specific face,
+   * not a layer/tag visibility toggle). */
+  hidden: boolean;
 }
 
 export interface CoEdge {
@@ -98,6 +101,10 @@ export interface Instance {
    * that inheritance themselves, like the official SDK does on export.
    */
   materialId: number | null;
+  /** Whether the instance itself is hidden (SketchUp's "Hide" on this
+   * specific component/group placement, not a layer/tag visibility
+   * toggle). */
+  hidden: boolean;
 }
 
 export interface Layer {
@@ -302,6 +309,7 @@ function buildDefinition(id: number, d: ParsedDefinition): Definition {
     uvTransformBack: fData.uvTransformBack ?? null,
     uvProjected: fData.uvProjected ?? false,
     uvProjectedBack: fData.uvProjectedBack ?? false,
+    hidden: fData.hidden ?? false,
   }));
   const instances: Instance[] = d.builder.instances.map((inst) => ({
     name: inst.name,
@@ -309,6 +317,7 @@ function buildDefinition(id: number, d: ParsedDefinition): Definition {
     guid: inst.refGuid,
     matrix: inst.matrix,
     materialId: inst.materialId,
+    hidden: inst.hidden ?? false,
   }));
 
   return {

--- a/packages/typescript/tests/face-instance-hidden.test.ts
+++ b/packages/typescript/tests/face-instance-hidden.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import { buildModelFromParsed, ParsedRawData } from '../src/model';
+import { GeometryBuilder } from '../src/geometry';
+
+/**
+ * Face.hidden / Instance.hidden - the same per-element "Hide" bit edges
+ * already exposed. Confirmed by directly scanning a real fixture
+ * (Untitled.skp) that every single face (1588/1588) and instance (46/46)
+ * carries a D307 child under its D007 container - the exact same
+ * display-flags record edges already read (base 0x06, +0x01 hidden bit) -
+ * just never looked up for these two entity types.
+ */
+
+function parsed(defsDict: Map<number | string, any>): ParsedRawData {
+  return {
+    version: 'test',
+    layerColors: new Map(),
+    layerHidden: new Map(),
+    layerIdToName: new Map(),
+    materialIdToName: new Map(),
+    materialsMap: new Map(),
+    materialsByFolder: new Map(),
+    styles: [],
+    defsDict,
+  };
+}
+
+describe('buildModelFromParsed face/instance hidden', () => {
+  it('reports a hidden face and instance as hidden', () => {
+    const builder = new GeometryBuilder();
+    builder.faces.set(1, { loops: [], normal: [0, 0, 1], hidden: true });
+    builder.faces.set(2, { loops: [], normal: [0, 0, 1], hidden: false });
+    builder.instances.push({
+      offset: 0,
+      refGuid: '',
+      refIdx: -1,
+      name: 'hidden_one',
+      matrix: [],
+      materialId: null,
+      hidden: true,
+      children: [],
+    });
+    builder.instances.push({
+      offset: 0,
+      refGuid: '',
+      refIdx: -1,
+      name: 'visible_one',
+      matrix: [],
+      materialId: null,
+      hidden: false,
+      children: [],
+    });
+
+    const defsDict = new Map<number | string, any>([
+      ['ROOT', { guid: 'ROOT', name: 'ROOT_MODEL', isImage: false, alwaysFacesCamera: false, builder }],
+    ]);
+
+    const model = buildModelFromParsed(parsed(defsDict));
+
+    expect(model.root.faces.find((f) => f.id === 1)?.hidden).toBe(true);
+    expect(model.root.faces.find((f) => f.id === 2)?.hidden).toBe(false);
+    expect(model.root.instances.find((i) => i.name === 'hidden_one')?.hidden).toBe(true);
+    expect(model.root.instances.find((i) => i.name === 'visible_one')?.hidden).toBe(false);
+  });
+
+  it('defaults to visible when hidden is missing', () => {
+    const builder = new GeometryBuilder();
+    builder.faces.set(1, { loops: [], normal: [0, 0, 1] });
+    builder.instances.push({
+      offset: 0,
+      refGuid: '',
+      refIdx: -1,
+      name: 'n',
+      matrix: [],
+      materialId: null,
+      children: [],
+    });
+
+    const defsDict = new Map<number | string, any>([
+      ['ROOT', { guid: 'ROOT', name: 'ROOT_MODEL', isImage: false, alwaysFacesCamera: false, builder }],
+    ]);
+
+    const model = buildModelFromParsed(parsed(defsDict));
+
+    expect(model.root.faces[0].hidden).toBe(false);
+    expect(model.root.instances[0].hidden).toBe(false);
+  });
+});

--- a/packages/typescript/tests/integration.test.ts
+++ b/packages/typescript/tests/integration.test.ts
@@ -103,6 +103,11 @@ describe('SketchUp Parser Integration Test', () => {
     expect(firstFace.backMaterialId).toBeNull();
     expect(firstFace.uvTransform).toBeNull();
     expect(firstFace.uvTransformBack).toBeNull();
+    // Real data: every face/instance in this fixture is visible - D307's
+    // flag byte reads the plain baseline (0x06) throughout.
+    for (const face of def66!.faces) {
+      expect(face.hidden).toBe(false);
+    }
 
     expect(firstEdge.soft).toBe(false);
     expect(firstEdge.smooth).toBe(false);

--- a/packages/typescript/tests/legacy.test.ts
+++ b/packages/typescript/tests/legacy.test.ts
@@ -124,6 +124,14 @@ describe('Legacy MFC reader (classic pre-2021 .skp)', () => {
       .map((i) => model.definitions.get(i.refIdx)?.name)
       .sort();
     expect(rootRefNames).toEqual(['grada', 'grada', 'puerta']);
+    for (const inst of model.root.instances) {
+      expect(inst.hidden).toBe(false);
+    }
+    for (const def of model.definitions.values()) {
+      for (const face of def.faces) {
+        expect(face.hidden).toBe(false);
+      }
+    }
   });
 
   it('gives every baked primitive valid uv coordinates alongside positions/normals', () => {


### PR DESCRIPTION
## What

Same fix as the Python PR (#93): the per-element "Hide" bit was already being read for faces and instances in both parse paths, just never carried through to the final model objects.

**Legacy path**: `drawbase()` (`legacy.ts:315`) already returns `'hidden'` - `readFace()`/instance readers store the result as `v.db`, but `fillBuilder()`'s face/instance object construction only pulled `mat`/`backMat`/`layer` out of `db`, not `hidden`.

**VFF/modern path**: confirmed by directly scanning a real fixture (`Untitled.skp`) that every single face (1588/1588) and instance (46/46) carries a `D307` child under its `D007` container - the exact same display-flags record edges already read (base `0x06`, `+0x01` hidden bit), just never looked up for these two entity types in `geometry.ts`'s `extractGeometryFromNodes()`.

## Change

Adds `Face.hidden` and `Instance.hidden` (both boolean). Wired through `GeometryBuilderFace.hidden` / `GeometryBuilderInstance.hidden` in both `geometry.ts` (VFF) and `legacy.ts`, read by `model.ts`'s `buildDefinition()`.

## Verification

2 new tests call `buildModelFromParsed` directly with a synthetic `GeometryBuilder` (hand-crafting a real hidden-face/instance file isn't practical) confirming both the true/false cases and a missing-key default. Real-fixture assertions added to both `integration.test.ts` (every face in Definition 66 of `Untitled.skp` reports `hidden=false`) and `legacy.test.ts` (every instance/face in the legacy fixture reports `hidden=false`), confirming the fields are actually populated end-to-end.

Full suite: 53/53 passing, `tsc --noEmit` clean.

Part of the ongoing repo-health checklist (Tier 2, item 6) - Python in #93, .NET/Dart/C++ follow separately.