### PR TITLE
Expose Face::hidden / Instance::hidden (C++)

### DIFF
--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -55,6 +55,9 @@ struct Face {
   bool uv_projected{};
   // Same for the face's back side.
   bool uv_projected_back{};
+  // Whether the face is hidden (SketchUp's "Hide" on this specific face,
+  // not a layer/tag visibility toggle).
+  bool hidden{};
 };
 
 struct Layer {
@@ -101,6 +104,10 @@ struct Instance {
   std::map<std::string, std::string> properties;
   std::vector<Instance> children;
   std::optional<EntityId> material_id;
+  // Whether the instance itself is hidden (SketchUp's "Hide" on this
+  // specific component/group placement, not a layer/tag visibility
+  // toggle).
+  bool hidden{};
 };
 
 struct Definition {

--- a/packages/cpp/src/geometry.cpp
+++ b/packages/cpp/src/geometry.cpp
@@ -178,6 +178,11 @@ void collect_geometry(const std::vector<TlvNode>& es, GeometryBuilder& b) {
                 f.material_id = parse_varint(x.payload, 0, x.payload.size());
               else if (x.tag == "DC05")
                 std::tie(f.uv_transform, f.uv_transform_back) = uv(x.payload);
+              // D307 = display flags, same record edges already read (base
+              // 0x06, +0x01 hidden) - faces carry the identical tag under
+              // their own D007 container.
+              else if (x.tag == "D307" && !x.payload.empty())
+                f.hidden = (x.payload[0] & 0x01) != 0;
             }
         for (auto& x : e.children)
           if (x.tag == "AF0D" && !x.payload.empty())
@@ -206,6 +211,10 @@ void collect_geometry(const std::vector<TlvNode>& es, GeometryBuilder& b) {
               i.layer = std::to_string(parse_varint(x.payload, 0, x.payload.size()));
             else if (x.tag == "DC05")
               scan_properties(x.payload, i.properties);
+            // D307 = display flags, same record edges/faces already read
+            // (base 0x06, +0x01 hidden).
+            else if (x.tag == "D307" && !x.payload.empty())
+              i.hidden = (x.payload[0] & 0x01) != 0;
           }
       b.instances.push_back(std::move(i));
     } else if (!e.children.empty())

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -31,6 +31,7 @@ struct RawFace {
   std::optional<std::array<double, 9>> uv_transform_back;
   bool uv_projected{};
   bool uv_projected_back{};
+  bool hidden{};
 };
 
 struct RawInstance {
@@ -43,6 +44,7 @@ struct RawInstance {
   std::vector<TlvNode> children;
   std::string layer;
   std::map<std::string, std::string> properties;
+  bool hidden{};
 };
 
 struct GeometryBuilder {

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -604,6 +604,7 @@ void fill(GeometryBuilder& b,
       f.normal = {v->plane[0], v->plane[1], v->plane[2]};
       if (v->mat) f.material_id = v->mat;
       if (v->back_mat) f.back_material_id = v->back_mat;
+      f.hidden = v->hidden != 0;
       for (auto& lp : v->loops) {
         std::vector<CoEdge> co;
         for (auto& u : lp->uses) {
@@ -649,6 +650,7 @@ void fill(GeometryBuilder& b,
       i.matrix = v->xf;
       if (v->mat) i.material_id = v->mat;
       if (v->layer) i.layer = std::to_string(v->layer);
+      i.hidden = v->hidden != 0;
       b.instances.push_back(std::move(i));
     }
   }

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -51,6 +51,7 @@ static Definition definition(EntityId id, RawDefinition&& r) {
     x.uv_transform_back = f.second.uv_transform_back;
     x.uv_projected = f.second.uv_projected;
     x.uv_projected_back = f.second.uv_projected_back;
+    x.hidden = f.second.hidden;
     d.faces.emplace(f.first, std::move(x));
   }
   for (auto& i : r.builder.instances)
@@ -61,7 +62,8 @@ static Definition definition(EntityId id, RawDefinition&& r) {
                            std::move(i.layer),
                            std::move(i.properties),
                            {},
-                           i.material_id});
+                           i.material_id,
+                           i.hidden});
   return d;
 }
 

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ include(GoogleTest)
 
 add_executable(
   openskp_tests
+  face_instance_hidden_test.cpp
   geometry_test.cpp
   glb_test.cpp
   layer_hidden_test.cpp

--- a/packages/cpp/tests/face_instance_hidden_test.cpp
+++ b/packages/cpp/tests/face_instance_hidden_test.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include <openskp/openskp.hpp>
+
+#include "internal.hpp"
+
+// Face::hidden / Instance::hidden - the same per-element "Hide" bit edges
+// already exposed. Confirmed by directly scanning a real fixture that every
+// single face and instance carries a D307 child under its D007 container -
+// the exact same display-flags record edges already read (base 0x06,
+// +0x01 hidden bit) - just never looked up for these two entity types (see
+// the Python port's PR for the scan methodology).
+//
+// build_model() is called directly with a synthetic RawParsed (hand-crafting
+// a real hidden-face/instance file isn't practical), matching the layer
+// hidden test's approach.
+
+namespace openskp::test {
+namespace {
+
+TEST(FaceInstanceHidden, ReportsHiddenFaceAndInstanceAsHidden) {
+  RawParsed parsed;
+
+  RawFace hiddenFace;
+  hiddenFace.hidden = true;
+  RawFace visibleFace;
+  visibleFace.hidden = false;
+  parsed.root.builder.faces[1] = hiddenFace;
+  parsed.root.builder.faces[2] = visibleFace;
+
+  RawInstance hiddenInst;
+  hiddenInst.name = "hidden_one";
+  hiddenInst.hidden = true;
+  RawInstance visibleInst;
+  visibleInst.name = "visible_one";
+  visibleInst.hidden = false;
+  parsed.root.builder.instances.push_back(hiddenInst);
+  parsed.root.builder.instances.push_back(visibleInst);
+
+  auto model = build_model(std::move(parsed));
+
+  ASSERT_TRUE(model.root().faces.count(1));
+  ASSERT_TRUE(model.root().faces.count(2));
+  EXPECT_TRUE(model.root().faces.at(1).hidden);
+  EXPECT_FALSE(model.root().faces.at(2).hidden);
+
+  bool foundHidden = false, foundVisible = false;
+  for (const auto& inst : model.root().instances) {
+    if (inst.name == "hidden_one") {
+      foundHidden = true;
+      EXPECT_TRUE(inst.hidden);
+    } else if (inst.name == "visible_one") {
+      foundVisible = true;
+      EXPECT_FALSE(inst.hidden);
+    }
+  }
+  EXPECT_TRUE(foundHidden);
+  EXPECT_TRUE(foundVisible);
+}
+
+TEST(FaceInstanceHidden, DefaultsToVisible) {
+  RawParsed parsed;
+  RawFace f;
+  parsed.root.builder.faces[1] = f;
+  RawInstance i;
+  i.name = "n";
+  parsed.root.builder.instances.push_back(i);
+
+  auto model = build_model(std::move(parsed));
+
+  ASSERT_TRUE(model.root().faces.count(1));
+  EXPECT_FALSE(model.root().faces.at(1).hidden);
+  ASSERT_FALSE(model.root().instances.empty());
+  EXPECT_FALSE(model.root().instances[0].hidden);
+}
+
+}  // namespace
+}  // namespace openskp::test

--- a/packages/cpp/tests/parser_test.cpp
+++ b/packages/cpp/tests/parser_test.cpp
@@ -51,6 +51,11 @@ TEST(Parser, ModernUntitled) {
   EXPECT_FALSE(face.back_material_id.has_value());
   EXPECT_FALSE(face.uv_transform.has_value());
   EXPECT_FALSE(face.uv_transform_back.has_value());
+  // Real data: every face in this fixture is visible - D307's flag byte
+  // reads the plain baseline (0x06) throughout.
+  for (const auto& [face_id, f] : definition.faces) {
+    EXPECT_FALSE(f.hidden);
+  }
 
   auto* joined_material = model.material_by_id(26180);
   ASSERT_NE(joined_material, nullptr);
@@ -165,6 +170,15 @@ TEST(Parser, LegacyMatchesReference) {
   EXPECT_NEAR(maximum[1], 51.969, 0.01);
   EXPECT_NEAR(maximum[2], 133.071, 0.01);
   EXPECT_EQ(model.root().instances.size(), 3);
+  for (const auto& inst : model.root().instances) {
+    EXPECT_FALSE(inst.hidden);
+  }
+  for (const auto& [face_id, f] : puerta.faces) {
+    EXPECT_FALSE(f.hidden);
+  }
+  for (const auto& [face_id, f] : grada.faces) {
+    EXPECT_FALSE(f.hidden);
+  }
 
   // Regression: CFace's attribute container (which carries any positioned/
   // photo-fitted CFaceTextureCoords record) was read and then silently


### PR DESCRIPTION
## What

Same fix as the Python/TypeScript/.NET/Dart PRs (#93-#96): the per-element "Hide" bit was already being read for faces and instances in both parse paths, just never carried through to the final model objects.

**Legacy path**: `draw()` (`legacy.cpp:237`) already sets `V::hidden` for every entity that calls it - the `CFace` and instance readers both call `draw()` (reusing the same field the recursion-guard/layer-hidden work already established this field carries), but `fill()`'s face/instance record construction only pulled `mat`/`back_mat`/`layer` out of the raw `V` record, not `hidden`.

**VFF/modern path**: same D007->D307 pattern confirmed present on every face/instance in a real fixture (see #93's Python PR for the scan methodology) - the exact same display-flags record edges already read (base `0x06`, `+0x01` hidden bit), just never looked up for these two entity types in `geometry.cpp`'s `collect_geometry()`.

## Change

Adds `Face::hidden` and `Instance::hidden` (both bool). Wired through `RawFace::hidden` / `RawInstance::hidden` in both `geometry.cpp` (VFF) and `legacy.cpp`, read by `model.cpp`'s `definition()` when building the public `Face`/`Instance` objects.

## Verification

**No C++ toolchain is available in this environment** - the standing caveat for every C++ change in this project.

Added 2 new tests calling `build_model()` directly with a synthetic `RawParsed` (hand-crafting a real hidden-face/instance file isn't practical - `build_model()` is a genuinely public, directly-callable seam, matching the layer-hidden test's approach) confirming both the true/false cases and a missing-field default. Real-fixture assertions added to the existing VFF and legacy parser tests.

Ran `clang-format` locally on every changed file. Relies entirely on CI (GCC/Clang/MSVC + sanitizers) as the actual correctness gate.

Part of the ongoing repo-health checklist (Tier 2, item 6) - Python in #93, TypeScript in #94, .NET in #95, Dart in #96. **This closes out the item across all 5 languages.**