### PR TITLE
Expose Face.hidden / Instance.hidden (Dart)

### DIFF
--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -16,6 +16,7 @@ class GeometryBuilderFace {
   List<double>? uvTransformBack;
   bool uvProjected = false;
   bool uvProjectedBack = false;
+  bool hidden = false;
 }
 
 class GeometryBuilderInstance {
@@ -25,6 +26,7 @@ class GeometryBuilderInstance {
   String? name;
   List<double> matrix = [];
   int? materialId;
+  bool hidden = false;
   List<TlvNode> children = const [];
 }
 
@@ -261,6 +263,7 @@ class Geometry {
           int? faceMatId;
           List<double>? uvFront;
           List<double>? uvBack;
+          var faceHidden = false;
           final d007 = el.children.where((c) => c.tag == 'D007').firstOrNull;
           if (d007 != null) {
             final d107 =
@@ -274,6 +277,14 @@ class Geometry {
               final (f, b) = extractUvTransforms(dc05.payload);
               uvFront = f;
               uvBack = b;
+            }
+            // D307 = display flags, same record edges already read (base
+            // 0x06, +0x01 hidden) - faces carry the identical tag under
+            // their own D007 container.
+            final d307 =
+                d007.children.where((c) => c.tag == 'D307').firstOrNull;
+            if (d307 != null && d307.payload.isNotEmpty) {
+              faceHidden = (d307.payload[0] & 0x01) != 0;
             }
           }
 
@@ -289,7 +300,8 @@ class Geometry {
             ..materialId = faceMatId
             ..backMaterialId = backMatId
             ..uvTransform = uvFront
-            ..uvTransformBack = uvBack;
+            ..uvTransformBack = uvBack
+            ..hidden = faceHidden;
         }
       } else if (tag == '6419') {
         final nodesToSearch = el.children.isNotEmpty ? el.children : [el];
@@ -319,12 +331,20 @@ class Geometry {
         }
 
         int? instMatId;
+        var instHidden = false;
         final instD007 = el.children.where((c) => c.tag == 'D007').firstOrNull;
         if (instD007 != null) {
           final d107 =
               instD007.children.where((c) => c.tag == 'D107').firstOrNull;
           if (d107 != null) {
             instMatId = Tlv.parseVarInt(d107.payload, 0, d107.payload.length);
+          }
+          // D307 = display flags, same record edges/faces already read
+          // (base 0x06, +0x01 hidden).
+          final instD307 =
+              instD007.children.where((c) => c.tag == 'D307').firstOrNull;
+          if (instD307 != null && instD307.payload.isNotEmpty) {
+            instHidden = (instD307.payload[0] & 0x01) != 0;
           }
         }
 
@@ -335,6 +355,7 @@ class Geometry {
           ..name = name
           ..matrix = matrix
           ..materialId = instMatId
+          ..hidden = instHidden
           ..children = el.children);
       } else if (el.children.isNotEmpty) {
         extractGeometryFromNodes(el.children, builder);

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -1145,7 +1145,8 @@ class Legacy {
           ..materialId = v.db.mat != 0 ? v.db.mat : null
           ..backMaterialId = v.backMat != 0 ? v.backMat : null
           ..uvTransform = null
-          ..uvTransformBack = null;
+          ..uvTransformBack = null
+          ..hidden = v.db.hidden != 0;
         final attrs = v.attrs;
         if (attrs != null) {
           for (final (_, cv) in attrs.children) {
@@ -1166,6 +1167,7 @@ class Legacy {
           ..refGuid = ''
           ..matrix = List<double>.from(v.xf)
           ..materialId = v.db.mat != 0 ? v.db.mat : null
+          ..hidden = v.db.hidden != 0
           ..children = const []);
       }
     }

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -48,6 +48,10 @@ class Face {
   /// Same for the face's back side.
   final bool uvProjectedBack;
 
+  /// Whether the face is hidden (SketchUp's "Hide" on this specific face,
+  /// not a layer/tag visibility toggle).
+  final bool hidden;
+
   Face({
     required this.id,
     this.loops = const [],
@@ -58,6 +62,7 @@ class Face {
     this.uvTransformBack,
     this.uvProjected = false,
     this.uvProjectedBack = false,
+    this.hidden = false,
   });
 }
 
@@ -142,6 +147,11 @@ class Instance {
   final List<Instance> children;
   final int? materialId;
 
+  /// Whether the instance itself is hidden (SketchUp's "Hide" on this
+  /// specific component/group placement, not a layer/tag visibility
+  /// toggle).
+  final bool hidden;
+
   Instance({
     this.name = '',
     this.refIdx,
@@ -151,6 +161,7 @@ class Instance {
     this.properties = const {},
     this.children = const [],
     this.materialId,
+    this.hidden = false,
   });
 }
 

--- a/packages/dart/lib/src/parser.dart
+++ b/packages/dart/lib/src/parser.dart
@@ -156,6 +156,7 @@ class SkpFile {
         uvTransformBack: f.uvTransformBack,
         uvProjected: f.uvProjected,
         uvProjectedBack: f.uvProjectedBack,
+        hidden: f.hidden,
       );
     }
 
@@ -166,6 +167,7 @@ class SkpFile {
         guid: inst.refGuid ?? '',
         matrix: inst.matrix,
         materialId: inst.materialId,
+        hidden: inst.hidden,
       ));
     }
 

--- a/packages/dart/test/integration_test.dart
+++ b/packages/dart/test/integration_test.dart
@@ -92,6 +92,11 @@ void main() {
     expect(firstFace.uvTransform, isNull);
     expect(firstFace.uvTransformBack, isNull);
     expect(firstFace.normal, isNotNull);
+    // Real data: every face in this fixture is visible - D307's flag byte
+    // reads the plain baseline (0x06) throughout.
+    for (final face in def66.faces.values) {
+      expect(face.hidden, isFalse);
+    }
 
     final firstEdge = def66.edges.values.first;
     expect(firstEdge.soft, isFalse);

--- a/packages/dart/test/legacy_test.dart
+++ b/packages/dart/test/legacy_test.dart
@@ -109,5 +109,13 @@ void main() {
         .toList()
       ..sort();
     expect(byRefIdx, ['grada', 'grada', 'puerta']);
+    for (final inst in model.root.instances) {
+      expect(inst.hidden, isFalse);
+    }
+    for (final def in model.definitions.values) {
+      for (final face in def.faces.values) {
+        expect(face.hidden, isFalse);
+      }
+    }
   });
 }


### PR DESCRIPTION
## What

Same fix as the Python/TypeScript/.NET PRs (#93-#95): the per-element "Hide" bit was already being read for faces and instances in both parse paths, just never carried through to the final model objects.

**Legacy path**: `drawbase()` (`legacy.dart:476`) already returns `DrawBase` with `hidden` - `readFace()`/instance readers store the result as `v.db`, but `_fillBuilder()`'s face/instance object construction only pulled `mat`/`backMat` out of `db`, not `hidden`.

**VFF/modern path**: same D007->D307 pattern confirmed present on every face/instance in a real fixture (see #93's Python PR for the scan methodology) - the exact same display-flags record edges already read (base `0x06`, `+0x01` hidden bit), just never looked up for these two entity types in `geometry.dart`'s `extractGeometryFromNodes()`.

## Change

Adds `Face.hidden` and `Instance.hidden` (both bool, default `false`). Wired through `GeometryBuilderFace.hidden` / `GeometryBuilderInstance.hidden` in both `geometry.dart` (VFF) and `legacy.dart`, read by `parser.dart`'s `_buildDefinition()`.

## Verification

Real-fixture assertions in both `integration_test.dart` (every face in Definition 66 of `Untitled.skp` reports `hidden=false`) and `legacy_test.dart` (every instance/face in the legacy fixture reports `hidden=false`), confirming the fields are actually populated end-to-end.

A synthetic mock-based unit test isn't practical here for the same reason noted in the `Layer.hidden` PR (#91) - no `RawParsed`-accepting entry point exists to inject one without adding a test-only seam.

All 9 test files pass individually (per the established display-quirk workaround for `dart test`'s piped/parallel output), `dart analyze` clean.

Part of the ongoing repo-health checklist (Tier 2, item 6) - Python in #93, TypeScript in #94, .NET in #95, C++ follows separately.