### PR TITLE
Port double-sided back-face material handling to BuildScene() (.NET)

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/SceneTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/SceneTests.cs
@@ -11,11 +11,15 @@ namespace OpenSkp.Tests
     /// scene-hierarchy + triangulation + GLB mesh capability, ported from
     /// the TypeScript reference implementation.
     ///
-    /// Cross-validated directly against Python's and TypeScript's
-    /// SkpFile.build_scene()/buildScene() on this exact fixture: mesh
-    /// count, mesh_index count, gltf_materials count, root instance count,
-    /// and the first three meshes' exact vertex/triangle counts and
-    /// material indices all match precisely.
+    /// Root instance count is cross-validated directly against Python's
+    /// and TypeScript's SkpFile.build_scene()/buildScene() on this exact
+    /// fixture. Mesh/GltfMaterials counts (21/21/13) instead match C++'s
+    /// independently-verified reference for this file - the correct
+    /// counts once faces with genuinely different front/back materials
+    /// are split into two single-sided primitives each, rather than the
+    /// pre-fix single-sided-only count (13/13/9). This fixture has 30
+    /// such faces (confirmed by direct inspection), so the split isn't a
+    /// rare edge case here.
     /// </summary>
     public class SceneTests
     {
@@ -27,9 +31,9 @@ namespace OpenSkp.Tests
         {
             var scene = SkpFile.BuildScene(FixturePath("capilla_quiroz_v17.skp"));
 
-            Assert.Equal(13, scene.GlbPrimitives.Count);
-            Assert.Equal(13, scene.MeshIndex.Count);
-            Assert.Equal(9, scene.GltfMaterials.Count);
+            Assert.Equal(21, scene.GlbPrimitives.Count);
+            Assert.Equal(21, scene.MeshIndex.Count);
+            Assert.Equal(13, scene.GltfMaterials.Count);
 
             Assert.Equal("ROOT", scene.SceneHierarchy.Name);
             Assert.Equal("ROOT_MODEL", scene.SceneHierarchy.DefinitionName);
@@ -61,7 +65,35 @@ namespace OpenSkp.Tests
             // BuildScene() must not require Parse()/Open() to have been
             // called first - it re-parses independently.
             var scene = SkpFile.BuildScene(FixturePath("capilla_quiroz_v17.skp"));
-            Assert.Equal(13, scene.GlbPrimitives.Count);
+            Assert.Equal(21, scene.GlbPrimitives.Count);
+        }
+
+        [Fact]
+        public void RendersBackFaceMaterialsCorrectly()
+        {
+            // This fixture has 30 faces (e.g. faces 133/152 in the
+            // 'puerta' definition) whose front and back materials resolve
+            // to genuinely different colors. Verified directly: front
+            // material 29 is blue (2, 0, 237), back material 27 is light
+            // blue (204, 235, 244).
+            var scene = SkpFile.BuildScene(FixturePath("capilla_quiroz_v17.skp"));
+
+            bool HasColor(int r, int g, int b) => scene.GltfMaterials.Any(m =>
+            {
+                var dict = (System.Collections.Generic.IDictionary<string, object>)m;
+                dynamic pbr = dict["pbrMetallicRoughness"];
+                double[] c = pbr.baseColorFactor;
+                return (int)Math.Round(c[0] * 255) == r &&
+                    (int)Math.Round(c[1] * 255) == g &&
+                    (int)Math.Round(c[2] * 255) == b;
+            });
+
+            Assert.True(HasColor(2, 0, 237));
+            Assert.True(HasColor(204, 235, 244));
+
+            int doubleSidedCount = scene.GltfMaterials.Count(m =>
+                ((System.Collections.Generic.IDictionary<string, object>)m).TryGetValue("doubleSided", out var v) && v is bool b && b);
+            Assert.Equal(4, doubleSidedCount);
         }
     }
 }

--- a/packages/dotnet/OpenSkp/Scene.cs
+++ b/packages/dotnet/OpenSkp/Scene.cs
@@ -90,6 +90,7 @@ namespace OpenSkp
         private sealed class FaceGroup
         {
             public (int R, int G, int B) Color;
+            public bool DoubleSided;
             public List<(double X, double Y, double Z)> LocalVerts = new List<(double, double, double)>();
             public List<(double U, double V)> LocalUvs = new List<(double, double)>();
             public List<double[]> NormalsAccum = new List<double[]>();
@@ -184,7 +185,7 @@ namespace OpenSkp
             var meshIndex = new Dictionary<string, MeshMetadata>();
             var glbPrimitives = new List<GlbPrimitive>();
 
-            var colorToMaterialIndex = new Dictionary<(int, int, int), int>();
+            var colorToMaterialIndex = new Dictionary<((int, int, int) Color, bool DoubleSided), int>();
             var gltfMaterials = new List<object>();
 
             // Definitions currently being instantiated on the active
@@ -200,21 +201,35 @@ namespace OpenSkp
                 return layerColors.TryGetValue(name, out var c) ? c : (136, 136, 136);
             }
 
-            int GetMaterialIndex((int R, int G, int B) color)
+            int GetMaterialIndex((int R, int G, int B) color, bool doubleSided)
             {
-                if (colorToMaterialIndex.TryGetValue(color, out var existing)) return existing;
+                var key = (color, doubleSided);
+                if (colorToMaterialIndex.TryGetValue(key, out var existing)) return existing;
                 int idx = gltfMaterials.Count;
-                gltfMaterials.Add(new
+                var material = new Dictionary<string, object>
                 {
-                    pbrMetallicRoughness = new
+                    ["pbrMetallicRoughness"] = new
                     {
                         baseColorFactor = new[] { color.R / 255.0, color.G / 255.0, color.B / 255.0, 1.0 },
                         metallicFactor = 0.0,
                         roughnessFactor = 0.8,
                     },
-                });
-                colorToMaterialIndex[color] = idx;
+                };
+                if (doubleSided) material["doubleSided"] = true;
+                gltfMaterials.Add(material);
+                colorToMaterialIndex[key] = idx;
                 return idx;
+            }
+
+            (Geometry.RawMaterial? Mat, (int R, int G, int B)? Color) ResolveMaterial(long? matId)
+            {
+                if (matId is long id && materialIdToName.TryGetValue(id, out var matName))
+                {
+                    var m = materials.TryGetValue(matName, out var m1) ? m1
+                        : materialsByFolder.TryGetValue(matName, out var m2) ? m2 : null;
+                    if (m != null) return (m, (m.R, m.G, m.B));
+                }
+                return (null, null);
             }
 
             List<InstanceNode> Instantiate(
@@ -252,30 +267,81 @@ namespace OpenSkp
             {
                 if (builder.Faces.Count > 0)
                 {
-                    var faceGroups = new Dictionary<(int, int, int), FaceGroup>();
+                    var faceGroups = new Dictionary<((int R, int G, int B) Color, bool DoubleSided), FaceGroup>();
+
+                    void AddSide(
+                        List<long[]> triangles, (double X, double Y, double Z) fn,
+                        (int R, int G, int B) color, bool doubleSided, bool reverse,
+                        Geometry.RawMaterial? mat, double[]? uvTransform,
+                        (double X, double Y, double Z) xr, (double X, double Y, double Z) yr)
+                    {
+                        var key = (color, doubleSided);
+                        if (!faceGroups.TryGetValue(key, out var group))
+                        {
+                            group = new FaceGroup { Color = color, DoubleSided = doubleSided };
+                            faceGroups[key] = group;
+                        }
+
+                        double? texW = mat?.Texture?.XScale;
+                        double? texH = mat?.Texture?.YScale;
+                        double tileW = (texW.HasValue && texW.Value > 1e-9) ? texW.Value : 1.0;
+                        double tileH = (texH.HasValue && texH.Value > 1e-9) ? texH.Value : 1.0;
+                        (double X, double Y, double Z) sideNormal = reverse ? (-fn.X, -fn.Y, -fn.Z) : fn;
+
+                        // Vertices are deduped per (vId, uv) rather than
+                        // just vId: UVs are inherently per-face, so a
+                        // vertex position shared by two faces that
+                        // disagree on texture mapping must become two
+                        // distinct output vertices (glTF requires
+                        // position/normal/uv aligned per index).
+                        var faceLocalMap = new Dictionary<long, int>();
+                        foreach (var tri in triangles)
+                        {
+                            var triIds = reverse ? new long[] { tri[0], tri[2], tri[1] } : tri;
+                            var faceIndices = new List<int>();
+                            foreach (var vId in triIds)
+                            {
+                                if (!builder.Vertices.ContainsKey(vId)) continue;
+                                if (!faceLocalMap.TryGetValue(vId, out int idx))
+                                {
+                                    var p = builder.Vertices[vId];
+                                    var (u, v) = ComputeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
+                                    var vkey = (vId, u, v);
+                                    if (!group.LocalVMap.TryGetValue(vkey, out idx))
+                                    {
+                                        group.LocalVerts.Add(p);
+                                        group.LocalUvs.Add((u, v));
+                                        group.NormalsAccum.Add(new double[] { sideNormal.X, sideNormal.Y, sideNormal.Z });
+                                        idx = group.LocalVerts.Count - 1;
+                                        group.LocalVMap[vkey] = idx;
+                                    }
+                                    else
+                                    {
+                                        var accum = group.NormalsAccum[idx];
+                                        accum[0] += sideNormal.X; accum[1] += sideNormal.Y; accum[2] += sideNormal.Z;
+                                    }
+                                    faceLocalMap[vId] = idx;
+                                }
+                                faceIndices.Add(idx);
+                            }
+                            if (faceIndices.Count == 3)
+                            {
+                                group.LocalFaces.Add(new long[] { faceIndices[0], faceIndices[1], faceIndices[2] });
+                            }
+                        }
+                    }
+
+                    var fallbackColor = inheritedColor ?? GetLayerColor(parentLayer);
 
                     foreach (var faceKv in builder.Faces)
                     {
                         long fId = faceKv.Key;
                         var fData = faceKv.Value;
-                        (int R, int G, int B)? faceColor = inheritedColor;
-                        Geometry.RawMaterial? mat = null;
-                        if (fData.MaterialId is long faceMatId)
-                        {
-                            if (materialIdToName.TryGetValue(faceMatId, out var matName))
-                            {
-                                mat = materials.TryGetValue(matName, out var m1) ? m1
-                                    : materialsByFolder.TryGetValue(matName, out var m2) ? m2 : null;
-                                if (mat != null) faceColor = (mat.R, mat.G, mat.B);
-                            }
-                        }
-                        var resolvedColor = faceColor ?? GetLayerColor(parentLayer);
 
-                        if (!faceGroups.TryGetValue(resolvedColor, out var group))
-                        {
-                            group = new FaceGroup { Color = resolvedColor };
-                            faceGroups[resolvedColor] = group;
-                        }
+                        var (frontMat, frontMatColor) = ResolveMaterial(fData.MaterialId);
+                        var (backMat, backMatColor) = ResolveMaterial(fData.BackMaterialId);
+                        var frontColor = frontMatColor ?? fallbackColor;
+                        var backColor = backMatColor ?? fallbackColor;
 
                         var loops = new List<List<long>>();
                         foreach (var loop in fData.Loops)
@@ -297,52 +363,19 @@ namespace OpenSkp
                                 stage: "build_scene", definitionId: defId, innerException: e);
                         }
                         var fn = fData.Normal;
-                        double? texW = mat?.Texture?.XScale;
-                        double? texH = mat?.Texture?.YScale;
-                        double tileW = (texW.HasValue && texW.Value > 1e-9) ? texW.Value : 1.0;
-                        double tileH = (texH.HasValue && texH.Value > 1e-9) ? texH.Value : 1.0;
                         var (xr, yr) = FaceUvBasis(fn);
                         var uvTransform = fData.UvTransform;
+                        var uvTransformBack = fData.UvTransformBack;
 
-                        // Vertices are deduped per (vId, uv) rather than
-                        // just vId: UVs are inherently per-face, so a
-                        // vertex position shared by two faces that
-                        // disagree on texture mapping must become two
-                        // distinct output vertices (glTF requires
-                        // position/normal/uv aligned per index).
-                        var faceLocalMap = new Dictionary<long, int>();
-                        foreach (var tri in triangles)
+                        bool sameColor = frontColor.R == backColor.R && frontColor.G == backColor.G && frontColor.B == backColor.B;
+                        if (sameColor)
                         {
-                            var faceIndices = new List<int>();
-                            foreach (var vId in tri)
-                            {
-                                if (!builder.Vertices.ContainsKey(vId)) continue;
-                                if (!faceLocalMap.TryGetValue(vId, out int idx))
-                                {
-                                    var p = builder.Vertices[vId];
-                                    var (u, v) = ComputeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
-                                    var key = (vId, u, v);
-                                    if (!group.LocalVMap.TryGetValue(key, out idx))
-                                    {
-                                        group.LocalVerts.Add(p);
-                                        group.LocalUvs.Add((u, v));
-                                        group.NormalsAccum.Add(new double[] { fn.X, fn.Y, fn.Z });
-                                        idx = group.LocalVerts.Count - 1;
-                                        group.LocalVMap[key] = idx;
-                                    }
-                                    else
-                                    {
-                                        var accum = group.NormalsAccum[idx];
-                                        accum[0] += fn.X; accum[1] += fn.Y; accum[2] += fn.Z;
-                                    }
-                                    faceLocalMap[vId] = idx;
-                                }
-                                faceIndices.Add(idx);
-                            }
-                            if (faceIndices.Count == 3)
-                            {
-                                group.LocalFaces.Add(new long[] { faceIndices[0], faceIndices[1], faceIndices[2] });
-                            }
+                            AddSide(triangles, fn, frontColor, true, false, frontMat, uvTransform, xr, yr);
+                        }
+                        else
+                        {
+                            AddSide(triangles, fn, frontColor, false, false, frontMat, uvTransform, xr, yr);
+                            AddSide(triangles, fn, backColor, false, true, backMat, uvTransformBack, xr, yr);
                         }
                     }
 
@@ -351,7 +384,7 @@ namespace OpenSkp
 
                     foreach (var groupKv in faceGroups)
                     {
-                        var color = groupKv.Key;
+                        var color = groupKv.Key.Color;
                         var group = groupKv.Value;
                         if (group.LocalFaces.Count == 0) continue;
 
@@ -361,7 +394,7 @@ namespace OpenSkp
 
                         string safePath = pathName.Replace(" / ", "__").Replace(" ", "_");
                         if (safePath.Length > 80) safePath = safePath.Substring(0, 80);
-                        string colorSuffix = multiGroup ? $"_{color.Item1}_{color.Item2}_{color.Item3}" : "";
+                        string colorSuffix = multiGroup ? $"_{color.Item1}_{color.Item2}_{color.Item3}_{(group.DoubleSided ? "ds" : "ss")}" : "";
                         string geomName = $"mesh_{meshCounter}_{safePath}_{parentLayer}{colorSuffix}";
                         meshCounter++;
 
@@ -432,7 +465,7 @@ namespace OpenSkp
                             indices[i * 3 + 2] = (uint)group.LocalFaces[i][2];
                         }
 
-                        int materialIndex = GetMaterialIndex(color);
+                        int materialIndex = GetMaterialIndex(color, group.DoubleSided);
                         glbPrimitives.Add(new GlbPrimitive
                         {
                             Positions = positions,


### PR DESCRIPTION
## Summary

.NET's `Scene.cs` resolved only the front material per face, discarding `BackMaterialId` entirely - a face painted with genuinely different front and back materials rendered with the front color on both sides, and no glTF material was ever marked `doubleSided` even in the shared-color case.

Ports C++'s `scene.cpp` reference behavior (the only language that already handled this correctly), following the same pattern already shipped for Python (#115), TypeScript (#116), and Dart (#117):

- Resolve front/back materials independently via a new `ResolveMaterial()` helper, falling back to the same inherited/layer color for whichever side lacks a material.
- Same resolved color on both sides → emit one triangle set via a new `AddSide()` local function, mark the glTF material `doubleSided: true`.
- Different colors → split into two single-sided triangle sets: front (normal winding, front material/UvTransform) and back (reversed winding - swap triangle indices 1 and 2 - negated per-vertex normals, back material/UvTransformBack).
- `FaceGroup`/`colorToMaterialIndex` keyed on `(Color, DoubleSided)` so same-color and split variants stay separate; geom-name color suffix gains a `ds`/`ss` marker when more than one group exists.
- `GltfMaterials` entries switch from anonymous types to `Dictionary<string, object>` so a `doubleSided` key can be added conditionally - `MiniJson.Write` already special-cases `IDictionary<string, object>` ahead of its reflection fallback, so GLB serialization is unaffected.

## Verification

Against the same real fixture used by the Python/TS/Dart ports: `capilla_quiroz_v17.skp` has 30 faces with genuinely different front/back render colors (e.g. `puerta` faces 133/152: front material 29 = blue `(2,0,237)`, back material 27 = light blue `(204,235,244)`).

- `GlbPrimitives`/`MeshIndex` count: 13 → 21
- `GltfMaterials` count: 9 → 13
- `doubleSided` materials: 4

These match C++'s independently-verified reference counts for this exact file, and the already-merged Python/TS/Dart counts exactly.

Added a dedicated regression test asserting both real resolved colors are present and the doubleSided count is 4.

- `dotnet build`: 0 warnings, 0 errors.
- `dotnet test`: 47/47 passing, including the updated `SceneTests` counts, the new back-face regression test, and the untouched `Untitled.skp` `IntegrationTests` fixture (its MeshIndex count of 43 is unaffected - confirmed it has no differing front/back faces).

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` all green (47/47, updated ground-truth counts + new regression test)
- [x] Cross-checked exact counts against C++'s pre-existing reference and Python/TS/Dart's already-merged ports