### PR TITLE
Parse meta/meta.dat for the model's unit-system string (C++)

### DIFF
--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -125,6 +125,11 @@ struct Definition {
 class OPENSKP_EXPORT SkpModel {
  public:
   std::string version{"unknown"};
+  // The model's unit-system string (e.g. "Millimeter"), read from
+  // meta/meta.dat in modern (VFF) files. Unset for legacy (pre-2021 MFC)
+  // files, which carry no equivalent container, or when the tag isn't
+  // found.
+  std::optional<std::string> units;
   std::map<EntityId, Definition> definitions;
   std::vector<Layer> layers;
   std::deque<Material> materials;

--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -271,6 +271,13 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
     if (i % progress_interval == 0 || i + 1 == total)
       emit_progress(o, ParseStage::tlv_walk, i + 1, total);
   }
+  // Units (meta/meta.dat) - VFF-only; legacy files carry no equivalent
+  // container.
+  try {
+    if (auto meta = zip.get("meta/meta.dat")) p.units = read_meta_units(*meta);
+  } catch (...) {
+    p.units = std::nullopt;
+  }
   if (!p.layer_id_to_name.count(1)) p.layer_id_to_name[1] = "Layer0";
   if (!p.layer_colors.count("Layer0")) p.layer_colors["Layer0"] = {136, 136, 136};
   if (!p.layer_hidden.count("Layer0")) p.layer_hidden["Layer0"] = false;

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -90,6 +90,9 @@ struct RawStyle {
 
 struct RawParsed {
   std::string version{"unknown"};
+  // The model's unit-system string (e.g. "Millimeter"), read from
+  // meta/meta.dat. Unset for legacy files or when the tag isn't found.
+  std::optional<std::string> units;
   std::map<std::string, Color3> layer_colors;
   // Modern (VFF) files derive layers from Layer_<name>-prefixed materials,
   // which carry no visibility flag of their own - unlike legacy MFC files,
@@ -112,6 +115,7 @@ double read_f64(const ByteBuffer&, std::size_t);
 std::uint64_t parse_varint(const ByteBuffer&, std::size_t, std::size_t);
 std::vector<TlvNode> parse_tlv_recursive(const ByteBuffer&, std::size_t, std::size_t);
 std::vector<std::pair<std::string, ByteBuffer>> parse_flat(const ByteBuffer&);
+std::optional<std::string> read_meta_units(const ByteBuffer&);
 std::string extract_version(const ByteBuffer&);
 bool valid_header(const ByteBuffer&);
 bool is_legacy(const ByteBuffer&);

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -662,6 +662,9 @@ RawParsed parse_legacy(const ByteBuffer& data, const ParseOptions& o) {
            "Parsing legacy MFC container (" + std::to_string(data.size()) + " bytes)");
   RawParsed out;
   out.version = extract_version(data);
+  // Legacy (pre-2021 MFC) files carry no meta/meta.dat container - that's
+  // a VFF/ZIP-only construct - so there is no known source for the
+  // model's unit-system string here (out.units stays unset).
   try {
     std::string ascii;
     for (size_t i = 0; i < std::min<size_t>(96, data.size()); ++i)

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -70,6 +70,7 @@ static Definition definition(EntityId id, RawDefinition&& r) {
 SkpModel build_model(RawParsed&& p) {
   SkpModel m;
   m.version = std::move(p.version);
+  m.units = std::move(p.units);
   auto resolve_layers = [&](RawDefinition& d) {
     for (auto& i : d.builder.instances)
       if (!i.layer.empty()) try {

--- a/packages/cpp/src/vff.cpp
+++ b/packages/cpp/src/vff.cpp
@@ -22,6 +22,31 @@ std::string extract_version(const ByteBuffer& d) {
   return a != std::string::npos && b != std::string::npos ? s.substr(a, b - a + 1) : "unknown";
 }
 
+namespace {
+// meta/meta.dat uses the exact same low-level TLV framing as model.dat
+// (2-byte tag + 4-byte little-endian length + payload), but as one flat,
+// non-recursive record list wrapped in a single outer record (tag
+// 0x6400/"6400"). Tag 0x6D00/"6D00" carries the model's unit-system
+// string ("Millimeter" etc.) as plain text. Confirmed byte-for-byte
+// against a real fixture - never opened by any parser in this codebase
+// before.
+constexpr const char* kMetaWrapperTag = "6400";
+constexpr const char* kMetaUnitsTag = "6D00";
+}  // namespace
+
+// Extract the model's unit-system string from a VFF file's meta/meta.dat
+// contents, or nullopt if the expected tags aren't found.
+std::optional<std::string> read_meta_units(const ByteBuffer& meta_bytes) {
+  auto records = parse_flat(meta_bytes);
+  for (auto& [tag, body] : records) {
+    if (tag == kMetaWrapperTag) return read_meta_units(body);
+  }
+  for (auto& [tag, body] : records) {
+    if (tag == kMetaUnitsTag) return std::string(body.begin(), body.end());
+  }
+  return std::nullopt;
+}
+
 bool is_legacy(const ByteBuffer& d) {
   if (!valid_header(d)) return false;
   auto v = extract_version(d);

--- a/packages/cpp/tests/meta_units_test.cpp
+++ b/packages/cpp/tests/meta_units_test.cpp
@@ -1,0 +1,126 @@
+#include <gtest/gtest.h>
+
+#include <openskp/openskp.hpp>
+
+#include "internal.hpp"
+#include "test_helpers.hpp"
+
+// SkpModel::units - the model's unit-system string, read from
+// meta/meta.dat in VFF files. Never opened by any parser before this
+// (zero references to the filename anywhere in the codebase). Confirmed
+// plaintext payload in a real fixture (Untitled.skp): meta.dat uses the
+// same low-level TLV framing as model.dat (2-byte tag + 4-byte
+// little-endian length + payload), one flat record list wrapped in a
+// single outer record (tag 0x6400); tag 0x6D00 carries the units string
+// as plain text.
+
+namespace openskp::test {
+namespace {
+
+ByteBuffer hex_to_bytes(const std::string& hex) {
+  ByteBuffer out(hex.size() / 2);
+  for (std::size_t i = 0; i < out.size(); ++i)
+    out[i] = static_cast<std::uint8_t>(std::stoul(hex.substr(i * 2, 2), nullptr, 16));
+  return out;
+}
+
+TEST(MetaUnits, ExtractsUnitsFromExactRealFixtureBytes) {
+  // The leading records of the real 388-byte meta/meta.dat payload from a
+  // real VFF fixture (Untitled.skp, SketchUp 25.0.575) - byte-for-byte, not
+  // hand-crafted - truncated right after the "6D00" units record, since
+  // read_meta_units returns as soon as it finds that tag and never needs
+  // the trailing save-path/thumbnail-metadata records that follow it in the
+  // real file.
+  const ByteBuffer payload = hex_to_bytes(
+      "6400"
+      "7e010000"
+      "7500"
+      "08000000"
+      "32352e302e353735"  // "25.0.575"
+      "7600"
+      "02000000"
+      "1800"
+      "7700"
+      "02000000"
+      "0200"
+      "7300"
+      "02000000"
+      "0100"
+      "7400"
+      "02000000"
+      "1100"
+      "6600"
+      "10000000"
+      "dcd4752a383d724783022fa29cda3224"
+      "6700"
+      "2e000000"
+      "2823"
+      "28000000"
+      "2923"
+      "04000000"
+      "04000000"
+      "2a23"
+      "18000000"
+      "6d6574612f6d6f64656c5f7468756d626e61696c2e706e67"  // "meta/model_thumbnail.png"
+      "6800"
+      "30000000"
+      "2823"
+      "2a000000"
+      "2923"
+      "04000000"
+      "04000000"
+      "2a23"
+      "1a000000"
+      "6d6574612f707265766965775f7468756d626e61696c2e706e67"  // "meta/preview_thumbnail.png"
+      "6900"
+      "01000000"
+      "01"
+      "6a00"
+      "00000000"
+      "6b00"
+      "00000000"
+      "6c00"
+      "00000000"
+      "6e00"
+      "00000000"
+      "7100"
+      "01000000"
+      "00"
+      "7900"
+      "01000000"
+      "00"
+      "7200"
+      "01000000"
+      "00"
+      "6d00"
+      "0a000000"
+      "4d696c6c696d65746572");  // "Millimeter"
+
+  auto result = read_meta_units(payload);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "Millimeter");
+}
+
+TEST(MetaUnits, ExtractsUnitsFromMinimalSyntheticRecord) {
+  auto inner = tlv("6D00", bytes("Inches"));
+  auto outer = tlv("6400", inner);
+
+  auto result = read_meta_units(outer);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(*result, "Inches");
+}
+
+TEST(MetaUnits, ReturnsNulloptWhenUnitsTagAbsent) {
+  auto inner = tlv("7500", bytes("25.0.575"));
+  auto outer = tlv("6400", inner);
+
+  EXPECT_FALSE(read_meta_units(outer).has_value());
+}
+
+TEST(MetaUnits, ReturnsNulloptForEmptyOrTruncatedBytes) {
+  EXPECT_FALSE(read_meta_units(ByteBuffer{}).has_value());
+  EXPECT_FALSE(read_meta_units(ByteBuffer{1, 2, 3}).has_value());
+}
+
+}  // namespace
+}  // namespace openskp::test

--- a/packages/cpp/tests/parser_test.cpp
+++ b/packages/cpp/tests/parser_test.cpp
@@ -14,6 +14,8 @@ namespace {
 TEST(Parser, ModernUntitled) {
   auto model = SkpFile::open(test::fixture("Untitled.skp")).parse();
   EXPECT_EQ(model.version, "{25.0.575}");
+  ASSERT_TRUE(model.units.has_value());
+  EXPECT_EQ(*model.units, "Millimeter");
   EXPECT_EQ(model.layers.size(), 14);
   EXPECT_EQ(model.materials.size(), 15);
   EXPECT_EQ(model.definitions.size(), 46);
@@ -105,6 +107,9 @@ TEST(Parser, LegacyMatchesReference) {
   auto file = SkpFile::open(test::fixture("capilla_quiroz_v17.skp"));
   auto model = file.parse();
   EXPECT_EQ(model.version, "{17.0.18899}");
+  // Legacy (pre-2021 MFC) files carry no meta/meta.dat container, so there
+  // is no known source for the model's unit-system string.
+  EXPECT_FALSE(model.units.has_value());
   ASSERT_EQ(model.definitions.size(), 2);
 
   const auto& puerta = model.definitions.at(40);


### PR DESCRIPTION
## Summary

Companion to #98 (Python), #99 (TypeScript), #100 (.NET), and #101 (Dart) - ports the same feature to C++. No parser in this repo had ever opened `meta/meta.dat` inside the VFF ZIP container. It uses the exact same low-level TLV framing as `model.dat` (2-byte tag + 4-byte little-endian length + payload), but as one flat, non-recursive record list wrapped in a single outer record (tag `0x6400`/`"6400"`). Tag `0x6D00`/`"6D00"` carries the model's unit-system string as plain text (`"Millimeter"` in the real fixture).

## Changes

- `vff.cpp`: added `read_meta_units(const ByteBuffer&)`, reusing the existing `parse_flat()` helper (already used elsewhere for flat TLV payloads, e.g. the D307 display-flags lookups) rather than writing a new byte-scanner from scratch.
- `internal.hpp`: added `units` (`std::optional<std::string>`) to `RawParsed`; declared `read_meta_units`.
- `core.cpp`: in `full_parse`, after the TLV walk completes, look up the `"meta/meta.dat"` ZIP entry via `Zip::get` (which already runs every entry through the existing decompression-bomb size/ratio guard before returning it - the same guard already applied to `model.dat` and material/style XML entries) and call `read_meta_units` on its bytes.
- `legacy.cpp`: legacy (pre-2021 MFC) files carry no `meta/meta.dat` container - that's a VFF/ZIP-only construct - so `RawParsed::units` stays unset (default-constructed `nullopt`) on that path.
- `model.hpp` / `model.cpp`: added `std::optional<std::string> units` to the public `SkpModel`, wired from `RawParsed::units` in `build_model()`.

## Test plan

- [x] New `meta_units_test.cpp` exercises `read_meta_units` directly against the leading records of the real 388-byte fixture payload (byte-for-byte, truncated right after the units record since the function returns as soon as it's found), a minimal synthetic record (built with the existing `tlv()`/`bytes()` test helpers), an absent-tag case, and empty/truncated bytes.
- [x] Real end-to-end assertions added to `parser_test.cpp`: `ModernUntitled` now checks `model.units == "Millimeter"` for the real `Untitled.skp` fixture, and `LegacyMatchesReference` checks `model.units` has no value for the real legacy fixture.
- [x] `clang-format` run locally against every changed file.
- [ ] **Could not compile/run locally** - this environment has no C++ toolchain (no cmake/g++/clang++/cl available). CI (GCC/Clang/MSVC + sanitizers, plus the format check) is the actual correctness gate for this PR, consistent with every other C++ PR in this series.