### PR TITLE
Add exact uv_transform regression count to legacy test (Dart)

### DIFF
--- a/packages/dart/test/legacy_test.dart
+++ b/packages/dart/test/legacy_test.dart
@@ -121,5 +121,29 @@ void main() {
         expect(face.hidden, isFalse);
       }
     }
+
+    // Regression: CFace's attribute container (which carries any
+    // positioned/photo-fitted CFaceTextureCoords record) was read and then
+    // silently discarded, so uvTransform never got populated for legacy
+    // files at all - every legacy face fell back to the default
+    // face-plane projection even when the SketchUp author had explicitly
+    // positioned a texture. 32 matches Python's/TS's/C++'s independently-
+    // verified count of faces with a real uvTransform on this exact
+    // fixture (0 have uvProjected - this file has no PROJECTED/
+    // terrain-drape textures).
+    var withUvTransform = 0;
+    var withUvProjected = 0;
+    for (final def in model.definitions.values) {
+      for (final face in def.faces.values) {
+        if (face.uvTransform != null) withUvTransform++;
+        if (face.uvProjected) withUvProjected++;
+      }
+    }
+    for (final face in model.root.faces.values) {
+      if (face.uvTransform != null) withUvTransform++;
+      if (face.uvProjected) withUvProjected++;
+    }
+    expect(withUvTransform, 32);
+    expect(withUvProjected, 0);
   });
 }


### PR DESCRIPTION
## Summary

Matches what C++'s `parser_test.cpp` already does (`with_uv_transform == 32` against `capilla_quiroz_v17.skp`). Only C++ would have caught a regression of the exact historical bug it already hit once: `CFace`'s attribute container (which carries any positioned/photo-fitted `CFaceTextureCoords` record) was read and then silently discarded, so `uvTransform` never got populated for legacy files at all - every legacy face fell back to the default face-plane projection even when the SketchUp author had explicitly positioned a texture.

## Changes

- Added a count of faces with `uvTransform` set (and `uvProjected`, for the same reason) across all definitions + root in `legacy_test.dart`'s existing real-fixture test.

## Test plan

- [x] Verified the counts directly against a fresh parse of the fixture before writing the assertion (32 / 0, matching Python's and C++'s independently-verified counts on this exact file - 0 have `uvProjected` since this file has no PROJECTED/terrain-drape textures).
- [x] Full suite: 45/45 passing.
- [x] `dart analyze` clean.