### PR TITLE
Port double-sided back-face material handling to buildScene() (TypeScript)

### DIFF
--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -166,9 +166,10 @@ export interface MeshMetadata {
   path: string;
 }
 
-/** One triangulated, world-space mesh: all faces sharing a single resolved
- * color from one flattened scene-graph position. Ready to hand straight to
- * a GLB/glTF exporter or any other renderer. */
+/** One triangulated, world-space mesh: all faces (or, for a face whose
+ * front/back colors genuinely differ, all *one side* of those faces)
+ * sharing a single resolved color from one flattened scene-graph position.
+ * Ready to hand straight to a GLB/glTF exporter or any other renderer. */
 export interface GlbPrimitive {
   /** Flat [x, y, z, x, y, z, ...] vertex positions, in metres, Y-up. */
   positions: Float32Array;
@@ -447,19 +448,21 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
   // the stack overflows.
   const activeDefinitions = new Set<number | string>();
 
-  function getMaterialIndex(color: { r: number; g: number; b: number }) {
-    const key = `${color.r},${color.g},${color.b}`;
+  function getMaterialIndex(color: { r: number; g: number; b: number }, doubleSided: boolean) {
+    const key = `${color.r},${color.g},${color.b},${doubleSided}`;
     if (colorToMaterialIndex.has(key)) {
       return colorToMaterialIndex.get(key)!;
     }
     const idx = gltfMaterials.length;
-    gltfMaterials.push({
+    const material: any = {
       pbrMetallicRoughness: {
         baseColorFactor: [color.r / 255, color.g / 255, color.b / 255, 1.0],
         metallicFactor: 0.0,
         roughnessFactor: 0.8,
       },
-    });
+    };
+    if (doubleSided) material.doubleSided = true;
+    gltfMaterials.push(material);
     colorToMaterialIndex.set(key, idx);
     return idx;
   }
@@ -477,37 +480,52 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
     const builder = d.builder;
 
     if (builder.faces.size > 0) {
-      const faceGroups = new Map<string, {
+      // Group faces sharing a resolved (color, doubleSided) pair into one
+      // mesh each - same grouping the C++ reference uses (the only port
+      // that already had this before this port): a face whose front/back
+      // resolve to the SAME color is emitted once, with its glTF material
+      // marked doubleSided so it's visible from either side without
+      // needing duplicate geometry; a face whose front/back genuinely
+      // differ is emitted as TWO single-sided triangle sets - one
+      // normal-wound using the front material, one reverse-wound using
+      // the back material - so each side renders its own correct color
+      // instead of the front material leaking onto (or the back
+      // vanishing from) the far side.
+      type FaceGroup = {
         color: { r: number; g: number; b: number };
+        doubleSided: boolean;
         localVerts: [number, number, number][];
         localUvs: [number, number][];
         normalsAccum: number[][];
         localFaces: number[][];
         localVMap: Map<string, number>;
-      }>();
+      };
+      const faceGroups = new Map<string, FaceGroup>();
 
-      for (const [fId, fData] of builder.faces.entries()) {
-        let faceColor = inheritedMaterialColor;
-        const faceMatId = (fData as any).materialId;
-        let mat: Material | undefined;
-        if (faceMatId !== undefined && faceMatId !== null) {
-          const matName = materialIdToName.get(faceMatId);
-          if (matName) {
-            mat = materialsMap.get(matName) || materialsByFolder.get(matName);
-            if (mat) {
-              faceColor = mat.color;
-            }
-          }
-        }
-        if (!faceColor) {
-          faceColor = getLayerColor(parentLayer);
-        }
+      const resolveMaterial = (matId: number | null | undefined): Material | undefined => {
+        if (matId === undefined || matId === null) return undefined;
+        const matName = materialIdToName.get(matId);
+        if (!matName) return undefined;
+        return materialsMap.get(matName) || materialsByFolder.get(matName);
+      };
 
-        const colorKey = `${faceColor.r},${faceColor.g},${faceColor.b}`;
+      const addSide = (
+        triangles: number[][],
+        fn: [number, number, number],
+        color: { r: number; g: number; b: number },
+        doubleSided: boolean,
+        reverse: boolean,
+        mat: Material | undefined,
+        uvTransform: number[] | null | undefined,
+        xr: [number, number, number],
+        yr: [number, number, number]
+      ) => {
+        const colorKey = `${color.r},${color.g},${color.b},${doubleSided}`;
         let group = faceGroups.get(colorKey);
         if (!group) {
           group = {
-            color: faceColor,
+            color,
+            doubleSided,
             localVerts: [],
             localUvs: [],
             normalsAccum: [],
@@ -516,6 +534,60 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
           };
           faceGroups.set(colorKey, group);
         }
+
+        const tex = mat?.texture;
+        const tileW = tex && tex.width > 1e-9 ? tex.width : 1;
+        const tileH = tex && tex.height > 1e-9 ? tex.height : 1;
+        const sideNormal: [number, number, number] = reverse
+          ? [-fn[0], -fn[1], -fn[2]]
+          : fn;
+
+        // Vertices are deduped per (vId, uv) rather than just vId: UVs are
+        // inherently per-face, so a vertex position shared by two faces
+        // that disagree on texture mapping must become two distinct
+        // output vertices (glTF requires position/normal/uv aligned per
+        // index).
+        const faceLocalMap = new Map<number, number>();
+        for (const tri of triangles) {
+          const triIds = reverse ? [tri[0], tri[2], tri[1]] : tri;
+          const faceIndices: number[] = [];
+          for (const vId of triIds) {
+            if (!builder.vertices.has(vId)) continue;
+            let idx = faceLocalMap.get(vId);
+            if (idx === undefined) {
+              const p = builder.vertices.get(vId)!;
+              const [u, v] = computeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
+              const key = `${vId},${u},${v}`;
+              idx = group.localVMap.get(key);
+              if (idx === undefined) {
+                group.localVerts.push(p);
+                group.localUvs.push([u, v]);
+                group.normalsAccum.push([sideNormal[0], sideNormal[1], sideNormal[2]]);
+                idx = group.localVerts.length - 1;
+                group.localVMap.set(key, idx);
+              } else {
+                const accum = group.normalsAccum[idx];
+                accum[0] += sideNormal[0];
+                accum[1] += sideNormal[1];
+                accum[2] += sideNormal[2];
+              }
+              faceLocalMap.set(vId, idx);
+            }
+            faceIndices.push(idx);
+          }
+          if (faceIndices.length === 3) {
+            group.localFaces.push(faceIndices);
+          }
+        }
+      };
+
+      for (const [fId, fData] of builder.faces.entries()) {
+        const fallbackColor = inheritedMaterialColor ?? getLayerColor(parentLayer);
+
+        const frontMat = resolveMaterial((fData as any).materialId);
+        const backMat = resolveMaterial((fData as any).backMaterialId);
+        const frontColor = frontMat?.color ?? fallbackColor;
+        const backColor = backMat?.color ?? fallbackColor;
 
         const loops: number[][] = [];
         for (const loop of fData.loops) {
@@ -538,51 +610,21 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         }
 
         const fn = fData.normal as [number, number, number];
-        const tex = mat?.texture;
-        const tileW = tex && tex.width > 1e-9 ? tex.width : 1;
-        const tileH = tex && tex.height > 1e-9 ? tex.height : 1;
         const { xr, yr } = faceUvBasis(fn);
         const uvTransform = (fData as any).uvTransform as number[] | null | undefined;
+        const uvTransformBack = (fData as any).uvTransformBack as number[] | null | undefined;
 
-        // Vertices are deduped per (vId, uv) rather than just vId: UVs are
-        // inherently per-face, so a vertex position shared by two faces
-        // that disagree on texture mapping must become two distinct
-        // output vertices (glTF requires position/normal/uv aligned per
-        // index).
-        const faceLocalMap = new Map<number, number>();
-        for (const tri of triangles) {
-          const faceIndices: number[] = [];
-          for (const vId of tri) {
-            if (!builder.vertices.has(vId)) continue;
-            let idx = faceLocalMap.get(vId);
-            if (idx === undefined) {
-              const p = builder.vertices.get(vId)!;
-              const [u, v] = computeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
-              const key = `${vId},${u},${v}`;
-              idx = group.localVMap.get(key);
-              if (idx === undefined) {
-                group.localVerts.push(p);
-                group.localUvs.push([u, v]);
-                group.normalsAccum.push([fn[0], fn[1], fn[2]]);
-                idx = group.localVerts.length - 1;
-                group.localVMap.set(key, idx);
-              } else {
-                const accum = group.normalsAccum[idx];
-                accum[0] += fn[0];
-                accum[1] += fn[1];
-                accum[2] += fn[2];
-              }
-              faceLocalMap.set(vId, idx);
-            }
-            faceIndices.push(idx);
-          }
-          if (faceIndices.length === 3) {
-            group.localFaces.push(faceIndices);
-          }
+        const sameColor =
+          frontColor.r === backColor.r && frontColor.g === backColor.g && frontColor.b === backColor.b;
+        if (sameColor) {
+          addSide(triangles, fn, frontColor, true, false, frontMat, uvTransform, xr, yr);
+        } else {
+          addSide(triangles, fn, frontColor, false, false, frontMat, uvTransform, xr, yr);
+          addSide(triangles, fn, backColor, false, true, backMat, uvTransformBack, xr, yr);
         }
       }
 
-      for (const [colorKey, group] of faceGroups.entries()) {
+      for (const group of faceGroups.values()) {
         if (group.localFaces.length === 0) continue;
 
         const isRoot = pathName === 'ROOT';
@@ -593,7 +635,10 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         let safePath = pathName.replace(/ \/ /g, '__').replace(/ /g, '_');
         if (safePath.length > 80) safePath = safePath.slice(0, 80);
 
-        const colorSuffix = faceGroups.size > 1 ? `_${colorKey.replace(/,/g, '_')}` : '';
+        const colorSuffix =
+          faceGroups.size > 1
+            ? `_${group.color.r}_${group.color.g}_${group.color.b}_${group.doubleSided ? 'ds' : 'ss'}`
+            : '';
         const geomName = `mesh_${meshCounter.count}_${safePath}_${parentLayer}${colorSuffix}`;
         meshCounter.count++;
 
@@ -649,7 +694,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
           indices[i * 3 + 2] = group.localFaces[i][2];
         }
 
-        const materialIndex = getMaterialIndex(group.color);
+        const materialIndex = getMaterialIndex(group.color, group.doubleSided);
 
         glbPrimitives.push({
           positions,

--- a/packages/typescript/tests/legacy.test.ts
+++ b/packages/typescript/tests/legacy.test.ts
@@ -175,4 +175,43 @@ describe('Legacy MFC reader (classic pre-2021 .skp)', () => {
       }
     }
   });
+
+  it('renders back-face materials correctly (item 14 regression)', () => {
+    // Faces with genuinely different front/back materials must produce two
+    // correctly-colored, correctly-wound single-sided primitives (not one
+    // primitive using only the front material, and not a hidden/invisible
+    // back side). Faces 133/152 in this fixture's puerta definition are a
+    // real, concrete example: front material 29 (a blue, (2, 0, 237)),
+    // back material 27 (a light blue, (204, 235, 244)) - confirmed by
+    // direct inspection before writing this test.
+    const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    const scene = buildScene(arrayBuffer);
+
+    const hasColor = (r: number, g: number, b: number) =>
+      scene.gltfMaterials.some((m: any) => {
+        const c = m.pbrMetallicRoughness.baseColorFactor;
+        return (
+          Math.abs(c[0] - r / 255) < 1e-6 &&
+          Math.abs(c[1] - g / 255) < 1e-6 &&
+          Math.abs(c[2] - b / 255) < 1e-6
+        );
+      });
+
+    expect(hasColor(2, 0, 237)).toBe(true);
+    expect(hasColor(204, 235, 244)).toBe(true);
+
+    // Faces whose front/back colors coincide (or have no back material at
+    // all) are emitted once with doubleSided=true instead of being split -
+    // confirmed count from direct inspection of this fixture.
+    const doubleSidedCount = scene.gltfMaterials.filter((m: any) => m.doubleSided).length;
+    expect(doubleSidedCount).toBe(4);
+
+    // Full scene counts: matches C++'s independently-verified reference
+    // for this exact fixture (parser_test.cpp) - 21 primitives/mesh
+    // entries instead of the pre-fix 13, since 30 faces in this fixture
+    // now correctly split into two single-sided primitives each.
+    expect(scene.glbPrimitives.length).toBe(21);
+    expect(Object.keys(scene.meshIndex).length).toBe(21);
+    expect(scene.gltfMaterials.length).toBe(13);
+  });
 });


### PR DESCRIPTION
## Summary

Companion to #115 (Python). C++'s `scene.cpp` was the only port that correctly rendered a face whose front and back are painted with genuinely different materials: it splits the face into two single-sided triangle sets (front normal-wound, back reverse-wound), each keeping its own material - so a wall painted white on one side and green on the other actually renders both colors. TypeScript (like Python/Dart/.NET) only ever resolved the FRONT material for the whole face, baked one single-sided mesh with normal winding, and never looked at `backMaterialId`/`uvTransformBack` at all - so the back side either showed the wrong (front) color or, with backface culling on (the default - no port ever set glTF's `doubleSided` flag), was invisible outright.

This is a real, verifiable defect: the legacy fixture (`capilla_quiroz_v17.skp`) has **30 faces with a front/back color that genuinely differs**. Unlike Python, TypeScript's `buildScene()` output IS what its own `toGLB()`/`exportGlb()` actually write to disk - no disconnected-pipeline caveat here, this fix changes real exported `.glb` output.

## Changes

- `model.ts`: `buildScene()`'s face-processing loop now resolves both `frontMat` (`materialId`) and `backMat` (`backMaterialId`) per face.
  - When their resolved colors match (including the common case of no back material at all), the face is emitted once as before, but its glTF material is now marked `doubleSided=true`.
  - When the colors differ, the face is split into two single-sided primitives: front (normal winding, front material/`uvTransform`/texture), back (reverse winding - swap triangle indices 1 and 2 - back material/`uvTransformBack`/texture, negated accumulated normal).
  - Mesh/material grouping keys extended from `color` to `(color, doubleSided)` to keep these two variants separate. Faithfully mirrors C++'s `GroupKey{color, doubleSided}` approach and Python's just-merged `addSide()` structure.

## Test plan

- [x] Verified against the real legacy fixture: `glbPrimitives`/`meshIndex`/`gltfMaterials` counts (21/21/13) now match C++'s and Python's independently-verified reference for this exact file exactly.
- [x] New `legacy.test.ts` assertion (item 14 regression) verifies two specific real faces' front (blue, `(2,0,237)`) and back (light blue, `(204,235,244)`) colors both appear as distinct `gltfMaterials` entries, that exactly 4 materials ended up `doubleSided`, and the full `glbPrimitives`/`meshIndex`/`gltfMaterials` counts.
- [x] No existing test assertions needed updating - `legacy.test.ts`'s `build_scene()` coverage never hardcoded exact primitive/material counts (unlike Python's, which did and needed updating in #115), and `glb.test.ts`'s real-fixture GLB comparison derives its expected count from `scene.glbPrimitives.length` dynamically rather than a hardcoded number.
- [x] Full suite: 66/66 passing.
- [x] `tsc --noEmit` clean.