### PR TITLE
Add exact uv_transform regression count to legacy test (.NET)

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/LegacyTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/LegacyTests.cs
@@ -115,6 +115,33 @@ namespace OpenSkp.Tests
             {
                 Assert.All(defn.Faces.Values, f => Assert.False(f.Hidden));
             }
+
+            // Regression: CFace's attribute container (which carries any
+            // positioned/photo-fitted CFaceTextureCoords record) was read
+            // and then silently discarded, so UvTransform never got
+            // populated for legacy files at all - every legacy face fell
+            // back to the default face-plane projection even when the
+            // SketchUp author had explicitly positioned a texture. 32
+            // matches Python's/TS's/C++'s independently-verified count of
+            // faces with a real UvTransform on this exact fixture (0 have
+            // UvProjected - this file has no PROJECTED/terrain-drape
+            // textures).
+            int withUvTransform = 0, withUvProjected = 0;
+            foreach (var defn in model.Definitions.Values)
+            {
+                foreach (var f in defn.Faces.Values)
+                {
+                    if (f.UvTransform != null) withUvTransform++;
+                    if (f.UvProjected) withUvProjected++;
+                }
+            }
+            foreach (var f in model.Root.Faces.Values)
+            {
+                if (f.UvTransform != null) withUvTransform++;
+                if (f.UvProjected) withUvProjected++;
+            }
+            Assert.Equal(32, withUvTransform);
+            Assert.Equal(0, withUvProjected);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

Matches what C++'s `parser_test.cpp` already does (`with_uv_transform == 32` against `capilla_quiroz_v17.skp`). Only C++ would have caught a regression of the exact historical bug it already hit once: `CFace`'s attribute container (which carries any positioned/photo-fitted `CFaceTextureCoords` record) was read and then silently discarded, so `UvTransform` never got populated for legacy files at all - every legacy face fell back to the default face-plane projection even when the SketchUp author had explicitly positioned a texture.

## Changes

- Added a count of faces with `UvTransform` set (and `UvProjected`, for the same reason) across all definitions + root in `LegacyTests.cs`'s existing real-fixture test.

## Test plan

- [x] Verified the counts directly against a fresh parse of the fixture before writing the assertion (32 / 0, matching Python's and C++'s independently-verified counts on this exact file - 0 have `UvProjected` since this file has no PROJECTED/terrain-drape textures).
- [x] Full suite: 46/46 passing.
- [x] Clean build, 0 warnings.