### PR TITLE
Fix legacy dynamic-component property extraction (Python)

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -624,7 +624,7 @@ def _read_definition(ar, r):
 
 def _read_instance(ar, r):
     cls = ar.current_class
-    _preamble(ar, r)
+    pre = _preamble(ar, r)
     db = _drawbase(ar, r)
     ds, dn, _ = ar.read_object(r, expect='CComponentDefinition')
     if dn != 'CComponentDefinition':
@@ -641,7 +641,7 @@ def _read_instance(ar, r):
     else:
         guid = b''
     return {'k': 'instance', 'db': db, 'def': ds, 'xf': xf,
-            'name': name, 'guid': guid.hex().upper()}
+            'name': name, 'guid': guid.hex().upper(), 'attrs': pre['attrs']}
 
 
 _READERS = {
@@ -829,6 +829,46 @@ def _walk_model(data: bytes, ver: int, start: int, mat_count: int,
     return ar, root, layers, materials
 
 
+# ── legacy dynamic-component properties ─────────────────────────────────
+
+# SketchUp's Dynamic Components extension stores its data in an attribute
+# dictionary literally named "dynamic_attributes" - a stable, publicly
+# documented part of the SketchUp Ruby API
+# (Entity#attribute_dictionary("dynamic_attributes")). The legacy walker
+# already fully decodes an entity's CAttributeContainer into typed
+# (dict-name, {key: value}) pairs via _read_attr_container/_read_attr_named
+# for other purposes (CFaceTextureCoords lookup) - this just looks up that
+# one dictionary by name, mirroring what the VFF path's
+# _core.extract_dynamic_properties() does for D007/DC05 TLV data.
+_DYNAMIC_ATTRIBUTES_DICT_NAME = 'dynamic_attributes'
+
+
+def _stringify_attr_value(value):
+    """Render an already-typed legacy attribute value (int, float, str,
+    list, 3-tuple, or None) as a string, matching the string-valued
+    Dict[str, str] contract the VFF path's extract_dynamic_properties()
+    produces."""
+    if value is None:
+        return ''
+    if isinstance(value, (list, tuple)):
+        return ','.join(_stringify_attr_value(v) for v in value)
+    return str(value)
+
+
+def _extract_legacy_dynamic_properties(attrs):
+    """Extract Dynamic Component attribute key/value pairs from a legacy
+    entity's already-parsed CAttributeContainer (see _DYNAMIC_ATTRIBUTES_
+    DICT_NAME above), or {} when the entity carries no attribute
+    container or no dynamic_attributes dictionary."""
+    if not isinstance(attrs, dict):
+        return {}
+    for name, value in attrs.get('children', []):
+        if name == _DYNAMIC_ATTRIBUTES_DICT_NAME and isinstance(value, dict):
+            entries = value.get('entries', {})
+            return {k: _stringify_attr_value(v) for k, v in entries.items()}
+    return {}
+
+
 # ── adapter to the full_parse dict shape ────────────────────────────────
 
 class _Builder:
@@ -881,7 +921,8 @@ def _fill_builder(builder, ents, slots):
                 'material_id': v['db']['mat'] or None,
                 'layer_id': v['db']['layer'] or None,
                 'hidden': bool(v['db']['hidden']),
-                'children': []})
+                'children': [],
+                'properties': _extract_legacy_dynamic_properties(v.get('attrs'))})
 
 
 def _add_edge(builder, slot, e, slots):

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -430,7 +430,12 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
 
             l_name = parent_layer
             inst_color = inherited_color
-            properties: Dict[str, str] = {}
+            # Legacy (pre-2021 MFC) instances carry a precomputed
+            # "properties" dict (see legacy._extract_legacy_dynamic_
+            # properties) - VFF instances don't set this key at all, so
+            # this stays {} for them and gets overwritten below via the
+            # D007/DC05 TLV walk instead.
+            properties: Dict[str, str] = dict(inst.get("properties") or {})
 
             d007 = next((c for c in inst["children"] if c["tag"] == "D007"), None)
             if d007:

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -1451,6 +1451,89 @@ class TestLegacyRealFile:
         assert all(isinstance(k, int) for k in model.definitions)
 
 
+class TestLegacyDynamicProperties:
+    """Legacy (pre-2021 MFC) instances now carry their already-parsed
+    ``CAttributeContainer`` through to ``build_scene()``, instead of it
+    being read (advancing the byte cursor correctly) and then silently
+    discarded. ``_read_instance`` was calling ``_preamble(ar, r)`` and
+    dropping its return value - the exact same "already-decoded-but-
+    discarded" shape as the Tier 2 layer/face/instance-hidden fixes, just
+    one level deeper (a whole sub-object tree instead of a single byte).
+
+    SketchUp's Dynamic Components extension stores its data under a
+    dictionary literally named ``"dynamic_attributes"`` (stable, publicly
+    documented Ruby API: ``Entity#attribute_dictionary("dynamic_attributes")``
+    - not something reverse-engineered from a fixture). The real legacy
+    fixture available in this repo (``capilla_quiroz_v17.skp``, a plain
+    chapel model) has no Dynamic Component data at all - confirmed by
+    direct inspection: none of its 3 instances carry an attribute
+    container of any kind - so the dictionary-lookup logic itself can only
+    be verified with synthetic data here; the real fixture instead proves
+    the plumbing fix doesn't break or crash on entities that render no
+    attributes.
+    """
+
+    def test_stringify_scalar_values(self) -> None:
+        from openskp.legacy import _stringify_attr_value
+        assert _stringify_attr_value(None) == ""
+        assert _stringify_attr_value(42) == "42"
+        assert _stringify_attr_value(3.5) == "3.5"
+        assert _stringify_attr_value("width") == "width"
+
+    def test_stringify_list_and_tuple_values(self) -> None:
+        from openskp.legacy import _stringify_attr_value
+        assert _stringify_attr_value([1, 2, 3]) == "1,2,3"
+        assert _stringify_attr_value((1.0, 2.0, 3.0)) == "1.0,2.0,3.0"
+
+    def test_extracts_dynamic_attributes_dict_by_name(self) -> None:
+        from openskp.legacy import _extract_legacy_dynamic_properties
+        attrs = {
+            "k": "attrs",
+            "children": [
+                ("SU_DefinitionSet", {"k": "dict", "name": "SU_DefinitionSet", "entries": {"unrelated": 1}}),
+                ("dynamic_attributes", {
+                    "k": "dict", "name": "dynamic_attributes",
+                    "entries": {"width": 10.0, "_width_label": "Width", "count": 4},
+                }),
+            ],
+        }
+        props = _extract_legacy_dynamic_properties(attrs)
+        assert props == {"width": "10.0", "_width_label": "Width", "count": "4"}
+
+    def test_returns_empty_dict_when_no_dynamic_attributes_dict(self) -> None:
+        from openskp.legacy import _extract_legacy_dynamic_properties
+        attrs = {"k": "attrs", "children": [
+            ("SU_DefinitionSet", {"k": "dict", "name": "SU_DefinitionSet", "entries": {"a": 1}}),
+        ]}
+        assert _extract_legacy_dynamic_properties(attrs) == {}
+
+    def test_returns_empty_dict_for_no_attribute_container(self) -> None:
+        from openskp.legacy import _extract_legacy_dynamic_properties
+        assert _extract_legacy_dynamic_properties(None) == {}
+
+    import pathlib as _pathlib
+
+    FIXTURE = _pathlib.Path(__file__).parent / "fixtures" / "capilla_quiroz_v17.skp"
+
+    def test_real_legacy_fixture_wires_through_without_crashing(self) -> None:
+        if not self.FIXTURE.exists():
+            pytest.skip("legacy fixture not present")
+        from openskp.model import SkpFile
+        scene = SkpFile.open(str(self.FIXTURE)).build_scene()
+
+        def walk(node):
+            assert isinstance(node.properties, dict)
+            # This fixture carries no Dynamic Component data on any
+            # instance (verified by direct inspection of the raw
+            # CAttributeContainer reads) - properties stay empty, but the
+            # plumbing must not raise or silently drop the instance.
+            assert node.properties == {}
+            for child in node.children:
+                walk(child)
+
+        walk(scene.scene_hierarchy)
+
+
 # ── Scene baking (opt-in build_scene(), separate from parse()) ──────────
 
 


### PR DESCRIPTION
## Summary

Legacy (pre-2021 MFC) instances have produced empty `properties` for every single file, in every language that implements dynamic-property extraction at all, because `_read_instance()` was calling `_preamble(ar, r)` - which reads the instance's `CAttributeContainer`, correctly advancing the byte cursor - and then discarding the return value entirely. This is the exact same "already-decoded-but-discarded" shape as the earlier layer/face/instance-hidden fixes (#88-#97), just one level deeper: a whole parsed sub-object tree instead of a single byte.

Net effect before this fix: dynamic component data - door/window schedules, parametric furniture attributes, cost/quantity metadata - was unreachable for **every legacy file, in all 5 languages**, despite the feature reading as universally supported from the outside.

This PR fixes the legacy-side plumbing for Python only. TypeScript and C++ already implement the same VFF-side `extract_dynamic_properties`-equivalent and need the identical legacy-side fix as a follow-up. Dart and .NET never implemented the VFF-side extraction at all and need it ported from scratch as a separate follow-up.

## Changes

- `legacy.py`: `_read_instance` now captures `pre = _preamble(ar, r)` and includes `'attrs': pre['attrs']` in its returned dict (previously the call's result was never even assigned to a variable).
- `legacy.py`: added `_extract_legacy_dynamic_properties(attrs)`, which looks up the entity's attribute-container children for a dictionary named `"dynamic_attributes"` - the stable, publicly documented SketchUp Ruby API name for where the Dynamic Components extension stores its data (`Entity#attribute_dictionary("dynamic_attributes")`). The legacy walker already fully decodes `CAttributeContainer` -> `CAttributeNamed` trees for other purposes (`CFaceTextureCoords` lookup on faces) - this just adds the by-name lookup for instances. Added `_stringify_attr_value()` alongside it, since the legacy reader already produces fully-typed values (int/float/str/list/3-tuple) where the VFF path's `extract_dynamic_properties()` only ever sees strings - stringifying keeps the public `Dict[str, str]` contract identical between both format paths.
- `legacy.py`: `_fill_builder`'s instance branch now calls `_extract_legacy_dynamic_properties(v.get('attrs'))` and stores the result under a new `'properties'` key on the raw instance dict.
- `scene.py`: `build_scene()`'s per-instance loop now seeds `properties` from `inst.get("properties")` before the existing D007/DC05 TLV walk runs. VFF instances never set this key, so this is `{}` for them and the existing extraction overwrites it unchanged - **zero behavior change on the already-working VFF path**. Legacy instances now have it pre-populated, and their D007 lookup already returns nothing (their `"children"` list is unrelated to this), so the precomputed value survives through to the final `SceneNode`.

## Test plan

- [x] New `TestLegacyDynamicProperties` class covers `_stringify_attr_value` (scalars, lists, tuples, `None`), `_extract_legacy_dynamic_properties` (dictionary found by name, absent dictionary, no attribute container at all), and a real-fixture regression test against `capilla_quiroz_v17.skp` confirming the plumbing doesn't crash end-to-end through `build_scene()`.
- [x] **Honest disclosure**: that fixture (a plain chapel model) has no Dynamic Component data on any of its 3 instances - confirmed by direct inspection of the raw attribute-container reads before writing this fix. The dictionary-lookup logic itself is verified with synthetic data only; no real fixture with actual Dynamic Component attributes was available to validate against end-to-end.
- [x] Full suite: 117/117 passing.
- [x] `ruff check src/ tests/` clean.