### PR TITLE
Add BuildScene/MeshIndex real-fixture coverage for modern fixtures (Dart)

### DIFF
--- a/packages/dart/test/integration_test.dart
+++ b/packages/dart/test/integration_test.dart
@@ -124,6 +124,20 @@ void main() {
     expect(model.styles[0].name, '[Construction Documentation Style]');
     expect(model.styles[0].frontColor, (255, 255, 255));
     expect(model.styles[0].backColor, (208, 209, 189));
+
+    // buildScene()/meshIndex - a separate, opt-in step from parse(), so it
+    // never costs a plain parse() call anything. TS/.NET/C++ all have this
+    // real-fixture coverage already; Dart's buildScene() tests only ever
+    // exercised the legacy fixture (scene_test.dart), never this one.
+    final scene = SkpFile.open(fixture('Untitled.skp')).buildScene();
+    expect(scene.sceneHierarchy.name, 'ROOT');
+    expect(scene.sceneHierarchy.definitionName, 'ROOT_MODEL');
+    expect(scene.sceneHierarchy.children.length, greaterThan(0));
+
+    expect(scene.meshIndex.length, 43);
+    final firstMesh = scene.meshIndex.values.first;
+    expect(firstMesh.name, isNotNull);
+    expect(firstMesh.layer, isNotNull);
   });
 
   test('parses SU_File.skp correctly', () {
@@ -141,5 +155,12 @@ void main() {
     // map (which excludes ROOT) is empty.
     expect(model.definitions, isEmpty);
     expect(model.root.name, 'ROOT_MODEL');
+
+    final scene = SkpFile.open(fixture('SU_File.skp')).buildScene();
+    expect(scene.sceneHierarchy.name, 'ROOT');
+    expect(scene.sceneHierarchy.definitionName, 'ROOT_MODEL');
+
+    expect(scene.meshIndex.length, 1);
+    expect(scene.meshIndex.values.first.definitionName, 'ROOT_MODEL');
   });
 }


### PR DESCRIPTION
## Summary

Bonus finding while working on item 13 (.NET's equivalent gap, PR #113): Dart's `buildScene()`/`meshIndex` real-fixture coverage (`scene_test.dart`) only ever exercised the legacy fixture (`capilla_quiroz_v17.skp`) - never the modern (VFF/2021+) fixtures (`Untitled.skp`, `SU_File.skp`), unlike TS/.NET/C++, which all test `buildScene()` against the modern fixture too in their own integration tests.

## Changes

Added the same assertions TS's/.NET's integration tests already make to `integration_test.dart`'s existing `parse()`-based tests, verified directly against a fresh `buildScene()` call on both fixtures before writing them:
- `Untitled.skp`: `sceneHierarchy.name == 'ROOT'`, `sceneHierarchy.definitionName == 'ROOT_MODEL'`, at least one child, `meshIndex.length == 43` (matches Python's/TS's/C++'s/.NET's independently-verified count on this exact file).
- `SU_File.skp`: same `sceneHierarchy` checks, `meshIndex` has exactly 1 entry whose `definitionName` is `'ROOT_MODEL'` (only ROOT holds geometry in this fixture).

## Test plan

- [x] Full suite: 45/45 passing.
- [x] `dart analyze` clean.