### PR TITLE
Fix legacy dynamic-component property extraction (TypeScript)

### DIFF
--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -12,6 +12,11 @@ export interface GeometryBuilderInstance {
   layerId?: number | null;
   hidden?: boolean;
   children: TlvNode[];
+  /** Dynamic Component properties precomputed for legacy (pre-2021 MFC)
+   * instances (see legacy.ts's extractLegacyDynamicProperties) - VFF
+   * instances don't set this, since their properties come from a lazy
+   * D007/DC05 TLV walk over `children` instead (see model.ts). */
+  properties?: Record<string, string>;
 }
 
 export interface GeometryBuilderFace {

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -456,6 +456,44 @@ function readAttrNamed(ar: Archive, r: R): any {
   return { k: 'dict', name: dictname, entries };
 }
 
+// SketchUp's Dynamic Components extension stores its data in an attribute
+// dictionary literally named "dynamic_attributes" - a stable, publicly
+// documented part of the SketchUp Ruby API
+// (Entity#attribute_dictionary("dynamic_attributes")). readAttrContainer/
+// readAttrNamed above already fully decode an entity's
+// CAttributeContainer into typed (dict-name, {key: value}) pairs for
+// other purposes (CFaceTextureCoords lookup on faces) - this just looks
+// up that one dictionary by name, mirroring what the VFF path's
+// extractDynamicProperties() (geometry.ts) does for D007/DC05 TLV data.
+const DYNAMIC_ATTRIBUTES_DICT_NAME = 'dynamic_attributes';
+
+/** Render an already-typed legacy attribute value (number, string, array,
+ * or null) as a string, matching the string-valued Record<string, string>
+ * contract the VFF path's extractDynamicProperties() produces. */
+export function stringifyAttrValue(value: any): string {
+  if (value === null || value === undefined) return '';
+  if (Array.isArray(value)) return value.map(stringifyAttrValue).join(',');
+  return String(value);
+}
+
+/** Extract Dynamic Component attribute key/value pairs from a legacy
+ * entity's already-parsed CAttributeContainer, or {} when the entity
+ * carries no attribute container or no dynamic_attributes dictionary. */
+export function extractLegacyDynamicProperties(attrs: any): Record<string, string> {
+  if (!attrs || typeof attrs !== 'object') return {};
+  for (const [name, value] of attrs.children || []) {
+    if (name === DYNAMIC_ATTRIBUTES_DICT_NAME && value && typeof value === 'object') {
+      const entries = value.entries || {};
+      const properties: Record<string, string> = {};
+      for (const key of Object.keys(entries)) {
+        properties[key] = stringifyAttrValue(entries[key]);
+      }
+      return properties;
+    }
+  }
+  return {};
+}
+
 function readLayer(ar: Archive, r: R): any {
   preamble(ar, r);
   const name = r.utf16();
@@ -762,7 +800,7 @@ function readDefinition(ar: Archive, r: R): any {
 
 function readInstance(ar: Archive, r: R): any {
   const cls = ar.currentClass;
-  preamble(ar, r);
+  const pre = preamble(ar, r);
   const db = drawbase(ar, r);
   const [ds, dn] = ar.readObject(r, 'CComponentDefinition');
   if (dn !== 'CComponentDefinition') {
@@ -778,7 +816,7 @@ function readInstance(ar: Archive, r: R): any {
   const schema = cls !== null ? ar.classSchema.get(cls) : undefined;
   const guid = schema === undefined || schema >= minSchema ? r.raw(16) : new Uint8Array(0);
 
-  return { k: 'instance', db, def: ds, xf, name, guid: toHex(guid) };
+  return { k: 'instance', db, def: ds, xf, name, guid: toHex(guid), attrs: pre.attrs };
 }
 
 const READERS: Record<string, (ar: Archive, r: R) => any> = {
@@ -1031,6 +1069,7 @@ function fillBuilder(builder: LegacyBuilder, ents: [number, string | null, any][
         layerId: v.db.layer || null,
         hidden: Boolean(v.db.hidden),
         children: [],
+        properties: extractLegacyDynamicProperties(v.attrs),
       });
     }
   }

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -671,7 +671,11 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
 
       let lName = parentLayer;
       let instColor = inheritedMaterialColor;
-      let properties: Record<string, string> = {};
+      // Legacy (pre-2021 MFC) instances carry a precomputed `properties`
+      // record (see legacy.ts's extractLegacyDynamicProperties) - VFF
+      // instances don't set this, so this stays {} for them and gets
+      // overwritten below via the D007/DC05 TLV walk instead.
+      let properties: Record<string, string> = { ...(inst.properties || {}) };
 
       // Layer and instance-material resolution use the fields already
       // extracted onto the builder instance (same source data for VFF -
@@ -691,9 +695,9 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         }
       }
 
-      // Dynamic properties are TLV-specific (no legacy equivalent decoded
-      // yet); inst.children is empty for legacy instances, so this is a
-      // no-op there.
+      // D007/DC05 TLV walk (VFF only); inst.children is always empty for
+      // legacy instances, so this is a no-op there and the precomputed
+      // `properties` seeded above survives unchanged.
       const d007 = inst.children.find((c) => c.tag === 'D007');
       if (d007) {
         try {

--- a/packages/typescript/tests/legacy-dynamic-properties.test.ts
+++ b/packages/typescript/tests/legacy-dynamic-properties.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { extractLegacyDynamicProperties, stringifyAttrValue } from '../src/legacy';
+import { buildScene } from '../src/index';
+
+/**
+ * Legacy (pre-2021 MFC) instances have produced empty properties for every
+ * single file, because readInstance() was calling preamble(ar, r) - which
+ * reads the instance's CAttributeContainer, correctly advancing the byte
+ * cursor - and then discarding the return value entirely. This is the same
+ * "already-decoded-but-discarded" shape as the earlier layer/face/
+ * instance-hidden fixes, just one level deeper: a whole parsed sub-object
+ * tree instead of a single byte.
+ *
+ * SketchUp's Dynamic Components extension stores its data under a
+ * dictionary literally named "dynamic_attributes" (stable, publicly
+ * documented Ruby API: Entity#attribute_dictionary("dynamic_attributes") -
+ * not something reverse-engineered from a fixture).
+ */
+
+describe('stringifyAttrValue', () => {
+  it('stringifies scalars', () => {
+    expect(stringifyAttrValue(null)).toBe('');
+    expect(stringifyAttrValue(undefined)).toBe('');
+    expect(stringifyAttrValue(42)).toBe('42');
+    expect(stringifyAttrValue(3.5)).toBe('3.5');
+    expect(stringifyAttrValue('width')).toBe('width');
+  });
+
+  it('stringifies arrays by joining', () => {
+    expect(stringifyAttrValue([1, 2, 3])).toBe('1,2,3');
+    expect(stringifyAttrValue([1.0, 2.0, 3.0])).toBe('1,2,3');
+  });
+});
+
+describe('extractLegacyDynamicProperties', () => {
+  it('extracts the dynamic_attributes dict by name', () => {
+    const attrs = {
+      k: 'attrs',
+      children: [
+        ['SU_DefinitionSet', { k: 'dict', name: 'SU_DefinitionSet', entries: { unrelated: 1 } }],
+        [
+          'dynamic_attributes',
+          {
+            k: 'dict',
+            name: 'dynamic_attributes',
+            entries: { width: 10.0, _width_label: 'Width', count: 4 },
+          },
+        ],
+      ],
+    };
+    expect(extractLegacyDynamicProperties(attrs)).toEqual({
+      width: '10',
+      _width_label: 'Width',
+      count: '4',
+    });
+  });
+
+  it('returns {} when no dynamic_attributes dict is present', () => {
+    const attrs = {
+      k: 'attrs',
+      children: [['SU_DefinitionSet', { k: 'dict', name: 'SU_DefinitionSet', entries: { a: 1 } }]],
+    };
+    expect(extractLegacyDynamicProperties(attrs)).toEqual({});
+  });
+
+  it('returns {} for no attribute container at all', () => {
+    expect(extractLegacyDynamicProperties(null)).toEqual({});
+    expect(extractLegacyDynamicProperties(undefined)).toEqual({});
+  });
+});
+
+describe('legacy real-fixture wiring', () => {
+  it('does not crash and reports {} for a fixture with no Dynamic Component data', () => {
+    // capilla_quiroz_v17.skp (a plain chapel model) has no Dynamic
+    // Component data on any of its 3 instances - confirmed by direct
+    // inspection of the raw attribute-container reads before writing this
+    // fix - so this proves the plumbing fix doesn't break or crash on
+    // entities that render no attributes, not the dictionary-lookup logic
+    // itself (covered above with synthetic data).
+    const filePath = path.join(__dirname, 'fixtures', 'capilla_quiroz_v17.skp');
+    const buf = fs.readFileSync(filePath);
+    const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    const scene = buildScene(arrayBuffer);
+
+    function walk(node: { properties: Record<string, string>; children: any[] }): void {
+      expect(node.properties).toEqual({});
+      for (const child of node.children) walk(child);
+    }
+    walk(scene.sceneHierarchy);
+  });
+});


### PR DESCRIPTION
## Summary

Companion to #103 (Python) - ports the identical legacy-side plumbing fix. Legacy (pre-2021 MFC) instances have produced empty `properties` for every single file, because `readInstance()` was calling `preamble(ar, r)` - which reads the instance's `CAttributeContainer`, correctly advancing the byte cursor - and then discarding the return value entirely. Same "already-decoded-but-discarded" shape as the earlier layer/face/instance-hidden fixes, just one level deeper: a whole parsed sub-object tree instead of a single byte.

## Changes

- `geometry.ts`: added an optional `properties?: Record<string, string>` field to `GeometryBuilderInstance`.
- `legacy.ts`: `readInstance` now captures `pre = preamble(ar, r)` and includes `attrs: pre.attrs` in its returned object (previously the call's result was never even assigned to a variable).
- `legacy.ts`: added `extractLegacyDynamicProperties(attrs)`, which looks up the entity's attribute-container children for a dictionary named `"dynamic_attributes"` - the stable, publicly documented SketchUp Ruby API name for where the Dynamic Components extension stores its data (`Entity#attribute_dictionary("dynamic_attributes")`). The legacy walker already fully decodes `CAttributeContainer` -> `CAttributeNamed` trees for other purposes (`CFaceTextureCoords` lookup on faces) - this just adds the by-name lookup for instances. Added `stringifyAttrValue()` alongside it, since the legacy reader already produces fully-typed values (number/string/array) where the VFF path's `extractDynamicProperties()` only ever sees strings.
- `legacy.ts`: the instance branch of the fill-builder loop now calls `extractLegacyDynamicProperties(v.attrs)` and stores the result on the new `properties` field.
- `model.ts`: `build_scene`'s per-instance loop now seeds `properties` from `inst.properties` before the existing D007/DC05 TLV walk runs. VFF instances never set this field, so it's `{}` for them and the existing extraction overwrites it unchanged - **zero behavior change on the already-working VFF path**.

## Test plan

- [x] New `legacy-dynamic-properties.test.ts` covers `stringifyAttrValue` (scalars, arrays), `extractLegacyDynamicProperties` (dictionary found by name, absent dictionary, no attribute container at all), and a real-fixture regression test against `capilla_quiroz_v17.skp` confirming the plumbing doesn't crash end-to-end through `buildScene()`.
- [x] **Honest disclosure**: as with the Python port, that fixture has no Dynamic Component data on any of its 3 instances (confirmed by direct inspection before writing the fix), so the dictionary-lookup logic itself is verified with synthetic data only.
- [x] Full suite: 65/65 passing.
- [x] `tsc --noEmit` clean.