### PR TITLE
Fix XML internal-entity-expansion (billion laughs) DoS in Python

### DIFF
--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "numpy>=1.20",
     "trimesh>=3.0",
     "shapely>=1.8",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -18,7 +18,14 @@ import struct
 import time
 import zipfile
 from typing import Any, Dict
-import xml.etree.ElementTree as ET
+# material.xml/style.xml come from inside the .skp's ZIP container, which is
+# fully attacker-controlled input - stdlib ElementTree expands internal
+# general entities with no limit, making a "billion laughs" DoS payload
+# trivial to embed. defusedxml.ElementTree is a drop-in replacement (same
+# ParseError class, same fromstring() signature) that rejects that class of
+# payload outright instead.
+import defusedxml.ElementTree as ET
+from defusedxml.common import DefusedXmlException
 
 import numpy as np
 import trimesh
@@ -837,7 +844,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
         try:
             _validate_zip_entry_size(zf, name)
             sroot = ET.fromstring(zf.read(name))
-        except ET.ParseError:
+        except (ET.ParseError, DefusedXmlException):
             continue
         STY = '{http://sketchup.google.com/schemas/sketchup/1.0/style}'
         TYP = '{http://sketchup.google.com/schemas/1.0/types}'

--- a/packages/python/src/openskp/materials.py
+++ b/packages/python/src/openskp/materials.py
@@ -7,7 +7,14 @@ TLV stream.  This module handles both sources.
 
 from __future__ import annotations
 
-import xml.etree.ElementTree as ET
+# Material XML comes from inside the .skp's ZIP container, which is fully
+# attacker-controlled input - stdlib ElementTree expands internal general
+# entities with no limit, making a "billion laughs" DoS payload trivial to
+# embed. defusedxml.ElementTree is a drop-in replacement (same ParseError
+# class, same fromstring() signature) that rejects that class of payload
+# outright instead.
+import defusedxml.ElementTree as ET
+from defusedxml.common import DefusedXmlException
 from typing import Dict, List, Optional, Tuple
 
 from .model import Layer, Material, TlvNode
@@ -72,7 +79,7 @@ def _parse_material_xml(xml_bytes: bytes) -> Optional[Material]:
     """
     try:
         root = ET.fromstring(xml_bytes)
-    except ET.ParseError:
+    except (ET.ParseError, DefusedXmlException):
         return None
 
     name: str = root.get("name", root.get("Name", "Unnamed"))

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -958,6 +958,52 @@ class TestStyles:
         assert st.back_color == ((v2 >> 16) & 255, (v2 >> 8) & 255, v2 & 255)
 
 
+class TestXmlEntityExpansion:
+    """material.xml/style.xml come from inside the .skp's ZIP container -
+    fully attacker-controlled input. Stdlib xml.etree.ElementTree expands
+    internal general entities with no limit, making a "billion laughs" DoS
+    payload trivial to embed. _core.py and materials.py both switched to
+    defusedxml.ElementTree, which rejects any entity declaration outright
+    (not just recursive/exponential ones - confirmed directly: even a
+    single non-recursive `<!ENTITY x "hi">` is blocked, so this doesn't
+    require actually triggering an expansion to prove the fix works)."""
+
+    # A single, non-recursive entity declaration is enough to trigger
+    # defusedxml's EntitiesForbidden - safe to construct directly (no
+    # actual expansion ever happens, unlike a real billion-laughs payload).
+    _ENTITY_BOMB = b"""<?xml version="1.0"?>
+<!DOCTYPE r [ <!ENTITY x "hi"> ]>
+<r>&x;</r>
+"""
+
+    def test_parse_material_xml_rejects_entity_declarations(self) -> None:
+        from openskp.materials import _parse_material_xml
+
+        assert _parse_material_xml(self._ENTITY_BOMB) is None
+
+    def test_full_parse_skips_malicious_material_and_style_xml(
+        self, tmp_path: pathlib.Path
+    ) -> None:
+        import io
+        import zipfile
+        from openskp.model import SkpFile
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("model.dat", b"")
+            zf.writestr("materials/Evil/material.xml", self._ENTITY_BOMB)
+            zf.writestr("styles/Evil/style.xml", self._ENTITY_BOMB)
+        path = tmp_path / "evil.skp"
+        path.write_bytes(b"\xFF\xFE\xFF\x0E" + b"\x00" * 28 + buf.getvalue())
+
+        # Must not hang, crash, or leak the exception - the malicious
+        # entries are silently skipped, exactly like a malformed
+        # (non-well-formed) material.xml/style.xml already was.
+        model = SkpFile.open(str(path)).parse()
+        assert model.materials == []
+        assert model.styles == []
+
+
 # ── Per-face UV transform tests ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

`material.xml` and `style.xml` both come from inside the `.skp`'s ZIP container - fully attacker-controlled input, since anyone can hand-craft a `.skp` with an arbitrary ZIP payload. Both parsing sites used `xml.etree.ElementTree.fromstring()`, which expands internal general entities with no limit by default - a classic "billion laughs" payload (a handful of nested entity definitions expanding to gigabytes in memory) is trivial to embed and would exhaust memory or hang the process on a small, otherwise-valid-looking file.

This is **not XXE** (no external entity/DTD fetching is involved) - it's the internal-entity-blowup class specifically, confirmed safe from XXE separately.

Switched both to `defusedxml.ElementTree`, a genuine drop-in replacement (same `ParseError` class, same `fromstring()` signature) that rejects any entity declaration outright - confirmed directly that even a single non-recursive `<!ENTITY x "hi">` triggers defusedxml's `EntitiesForbidden` before any expansion is attempted, so there's no window where expansion partially happens.

## Changes

- `pyproject.toml`: added `defusedxml>=0.7.1` as a new dependency.
- `_core.py`: swapped `import xml.etree.ElementTree as ET` for `import defusedxml.ElementTree as ET` (the two call sites - material.xml, style.xml - are otherwise unchanged, since the API is identical). The material.xml site's existing `except Exception: pass` already catches defusedxml's exceptions; the style.xml site's `except ET.ParseError: continue` did not (`EntitiesForbidden` etc. subclass `ValueError`, not `ET.ParseError`), so it's now `except (ET.ParseError, DefusedXmlException): continue`, keeping the existing "skip malformed entries, don't abort the whole parse" behavior for malicious entries too.
- `materials.py`: same import swap and except-clause widening for `_parse_material_xml`. This function turned out to be dead code from the live parsing path's perspective (never imported by `_core.py`/`model.py`/`legacy.py`/`scene.py` - only by tests, the same shape of discovery as an earlier item's `vff.py` finding) - fixed anyway since `parse_materials()` is public, non-underscore-prefixed API that accepts untrusted bytes directly.

## Test plan

- [x] New `TestXmlEntityExpansion` class covers `_parse_material_xml` returning `None` for an entity-bearing payload, and a full synthetic-`.skp` regression test (real ZIP, both a malicious material.xml and a malicious style.xml embedded) confirming `SkpFile.open(...).parse()` completes cleanly with both malicious entries silently skipped (`materials == []`, `styles == []`) - matching the existing "malformed XML is skipped, not fatal" behavior.
- [x] Full suite: 119/119 passing.
- [x] `ruff check src/ tests/` clean.