### PR TITLE
Fix legacy dynamic-component property extraction (C++)

### DIFF
--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -110,6 +110,10 @@ struct V {
   // slot 0 is a legitimate real slot (the first object allocated in the
   // archive), so 0 can't double as a sentinel for "absent."
   std::optional<std::uint64_t> attrs;
+  // Only populated for "dict" (CAttributeNamed) entities: this
+  // dictionary's own key/value pairs, already stringified (see
+  // Archive::typed()).
+  std::map<std::string, std::string> entries;
   std::uint64_t tex_dib{};
   bool sense{};
   bool faces_camera{};
@@ -319,7 +323,7 @@ struct Archive {
       while (true) {
         auto key = r.utf16();
         if (key.empty()) break;
-        typed(r.u8());
+        v->entries[key] = typed(r.u8());
       }
       r.u32();
     } else if (n == "CLayer") {
@@ -508,7 +512,7 @@ struct Archive {
       v->faces_camera = gap.size() >= 9 && (gap[gap.size() - 9] & 1);
       object("CThumbnail");
     } else if (n == "CComponentInstance" || n == "CGroup") {
-      preamble();
+      v->attrs = preamble();
       v->k = "instance";
       draw(*v);
       auto q = object("CComponentDefinition");
@@ -527,34 +531,37 @@ struct Archive {
     return v;
   }
 
-  void typed(uint8_t t) {
+  // Reads one typed CAttributeNamed value off the stream and returns its
+  // string representation, matching the string-valued properties contract
+  // extract_legacy_dynamic_properties() (below) produces.
+  std::string typed(uint8_t t) {
     switch (t) {
       case 0:
-        return;
+        return "";
       case 4:
-        r.raw(4);
-        return;
+        return std::to_string(read_i32(r.raw(4), 0));
       case 6:
-        r.f64();
-        return;
+        return std::to_string(r.f64());
       case 7:
-        r.u8();
-        return;
+        return std::to_string(r.u8());
       case 9:
-        r.u32();
-        return;
+        return std::to_string(r.u32());
       case 10:
-        r.utf16();
-        return;
+        return r.utf16();
       case 11: {
         auto n = r.u32();
         if (n > 100000) throw std::runtime_error("attr array too large");
-        while (n--) typed(r.u8());
-        return;
+        std::string joined;
+        while (n--) {
+          if (!joined.empty()) joined += ",";
+          joined += typed(r.u8());
+        }
+        return joined;
       }
-      case 18:
-        r.f64s(3);
-        return;
+      case 18: {
+        auto v = r.f64s(3);
+        return std::to_string(v[0]) + "," + std::to_string(v[1]) + "," + std::to_string(v[2]);
+      }
       default:
         throw std::runtime_error("unknown legacy attribute type");
     }
@@ -588,6 +595,27 @@ void add_edge(GeometryBuilder& b, uint64_t s, const V& e,
   b.edges[s] = {EntityId(e.v1), EntityId(e.v2)};
   int f = (e.soft ? 8 : 0) | (e.smooth ? 16 : 0) | (e.hidden ? 1 : 0);
   if (f) b.edge_flags[s] = f;
+}
+
+// SketchUp's Dynamic Components extension stores its data in an attribute
+// dictionary literally named "dynamic_attributes" - a stable, publicly
+// documented part of the SketchUp Ruby API
+// (Entity#attribute_dictionary("dynamic_attributes")). CAttributeContainer/
+// CAttributeNamed reading above already fully decodes an entity's
+// attribute dictionaries for other purposes (CFaceTextureCoords lookup on
+// faces) - this just looks up that one dictionary by name, mirroring what
+// the VFF path's dynamic-properties extraction does for D007/DC05 TLV
+// data.
+std::map<std::string, std::string> extract_legacy_dynamic_properties(
+    std::optional<uint64_t> attrs_slot, const std::unordered_map<uint64_t, Entry>& slots) {
+  if (!attrs_slot) return {};
+  auto ai = slots.find(*attrs_slot);
+  if (ai == slots.end() || !ai->second.v) return {};
+  for (auto& ent : ai->second.v->ents) {
+    auto& ev = std::get<2>(ent);
+    if (ev && ev->k == "dict" && ev->name == "dynamic_attributes") return ev->entries;
+  }
+  return {};
 }
 
 void fill(GeometryBuilder& b,
@@ -651,6 +679,7 @@ void fill(GeometryBuilder& b,
       if (v->mat) i.material_id = v->mat;
       if (v->layer) i.layer = std::to_string(v->layer);
       i.hidden = v->hidden != 0;
+      i.properties = extract_legacy_dynamic_properties(v->attrs, slots);
       b.instances.push_back(std::move(i));
     }
   }

--- a/packages/cpp/tests/parser_test.cpp
+++ b/packages/cpp/tests/parser_test.cpp
@@ -110,6 +110,18 @@ TEST(Parser, LegacyMatchesReference) {
   // Legacy (pre-2021 MFC) files carry no meta/meta.dat container, so there
   // is no known source for the model's unit-system string.
   EXPECT_FALSE(model.units.has_value());
+  // Legacy instances now carry their already-parsed CAttributeContainer
+  // through to the public model (previously read off the wire, correctly
+  // advancing the cursor, then discarded). This fixture (a plain chapel
+  // model) has no Dynamic Component data on any instance - confirmed by
+  // direct inspection before writing the fix - so this proves the
+  // plumbing doesn't crash or silently drop instances, not the
+  // dynamic_attributes dictionary lookup itself (which has no legacy
+  // fixture available to exercise end-to-end).
+  for (const auto& kv : model.definitions) {
+    for (const auto& inst : kv.second.instances) EXPECT_TRUE(inst.properties.empty());
+  }
+  for (const auto& inst : model.root().instances) EXPECT_TRUE(inst.properties.empty());
   ASSERT_EQ(model.definitions.size(), 2);
 
   const auto& puerta = model.definitions.at(40);


### PR DESCRIPTION
## Summary

Companion to #103 (Python) and #104 (TypeScript) - ports the legacy-side plumbing fix. Legacy (pre-2021 MFC) instances have produced empty `properties` for every single file: `Archive::read()`'s `CComponentInstance`/`CGroup` branch was calling `preamble()` - which reads the instance's `CAttributeContainer`, correctly advancing the byte cursor - and then discarding the return value entirely. Same "already-decoded-but-discarded" shape as the earlier layer/face/instance-hidden fixes, just one level deeper.

**C++ had a second, independent gap** beyond the discarded `preamble()` call: `Archive::typed()` (which decodes one `CAttributeNamed` value) returned `void` and only ever advanced the cursor - it never captured the value it read, for any entity, anywhere. Python and TypeScript's equivalent readers already built a real `{key: value}` entries map; C++'s `CAttributeNamed` reader called `typed()` in a loop and threw every value away, so even resolving an attribute dictionary by name would have produced no data to extract.

## Changes

- `legacy.cpp`: added `std::map<std::string, std::string> entries` to `struct V` (only populated for `"dict"`-kind entities).
- `legacy.cpp`: `Archive::typed()` now returns `std::string` instead of `void`, stringifying each of the 7 attribute value types (int32, f64, u8, u32/time_t, utf16 string, array, 3D vector) - matching the string-valued properties contract the VFF path already produces. The array case recursively stringifies and comma-joins its elements.
- `legacy.cpp`: `CAttributeNamed` reading now does `v->entries[key] = typed(r.u8());` instead of discarding the result.
- `legacy.cpp`: `CComponentInstance`/`CGroup` reading now does `v->attrs = preamble();` instead of discarding it (same fix already applied to `CFace` for the `CFaceTextureCoords` lookup).
- `legacy.cpp`: added `extract_legacy_dynamic_properties()`, which resolves an instance's `attrs` slot through `Archive::slots` and looks for a `CAttributeNamed` dictionary named `"dynamic_attributes"` - the stable, publicly documented SketchUp Ruby API name for where the Dynamic Components extension stores its data (`Entity#attribute_dictionary("dynamic_attributes")`).
- `legacy.cpp`: `fill()`'s instance branch now calls this and sets `i.properties` on the `RawInstance` - already wired through to the public `SkpModel` via `model.cpp` (no changes needed there; C++ already has `RawInstance::properties`/`Instance::properties` from the existing VFF-side implementation).

## Test plan

- [x] Added a real-fixture assertion to `parser_test.cpp`'s `LegacyMatchesReference` confirming every instance (root and nested) has empty `properties` for `capilla_quiroz_v17.skp` - proving the plumbing doesn't crash or silently drop instances.
- [x] **Honest disclosure**: unlike Python/TypeScript, this could not be covered by a synthetic unit test for the dictionary-lookup logic itself: `V`/`Entry`/`Archive`/`extract_legacy_dynamic_properties` are all scoped inside `legacy.cpp`'s anonymous namespace (internal linkage), so no test file outside this translation unit can call them directly - only the public `parse_legacy()`/`SkpFile::open()` entry point is reachable, and no real fixture with actual Dynamic Component data was available to exercise it end-to-end.
- [x] `clang-format` run locally against every changed file.
- [ ] **Could not compile/run locally** - this environment has no C++ toolchain (no cmake/g++/clang++/cl available). CI (GCC/Clang/MSVC + sanitizers, plus the format check) is the actual correctness gate for this PR, consistent with every other C++ PR in this series.