### PR TITLE
Add exact uv_transform regression count to legacy test (TypeScript)

### DIFF
--- a/packages/typescript/tests/legacy.test.ts
+++ b/packages/typescript/tests/legacy.test.ts
@@ -136,6 +136,30 @@ describe('Legacy MFC reader (classic pre-2021 .skp)', () => {
         expect(face.hidden).toBe(false);
       }
     }
+
+    // Regression: CFace's attribute container (which carries any
+    // positioned/photo-fitted CFaceTextureCoords record) was read and then
+    // silently discarded, so uvTransform never got populated for legacy
+    // files at all - every legacy face fell back to the default
+    // face-plane projection even when the SketchUp author had explicitly
+    // positioned a texture. 32 matches Python's/C++'s independently-
+    // verified count of faces with a real uvTransform on this exact
+    // fixture (0 have uvProjected - this file has no PROJECTED/
+    // terrain-drape textures).
+    let withUvTransform = 0;
+    let withUvProjected = 0;
+    for (const def of model.definitions.values()) {
+      for (const face of def.faces) {
+        if (face.uvTransform) withUvTransform++;
+        if (face.uvProjected) withUvProjected++;
+      }
+    }
+    for (const face of model.root.faces) {
+      if (face.uvTransform) withUvTransform++;
+      if (face.uvProjected) withUvProjected++;
+    }
+    expect(withUvTransform).toBe(32);
+    expect(withUvProjected).toBe(0);
   });
 
   it('gives every baked primitive valid uv coordinates alongside positions/normals', () => {


### PR DESCRIPTION
## Summary

Matches what C++'s `parser_test.cpp` already does (`with_uv_transform == 32` against `capilla_quiroz_v17.skp`). Only C++ would have caught a regression of the exact historical bug it already hit once: `CFace`'s attribute container (which carries any positioned/photo-fitted `CFaceTextureCoords` record) was read and then silently discarded, so `uvTransform` never got populated for legacy files at all - every legacy face fell back to the default face-plane projection even when the SketchUp author had explicitly positioned a texture.

## Changes

- Added a count of faces with `uvTransform` set (and `uvProjected`, for the same reason) across all definitions + root in `legacy.test.ts`'s existing real-fixture test.

## Test plan

- [x] Verified the counts directly against a fresh parse of the fixture before writing the assertion (32 / 0, matching Python's and C++'s independently-verified counts on this exact file - 0 have `uvProjected` since this file has no PROJECTED/terrain-drape textures).
- [x] Full suite: 65/65 passing.
- [x] `tsc --noEmit` clean.