### PR TITLE
Parse meta/meta.dat for the model's unit-system string (Python)

### DIFF
--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -588,6 +588,38 @@ def _validate_zip_entry_size(zf: "zipfile.ZipFile", name: str) -> None:
             )
 
 
+# ── Model metadata (meta/meta.dat) ───────────────────────────────────────
+
+# meta/meta.dat uses the same low-level TLV framing as model.dat (2-byte
+# tag + 4-byte little-endian length + payload), but as one flat
+# (non-recursive) record list wrapped in a single outer record. Confirmed
+# against a real fixture: the outer wrapper is tag 0x6400; among its
+# direct children, tag 0x6D00 carries the model's unit-system string as
+# plain text ("Millimeter" in the fixture) - siblings carry the SketchUp
+# version, save path, and thumbnail references, none of which any parser
+# currently surfaces either.
+_META_WRAPPER_TAG = b'\x64\x00'
+_META_UNITS_TAG = b'\x6D\x00'
+
+
+def _read_meta_units(meta_bytes: bytes):
+    """Extract the model's unit-system string from a VFF file's
+    meta/meta.dat contents, or ``None`` if the expected tags aren't
+    found."""
+    pos = 0
+    while pos + 6 <= len(meta_bytes):
+        tag = meta_bytes[pos:pos + 2]
+        size = struct.unpack_from('<I', meta_bytes, pos + 2)[0]
+        if pos + 6 + size > len(meta_bytes):
+            break
+        if tag == _META_WRAPPER_TAG:
+            return _read_meta_units(meta_bytes[pos + 6:pos + 6 + size])
+        if tag == _META_UNITS_TAG:
+            return meta_bytes[pos + 6:pos + 6 + size].decode('utf-8', errors='replace')
+        pos += 6 + size
+    return None
+
+
 # ── Texture extraction ───────────────────────────────────────────────────
 
 def _extract_texture(zf, xml_name, mat_elem, ns):
@@ -783,6 +815,16 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
         _validate_zip_entry_size(zf, 'meta/model_thumbnail.png')
         thumbnail_data = zf.read('meta/model_thumbnail.png')
 
+    # Units (meta/meta.dat) - VFF-only; legacy files carry no equivalent
+    # container.
+    units = None
+    if 'meta/meta.dat' in zf.namelist():
+        try:
+            _validate_zip_entry_size(zf, 'meta/meta.dat')
+            units = _read_meta_units(zf.read('meta/meta.dat'))
+        except Exception:
+            units = None
+
     # Styles: face colors live in styles/*/style.xml as signed-int32 ARGB
     # variants — item id 4000 is the front (default) face color, 4001 the
     # back face color. Viewers need them to shade unpainted faces the way
@@ -958,6 +1000,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
         'defs_dict': defs_dict,
         'thumbnail_data': thumbnail_data,
         'styles': styles,
+        'units': units,
     }
 
 

--- a/packages/python/src/openskp/export/json_export.py
+++ b/packages/python/src/openskp/export/json_export.py
@@ -110,6 +110,7 @@ def to_dict(model: SkpModel, scene: Optional[Scene] = None) -> Dict[str, Any]:
     """
     return {
         "version": model.version,
+        "units": model.units,
         "root": _definition_to_dict(model.root),
         "definitions": {
             str(k): _definition_to_dict(v)

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -1015,4 +1015,8 @@ def full_parse_legacy(skp_path: str) -> Dict[str, Any]:
         'elements': [],
         'thumbnail_data': None,
         'styles': [],
+        # Legacy (pre-2021 MFC) files carry no meta/meta.dat container -
+        # that's a VFF/ZIP-only construct - so there is no known source
+        # for the model's unit-system string here.
+        'units': None,
     }

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -358,6 +358,10 @@ class SkpModel:
             the join table for :attr:`Face.material_id`.  Several IDs may
             alias the same :class:`Material` object.
         styles: List of :class:`Style` objects found in the file.
+        units: The model's unit-system string (e.g. ``"Millimeter"``),
+            read from ``meta/meta.dat`` in modern (VFF) files.  ``None``
+            for legacy (pre-2021 MFC) files, which carry no equivalent
+            container, or when the tag isn't found.
 
     Note:
         The resolved, world-space scene graph (with baked instance
@@ -374,6 +378,7 @@ class SkpModel:
     materials: List[Material] = field(default_factory=list)
     materials_by_id: Dict[int, Material] = field(default_factory=dict)
     styles: List[Style] = field(default_factory=list)
+    units: Optional[str] = None
 
 
 # ── SkpFile entry-point ──────────────────────────────────────────────────
@@ -448,6 +453,7 @@ class SkpFile:
 
         model = SkpModel()
         model.version = parsed.get("version", "unknown")
+        model.units = parsed.get("units")
 
         # Convert defs_dict to Definition dataclasses
         for def_id, d in parsed["defs_dict"].items():

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -370,6 +370,7 @@ class TestJsonExport:
         model = SkpModel()
         d = to_dict(model)
         assert d["version"] == "unknown"
+        assert d["units"] is None
         assert d["root"] == {
             "id": 0, "guid": "", "name": "", "vertex_count": 0,
             "edge_count": 0, "face_count": 0, "vertices": [], "instances": [],
@@ -752,6 +753,122 @@ class TestFaceInstanceHidden:
                 assert face.hidden is False
         for inst in model.root.instances:
             assert inst.hidden is False
+
+
+class TestMetaUnits:
+    """``SkpModel.units`` - the model's unit-system string, read from
+    ``meta/meta.dat`` in VFF files. Never opened by any parser before this
+    (zero references to the filename anywhere in the codebase). Confirmed
+    plaintext payload in a real fixture (Untitled.skp): ``meta.dat`` uses
+    the same low-level TLV framing as ``model.dat`` (2-byte tag + 4-byte
+    little-endian length + payload), one flat record list wrapped in a
+    single outer record (tag 0x6400); tag 0x6D00 carries the units string
+    as plain text, alongside sibling tags for the SketchUp version, save
+    path, and thumbnail references that no parser surfaces either.
+    """
+
+    @staticmethod
+    def _tlv(tag: bytes, payload: bytes) -> bytes:
+        return tag + struct.pack('<I', len(payload)) + payload
+
+    def test_extracts_units_from_real_fixture_bytes(self) -> None:
+        # The exact 388-byte meta/meta.dat payload from a real VFF fixture
+        # (Untitled.skp, SketchUp 25.0.575) - byte-for-byte, not
+        # hand-crafted. Confirms _read_meta_units against genuine data,
+        # not just a minimal synthetic record.
+        from openskp._core import _read_meta_units
+
+        real_meta_dat = (
+            b'd\x00~\x01\x00\x00u\x00\x08\x00\x00\x0025.0.575v\x00\x02\x00\x00\x00\x18\x00'
+            b'w\x00\x02\x00\x00\x00\x02\x00s\x00\x02\x00\x00\x00\x01\x00t\x00\x02\x00\x00'
+            b'\x00\x11\x00f\x00\x10\x00\x00\x00\xdc\xd4u*8=rG\x83\x02/\xa2\x9c\xda2$'
+            b'g\x00.\x00\x00\x00(#(\x00\x00\x00)#\x04\x00\x00\x00\x04\x00\x00\x00'
+            b'*#\x18\x00\x00\x00meta/model_thumbnail.png'
+            b'h\x000\x00\x00\x00(#*\x00\x00\x00)#\x04\x00\x00\x00\x04\x00\x00\x00'
+            b'*#\x1a\x00\x00\x00meta/preview_thumbnail.png'
+            b'i\x00\x01\x00\x00\x00\x01j\x00\x00\x00\x00\x00k\x00\x00\x00\x00\x00'
+            b'l\x00\x00\x00\x00\x00n\x00\x00\x00\x00\x00q\x00\x01\x00\x00\x00\x00'
+            b'y\x00\x01\x00\x00\x00\x00r\x00\x01\x00\x00\x00\x00'
+            b'm\x00\n\x00\x00\x00Millimeter'
+            b'p\x00\x01\x00\x00\x00\x01'
+            b"o\x00'\x00\x00\x00E:/Devs/TEst/Skp Test/ref2/Untitled.skp"
+            b'x\x00R\x00\x00\x00\xc8\x00L\x00\x00\x00\xc9\x00F\x00\x00\x00\xca\x00'
+            b'@\x00\x00\x00\xcb\x00"\x00\x00\x00SketchUp Client (Windows) 25.0.575'
+            b'\xcc\x00\x04\x00\x00\x00#\xc52j'
+            b'\xcd\x00\x08\x00\x00\x00\xecD=\xc9\xb4\xdb\x98w'
+        )
+        assert _read_meta_units(real_meta_dat) == 'Millimeter'
+
+    def test_extracts_units_from_minimal_synthetic_record(self) -> None:
+        from openskp._core import _read_meta_units
+
+        inner = self._tlv(b'\x6D\x00', b'Inches')
+        outer = self._tlv(b'\x64\x00', inner)
+        assert _read_meta_units(outer) == 'Inches'
+
+    def test_returns_none_when_units_tag_absent(self) -> None:
+        from openskp._core import _read_meta_units
+
+        inner = self._tlv(b'\x75\x00', b'25.0.575')  # version tag, not units
+        outer = self._tlv(b'\x64\x00', inner)
+        assert _read_meta_units(outer) is None
+
+    def test_returns_none_for_empty_or_truncated_bytes(self) -> None:
+        from openskp._core import _read_meta_units
+
+        assert _read_meta_units(b'') is None
+        assert _read_meta_units(b'\x01\x02\x03') is None
+
+    def test_model_units_wired_from_parsed_dict(self, monkeypatch, tmp_path: pathlib.Path) -> None:
+        import openskp._core as _core
+        from openskp.model import SkpFile
+
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {},
+            "units": "Millimeter",
+        }
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "model.skp"
+        fake.write_bytes(b"")
+        model = SkpFile.open(str(fake)).parse()
+
+        assert model.units == "Millimeter"
+
+    def test_model_units_defaults_to_none_when_absent(self, monkeypatch, tmp_path: pathlib.Path) -> None:
+        import openskp._core as _core
+        from openskp.model import SkpFile
+
+        parsed = {
+            "version": "test",
+            "defs_dict": {},
+            "layer_colors": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "material_id_to_name": {},
+        }
+        monkeypatch.setattr(_core, "full_parse", lambda path: parsed)
+        fake = tmp_path / "model.skp"
+        fake.write_bytes(b"")
+        model = SkpFile.open(str(fake)).parse()
+
+        assert model.units is None
+
+    def test_real_legacy_fixture_has_no_units(self) -> None:
+        # Legacy (pre-2021 MFC) files carry no meta/meta.dat container -
+        # confirms this returns None cleanly rather than raising.
+        import pytest as _pytest
+        fixture = pathlib.Path(__file__).parent / "fixtures" / "capilla_quiroz_v17.skp"
+        if not fixture.exists():
+            _pytest.skip("legacy fixture not present")
+        from openskp.model import SkpFile
+
+        model = SkpFile.open(str(fixture)).parse()
+        assert model.units is None
 
 
 # ── Instance material tests ──────────────────────────────────────────────


### PR DESCRIPTION
## What

`meta/meta.dat` was never opened by any parser in this project - zero references to the filename anywhere in the codebase before this. It's a small metadata blob inside the VFF ZIP container that SketchUp writes alongside `model.dat`, holding (among other things) the model's configured unit system as plain text.

Reverse-engineered its framing by inspecting a real fixture (`Untitled.skp`) byte-for-byte: `meta.dat` uses the exact same low-level TLV framing as `model.dat` (2-byte tag + 4-byte little-endian length + payload), but as one flat (non-recursive) record list wrapped in a single outer record (tag `0x6400`). Among its direct children, tag `0x6D00` carries the unit-system string as plain text (`"Millimeter"` in the fixture) - siblings carry the SketchUp version, save path, and thumbnail references, none of which any parser surfaces either (left for a future item, out of scope here).

## Change

Adds `SkpModel.units: Optional[str] = None`, extracted via a new `_read_meta_units()` helper in `_core.py` (called only when `meta/meta.dat` is present, with the same `_validate_zip_entry_size()` guard already applied to every other ZIP-entry read). Legacy (pre-2021 MFC) files carry no equivalent container - they're not ZIP archives at all - so `units` is always `None` there, documented on the field itself rather than guessed at.

`export/json_export.py`'s `to_dict()` also gained the `"units"` key, for parity with the rest of `SkpModel`'s top-level fields.

## Verification

`_read_meta_units()` is tested directly against the exact 388-byte real `meta/meta.dat` payload from `Untitled.skp` (byte-for-byte, not hand-crafted) plus synthetic minimal/absent/truncated cases. `model.units` wiring is tested via stubbed `full_parse` (both present and absent `'units'` keys). A real-fixture test confirms the legacy path returns `None` cleanly rather than raising.

Full suite: 111/111 passing, `ruff check src/ tests/` clean.

Part of the ongoing repo-health checklist (Tier 2, item 7) - TypeScript/.NET/Dart/C++ follow separately.