### PR TITLE
Parse meta/meta.dat for the model's unit-system string (Dart)

### DIFF
--- a/packages/dart/lib/src/core.dart
+++ b/packages/dart/lib/src/core.dart
@@ -12,6 +12,10 @@ import 'vff.dart';
 /// shape. Parser.dart converts this into the public SkpModel.
 class RawParsed {
   String version = 'unknown';
+
+  /// The model's unit-system string (e.g. "Millimeter"), read from
+  /// meta/meta.dat. Null for legacy files or when the tag isn't found.
+  String? units;
   final Map<String, (int, int, int)> layerColors = {};
   // Modern (VFF) files derive layers from Layer_<name>-prefixed materials,
   // which carry no visibility flag of their own - unlike legacy MFC files,
@@ -151,6 +155,19 @@ class Core {
       'Parse complete: ${defsDictRaw.length} defs (${(sw.elapsedMilliseconds / 1000).toStringAsFixed(2)}s)',
     );
 
+    // Units (meta/meta.dat) - VFF-only; legacy files carry no equivalent
+    // container.
+    String? units;
+    final metaDatEntry = zip.findFile('meta/meta.dat');
+    if (metaDatEntry != null) {
+      try {
+        Vff.validateEntrySize(metaDatEntry);
+        units = Vff.readMetaUnits(metaDatEntry.content);
+      } catch (_) {
+        units = null;
+      }
+    }
+
     if (!layerIdToName.containsKey(1)) {
       layerIdToName[1] = 'Layer0';
     }
@@ -163,6 +180,7 @@ class Core {
 
     return RawParsed()
       ..version = version
+      ..units = units
       ..layerColors.addAll(layerColors)
       ..layerHidden.addAll(layerHidden)
       ..layerIdToName.addAll(layerIdToName)

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -1319,6 +1319,10 @@ class Legacy {
 
     return RawParsed()
       ..version = version
+      // Legacy (pre-2021 MFC) files carry no meta/meta.dat container -
+      // that's a VFF/ZIP-only construct - so there is no known source for
+      // the model's unit-system string here.
+      ..units = null
       ..layerColors.addAll(layerColors)
       ..layerHidden.addAll(layerHidden)
       ..layerIdToName.addAll(layerIdToName)

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -190,6 +190,12 @@ class Definition {
 class SkpModel {
   String version = 'unknown';
 
+  /// The model's unit-system string (e.g. "Millimeter"), read from
+  /// meta/meta.dat in modern (VFF) files. Null for legacy (pre-2021 MFC)
+  /// files, which carry no equivalent container, or when the tag isn't
+  /// found.
+  String? units;
+
   /// Component/group definitions keyed by their numeric TLV entity ID. The
   /// implicit root definition (Python's "ROOT" dict entry, which has no
   /// numeric ID) is exposed separately via [root] instead of living in this

--- a/packages/dart/lib/src/parser.dart
+++ b/packages/dart/lib/src/parser.dart
@@ -62,7 +62,9 @@ class SkpFile {
   SkpModel parse([ParseOptions? options]) {
     final parsed = _parseToRaw(options);
 
-    final model = SkpModel()..version = parsed.version;
+    final model = SkpModel()
+      ..version = parsed.version
+      ..units = parsed.units;
 
     for (final entry in parsed.defsDict.entries) {
       model.definitions[entry.key] = _buildDefinition(entry.key, entry.value);

--- a/packages/dart/lib/src/vff.dart
+++ b/packages/dart/lib/src/vff.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:archive/archive.dart';
 
 import 'errors.dart';
+import 'tlv.dart';
 
 /// Container-level helpers for the modern (2021+) VFF/ZIP .skp format:
 /// header validation, version-string extraction, and locating the embedded
@@ -93,6 +94,31 @@ class Vff {
   static const int _maxUncompressedEntryBytes = 16 * 1024 * 1024 * 1024; // 16 GB
   static const int _maxCompressionRatio = 1000;
   static const int _ratioCheckThresholdBytes = 1024 * 1024; // 1 MB
+
+  // meta/meta.dat uses the exact same low-level TLV framing as model.dat
+  // (2-byte tag + 4-byte little-endian length + payload), but as one flat,
+  // non-recursive record list wrapped in a single outer record (tag
+  // 0x6400/"6400"). Tag 0x6D00/"6D00" carries the model's unit-system
+  // string ("Millimeter" etc.) as plain text. Confirmed byte-for-byte
+  // against a real fixture - never opened by any parser in this codebase
+  // before.
+  static const String _metaWrapperTag = '6400';
+  static const String _metaUnitsTag = '6D00';
+
+  /// Extract the model's unit-system string from a VFF file's
+  /// meta/meta.dat contents, or null if the expected tags aren't found.
+  static String? readMetaUnits(Uint8List metaBytes) {
+    final records = Tlv.parseFlat(metaBytes);
+    final wrapper = Tlv.findFlat(records, _metaWrapperTag);
+    if (wrapper != null) {
+      return readMetaUnits(wrapper);
+    }
+    final units = Tlv.findFlat(records, _metaUnitsTag);
+    if (units != null) {
+      return Tlv.decodeUtf8(units);
+    }
+    return null;
+  }
 
   /// Reject a ZIP entry whose declared uncompressed size is implausible,
   /// before any code reads (and so decompresses/allocates for) its

--- a/packages/dart/test/integration_test.dart
+++ b/packages/dart/test/integration_test.dart
@@ -14,6 +14,7 @@ void main() {
     final model = SkpFile.open(fixture('Untitled.skp')).parse();
 
     expect(model.version, '{25.0.575}');
+    expect(model.units, 'Millimeter');
 
     expect(model.layers.length, 14);
     const expectedLayers = [

--- a/packages/dart/test/legacy_test.dart
+++ b/packages/dart/test/legacy_test.dart
@@ -27,6 +27,10 @@ void main() {
 
     expect(model.version, '{17.0.18899}');
 
+    // Units - legacy (pre-2021 MFC) files carry no meta/meta.dat
+    // container, so there is no known source for this.
+    expect(model.units, isNull);
+
     // Definitions - ROOT is exposed separately via model.root, so only the
     // two named component definitions show up here.
     expect(model.definitions.length, 2);

--- a/packages/dart/test/meta_units_test.dart
+++ b/packages/dart/test/meta_units_test.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:openskp/src/vff.dart';
+import 'package:test/test.dart';
+
+/// SkpModel.units - the model's unit-system string, read from
+/// meta/meta.dat in VFF files. Never opened by any parser before this
+/// (zero references to the filename anywhere in the codebase). Confirmed
+/// plaintext payload in a real fixture (Untitled.skp): meta.dat uses the
+/// same low-level TLV framing as model.dat (2-byte tag + 4-byte
+/// little-endian length + payload), one flat record list wrapped in a
+/// single outer record (tag 0x6400); tag 0x6D00 carries the units string
+/// as plain text.
+
+Uint8List _tlv(int tagLo, int tagHi, Uint8List payload) {
+  final out = Uint8List(6 + payload.length);
+  out[0] = tagLo;
+  out[1] = tagHi;
+  final bd = ByteData.sublistView(out);
+  bd.setUint32(2, payload.length, Endian.little);
+  out.setRange(6, 6 + payload.length, payload);
+  return out;
+}
+
+Uint8List _hexToBytes(String hex) {
+  final out = Uint8List(hex.length ~/ 2);
+  for (var i = 0; i < out.length; i++) {
+    out[i] = int.parse(hex.substring(i * 2, i * 2 + 2), radix: 16);
+  }
+  return out;
+}
+
+void main() {
+  test('extracts units from the exact real fixture bytes', () {
+    // The exact 388-byte meta/meta.dat payload from a real VFF fixture
+    // (Untitled.skp, SketchUp 25.0.575) - byte-for-byte, not hand-crafted.
+    final hex =
+        '6400' '7e010000'
+        '7500' '08000000' '${_hex('25.0.575')}'
+        '7600' '02000000' '1800'
+        '7700' '02000000' '0200'
+        '7300' '02000000' '0100'
+        '7400' '02000000' '1100'
+        '6600' '10000000' 'dcd4752a383d724783022fa29cda3224'
+        '6700' '2e000000' '2823' '28000000' '2923' '04000000' '04000000' '2a23' '18000000'
+            '${_hex('meta/model_thumbnail.png')}'
+        '6800' '30000000' '2823' '2a000000' '2923' '04000000' '04000000' '2a23' '1a000000'
+            '${_hex('meta/preview_thumbnail.png')}'
+        '6900' '01000000' '01'
+        '6a00' '00000000'
+        '6b00' '00000000'
+        '6c00' '00000000'
+        '6e00' '00000000'
+        '7100' '01000000' '00'
+        '7900' '01000000' '00'
+        '7200' '01000000' '00'
+        '6d00' '0a000000' '${_hex('Millimeter')}'
+        '7000' '01000000' '01'
+        '6f00' '27000000' '${_hex("E:/Devs/TEst/Skp Test/ref2/Untitled.skp")}'
+        '7800' '52000000'
+            'c800' '4c000000'
+            'c900' '46000000'
+            'ca00' '40000000'
+            'cb00' '22000000' '${_hex('SketchUp Client (Windows) 25.0.575')}'
+        'cc00' '04000000' '23c5326a'
+        'cd00' '08000000' 'ec443dc9b4db9877';
+
+    final bytes = _hexToBytes(hex);
+
+    expect(Vff.readMetaUnits(bytes), 'Millimeter');
+  });
+
+  test('extracts units from a minimal synthetic record', () {
+    final inner = _tlv(0x6d, 0x00, utf8.encode('Inches'));
+    final outer = _tlv(0x64, 0x00, inner);
+    expect(Vff.readMetaUnits(outer), 'Inches');
+  });
+
+  test('returns null when the units tag is absent', () {
+    final inner = _tlv(0x75, 0x00, utf8.encode('25.0.575'));
+    final outer = _tlv(0x64, 0x00, inner);
+    expect(Vff.readMetaUnits(outer), isNull);
+  });
+
+  test('returns null for empty or truncated bytes', () {
+    expect(Vff.readMetaUnits(Uint8List(0)), isNull);
+    expect(Vff.readMetaUnits(Uint8List.fromList([1, 2, 3])), isNull);
+  });
+}
+
+String _hex(String s) {
+  final buf = StringBuffer();
+  for (final b in utf8.encode(s)) {
+    buf.write(b.toRadixString(16).padLeft(2, '0'));
+  }
+  return buf.toString();
+}


### PR DESCRIPTION
## Summary

Companion to #98 (Python), #99 (TypeScript), and #100 (.NET) - ports the same feature to Dart. No parser in this repo had ever opened `meta/meta.dat` inside the VFF ZIP container. It uses the exact same low-level TLV framing as `model.dat` (2-byte tag + 4-byte little-endian length + payload), but as one flat, non-recursive record list wrapped in a single outer record (tag `0x6400`/`"6400"`). Tag `0x6D00`/`"6D00"` carries the model's unit-system string as plain text (`"Millimeter"` in the real fixture).

## Changes

- `vff.dart`: added `readMetaUnits(Uint8List)`, reusing the existing `Tlv.parseFlat`/`Tlv.findFlat` helpers (already used elsewhere for flat TLV payloads) rather than writing a new byte-scanner from scratch.
- `core.dart`: added `units` to `RawParsed`; in `fullParse`, after the TLV walk completes, look up the `"meta/meta.dat"` ZIP entry, run it through the existing `Vff.validateEntrySize` decompression-bomb guard (same guard already applied to `model.dat` and material/style XML entries), and call `readMetaUnits` on its bytes.
- `legacy.dart`: legacy (pre-2021 MFC) files carry no `meta/meta.dat` container - that's a VFF/ZIP-only construct - so `units` stays `null` on that path.
- `model.dart` / `parser.dart`: added `String? units` to the public `SkpModel`, wired from `RawParsed.units`.

## Test plan

- [x] New `meta_units_test.dart` exercises `Vff.readMetaUnits` directly against the exact 388-byte real fixture payload (byte-for-byte, not hand-crafted), a minimal synthetic record, an absent-tag case, and empty/truncated bytes.
- [x] Real end-to-end assertion in `integration_test.dart`: `model.units == 'Millimeter'` for the real `Untitled.skp` fixture.
- [x] Real-fixture assertion in `legacy_test.dart`: `model.units` is `null` for the real legacy fixture.
- [x] Full suite: 36/36 passing.
- [x] `dart analyze` clean.