### PR TITLE
Implement dynamic-component property extraction (.NET)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ OpenSKP is the **first and only** open-source, cross-platform parser for SketchU
 | **Layers / Tags** | ⚠️ | Layer definitions with colors — on/off visibility state is read from the file internally but not yet exposed on the public model in any language |
 | **Materials & Textures** | ✅ | Material properties, colors, transparency, colorized materials, and embedded texture images |
 | **Styles** | ✅ | Front/back face colors for unpainted faces |
-| **Dynamic Components** | ⚠️ | Extracts dynamic component attribute key-value pairs for both modern (2021+) and legacy (2013–2020) files in Python, TypeScript, Dart, and C++ — not yet supported in .NET |
+| **Dynamic Components** | ✅ | Extracts dynamic component attribute key-value pairs for both modern (2021+) and legacy (2013–2020) files, in all five languages |
 | **Observability** | ✅ | Opt-in progress reporting + structured, location-carrying parse errors — see [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
 | **Export to GLB / OBJ / JSON** | ⚠️ | GLB export is available in all five languages; OBJ and JSON metadata export are currently Python-only (JSON also in TypeScript) — see [Export capabilities](docs/DEVELOPER_GUIDE.md#export-capabilities) |
 | **Streaming / low-memory parsing** | ✅ | Peak memory bounded by the largest single definition, not the whole file — see [Memory architecture](docs/ARCHITECTURE.md#memory-architecture) |

--- a/packages/dotnet/OpenSkp.Tests/DynamicPropertiesTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/DynamicPropertiesTests.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// .NET never implemented Dynamic Component property extraction at all -
+    /// neither the VFF-side D007/DC05/B636/AD38 TLV walk (Python/TypeScript/
+    /// C++/Dart already had it) nor the legacy-side attribute-container
+    /// plumbing. This file covers both halves of that port in one go.
+    ///
+    /// Legacy (pre-2021 MFC) instances have produced empty properties for
+    /// every single file, because LegacyReaders.ReadInstance was calling
+    /// Preamble(ar, r) - which reads the instance's CAttributeContainer,
+    /// correctly advancing the byte cursor - and then discarding the return
+    /// value entirely. Same "already-decoded-but-discarded" shape as the
+    /// earlier layer/face/instance-hidden fixes, just one level deeper.
+    ///
+    /// SketchUp's Dynamic Components extension stores its data under a
+    /// dictionary literally named "dynamic_attributes" (stable, publicly
+    /// documented Ruby API: Entity#attribute_dictionary("dynamic_attributes")
+    /// - not something reverse-engineered from a fixture).
+    /// </summary>
+    public class DynamicPropertiesTests
+    {
+        private static string FixturePath(string name) =>
+            Path.Combine(AppContext.BaseDirectory, "fixtures", name);
+
+        private static byte[] Tlv(string tagHex, byte[] payload)
+        {
+            var tag = new byte[] { Convert.ToByte(tagHex.Substring(0, 2), 16), Convert.ToByte(tagHex.Substring(2, 2), 16) };
+            var len = BitConverter.GetBytes((uint)payload.Length);
+            var result = new byte[6 + payload.Length];
+            Array.Copy(tag, 0, result, 0, 2);
+            Array.Copy(len, 0, result, 2, 4);
+            Array.Copy(payload, 0, result, 6, payload.Length);
+            return result;
+        }
+
+        [Fact]
+        public void StringifyAttrValue_HandlesScalars()
+        {
+            Assert.Equal("", LegacyReaders.StringifyAttrValue(null));
+            Assert.Equal("42", LegacyReaders.StringifyAttrValue(42));
+            Assert.Equal("width", LegacyReaders.StringifyAttrValue("width"));
+        }
+
+        [Fact]
+        public void StringifyAttrValue_JoinsLists()
+        {
+            var list = new List<object?> { 1, 2, 3 };
+            Assert.Equal("1,2,3", LegacyReaders.StringifyAttrValue(list));
+        }
+
+        [Fact]
+        public void ExtractLegacyDynamicProperties_FindsDictByName()
+        {
+            var dynamicDict = new DictRec
+            {
+                Name = "dynamic_attributes",
+                Entries = new Dictionary<string, object?> { ["width"] = 10.0, ["_width_label"] = "Width", ["count"] = 4 },
+            };
+            var otherDict = new DictRec { Name = "SU_DefinitionSet", Entries = new Dictionary<string, object?> { ["unrelated"] = 1 } };
+            var attrs = new AttrsRec
+            {
+                Children = new List<(string?, object?)> { ("SU_DefinitionSet", otherDict), ("dynamic_attributes", dynamicDict) },
+            };
+
+            var props = LegacyReaders.ExtractLegacyDynamicProperties(attrs);
+
+            Assert.Equal("10", props["width"]);
+            Assert.Equal("Width", props["_width_label"]);
+            Assert.Equal("4", props["count"]);
+        }
+
+        [Fact]
+        public void ExtractLegacyDynamicProperties_ReturnsEmptyWhenAbsent()
+        {
+            var attrs = new AttrsRec
+            {
+                Children = new List<(string?, object?)> { ("SU_DefinitionSet", new DictRec { Name = "SU_DefinitionSet" }) },
+            };
+            Assert.Empty(LegacyReaders.ExtractLegacyDynamicProperties(attrs));
+        }
+
+        [Fact]
+        public void ExtractLegacyDynamicProperties_ReturnsEmptyForNoAttributeContainer()
+        {
+            Assert.Empty(LegacyReaders.ExtractLegacyDynamicProperties(null));
+        }
+
+        [Fact]
+        public void ExtractDynamicProperties_ExtractsKeyValuePairFromDc05Payload()
+        {
+            var dc05Payload = new List<byte>();
+            dc05Payload.AddRange(Tlv("B636", Encoding.UTF8.GetBytes("width")));
+            dc05Payload.AddRange(Tlv("AD38", Encoding.UTF8.GetBytes("10")));
+            var dc05 = new TlvNode { Tag = "DC05", Payload = dc05Payload.ToArray() };
+            var d007 = new TlvNode { Tag = "D007", Children = new List<TlvNode> { dc05 } };
+
+            var props = Geometry.ExtractDynamicProperties(d007);
+
+            Assert.Equal("10", props["width"]);
+        }
+
+        [Fact]
+        public void ExtractDynamicProperties_ReturnsEmptyWhenNoDc05Child()
+        {
+            var d007 = new TlvNode { Tag = "D007", Children = new List<TlvNode>() };
+            Assert.Empty(Geometry.ExtractDynamicProperties(d007));
+        }
+
+        [Fact]
+        public void ExtractDynamicProperties_ReturnsEmptyForEmptyDc05Payload()
+        {
+            var dc05 = new TlvNode { Tag = "DC05", Payload = Array.Empty<byte>() };
+            var d007 = new TlvNode { Tag = "D007", Children = new List<TlvNode> { dc05 } };
+            Assert.Empty(Geometry.ExtractDynamicProperties(d007));
+        }
+
+        [Fact]
+        public void RealLegacyFixture_DoesNotCrashAndReportsEmptyProperties()
+        {
+            // capilla_quiroz_v17.skp (a plain chapel model) has no Dynamic
+            // Component data on any of its 3 instances - confirmed by direct
+            // inspection of the raw attribute-container reads before writing
+            // this fix - so this proves the plumbing fix doesn't break or
+            // crash on entities that render no attributes, not the
+            // dictionary-lookup logic itself (covered above with synthetic
+            // data).
+            var scene = SkpFile.BuildScene(FixturePath("capilla_quiroz_v17.skp"));
+
+            void Walk(InstanceNode node)
+            {
+                Assert.Empty(node.Properties);
+                foreach (var child in node.Children) Walk(child);
+            }
+
+            Walk(scene.SceneHierarchy);
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Geometry.cs
+++ b/packages/dotnet/OpenSkp/Geometry.cs
@@ -30,6 +30,12 @@ namespace OpenSkp
         public long? MaterialId;
         public bool Hidden;
         public List<TlvNode> Children = new List<TlvNode>();
+        /// <summary>Dynamic Component properties precomputed for legacy
+        /// (pre-2021 MFC) instances (see Legacy.ExtractLegacyDynamicProperties)
+        /// - VFF instances don't set this, since their properties come from a
+        /// lazy D007/DC05 TLV walk over <see cref="Children"/> instead (see
+        /// Scene.cs).</summary>
+        public Dictionary<string, string>? Properties;
     }
 
     /// <summary>Accumulates the raw geometry extracted for one component
@@ -137,6 +143,47 @@ namespace OpenSkp
             var mat = new double[9];
             for (int i = 0; i < 9; i++) mat[i] = Tlv.ReadF64(t1527, i * 8);
             return mat;
+        }
+
+        /// <summary>Dynamic Component key/value pairs from an instance's D007
+        /// attribute container. Mirrors Python's _core.extract_dynamic_properties
+        /// and TypeScript's extractDynamicProperties: DC05's payload isn't part
+        /// of the main model.dat TLV tree (DC05 isn't a top-level container
+        /// tag), so it's re-parsed here with its own, more specific
+        /// container-tag set - within that tree, a B636 tag carries a property
+        /// key and the AD38 tag immediately after it carries that property's
+        /// value.</summary>
+        private static readonly HashSet<string> PropContainerTags = new HashSet<string>
+        {
+            "DD05", "B536", "B136", "B236", "B336", "B036", "A438",
+        };
+
+        public static Dictionary<string, string> ExtractDynamicProperties(TlvNode d007)
+        {
+            var dc05 = d007.Children.FirstOrDefault(c => c.Tag == "DC05");
+            if (dc05 == null) return new Dictionary<string, string>();
+            var buffer = ChunkedBuffer.FromArray(dc05.Payload);
+            var propElements = Tlv.ParseRecursive(buffer, 0, buffer.Length, PropContainerTags);
+            var properties = new Dictionary<string, string>();
+            string? currentKey = null;
+            void ExtractProps(List<TlvNode> nodes)
+            {
+                foreach (var n in nodes)
+                {
+                    if (n.Tag == "B636")
+                    {
+                        currentKey = Encoding.UTF8.GetString(n.Payload);
+                    }
+                    else if (n.Tag == "AD38" && currentKey != null)
+                    {
+                        properties[currentKey] = Encoding.UTF8.GetString(n.Payload);
+                        currentKey = null;
+                    }
+                    ExtractProps(n.Children);
+                }
+            }
+            ExtractProps(propElements);
+            return properties;
         }
 
         public static void ExtractGeometryFromNodes(List<TlvNode> elements, GeometryBuilder builder)

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -431,6 +431,7 @@ namespace OpenSkp
         public double[] Xf = new double[13];
         public string Name = "";
         public string Guid = "";
+        public AttrsRec? Attrs;
     }
 
     internal static class LegacyReaders
@@ -944,7 +945,7 @@ namespace OpenSkp
         public static object ReadInstance(Archive ar, LR r)
         {
             string? cls = ar.CurrentClass;
-            Preamble(ar, r);
+            var pre = Preamble(ar, r);
             var db = Drawbase(ar, r);
             var (ds, dn, _) = ar.ReadObject(r, "CComponentDefinition");
             if (dn != "CComponentDefinition")
@@ -961,7 +962,54 @@ namespace OpenSkp
             int? schema = (cls != null && ar.ClassSchema.TryGetValue(cls, out int s)) ? s : (int?)null;
             byte[] guid = (schema == null || schema >= minSchema) ? r.Raw(16) : Array.Empty<byte>();
 
-            return new InstanceRec { Db = db, Def = ds, Xf = xf, Name = name, Guid = LegacyBytes.ToHex(guid) };
+            return new InstanceRec { Db = db, Def = ds, Xf = xf, Name = name, Guid = LegacyBytes.ToHex(guid), Attrs = pre.Attrs as AttrsRec };
+        }
+
+        // SketchUp's Dynamic Components extension stores its data in an
+        // attribute dictionary literally named "dynamic_attributes" - a
+        // stable, publicly documented part of the SketchUp Ruby API
+        // (Entity#attribute_dictionary("dynamic_attributes")).
+        // ReadAttrContainer/ReadAttrNamed above already fully decode an
+        // entity's CAttributeContainer into typed (dict-name, {key: value})
+        // pairs for other purposes (CFaceTextureCoords lookup on faces) -
+        // this just looks up that one dictionary by name, mirroring what the
+        // VFF path's Geometry.ExtractDynamicProperties does for D007/DC05 TLV
+        // data.
+        private const string DynamicAttributesDictName = "dynamic_attributes";
+
+        /// <summary>Render an already-typed legacy attribute value (number,
+        /// string, list, or null) as a string, matching the string-valued
+        /// Dictionary&lt;string, string&gt; contract the VFF path's
+        /// Geometry.ExtractDynamicProperties produces.</summary>
+        public static string StringifyAttrValue(object? value)
+        {
+            if (value == null) return "";
+            if (value is System.Collections.IEnumerable list && !(value is string))
+            {
+                var parts = new List<string>();
+                foreach (var v in list) parts.Add(StringifyAttrValue(v));
+                return string.Join(",", parts);
+            }
+            return Convert.ToString(value, System.Globalization.CultureInfo.InvariantCulture) ?? "";
+        }
+
+        /// <summary>Extract Dynamic Component attribute key/value pairs from a
+        /// legacy entity's already-parsed CAttributeContainer, or {} when the
+        /// entity carries no attribute container or no dynamic_attributes
+        /// dictionary.</summary>
+        public static Dictionary<string, string> ExtractLegacyDynamicProperties(AttrsRec? attrs)
+        {
+            if (attrs == null) return new Dictionary<string, string>();
+            foreach (var (name, value) in attrs.Children)
+            {
+                if (name == DynamicAttributesDictName && value is DictRec dict)
+                {
+                    var result = new Dictionary<string, string>();
+                    foreach (var kv in dict.Entries) result[kv.Key] = StringifyAttrValue(kv.Value);
+                    return result;
+                }
+            }
+            return new Dictionary<string, string>();
         }
 
         public static readonly Dictionary<string, LegacyReader> Readers = new Dictionary<string, LegacyReader>
@@ -1242,6 +1290,7 @@ namespace OpenSkp
                         MaterialId = instRec.Db.Mat != 0 ? instRec.Db.Mat : (long?)null,
                         Hidden = instRec.Db.Hidden != 0,
                         Children = new List<TlvNode>(),
+                        Properties = LegacyReaders.ExtractLegacyDynamicProperties(instRec.Attrs),
                     });
                 }
             }

--- a/packages/dotnet/OpenSkp/Scene.cs
+++ b/packages/dotnet/OpenSkp/Scene.cs
@@ -453,9 +453,16 @@ namespace OpenSkp
 
                     string lName = parentLayer;
                     (int R, int G, int B)? instColor = inheritedColor;
-                    var properties = new Dictionary<string, string>();
+                    // Legacy (pre-2021 MFC) instances carry a precomputed
+                    // Properties dict (see Legacy.ExtractLegacyDynamicProperties)
+                    // - VFF instances don't set this, so this stays {} for
+                    // them and gets overwritten below via the D007/DC05 TLV
+                    // walk instead.
+                    var properties = inst.Properties != null
+                        ? new Dictionary<string, string>(inst.Properties)
+                        : new Dictionary<string, string>();
 
-                    // Layer/material/dynamic-properties resolution mirrors
+                    // Layer/material resolution mirrors
                     // Geometry.ExtractGeometryFromNodes's D007 handling;
                     // re-derived here (from inst.Children) to match the
                     // Python/TS reference exactly rather than needing a
@@ -481,8 +488,14 @@ namespace OpenSkp
                                 if (mat != null) instColor = (mat.R, mat.G, mat.B);
                             }
                         }
-                        // Dynamic properties (attribute dictionaries under
-                        // D007) are not yet ported for .NET; left empty.
+                        try
+                        {
+                            properties = Geometry.ExtractDynamicProperties(d007);
+                        }
+                        catch
+                        {
+                            // Ignore
+                        }
                     }
 
                     string instName = !string.IsNullOrEmpty(inst.Name) ? inst.Name! : $"Component_{refIdx}";


### PR DESCRIPTION
## Summary

Companion to #106 (Dart) - the last of the 5 languages. .NET never implemented Dynamic Component property extraction at all - neither the VFF-side D007/DC05/B636/AD38 TLV walk that Python/TypeScript/C++/Dart already had, nor the legacy-side attribute-container plumbing. This PR ports both halves in one go, since .NET had no partial implementation to build on top of.

## VFF side (new)

- `Geometry.cs`: added `Geometry.ExtractDynamicProperties(TlvNode d007)`, a direct port of Python's `_core.extract_dynamic_properties` / TypeScript's `extractDynamicProperties`. DC05 isn't a top-level container tag in the main `model.dat` TLV tree, so its payload arrives as opaque bytes under D007 - this wraps that payload in a `ChunkedBuffer` and re-parses it via the existing `Tlv.ParseRecursive` with its own container-tag set (`DD05, B536, B136, B236, B336, B036, A438`), then walks the result for `B636` (key) / `AD38` (value) pairs.
- `Geometry.cs`: added an optional `Properties` field to `GeometryBuilderInstance`.
- `Scene.cs`: `BuildScene`'s per-instance loop now calls `Geometry.ExtractDynamicProperties(d007)` instead of leaving properties permanently empty with a "not yet ported for .NET" comment.

## Legacy side (same fix as #103/#104/#105/#106)

- `Legacy.cs`: `LegacyReaders.ReadInstance` now captures `var pre = Preamble(ar, r)` and includes it on the returned `InstanceRec` (previously the call's result was never even assigned to a variable) - the same "already-decoded-but-discarded" shape as the earlier layer/face/instance-hidden fixes.
- `Legacy.cs`: added `LegacyReaders.ExtractLegacyDynamicProperties`, which looks up the entity's attribute-container children for a dictionary named `"dynamic_attributes"` - the stable, publicly documented SketchUp Ruby API name for where the Dynamic Components extension stores its data (`Entity#attribute_dictionary("dynamic_attributes")`). .NET's `CAttributeNamed` reader (`ReadAttrNamed`) already correctly builds a typed entries map (unlike C++, which had a second, independent bug here - see #105), so this just adds the by-name lookup.
- `Legacy.cs`: the instance branch of `FillBuilder` now calls this and sets `Properties` on the new `GeometryBuilderInstance` field.
- `Scene.cs`: seeds `properties` from `inst.Properties` before the D007/DC05 TLV walk runs, so legacy instances get their precomputed value and VFF instances get the lazy walk's result unchanged.

Also updated the top-level README's feature matrix: Dynamic Components now reads as fully supported (✅) across all five languages, both formats.

## Test plan

- [x] New `DynamicPropertiesTests.cs` covers `StringifyAttrValue`, `ExtractLegacyDynamicProperties` (dictionary found by name, absent dictionary, no attribute container), `Geometry.ExtractDynamicProperties` (synthetic DC05 payload, no DC05 child, empty DC05 payload), and a real-fixture regression test against `capilla_quiroz_v17.skp` confirming the plumbing doesn't crash end-to-end through `BuildScene()`.
- [x] **Honest disclosure**: as with the other ports, that fixture has no Dynamic Component data on any of its 3 instances (confirmed by direct inspection before writing the fix), so the dictionary-lookup logic itself is verified with synthetic data only.
- [x] Full suite: 46/46 passing.
- [x] Clean build, 0 warnings.