### PR TITLE
Parse meta/meta.dat for the model's unit-system string (.NET)

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
@@ -22,6 +22,7 @@ namespace OpenSkp.Tests
             var model = SkpFile.Open(FixturePath("Untitled.skp"));
 
             Assert.Equal("{25.0.575}", model.Version);
+            Assert.Equal("Millimeter", model.Units);
 
             Assert.Equal(14, model.Layers.Count);
             var expectedLayers = new[]

--- a/packages/dotnet/OpenSkp.Tests/LegacyTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/LegacyTests.cs
@@ -27,6 +27,10 @@ namespace OpenSkp.Tests
 
             Assert.Equal("{17.0.18899}", model.Version);
 
+            // Units - legacy (pre-2021 MFC) files carry no meta/meta.dat
+            // container, so there is no known source for this.
+            Assert.Null(model.Units);
+
             // Definitions - ROOT is exposed separately via model.Root, so
             // only the two named component definitions show up here.
             Assert.Equal(2, model.Definitions.Count);

--- a/packages/dotnet/OpenSkp.Tests/MetaUnitsTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/MetaUnitsTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Text;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// SkpModel.Units - the model's unit-system string, read from
+    /// meta/meta.dat in VFF files. Never opened by any parser before this
+    /// (zero references to the filename anywhere in the codebase).
+    /// Confirmed plaintext payload in a real fixture (Untitled.skp):
+    /// meta.dat uses the same low-level TLV framing as model.dat (2-byte
+    /// tag + 4-byte little-endian length + payload), one flat record list
+    /// wrapped in a single outer record (tag 0x6400); tag 0x6D00 carries
+    /// the units string as plain text.
+    /// </summary>
+    public class MetaUnitsTests
+    {
+        private static byte[] Tlv(string tagHex, byte[] payload)
+        {
+            var tag = new byte[] { Convert.ToByte(tagHex.Substring(0, 2), 16), Convert.ToByte(tagHex.Substring(2, 2), 16) };
+            var len = BitConverter.GetBytes((uint)payload.Length);
+            var result = new byte[6 + payload.Length];
+            Array.Copy(tag, 0, result, 0, 2);
+            Array.Copy(len, 0, result, 2, 4);
+            Array.Copy(payload, 0, result, 6, payload.Length);
+            return result;
+        }
+
+        private static byte[] HexToBytes(string hex)
+        {
+            var result = new byte[hex.Length / 2];
+            for (int i = 0; i < result.Length; i++)
+            {
+                result[i] = Convert.ToByte(hex.Substring(i * 2, 2), 16);
+            }
+            return result;
+        }
+
+        [Fact]
+        public void ExtractsUnitsFromExactRealFixtureBytes()
+        {
+            // The exact 388-byte meta/meta.dat payload from a real VFF
+            // fixture (Untitled.skp, SketchUp 25.0.575) - byte-for-byte,
+            // not hand-crafted.
+            string hex =
+                "6400" + "7e010000" +
+                "7500" + "08000000" + Convert.ToHexString(Encoding.ASCII.GetBytes("25.0.575")) +
+                "7600" + "02000000" + "1800" +
+                "7700" + "02000000" + "0200" +
+                "7300" + "02000000" + "0100" +
+                "7400" + "02000000" + "1100" +
+                "6600" + "10000000" + "dcd4752a383d724783022fa29cda3224" +
+                "6700" + "2e000000" + "2823" + "28000000" + "2923" + "04000000" + "04000000" + "2a23" + "18000000" +
+                    Convert.ToHexString(Encoding.ASCII.GetBytes("meta/model_thumbnail.png")) +
+                "6800" + "30000000" + "2823" + "2a000000" + "2923" + "04000000" + "04000000" + "2a23" + "1a000000" +
+                    Convert.ToHexString(Encoding.ASCII.GetBytes("meta/preview_thumbnail.png")) +
+                "6900" + "01000000" + "01" +
+                "6a00" + "00000000" +
+                "6b00" + "00000000" +
+                "6c00" + "00000000" +
+                "6e00" + "00000000" +
+                "7100" + "01000000" + "00" +
+                "7900" + "01000000" + "00" +
+                "7200" + "01000000" + "00" +
+                "6d00" + "0a000000" + Convert.ToHexString(Encoding.ASCII.GetBytes("Millimeter")) +
+                "7000" + "01000000" + "01" +
+                "6f00" + "27000000" + Convert.ToHexString(Encoding.ASCII.GetBytes("E:/Devs/TEst/Skp Test/ref2/Untitled.skp")) +
+                "7800" + "52000000" +
+                    "c800" + "4c000000" +
+                    "c900" + "46000000" +
+                    "ca00" + "40000000" +
+                    "cb00" + "22000000" + Convert.ToHexString(Encoding.ASCII.GetBytes("SketchUp Client (Windows) 25.0.575")) +
+                "cc00" + "04000000" + "23c5326a" +
+                "cd00" + "08000000" + "ec443dc9b4db9877";
+
+            byte[] bytes = HexToBytes(hex);
+
+            Assert.Equal("Millimeter", Vff.ReadMetaUnits(bytes));
+        }
+
+        [Fact]
+        public void ExtractsUnitsFromMinimalSyntheticRecord()
+        {
+            var inner = Tlv("6D00", Encoding.UTF8.GetBytes("Inches"));
+            var outer = Tlv("6400", inner);
+
+            Assert.Equal("Inches", Vff.ReadMetaUnits(outer));
+        }
+
+        [Fact]
+        public void ReturnsNullWhenUnitsTagAbsent()
+        {
+            var inner = Tlv("7500", Encoding.UTF8.GetBytes("25.0.575"));
+            var outer = Tlv("6400", inner);
+
+            Assert.Null(Vff.ReadMetaUnits(outer));
+        }
+
+        [Fact]
+        public void ReturnsNullForEmptyOrTruncatedBytes()
+        {
+            Assert.Null(Vff.ReadMetaUnits(Array.Empty<byte>()));
+            Assert.Null(Vff.ReadMetaUnits(new byte[] { 1, 2, 3 }));
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Core.cs
+++ b/packages/dotnet/OpenSkp/Core.cs
@@ -14,6 +14,10 @@ namespace OpenSkp
         internal sealed class RawParsed
         {
             public string Version = "unknown";
+            /// <summary>The model's unit-system string (e.g. "Millimeter"),
+            /// read from meta/meta.dat. Null for legacy files or when the
+            /// tag isn't found.</summary>
+            public string? Units = null;
             public Dictionary<string, (int R, int G, int B)> LayerColors = new Dictionary<string, (int, int, int)>();
             // Modern (VFF) files derive layers from Layer_<name>-prefixed
             // materials, which carry no visibility flag of their own -
@@ -200,6 +204,30 @@ namespace OpenSkp
                 options, SkpLogLevel.Information,
                 $"Parse complete: {defsDictRaw.Count} defs ({sw.Elapsed.TotalSeconds:F2}s)");
 
+            // Units (meta/meta.dat) - VFF-only; legacy files carry no
+            // equivalent container.
+            string? units = null;
+            var metaDatEntry = zip.GetEntry("meta/meta.dat");
+            if (metaDatEntry != null)
+            {
+                try
+                {
+                    Vff.ValidateEntrySize(metaDatEntry);
+                    byte[] metaData;
+                    using (var s = metaDatEntry.Open())
+                    using (var ms = new System.IO.MemoryStream())
+                    {
+                        s.CopyTo(ms);
+                        metaData = ms.ToArray();
+                    }
+                    units = Vff.ReadMetaUnits(metaData);
+                }
+                catch
+                {
+                    units = null;
+                }
+            }
+
             if (!layerIdToName.ContainsKey(1))
             {
                 layerIdToName[1] = "Layer0";
@@ -216,6 +244,7 @@ namespace OpenSkp
             return new RawParsed
             {
                 Version = version,
+                Units = units,
                 LayerColors = layerColors,
                 LayerHidden = layerHidden,
                 LayerIdToName = layerIdToName,

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -1394,6 +1394,11 @@ namespace OpenSkp
             return new Core.RawParsed
             {
                 Version = version,
+                // Legacy (pre-2021 MFC) files carry no meta/meta.dat
+                // container - that's a VFF/ZIP-only construct - so there
+                // is no known source for the model's unit-system string
+                // here.
+                Units = null,
                 LayerColors = layerColors,
                 LayerHidden = layerHidden,
                 LayerIdToName = layerIdToName,

--- a/packages/dotnet/OpenSkp/Model.cs
+++ b/packages/dotnet/OpenSkp/Model.cs
@@ -149,6 +149,12 @@ namespace OpenSkp
     {
         public string Version { get; set; } = "unknown";
 
+        /// <summary>The model's unit-system string (e.g. "Millimeter"),
+        /// read from meta/meta.dat in modern (VFF) files. Null for legacy
+        /// (pre-2021 MFC) files, which carry no equivalent container, or
+        /// when the tag isn't found.</summary>
+        public string? Units { get; set; }
+
         /// <summary>Component/group definitions keyed by their numeric TLV
         /// entity ID. The implicit root definition (Python's "ROOT" dict
         /// entry, which has no numeric ID) is exposed separately via

--- a/packages/dotnet/OpenSkp/Parser.cs
+++ b/packages/dotnet/OpenSkp/Parser.cs
@@ -19,7 +19,7 @@ namespace OpenSkp
         {
             var parsed = Core.FullParse(buffer, options);
 
-            var model = new SkpModel { Version = parsed.Version };
+            var model = new SkpModel { Version = parsed.Version, Units = parsed.Units };
 
             foreach (var kv in parsed.DefsDict)
             {

--- a/packages/dotnet/OpenSkp/Vff.cs
+++ b/packages/dotnet/OpenSkp/Vff.cs
@@ -116,6 +116,35 @@ namespace OpenSkp
         private const long MaxCompressionRatio = 1000;
         private const long RatioCheckThresholdBytes = 1024 * 1024; // 1 MB
 
+        // meta/meta.dat uses the exact same low-level TLV framing as
+        // model.dat (2-byte tag + 4-byte little-endian length + payload),
+        // but as one flat, non-recursive record list wrapped in a single
+        // outer record (tag 0x6400/"6400"). Tag 0x6D00/"6D00" carries the
+        // model's unit-system string ("Millimeter" etc.) as plain text.
+        // Confirmed byte-for-byte against a real fixture - never opened by
+        // any parser in this codebase before.
+        private const string MetaWrapperTag = "6400";
+        private const string MetaUnitsTag = "6D00";
+
+        /// <summary>Extract the model's unit-system string from a VFF
+        /// file's meta/meta.dat contents, or null if the expected tags
+        /// aren't found.</summary>
+        public static string? ReadMetaUnits(byte[] metaBytes)
+        {
+            var records = Tlv.ParseFlat(metaBytes);
+            var wrapper = Tlv.FindFlat(records, MetaWrapperTag);
+            if (wrapper != null)
+            {
+                return ReadMetaUnits(wrapper);
+            }
+            var units = Tlv.FindFlat(records, MetaUnitsTag);
+            if (units != null)
+            {
+                return Encoding.UTF8.GetString(units);
+            }
+            return null;
+        }
+
         /// <summary>Reject a ZIP entry whose declared uncompressed size is
         /// implausible, before any code allocates memory sized off it.</summary>
         public static void ValidateEntrySize(ZipArchiveEntry entry)


### PR DESCRIPTION
## Summary

Companion to #98 (Python) and #99 (TypeScript) - ports the same feature to .NET. No parser in this repo had ever opened `meta/meta.dat` inside the VFF ZIP container. It uses the exact same low-level TLV framing as `model.dat` (2-byte tag + 4-byte little-endian length + payload), but as one flat, non-recursive record list wrapped in a single outer record (tag `0x6400`/`"6400"`). Tag `0x6D00`/`"6D00"` carries the model's unit-system string as plain text (`"Millimeter"` in the real fixture).

## Changes

- `Vff.cs`: added `ReadMetaUnits(byte[])`, reusing the existing `Tlv.ParseFlat`/`Tlv.FindFlat` helpers (already used elsewhere for flat TLV payloads) rather than writing a new byte-scanner from scratch.
- `Core.cs`: added `Units` to `RawParsed`; in `FullParse`, after the TLV walk completes, look up the `"meta/meta.dat"` ZIP entry, run it through the existing `Vff.ValidateEntrySize` decompression-bomb guard (same guard already applied to `model.dat` and material/style XML entries), and call `ReadMetaUnits` on its bytes.
- `Legacy.cs`: legacy (pre-2021 MFC) files carry no `meta/meta.dat` container - that's a VFF/ZIP-only construct - so `Units` stays `null` on that path.
- `Model.cs` / `Parser.cs`: added `string? Units` to the public `SkpModel`, wired from `RawParsed.Units`.

## Test plan

- [x] New `MetaUnitsTests.cs` exercises `Vff.ReadMetaUnits` directly (internal, visible to `OpenSkp.Tests` via `InternalsVisibleTo`) against the exact 388-byte real fixture payload (byte-for-byte, not hand-crafted), a minimal synthetic record, an absent-tag case, and empty/truncated bytes.
- [x] Real end-to-end assertion in `IntegrationTests.cs`: `model.Units == "Millimeter"` for the real `Untitled.skp` fixture.
- [x] Real-fixture assertion in `LegacyTests.cs`: `model.Units` is `null` for the real legacy fixture.
- [x] Full suite: 37/37 passing.
- [x] Clean build, 0 warnings.