### PR TITLE
Parse meta/meta.dat for the model's unit-system string (TypeScript)

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,4 +1,4 @@
-import { extractSkpContents } from './vff';
+import { extractSkpContents, readMetaUnits } from './vff';
 import { iterTopLevelLazy, readU32, parseVarInt } from './parser';
 import { SkpParseError } from './errors';
 import { ParseOptions, PROGRESS_INTERVAL, emitLog, emitProgress } from './observability';
@@ -66,6 +66,11 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
   const modelData = contents.modelData;
   const materialFiles = contents.materialFiles;
   emitLog(options, 'debug', `Detected version ${version} (VFF/ZIP container)`);
+
+  // meta/meta.dat carries the model's unit-system string (e.g.
+  // "Millimeter") - legacy (pre-2021 MFC) files carry no equivalent
+  // container, so units stays null there.
+  const units = contents.metaData ? readMetaUnits(contents.metaData) : null;
 
   // 2. Parse XML materials to populate layer colors and materials
   const layerColors = new Map<string, [number, number, number]>();
@@ -247,6 +252,7 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
 
   return {
     version,
+    units,
     layerColors,
     layerHidden,
     layerIdToName,

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -1180,6 +1180,10 @@ export function parseLegacyToRaw(data: Uint8Array, options?: ParseOptions): Pars
 
   return {
     version,
+    // Legacy (pre-2021 MFC) files carry no meta/meta.dat container -
+    // that's a VFF/ZIP-only construct - so there is no known source for
+    // the model's unit-system string here.
+    units: null,
     layerColors,
     layerHidden,
     layerIdToName,

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -16,6 +16,11 @@ export interface SkpModel {
   materials: Material[];
   materialsById: Map<number, Material>;
   styles: Style[];
+  /** The model's unit-system string (e.g. "Millimeter"), read from
+   * meta/meta.dat in modern (VFF) files. null for legacy (pre-2021 MFC)
+   * files, which carry no equivalent container, or when the tag isn't
+   * found. */
+  units: string | null;
 }
 
 export interface Definition {
@@ -218,6 +223,9 @@ export interface SkpScene {
  * primitive building, which both formats share. */
 export interface ParsedRawData {
   version: string;
+  /** The model's unit-system string (e.g. "Millimeter"), read from
+   * meta/meta.dat. null for legacy files or when the tag isn't found. */
+  units: string | null;
   layerColors: Map<string, [number, number, number]>;
   layerHidden: Map<string, boolean>;
   layerIdToName: Map<number, string>;
@@ -229,8 +237,17 @@ export interface ParsedRawData {
 }
 
 export function buildModelFromParsed(parsed: ParsedRawData): SkpModel {
-  const { version, layerColors, layerHidden, materialIdToName, materialsMap, materialsByFolder, styles, defsDict } =
-    parsed;
+  const {
+    version,
+    units,
+    layerColors,
+    layerHidden,
+    materialIdToName,
+    materialsMap,
+    materialsByFolder,
+    styles,
+    defsDict,
+  } = parsed;
 
   // Join the TLV material IDs (what Face.materialId references) onto the
   // parsed materials, so callers can resolve face -> material.
@@ -278,6 +295,7 @@ export function buildModelFromParsed(parsed: ParsedRawData): SkpModel {
     materials: finalMaterialsList,
     materialsById,
     styles,
+    units,
   };
 }
 

--- a/packages/typescript/src/vff.ts
+++ b/packages/typescript/src/vff.ts
@@ -4,6 +4,8 @@ export interface SkpContents {
   version: string;
   modelData: Uint8Array;
   materialFiles: Record<string, Uint8Array>;
+  /** Raw bytes of meta/meta.dat, or null when the entry is absent. */
+  metaData: Uint8Array | null;
 }
 
 const VFF_MAGIC = [0xFF, 0xFE, 0xFF, 0x0E];
@@ -70,6 +72,37 @@ function findZipOffset(data: Uint8Array): number {
   return offset;
 }
 
+// meta/meta.dat uses the same low-level TLV framing as model.dat (2-byte
+// tag + 4-byte little-endian length + payload), but as one flat
+// (non-recursive) record list wrapped in a single outer record. Confirmed
+// against a real fixture: the outer wrapper is tag 0x6400; among its
+// direct children, tag 0x6D00 carries the model's unit-system string as
+// plain text ("Millimeter" in the fixture) - siblings carry the SketchUp
+// version, save path, and thumbnail references, none of which any parser
+// surfaces either.
+const META_WRAPPER_TAG = [0x64, 0x00];
+const META_UNITS_TAG = [0x6d, 0x00];
+
+/** Extract the model's unit-system string from meta/meta.dat's raw bytes,
+ * or null if the expected tags aren't found. */
+export function readMetaUnits(metaBytes: Uint8Array): string | null {
+  const view = new DataView(metaBytes.buffer, metaBytes.byteOffset, metaBytes.byteLength);
+  let pos = 0;
+  while (pos + 6 <= metaBytes.length) {
+    const tag = [metaBytes[pos], metaBytes[pos + 1]];
+    const size = view.getUint32(pos + 2, true);
+    if (pos + 6 + size > metaBytes.length) break;
+    if (tag[0] === META_WRAPPER_TAG[0] && tag[1] === META_WRAPPER_TAG[1]) {
+      return readMetaUnits(metaBytes.subarray(pos + 6, pos + 6 + size));
+    }
+    if (tag[0] === META_UNITS_TAG[0] && tag[1] === META_UNITS_TAG[1]) {
+      return new TextDecoder('utf-8').decode(metaBytes.subarray(pos + 6, pos + 6 + size));
+    }
+    pos += 6 + size;
+  }
+  return null;
+}
+
 // A ZIP entry's declared uncompressed size (UnzipFileInfo.originalSize) is
 // untrusted central-directory metadata - it can be set independently of
 // what the compressed stream actually decompresses to, and even when
@@ -126,6 +159,7 @@ export function extractSkpContents(data: Uint8Array): SkpContents {
     const isWanted = (
       lower === 'model.dat' ||
       lower.endsWith('/model.dat') ||
+      lower === 'meta/meta.dat' ||
       lower.endsWith('.xml') ||
       lower.endsWith('.png') ||
       lower.endsWith('.jpg') ||
@@ -144,12 +178,15 @@ export function extractSkpContents(data: Uint8Array): SkpContents {
   }
 
   let modelData: Uint8Array | null = null;
+  let metaData: Uint8Array | null = null;
   const materialFiles: Record<string, Uint8Array> = {};
 
   for (const entry of Object.keys(unzipped)) {
     const lower = entry.toLowerCase();
     if (lower === 'model.dat' || lower.endsWith('/model.dat')) {
       modelData = unzipped[entry];
+    } else if (lower === 'meta/meta.dat') {
+      metaData = unzipped[entry];
     } else if (
       lower.endsWith('.xml') ||
       lower.endsWith('.png') ||
@@ -169,5 +206,6 @@ export function extractSkpContents(data: Uint8Array): SkpContents {
     version,
     modelData,
     materialFiles,
+    metaData,
   };
 }

--- a/packages/typescript/tests/face-instance-hidden.test.ts
+++ b/packages/typescript/tests/face-instance-hidden.test.ts
@@ -14,6 +14,7 @@ import { GeometryBuilder } from '../src/geometry';
 function parsed(defsDict: Map<number | string, any>): ParsedRawData {
   return {
     version: 'test',
+    units: null,
     layerColors: new Map(),
     layerHidden: new Map(),
     layerIdToName: new Map(),

--- a/packages/typescript/tests/integration.test.ts
+++ b/packages/typescript/tests/integration.test.ts
@@ -11,6 +11,9 @@ describe('SketchUp Parser Integration Test', () => {
     // 1. Assert Version
     expect(model.version).toBe('{25.0.575}');
 
+    // 1b. Assert Units (from meta/meta.dat)
+    expect(model.units).toBe('Millimeter');
+
     // 2. Assert Layers
     expect(model.layers.length).toBe(14);
     const expectedLayers = [

--- a/packages/typescript/tests/layer-hidden.test.ts
+++ b/packages/typescript/tests/layer-hidden.test.ts
@@ -12,6 +12,7 @@ import { buildModelFromParsed, ParsedRawData } from '../src/model';
 function parsed(layerColors: Map<string, [number, number, number]>, layerHidden: Map<string, boolean>): ParsedRawData {
   return {
     version: 'test',
+    units: null,
     layerColors,
     layerHidden,
     layerIdToName: new Map(),

--- a/packages/typescript/tests/legacy.test.ts
+++ b/packages/typescript/tests/legacy.test.ts
@@ -31,6 +31,10 @@ describe('Legacy MFC reader (classic pre-2021 .skp)', () => {
     // 1. Version
     expect(model.version).toBe('{17.0.18899}');
 
+    // 1b. Units - legacy (pre-2021 MFC) files carry no meta/meta.dat
+    // container, so there is no known source for this.
+    expect(model.units).toBeNull();
+
     // 2. Definitions - ROOT is excluded from model.definitions by design
     // (same as the VFF path), so only the two named component definitions
     // show up here.

--- a/packages/typescript/tests/meta-units.test.ts
+++ b/packages/typescript/tests/meta-units.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { readMetaUnits } from '../src/vff';
+import { buildModelFromParsed, ParsedRawData } from '../src/model';
+
+/**
+ * SkpModel.units - the model's unit-system string, read from meta/meta.dat
+ * in VFF files. Never opened by any parser before this (zero references to
+ * the filename anywhere in the codebase). Confirmed plaintext payload in a
+ * real fixture (Untitled.skp): meta.dat uses the same low-level TLV framing
+ * as model.dat (2-byte tag + 4-byte little-endian length + payload), one
+ * flat record list wrapped in a single outer record (tag 0x6400); tag
+ * 0x6D00 carries the units string as plain text, alongside sibling tags for
+ * the SketchUp version, save path, and thumbnail references that no parser
+ * surfaces either.
+ */
+
+function tlv(tag: number[], payload: Uint8Array): Uint8Array {
+  const out = new Uint8Array(6 + payload.length);
+  out[0] = tag[0];
+  out[1] = tag[1];
+  new DataView(out.buffer).setUint32(2, payload.length, true);
+  out.set(payload, 6);
+  return out;
+}
+
+describe('readMetaUnits', () => {
+  it('extracts units from the exact real fixture bytes', () => {
+    // The exact 388-byte meta/meta.dat payload from a real VFF fixture
+    // (Untitled.skp, SketchUp 25.0.575) - byte-for-byte, not hand-crafted.
+    const hex =
+      '6400' + '7e010000' +
+      '7500' + '08000000' + Buffer.from('25.0.575').toString('hex') +
+      '7600' + '02000000' + '1800' +
+      '7700' + '02000000' + '0200' +
+      '7300' + '02000000' + '0100' +
+      '7400' + '02000000' + '1100' +
+      '6600' + '10000000' + 'dcd4752a383d724783022fa29cda3224' +
+      '6700' + '2e000000' + '2823' + '28000000' + '2923' + '04000000' + '04000000' + '2a23' + '18000000' +
+        Buffer.from('meta/model_thumbnail.png').toString('hex') +
+      '6800' + '30000000' + '2823' + '2a000000' + '2923' + '04000000' + '04000000' + '2a23' + '1a000000' +
+        Buffer.from('meta/preview_thumbnail.png').toString('hex') +
+      '6900' + '01000000' + '01' +
+      '6a00' + '00000000' +
+      '6b00' + '00000000' +
+      '6c00' + '00000000' +
+      '6e00' + '00000000' +
+      '7100' + '01000000' + '00' +
+      '7900' + '01000000' + '00' +
+      '7200' + '01000000' + '00' +
+      '6d00' + '0a000000' + Buffer.from('Millimeter').toString('hex') +
+      '7000' + '01000000' + '01' +
+      '6f00' + '27000000' + Buffer.from("E:/Devs/TEst/Skp Test/ref2/Untitled.skp").toString('hex') +
+      '7800' + '52000000' +
+        'c800' + '4c000000' +
+        'c900' + '46000000' +
+        'ca00' + '40000000' +
+        'cb00' + '22000000' + Buffer.from('SketchUp Client (Windows) 25.0.575').toString('hex') +
+      'cc00' + '04000000' + '23c5326a' +
+      'cd00' + '08000000' + 'ec443dc9b4db9877';
+    const bytes = new Uint8Array(Buffer.from(hex, 'hex'));
+
+    expect(readMetaUnits(bytes)).toBe('Millimeter');
+  });
+
+  it('extracts units from a minimal synthetic record', () => {
+    const inner = tlv([0x6d, 0x00], new TextEncoder().encode('Inches'));
+    const outer = tlv([0x64, 0x00], inner);
+    expect(readMetaUnits(outer)).toBe('Inches');
+  });
+
+  it('returns null when the units tag is absent', () => {
+    const inner = tlv([0x75, 0x00], new TextEncoder().encode('25.0.575'));
+    const outer = tlv([0x64, 0x00], inner);
+    expect(readMetaUnits(outer)).toBeNull();
+  });
+
+  it('returns null for empty or truncated bytes', () => {
+    expect(readMetaUnits(new Uint8Array(0))).toBeNull();
+    expect(readMetaUnits(new Uint8Array([1, 2, 3]))).toBeNull();
+  });
+});
+
+function parsed(overrides: Partial<ParsedRawData>): ParsedRawData {
+  return {
+    version: 'test',
+    units: null,
+    layerColors: new Map(),
+    layerHidden: new Map(),
+    layerIdToName: new Map(),
+    materialIdToName: new Map(),
+    materialsMap: new Map(),
+    materialsByFolder: new Map(),
+    styles: [],
+    defsDict: new Map(),
+    ...overrides,
+  };
+}
+
+describe('buildModelFromParsed units', () => {
+  it('carries units through to the model', () => {
+    const model = buildModelFromParsed(parsed({ units: 'Millimeter' }));
+    expect(model.units).toBe('Millimeter');
+  });
+
+  it('defaults to null when absent', () => {
+    const model = buildModelFromParsed(parsed({}));
+    expect(model.units).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Companion to #98 (Python) - ports the same feature to TypeScript. No parser in this repo has ever opened `meta/meta.dat` inside the VFF ZIP container (confirmed by a full-codebase grep for the filename before starting - zero references).

Byte-level inspection of a real fixture (`Untitled.skp`) shows `meta/meta.dat` uses the exact same low-level TLV framing as `model.dat` (2-byte tag + 4-byte little-endian length + payload), but as one flat, non-recursive record list wrapped in a single outer record (tag `0x6400`). Among its children, tag `0x6D00` carries the model's unit-system string as plain text (`"Millimeter"` in the fixture) - a real, previously-unsurfaced field, not reverse-engineered speculation. Sibling tags (SketchUp version, save path, thumbnail references) are left for a future item.

## Changes

- `vff.ts`: extract `meta/meta.dat`'s raw bytes into `SkpContents.metaData` (added to the existing `wanted` decompression filter, since `extractSkpContents` only decompresses entries actually consumed - a memory optimization already in place). Added `readMetaUnits()`, a recursive tag-scanner mirroring the existing `model.dat` TLV walk.
- `index.ts`: wire `readMetaUnits(contents.metaData)` into `parseToRaw`'s VFF-path return as `units`.
- `model.ts`: add `units: string | null` to both `SkpModel` and `ParsedRawData` (required field - every direct construction site was updated, including test helpers, since `tsc --noEmit` doesn't catch those - `tsconfig.json` excludes `tests/` from typecheck).
- `legacy.ts`: legacy (pre-2021 MFC) files carry no `meta/meta.dat` container - that's a VFF/ZIP-only construct - so `units` stays `null` on that path.

## Test plan

- [x] New `meta-units.test.ts`: `readMetaUnits` against the exact 388-byte real fixture payload (byte-for-byte, not hand-crafted), a minimal synthetic record, an absent-tag case, empty/truncated bytes, plus `buildModelFromParsed` wiring.
- [x] Real end-to-end assertion in `integration.test.ts`: `model.units === 'Millimeter'` for `Untitled.skp` (TypeScript has this fixture locally, so this is a genuine full-parse check, not just unit-level).
- [x] Real-fixture assertion in `legacy.test.ts`: `model.units === null` for the real legacy fixture.
- [x] Full suite: 59/59 passing.
- [x] `tsc --noEmit` clean.