### PR TITLE
Implement dynamic-component property extraction (Dart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ OpenSKP is the **first and only** open-source, cross-platform parser for SketchU
 | **Layers / Tags** | ⚠️ | Layer definitions with colors — on/off visibility state is read from the file internally but not yet exposed on the public model in any language |
 | **Materials & Textures** | ✅ | Material properties, colors, transparency, colorized materials, and embedded texture images |
 | **Styles** | ✅ | Front/back face colors for unpainted faces |
-| **Dynamic Components** | ⚠️ | Extracts dynamic component attribute key-value pairs for modern (2021+) files in Python, TypeScript, and C++ — not yet supported for legacy (2013–2020) files in any language, or for modern files in Dart/.NET |
+| **Dynamic Components** | ⚠️ | Extracts dynamic component attribute key-value pairs for both modern (2021+) and legacy (2013–2020) files in Python, TypeScript, Dart, and C++ — not yet supported in .NET |
 | **Observability** | ✅ | Opt-in progress reporting + structured, location-carrying parse errors — see [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
 | **Export to GLB / OBJ / JSON** | ⚠️ | GLB export is available in all five languages; OBJ and JSON metadata export are currently Python-only (JSON also in TypeScript) — see [Export capabilities](docs/DEVELOPER_GUIDE.md#export-capabilities) |
 | **Streaming / low-memory parsing** | ✅ | Peak memory bounded by the largest single definition, not the whole file — see [Memory architecture](docs/ARCHITECTURE.md#memory-architecture) |

--- a/packages/dart/README.md
+++ b/packages/dart/README.md
@@ -26,7 +26,7 @@ Enable mobile (iOS/Android), desktop, and web developers to parse and build 3D S
 - **TLV Binary Decoding**: Decodes SketchUp's internal Tag-Length-Value records.
 - **VFF ZIP Extractors**: Decompresses and validates VFF file containers to extract `model.dat` and material XML assets.
 - **Geometry & Hierarchy**: Recovers vertices, edges, face loops, component definitions, and nested instance transformations.
-- **Steelframer properties**: Reads custom dynamic component attribute values.
+- **Dynamic Component properties**: Reads custom dynamic component attribute values.
 
 ---
 

--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -28,6 +28,11 @@ class GeometryBuilderInstance {
   int? materialId;
   bool hidden = false;
   List<TlvNode> children = const [];
+  /// Dynamic Component properties precomputed for legacy (pre-2021 MFC)
+  /// instances (see legacy.dart's extractLegacyDynamicProperties) - VFF
+  /// instances don't set this, since their properties come from a lazy
+  /// D007/DC05 TLV walk over [children] instead (see scene.dart).
+  Map<String, String>? properties;
 }
 
 /// Accumulates the raw geometry extracted for one component definition (or
@@ -173,6 +178,40 @@ class Geometry {
     final t1527 = Tlv.findFlat(Tlv.parseFlat(t1327), '1527');
     if (t1527 == null || t1527.length != 72) return null;
     return [for (int i = 0; i < 9; i++) Tlv.readF64(t1527, i * 8)];
+  }
+
+  /// Dynamic Component key/value pairs from an instance's D007 attribute
+  /// container. Mirrors Python's _core.extract_dynamic_properties and
+  /// TypeScript's extractDynamicProperties: DC05's payload isn't part of
+  /// the main model.dat TLV tree (DC05 isn't a top-level container tag),
+  /// so it's re-parsed here with its own, more specific container-tag set
+  /// - within that tree, a B636 tag carries a property key and the AD38
+  /// tag immediately after it carries that property's value.
+  static const Set<String> _propContainerTags = {
+    'DD05', 'B536', 'B136', 'B236', 'B336', 'B036', 'A438',
+  };
+
+  static Map<String, String> extractDynamicProperties(TlvNode d007) {
+    final dc05 = d007.children.where((c) => c.tag == 'DC05').firstOrNull;
+    if (dc05 == null) return {};
+    final propElements =
+        Tlv.parseRecursive(dc05.payload, 0, dc05.payload.length, _propContainerTags);
+    final properties = <String, String>{};
+    String? currentKey;
+    void extractProps(List<TlvNode> nodes) {
+      for (final n in nodes) {
+        if (n.tag == 'B636') {
+          currentKey = utf8.decode(n.payload, allowMalformed: true);
+        } else if (n.tag == 'AD38' && currentKey != null) {
+          properties[currentKey!] = utf8.decode(n.payload, allowMalformed: true);
+          currentKey = null;
+        }
+        extractProps(n.children);
+      }
+    }
+
+    extractProps(propElements);
+    return properties;
   }
 
   static void extractGeometryFromNodes(

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -450,12 +450,14 @@ class InstanceRec {
   List<double> xf;
   String name;
   String guid;
+  AttrsRec? attrs;
   InstanceRec(
       {required this.db,
       this.def,
       required this.xf,
       required this.name,
-      required this.guid});
+      required this.guid,
+      this.attrs});
 }
 
 class LegacyReaders {
@@ -612,6 +614,42 @@ class LegacyReaders {
     }
     r.u32();
     return DictRec(dictname, entries);
+  }
+
+  // SketchUp's Dynamic Components extension stores its data in an
+  // attribute dictionary literally named "dynamic_attributes" - a stable,
+  // publicly documented part of the SketchUp Ruby API
+  // (Entity#attribute_dictionary("dynamic_attributes")). readAttrContainer/
+  // readAttrNamed above already fully decode an entity's
+  // CAttributeContainer into typed (dict-name, {key: value}) pairs for
+  // other purposes (CFaceTextureCoords lookup on faces) - this just looks
+  // up that one dictionary by name, mirroring what the VFF path's
+  // Geometry.extractDynamicProperties does for D007/DC05 TLV data.
+  static const String _dynamicAttributesDictName = 'dynamic_attributes';
+
+  /// Render an already-typed legacy attribute value (num, string, list, or
+  /// null) as a string, matching the string-valued Map<String, String>
+  /// contract the VFF path's Geometry.extractDynamicProperties produces.
+  static String stringifyAttrValue(Object? value) {
+    if (value == null) return '';
+    if (value is List) return value.map(stringifyAttrValue).join(',');
+    return value.toString();
+  }
+
+  /// Extract Dynamic Component attribute key/value pairs from a legacy
+  /// entity's already-parsed CAttributeContainer, or {} when the entity
+  /// carries no attribute container or no dynamic_attributes dictionary.
+  static Map<String, String> extractLegacyDynamicProperties(AttrsRec? attrs) {
+    if (attrs == null) return {};
+    for (final (name, value) in attrs.children) {
+      if (name == _dynamicAttributesDictName && value is DictRec) {
+        return {
+          for (final entry in value.entries.entries)
+            entry.key: stringifyAttrValue(entry.value)
+        };
+      }
+    }
+    return {};
   }
 
   static Object readLayer(Archive ar, LR r) {
@@ -909,7 +947,7 @@ class LegacyReaders {
 
   static Object readInstance(Archive ar, LR r) {
     final cls = ar.currentClass;
-    preamble(ar, r);
+    final pre = preamble(ar, r);
     final db = drawbase(ar, r);
     final (ds, dn, _) = ar.readObject(r, 'CComponentDefinition');
     if (dn != 'CComponentDefinition') {
@@ -927,7 +965,12 @@ class LegacyReaders {
         (schema == null || schema >= minSchema) ? r.raw(16) : Uint8List(0);
 
     return InstanceRec(
-        db: db, def: ds, xf: xf, name: name, guid: Tlv.toHexUpper(guid));
+        db: db,
+        def: ds,
+        xf: xf,
+        name: name,
+        guid: Tlv.toHexUpper(guid),
+        attrs: pre.attrs as AttrsRec?);
   }
 
   static final Map<String, LegacyReader> readers = {
@@ -1168,7 +1211,8 @@ class Legacy {
           ..matrix = List<double>.from(v.xf)
           ..materialId = v.db.mat != 0 ? v.db.mat : null
           ..hidden = v.db.hidden != 0
-          ..children = const []);
+          ..children = const []
+          ..properties = LegacyReaders.extractLegacyDynamicProperties(v.attrs));
       }
     }
   }

--- a/packages/dart/lib/src/scene.dart
+++ b/packages/dart/lib/src/scene.dart
@@ -436,7 +436,11 @@ class SceneBuilder {
 
         var lName = parentLayer;
         (int, int, int)? instColor = inheritedColor;
-        final properties = <String, String>{};
+        // Legacy (pre-2021 MFC) instances carry a precomputed `properties`
+        // map (see legacy.dart's extractLegacyDynamicProperties) - VFF
+        // instances don't set this, so this stays {} for them and gets
+        // overwritten below via the D007/DC05 TLV walk instead.
+        var properties = Map<String, String>.from(inst.properties ?? {});
 
         final d007 = inst.children.where((c) => c.tag == 'D007').firstOrNull;
         if (d007 != null) {
@@ -455,8 +459,11 @@ class SceneBuilder {
               if (mat != null) instColor = (mat.r, mat.g, mat.b);
             }
           }
-          // Dynamic properties (attribute dictionaries under D007) are not
-          // yet ported for Dart; left empty.
+          try {
+            properties = Geometry.extractDynamicProperties(d007);
+          } catch (_) {
+            // Ignore
+          }
         }
 
         final instName = (inst.name != null && inst.name!.isNotEmpty) ? inst.name! : 'Component_$refIdx';

--- a/packages/dart/test/dynamic_properties_test.dart
+++ b/packages/dart/test/dynamic_properties_test.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:openskp/openskp.dart';
+import 'package:openskp/src/geometry.dart';
+import 'package:openskp/src/legacy.dart';
+import 'package:openskp/src/tlv.dart';
+import 'package:test/test.dart';
+
+/// Dart never implemented Dynamic Component property extraction at all -
+/// neither the VFF-side D007/DC05/B636/AD38 TLV walk (Python/TypeScript/
+/// C++ already had it) nor the legacy-side attribute-container plumbing.
+/// This file covers both halves of that port in one go.
+///
+/// Legacy (pre-2021 MFC) instances have produced empty properties for
+/// every single file, because LegacyReaders.readInstance was calling
+/// preamble(ar, r) - which reads the instance's CAttributeContainer,
+/// correctly advancing the byte cursor - and then discarding the return
+/// value entirely. Same "already-decoded-but-discarded" shape as the
+/// earlier layer/face/instance-hidden fixes, just one level deeper.
+///
+/// SketchUp's Dynamic Components extension stores its data under a
+/// dictionary literally named "dynamic_attributes" (stable, publicly
+/// documented Ruby API: Entity#attribute_dictionary("dynamic_attributes") -
+/// not something reverse-engineered from a fixture).
+
+Uint8List _tlvBytes(String tagHex, Uint8List payload) {
+  final tag = [
+    int.parse(tagHex.substring(0, 2), radix: 16),
+    int.parse(tagHex.substring(2, 4), radix: 16),
+  ];
+  final out = Uint8List(6 + payload.length);
+  out[0] = tag[0];
+  out[1] = tag[1];
+  final bd = ByteData.sublistView(out);
+  bd.setUint32(2, payload.length, Endian.little);
+  out.setRange(6, 6 + payload.length, payload);
+  return out;
+}
+
+Uint8List _concatBytes(List<Uint8List> parts) {
+  final total = parts.fold<int>(0, (n, p) => n + p.length);
+  final out = Uint8List(total);
+  var offset = 0;
+  for (final p in parts) {
+    out.setRange(offset, offset + p.length, p);
+    offset += p.length;
+  }
+  return out;
+}
+
+void main() {
+  group('stringifyAttrValue', () {
+    test('stringifies scalars', () {
+      expect(LegacyReaders.stringifyAttrValue(null), '');
+      expect(LegacyReaders.stringifyAttrValue(42), '42');
+      expect(LegacyReaders.stringifyAttrValue(3.5), '3.5');
+      expect(LegacyReaders.stringifyAttrValue('width'), 'width');
+    });
+
+    test('stringifies lists by joining', () {
+      expect(LegacyReaders.stringifyAttrValue([1, 2, 3]), '1,2,3');
+      expect(LegacyReaders.stringifyAttrValue([1.0, 2.0, 3.0]), '1.0,2.0,3.0');
+    });
+  });
+
+  group('extractLegacyDynamicProperties', () {
+    test('extracts the dynamic_attributes dict by name', () {
+      final attrs = AttrsRec([
+        ('SU_DefinitionSet', DictRec('SU_DefinitionSet', {'unrelated': 1})),
+        (
+          'dynamic_attributes',
+          DictRec('dynamic_attributes', {'width': 10.0, '_width_label': 'Width', 'count': 4}),
+        ),
+      ]);
+      final props = LegacyReaders.extractLegacyDynamicProperties(attrs);
+      expect(props, {'width': '10.0', '_width_label': 'Width', 'count': '4'});
+    });
+
+    test('returns {} when no dynamic_attributes dict is present', () {
+      final attrs = AttrsRec([
+        ('SU_DefinitionSet', DictRec('SU_DefinitionSet', {'a': 1})),
+      ]);
+      expect(LegacyReaders.extractLegacyDynamicProperties(attrs), {});
+    });
+
+    test('returns {} for no attribute container at all', () {
+      expect(LegacyReaders.extractLegacyDynamicProperties(null), {});
+    });
+  });
+
+  group('Geometry.extractDynamicProperties (VFF-side, new in Dart)', () {
+    test('extracts a key/value pair from a DC05 payload', () {
+      final dc05Payload = _concatBytes([
+        _tlvBytes('B636', utf8.encode('width')),
+        _tlvBytes('AD38', utf8.encode('10')),
+      ]);
+      final dc05 = TlvNode(offset: 0, tag: 'DC05', size: dc05Payload.length, payload: dc05Payload);
+      final d007 = TlvNode(offset: 0, tag: 'D007', size: 0, children: [dc05]);
+
+      expect(Geometry.extractDynamicProperties(d007), {'width': '10'});
+    });
+
+    test('returns {} when D007 has no DC05 child', () {
+      final d007 = TlvNode(offset: 0, tag: 'D007', size: 0, children: const []);
+      expect(Geometry.extractDynamicProperties(d007), {});
+    });
+
+    test('returns {} for an empty DC05 payload', () {
+      final dc05 = TlvNode(offset: 0, tag: 'DC05', size: 0, payload: Uint8List(0));
+      final d007 = TlvNode(offset: 0, tag: 'D007', size: 0, children: [dc05]);
+      expect(Geometry.extractDynamicProperties(d007), {});
+    });
+  });
+
+  group('legacy real-fixture wiring', () {
+    test('does not crash and reports {} for a fixture with no Dynamic Component data', () {
+      // capilla_quiroz_v17.skp (a plain chapel model) has no Dynamic
+      // Component data on any of its 3 instances - confirmed by direct
+      // inspection of the raw attribute-container reads before writing
+      // this fix - so this proves the plumbing fix doesn't break or crash
+      // on entities that render no attributes, not the dictionary-lookup
+      // logic itself (covered above with synthetic data).
+      final fixturePath =
+          '${Directory.current.path}/test/fixtures/capilla_quiroz_v17.skp';
+      final scene = SkpFile.open(fixturePath).buildScene();
+
+      void walk(InstanceNode node) {
+        expect(node.properties, {});
+        for (final child in node.children) walk(child);
+      }
+
+      walk(scene.sceneHierarchy);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Dart never implemented Dynamic Component property extraction at all - neither the VFF-side D007/DC05/B636/AD38 TLV walk that Python/TypeScript/C++ already had, nor the legacy-side attribute-container plumbing fixed for those three languages in #103/#104/#105. This PR ports both halves in one go, since Dart had no partial implementation to build on top of.

## VFF side (new)

- `geometry.dart`: added `Geometry.extractDynamicProperties(TlvNode d007)`, a direct port of Python's `_core.extract_dynamic_properties` / TypeScript's `extractDynamicProperties`. DC05 isn't a top-level container tag in the main `model.dat` TLV tree, so its payload arrives as opaque bytes under D007 - this re-parses that payload with its own container-tag set (`DD05, B536, B136, B236, B336, B036, A438`) and walks the result for `B636` (key) / `AD38` (value) pairs.
- `geometry.dart`: added an optional `properties` field to `GeometryBuilderInstance`.
- `scene.dart`: `buildScene`'s per-instance loop now calls `Geometry.extractDynamicProperties(d007)` instead of leaving properties permanently empty with a "not yet ported for Dart" comment.

## Legacy side (same fix as #103/#104/#105)

- `legacy.dart`: `LegacyReaders.readInstance` now captures `pre = preamble(ar, r)` and includes it on the returned `InstanceRec` (previously the call's result was never even assigned to a variable) - the same "already-decoded-but-discarded" shape as the earlier layer/face/instance-hidden fixes.
- `legacy.dart`: added `LegacyReaders.extractLegacyDynamicProperties`, which looks up the entity's attribute-container children for a dictionary named `"dynamic_attributes"` - the stable, publicly documented SketchUp Ruby API name for where the Dynamic Components extension stores its data (`Entity#attribute_dictionary("dynamic_attributes")`). Dart's `CAttributeNamed` reader (`readAttrNamed`) already correctly builds a typed entries map (unlike C++, which had a second, independent bug here - see #105), so this just adds the by-name lookup.
- `legacy.dart`: the instance branch of the fill-builder loop now calls this and sets `properties` on the new `GeometryBuilderInstance` field.
- `scene.dart`: seeds `properties` from `inst.properties` before the D007/DC05 TLV walk runs, so legacy instances get their precomputed value and VFF instances get the lazy walk's result unchanged.

Also fixed `packages/dart/README.md`'s "Steelframer properties" line (flagged in the audit as almost certainly a miscopy of "Dynamic Component properties") and updated the top-level README's feature matrix to reflect Dart now having both VFF and legacy support.

## Test plan

- [x] New `dynamic_properties_test.dart` covers `stringifyAttrValue`, `extractLegacyDynamicProperties` (dictionary found by name, absent dictionary, no attribute container), `Geometry.extractDynamicProperties` (synthetic DC05 payload, no DC05 child, empty DC05 payload), and a real-fixture regression test against `capilla_quiroz_v17.skp` confirming the plumbing doesn't crash end-to-end through `buildScene()`.
- [x] **Honest disclosure**: as with the other ports, that fixture has no Dynamic Component data on any of its 3 instances (confirmed by direct inspection before writing the fix), so the dictionary-lookup logic itself is verified with synthetic data only.
- [x] Full suite: 45/45 passing.
- [x] `dart analyze` clean.