### PR TITLE
Port double-sided back-face material handling to buildScene() (Dart)

### DIFF
--- a/packages/dart/lib/src/scene.dart
+++ b/packages/dart/lib/src/scene.dart
@@ -106,12 +106,13 @@ class Scene {
 
 class _FaceGroup {
   final (int, int, int) color;
+  final bool doubleSided;
   final List<(double, double, double)> localVerts = [];
   final List<(double, double)> localUvs = [];
   final List<List<double>> normalsAccum = [];
   final List<List<int>> localFaces = [];
   final Map<(int, double, double), int> localVMap = {};
-  _FaceGroup(this.color);
+  _FaceGroup(this.color, this.doubleSided);
 }
 
 const double _inchesToMm = 25.4;
@@ -195,7 +196,7 @@ class SceneBuilder {
     final meshIndex = <String, MeshMetadata>{};
     final glbPrimitives = <GlbPrimitive>[];
 
-    final colorToMaterialIndex = <(int, int, int), int>{};
+    final colorToMaterialIndex = <((int, int, int), bool), int>{};
     final gltfMaterials = <Map<String, dynamic>>[];
 
     // Definitions currently being instantiated on the active recursion path
@@ -207,19 +208,22 @@ class SceneBuilder {
 
     (int, int, int) getLayerColor(String name) => layerColors[name] ?? (136, 136, 136);
 
-    int getMaterialIndex((int, int, int) color) {
-      final existing = colorToMaterialIndex[color];
+    int getMaterialIndex((int, int, int) color, bool doubleSided) {
+      final key = (color, doubleSided);
+      final existing = colorToMaterialIndex[key];
       if (existing != null) return existing;
       final idx = gltfMaterials.length;
       final (r, g, b) = color;
-      gltfMaterials.add({
+      final material = <String, dynamic>{
         'pbrMetallicRoughness': {
           'baseColorFactor': [r / 255, g / 255, b / 255, 1.0],
           'metallicFactor': 0.0,
           'roughnessFactor': 0.8,
         },
-      });
-      colorToMaterialIndex[color] = idx;
+      };
+      if (doubleSided) material['doubleSided'] = true;
+      gltfMaterials.add(material);
+      colorToMaterialIndex[key] = idx;
       return idx;
     }
 
@@ -250,23 +254,92 @@ class SceneBuilder {
       (int, int, int)? inheritedColor,
     ) {
       if (builder.faces.isNotEmpty) {
-        final faceGroups = <(int, int, int), _FaceGroup>{};
+        // Group faces sharing a resolved (color, doubleSided) pair into one
+        // mesh each - same grouping the C++ reference uses (the only port
+        // that already had this before this port): a face whose front/back
+        // resolve to the SAME color is emitted once, with its glTF material
+        // marked doubleSided so it's visible from either side without
+        // needing duplicate geometry; a face whose front/back genuinely
+        // differ is emitted as TWO single-sided triangle sets - one
+        // normal-wound using the front material, one reverse-wound using
+        // the back material - so each side renders its own correct color
+        // instead of the front material leaking onto (or the back
+        // vanishing from) the far side.
+        final faceGroups = <((int, int, int), bool), _FaceGroup>{};
+
+        RawMaterial? resolveMaterial(int? matId) {
+          if (matId == null) return null;
+          final matName = materialIdToName[matId];
+          if (matName == null) return null;
+          return materials[matName] ?? materialsByFolder[matName];
+        }
+
+        void addSide(
+          List<List<int>> triangles,
+          (double, double, double) fn,
+          (int, int, int) color,
+          bool doubleSided,
+          bool reverse,
+          RawMaterial? mat,
+          List<double>? uvTransform,
+          (double, double, double) xr,
+          (double, double, double) yr,
+        ) {
+          final key = (color, doubleSided);
+          final group = faceGroups.putIfAbsent(key, () => _FaceGroup(color, doubleSided));
+
+          final tex = mat?.texture;
+          final tileW = (tex != null && tex.xScale > 1e-9) ? tex.xScale : 1.0;
+          final tileH = (tex != null && tex.yScale > 1e-9) ? tex.yScale : 1.0;
+          final sideNormal = reverse ? (-fn.$1, -fn.$2, -fn.$3) : fn;
+
+          // Vertices are deduped per (vId, uv) rather than just vId: UVs
+          // are inherently per-face, so a vertex position shared by two
+          // faces that disagree on texture mapping must become two
+          // distinct output vertices (glTF requires position/normal/uv
+          // aligned per index).
+          final faceLocalMap = <int, int>{};
+          for (final tri in triangles) {
+            final triIds = reverse ? [tri[0], tri[2], tri[1]] : tri;
+            final faceIndices = <int>[];
+            for (final vId in triIds) {
+              if (!builder.vertices.containsKey(vId)) continue;
+              var idx = faceLocalMap[vId];
+              if (idx == null) {
+                final p = builder.vertices[vId]!;
+                final (u, v) = _computeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
+                final key = (vId, u, v);
+                idx = group.localVMap[key];
+                if (idx == null) {
+                  group.localVerts.add(p);
+                  group.localUvs.add((u, v));
+                  group.normalsAccum.add([sideNormal.$1, sideNormal.$2, sideNormal.$3]);
+                  idx = group.localVerts.length - 1;
+                  group.localVMap[key] = idx;
+                } else {
+                  final accum = group.normalsAccum[idx];
+                  accum[0] += sideNormal.$1;
+                  accum[1] += sideNormal.$2;
+                  accum[2] += sideNormal.$3;
+                }
+                faceLocalMap[vId] = idx;
+              }
+              faceIndices.add(idx);
+            }
+            if (faceIndices.length == 3) {
+              group.localFaces.add(faceIndices);
+            }
+          }
+        }
 
         for (final faceEntry in builder.faces.entries) {
           final fData = faceEntry.value;
-          (int, int, int)? faceColor = inheritedColor;
-          final faceMatId = fData.materialId;
-          RawMaterial? mat;
-          if (faceMatId != null) {
-            final matName = materialIdToName[faceMatId];
-            if (matName != null) {
-              mat = materials[matName] ?? materialsByFolder[matName];
-              if (mat != null) faceColor = (mat.r, mat.g, mat.b);
-            }
-          }
-          final resolvedColor = faceColor ?? getLayerColor(parentLayer);
+          final fallbackColor = inheritedColor ?? getLayerColor(parentLayer);
 
-          final group = faceGroups.putIfAbsent(resolvedColor, () => _FaceGroup(resolvedColor));
+          final frontMat = resolveMaterial(fData.materialId);
+          final backMat = resolveMaterial(fData.backMaterialId);
+          final frontColor = (frontMat != null) ? (frontMat.r, frontMat.g, frontMat.b) : fallbackColor;
+          final backColor = (backMat != null) ? (backMat.r, backMat.g, backMat.b) : fallbackColor;
 
           final loops = <List<int>>[];
           for (final loop in fData.loops) {
@@ -286,56 +359,23 @@ class SceneBuilder {
           }
 
           final fn = fData.normal;
-          final tex = mat?.texture;
-          final tileW = (tex != null && tex.xScale > 1e-9) ? tex.xScale : 1.0;
-          final tileH = (tex != null && tex.yScale > 1e-9) ? tex.yScale : 1.0;
           final (xr, yr) = _faceUvBasis(fn);
           final uvTransform = fData.uvTransform;
+          final uvTransformBack = fData.uvTransformBack;
 
-          // Vertices are deduped per (vId, uv) rather than just vId: UVs
-          // are inherently per-face, so a vertex position shared by two
-          // faces that disagree on texture mapping must become two
-          // distinct output vertices (glTF requires position/normal/uv
-          // aligned per index).
-          final faceLocalMap = <int, int>{};
-          for (final tri in triangles) {
-            final faceIndices = <int>[];
-            for (final vId in tri) {
-              if (!builder.vertices.containsKey(vId)) continue;
-              var idx = faceLocalMap[vId];
-              if (idx == null) {
-                final p = builder.vertices[vId]!;
-                final (u, v) = _computeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
-                final key = (vId, u, v);
-                idx = group.localVMap[key];
-                if (idx == null) {
-                  group.localVerts.add(p);
-                  group.localUvs.add((u, v));
-                  group.normalsAccum.add([fn.$1, fn.$2, fn.$3]);
-                  idx = group.localVerts.length - 1;
-                  group.localVMap[key] = idx;
-                } else {
-                  final accum = group.normalsAccum[idx];
-                  accum[0] += fn.$1;
-                  accum[1] += fn.$2;
-                  accum[2] += fn.$3;
-                }
-                faceLocalMap[vId] = idx;
-              }
-              faceIndices.add(idx);
-            }
-            if (faceIndices.length == 3) {
-              group.localFaces.add(faceIndices);
-            }
+          if (frontColor == backColor) {
+            addSide(triangles, fn, frontColor, true, false, frontMat, uvTransform, xr, yr);
+          } else {
+            addSide(triangles, fn, frontColor, false, false, frontMat, uvTransform, xr, yr);
+            addSide(triangles, fn, backColor, false, true, backMat, uvTransformBack, xr, yr);
           }
         }
 
         final isRootPath = pathName == 'ROOT';
         final multiGroup = faceGroups.length > 1;
 
-        for (final groupEntry in faceGroups.entries) {
-          final color = groupEntry.key;
-          final group = groupEntry.value;
+        for (final group in faceGroups.values) {
+          final color = group.color;
           if (group.localFaces.isEmpty) continue;
 
           final tx = isRootPath ? 0.0 : (currentMatrix.length > 9 ? currentMatrix[9] : 0.0) * _inchesToMm;
@@ -344,7 +384,9 @@ class SceneBuilder {
 
           var safePath = pathName.replaceAll(' / ', '__').replaceAll(' ', '_');
           if (safePath.length > 80) safePath = safePath.substring(0, 80);
-          final colorSuffix = multiGroup ? '_${color.$1}_${color.$2}_${color.$3}' : '';
+          final colorSuffix = multiGroup
+              ? '_${color.$1}_${color.$2}_${color.$3}_${group.doubleSided ? 'ds' : 'ss'}'
+              : '';
           final geomName = 'mesh_${meshCounter}_${safePath}_$parentLayer$colorSuffix';
           meshCounter++;
 
@@ -417,7 +459,7 @@ class SceneBuilder {
             indices.add(tri[2]);
           }
 
-          final materialIndex = getMaterialIndex(color);
+          final materialIndex = getMaterialIndex(color, group.doubleSided);
           glbPrimitives.add(GlbPrimitive(
             positions: positions,
             normals: normals,

--- a/packages/dart/test/scene_test.dart
+++ b/packages/dart/test/scene_test.dart
@@ -7,20 +7,24 @@ import 'package:test/test.dart';
 /// scene-hierarchy + triangulation + GLB mesh capability, ported from the
 /// TypeScript reference implementation.
 ///
-/// Cross-validated directly against Python's and TypeScript's
-/// build_scene()/buildScene() on this exact fixture: mesh count,
-/// mesh_index count, gltf_materials count, root instance count, and the
-/// first three meshes' exact vertex/triangle counts and material indices
-/// all match precisely.
+/// Root instance count is cross-validated directly against Python's and
+/// TypeScript's build_scene()/buildScene() on this exact fixture.
+/// Mesh/gltfMaterials counts (21/21/13) instead match C++'s
+/// independently-verified reference for this file - the correct counts
+/// once faces with genuinely different front/back materials are split
+/// into two single-sided primitives each, rather than the pre-fix
+/// single-sided-only count (13/13/9). This fixture has 30 such faces
+/// (confirmed by direct inspection), so the split isn't a rare edge case
+/// here.
 void main() {
   final fixturePath = '${Directory.current.path}/test/fixtures/capilla_quiroz_v17.skp';
 
   test('buildScene matches Python and TypeScript ground truth', () {
     final scene = SkpFile.open(fixturePath).buildScene();
 
-    expect(scene.glbPrimitives.length, 13);
-    expect(scene.meshIndex.length, 13);
-    expect(scene.gltfMaterials.length, 9);
+    expect(scene.glbPrimitives.length, 21);
+    expect(scene.meshIndex.length, 21);
+    expect(scene.gltfMaterials.length, 13);
 
     expect(scene.sceneHierarchy.name, 'ROOT');
     expect(scene.sceneHierarchy.definitionName, 'ROOT_MODEL');
@@ -52,6 +56,30 @@ void main() {
     // buildScene() must not require parse() to have been called first -
     // it re-parses independently.
     final scene = SkpFile.open(fixturePath).buildScene();
-    expect(scene.glbPrimitives.length, 13);
+    expect(scene.glbPrimitives.length, 21);
+  });
+
+  test('renders back-face materials correctly (item 14 regression)', () {
+    // This fixture has 30 faces (e.g. faces 133/152 in the 'puerta'
+    // definition) whose front and back materials resolve to genuinely
+    // different colors. Verified directly: front material 29 is blue
+    // (2, 0, 237), back material 27 is light blue (204, 235, 244).
+    final scene = SkpFile.open(fixturePath).buildScene();
+
+    bool hasColor(int r, int g, int b) {
+      return scene.gltfMaterials.any((m) {
+        final pbr = m['pbrMetallicRoughness'] as Map<String, dynamic>;
+        final c = pbr['baseColorFactor'] as List;
+        return ((c[0] as double) * 255).round() == r &&
+            ((c[1] as double) * 255).round() == g &&
+            ((c[2] as double) * 255).round() == b;
+      });
+    }
+
+    expect(hasColor(2, 0, 237), true);
+    expect(hasColor(204, 235, 244), true);
+
+    final doubleSidedCount = scene.gltfMaterials.where((m) => m['doubleSided'] == true).length;
+    expect(doubleSidedCount, 4);
   });
 }


### PR DESCRIPTION
## Summary

Dart's `scene.dart` resolved only the front material per face, discarding `backMaterialId` entirely - a face painted with genuinely different front and back materials rendered with the front color on both sides, and no glTF material was ever marked `doubleSided` even in the shared-color case.

Ports C++'s `scene.cpp` reference behavior (the only language that already handled this correctly) - see the already-merged Python (#115) and TypeScript (#116) ports of the same fix for prior art:

- Resolve front/back materials independently, falling back to the same inherited/layer color for whichever side lacks a material.
- Same resolved color on both sides → emit one triangle set, mark the glTF material `doubleSided: true`.
- Different colors → split into two single-sided triangle sets: front (normal winding, front material/uvTransform) and back (reversed winding - swap triangle indices 1 and 2 - negated per-vertex normals, back material/uvTransformBack).
- `_FaceGroup`/`colorToMaterialIndex` keyed on `(color, doubleSided)` so same-color and split variants stay separate; geom-name color suffix gains a `ds`/`ss` marker when more than one group exists.

## Verification

Against the same real fixture used by the Python/TS ports: `capilla_quiroz_v17.skp` has 30 faces with genuinely different front/back render colors (e.g. `puerta` faces 133/152: front material 29 = blue `(2,0,237)`, back material 27 = light blue `(204,235,244)`).

- `glbPrimitives`/`meshIndex` count: 13 → 21
- `gltfMaterials` count: 9 → 13
- `doubleSided` materials: 4

These match C++'s independently-verified reference counts for this exact file (`parser_test.cpp`'s `EXPECT_EQ(scene.glb_primitives.size(), 21)` / `EXPECT_EQ(scene.gltf_materials.size(), 13)`), and the already-merged Python/TS counts exactly.

Added a dedicated regression test asserting both real resolved colors are present and the doubleSided count is 4.

- `dart analyze`: clean, no issues.
- `dart test`: all passing, including the updated `scene_test.dart` counts and the new back-face regression test.

## Test plan

- [x] `dart analyze` clean
- [x] `dart test` all green (updated ground-truth counts + new regression test)
- [x] Cross-checked exact counts against C++'s pre-existing reference and Python/TS's already-merged ports