### PR TITLE
Add BuildScene/MeshIndex real-fixture coverage to .NET IntegrationTests.cs

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
@@ -112,6 +112,21 @@ namespace OpenSkp.Tests
             Assert.Equal("[Construction Documentation Style]", model.Styles[0].Name);
             Assert.Equal((255, 255, 255), model.Styles[0].FrontColor);
             Assert.Equal((208, 209, 189), model.Styles[0].BackColor);
+
+            // BuildScene/MeshIndex - a separate, opt-in step from Parse(), so
+            // it never costs a plain Parse() call anything. TS/Dart/C++ all
+            // have this real-fixture coverage already; .NET's stopped at
+            // parsing.
+            var scene = SkpFile.BuildScene(FixturePath("Untitled.skp"));
+            Assert.NotNull(scene.SceneHierarchy);
+            Assert.Equal("ROOT", scene.SceneHierarchy.Name);
+            Assert.Equal("ROOT_MODEL", scene.SceneHierarchy.DefinitionName);
+            Assert.True(scene.SceneHierarchy.Children.Count > 0);
+
+            Assert.Equal(43, scene.MeshIndex.Count);
+            var firstMesh = scene.MeshIndex.Values.First();
+            Assert.NotNull(firstMesh.Name);
+            Assert.NotNull(firstMesh.Layer);
         }
 
         [Fact]
@@ -131,6 +146,14 @@ namespace OpenSkp.Tests
             // Definitions map (which excludes ROOT) is empty.
             Assert.Empty(model.Definitions);
             Assert.Equal("ROOT_MODEL", model.Root.Name);
+
+            var scene = SkpFile.BuildScene(FixturePath("SU_File.skp"));
+            Assert.NotNull(scene.SceneHierarchy);
+            Assert.Equal("ROOT", scene.SceneHierarchy.Name);
+            Assert.Equal("ROOT_MODEL", scene.SceneHierarchy.DefinitionName);
+
+            Assert.Single(scene.MeshIndex);
+            Assert.Equal("ROOT_MODEL", scene.MeshIndex.Values.First().DefinitionName);
         }
     }
 }


### PR DESCRIPTION
## Summary

TS/C++ both already exercise `BuildScene()`/`MeshIndex` against the real modern (VFF/2021+) fixtures (`Untitled.skp`, `SU_File.skp`) in their integration tests - .NET's real-fixture coverage stopped at `Parse()`, leaving the opt-in scene-baking path (`SceneBuilder`, mesh grouping, GLB-ready output) completely untested against a real file.

## Changes

Added the same assertions TS's `integration.test.ts` already makes, verified directly against a fresh `BuildScene()` call on both fixtures before writing them:
- `Untitled.skp`: `SceneHierarchy.Name == "ROOT"`, `SceneHierarchy.DefinitionName == "ROOT_MODEL"`, at least one child, `MeshIndex.Count == 43` (matches TS's/Python's/C++'s independently-verified count on this exact file).
- `SU_File.skp`: same `SceneHierarchy` checks, `MeshIndex` has exactly 1 entry whose `DefinitionName` is `"ROOT_MODEL"` (only ROOT holds geometry in this fixture).

## Test plan

- [x] Full suite: 46/46 passing.
- [x] Clean build, 0 warnings.