### PR TITLE
Unify Python's to_dict and TS's toJSON into one canonical JSON schema

### DIFF
--- a/packages/python/src/openskp/export/json_export.py
+++ b/packages/python/src/openskp/export/json_export.py
@@ -1,11 +1,34 @@
 """Full metadata JSON export.
 
-Serialises a parsed :class:`~openskp.model.SkpModel` - definitions,
+Serialises a parsed :class:`~openskp.model.SkpModel` - definitions
+(with full vertex/edge/face arrays and their unresolved instance trees),
 layers, materials - into a JSON-compatible dict, and optionally writes it
 to disk. Pass the result of :meth:`SkpFile.build_scene` as *scene* to
 also include the resolved, world-space scene hierarchy; omit it for a
 lighter summary covering just the raw model (``scene_hierarchy`` is then
 ``None`` rather than a placeholder).
+
+This is openskp's canonical JSON export schema, shared with the
+TypeScript port's ``toJSON`` (and, from here, Dart/.NET/C++). It used to
+diverge from TypeScript's in two real ways - this module kept only
+vertex/edge/face *counts*, dropping the full ``edges``/``faces`` arrays
+TypeScript included, while TypeScript never included ``root`` or any
+per-definition ``instances`` tree at all - so a consumer switching
+between the two ports got a genuinely different shape, not just
+missing/extra fields. Both now match this one schema.
+
+Note ``Instance``'s ``layer``/``properties``/``children`` fields are
+deliberately *not* included in a definition's raw (pre-bake)
+``instances`` list here: they're always empty defaults in Python's (and
+Dart's/.NET's) parsed model - never assigned during parsing (``children``
+included: a definition's placed instances are always a flat list at
+parse time, matching TypeScript's ``Instance`` type, which doesn't
+declare any of the three) - and only C++ actually populates ``layer``/
+``properties``. Encoding known-dead placeholders into a schema meant to
+be identical across languages would just bake that inconsistency in. The
+*resolved*, genuinely nested per-instance tree (with correct layer/
+properties) is already available via ``scene_hierarchy`` (pass
+``scene=SkpFile.build_scene()``).
 """
 
 from __future__ import annotations
@@ -14,7 +37,7 @@ import json
 import pathlib
 from typing import Any, Dict, Optional, Union
 
-from ..model import Definition, Instance, SkpModel
+from ..model import Definition, Edge, Face, Instance, SkpModel, Vertex
 from ..scene import InstanceNode, Scene
 
 
@@ -23,19 +46,35 @@ def _instance_to_dict(inst: Instance) -> Dict[str, Any]:
     JSON-compatible dict.
 
     Args:
-        inst: An :class:`Instance` (may have nested children).
+        inst: An :class:`Instance`.
 
     Returns:
-        Dict representation including recursive children.
+        Dict representation.
     """
     return {
         "name": inst.name,
         "ref_idx": inst.ref_idx,
         "guid": inst.guid,
         "matrix": inst.matrix,
-        "layer": inst.layer,
-        "properties": inst.properties,
-        "children": [_instance_to_dict(c) for c in inst.children],
+    }
+
+
+def _vertex_to_dict(v: Vertex) -> Dict[str, Any]:
+    return {"id": v.id, "x": v.x, "y": v.y, "z": v.z}
+
+
+def _edge_to_dict(e: Edge) -> Dict[str, Any]:
+    return {"id": e.id, "v1_id": e.v1_id, "v2_id": e.v2_id}
+
+
+def _face_to_dict(f: Face) -> Dict[str, Any]:
+    return {
+        "id": f.id,
+        "loops": [
+            [{"edge_id": edge_id, "orientation": orient} for edge_id, orient in loop]
+            for loop in f.loops
+        ],
+        "normal": list(f.normal) if f.normal is not None else None,
     }
 
 
@@ -61,10 +100,9 @@ def _instance_node_to_dict(node: InstanceNode) -> Dict[str, Any]:
 
 
 def _definition_to_dict(defn: Definition) -> Dict[str, Any]:
-    """Convert a :class:`Definition` to a JSON-compatible dict.
-
-    Geometry data (vertices, edges, faces) is summarised by count to
-    keep the JSON output manageable.
+    """Convert a :class:`Definition` to a JSON-compatible dict, with full
+    vertex/edge/face arrays (not just counts) and its unresolved
+    ``instances`` tree.
 
     Args:
         defn: A :class:`Definition`.
@@ -79,10 +117,9 @@ def _definition_to_dict(defn: Definition) -> Dict[str, Any]:
         "vertex_count": len(defn.vertices),
         "edge_count": len(defn.edges),
         "face_count": len(defn.faces),
-        "vertices": [
-            {"id": v.id, "x": v.x, "y": v.y, "z": v.z}
-            for v in defn.vertices.values()
-        ],
+        "vertices": [_vertex_to_dict(v) for v in defn.vertices.values()],
+        "edges": [_edge_to_dict(e) for e in defn.edges.values()],
+        "faces": [_face_to_dict(f) for f in defn.faces.values()],
         "instances": [_instance_to_dict(i) for i in defn.instances],
     }
 
@@ -108,20 +145,22 @@ def to_dict(model: SkpModel, scene: Optional[Scene] = None) -> Dict[str, Any]:
         :attr:`SkpModel.root`) alongside ``definitions`` (numeric-ID-keyed
         component/group definitions).
     """
+    definitions_dict = {
+        str(k): _definition_to_dict(v) for k, v in model.definitions.items()
+    }
     return {
-        "version": model.version,
+        "format_version": "1.0",
+        "sketchup_version": model.version,
         "units": model.units,
+        "total_definitions": len(model.definitions),
+        "total_layers": len(model.layers),
+        "total_meshes": len(scene.mesh_index) if scene is not None else 0,
         "root": _definition_to_dict(model.root),
-        "definitions": {
-            str(k): _definition_to_dict(v)
-            for k, v in model.definitions.items()
-        },
+        "definitions": definitions_dict,
         "layers": [
             {
                 "name": layer.name,
-                "color_r": layer.color_r,
-                "color_g": layer.color_g,
-                "color_b": layer.color_b,
+                "color": {"r": layer.color_r, "g": layer.color_g, "b": layer.color_b},
                 "hidden": layer.hidden,
             }
             for layer in model.layers
@@ -129,11 +168,25 @@ def to_dict(model: SkpModel, scene: Optional[Scene] = None) -> Dict[str, Any]:
         "materials": [
             {
                 "name": mat.name,
-                "color": list(mat.color),
+                "color": {"r": mat.color[0], "g": mat.color[1], "b": mat.color[2], "a": mat.color[3]},
                 "transparency": mat.transparency,
             }
             for mat in model.materials
         ],
+        "mesh_index": (
+            {
+                name: {
+                    "name": m.name,
+                    "definition_name": m.definition_name,
+                    "layer": m.layer,
+                    "position_mm": list(m.position_mm),
+                    "properties": dict(m.properties),
+                    "path": m.path,
+                }
+                for name, m in scene.mesh_index.items()
+            }
+            if scene is not None else {}
+        ),
         "scene_hierarchy": (
             _instance_node_to_dict(scene.scene_hierarchy) if scene is not None else None
         ),

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -369,15 +369,21 @@ class TestJsonExport:
 
         model = SkpModel()
         d = to_dict(model)
-        assert d["version"] == "unknown"
+        assert d["format_version"] == "1.0"
+        assert d["sketchup_version"] == "unknown"
         assert d["units"] is None
+        assert d["total_definitions"] == 0
+        assert d["total_layers"] == 0
+        assert d["total_meshes"] == 0
         assert d["root"] == {
             "id": 0, "guid": "", "name": "", "vertex_count": 0,
-            "edge_count": 0, "face_count": 0, "vertices": [], "instances": [],
+            "edge_count": 0, "face_count": 0, "vertices": [], "edges": [],
+            "faces": [], "instances": [],
         }
         assert d["definitions"] == {}
         assert d["layers"] == []
         assert d["materials"] == []
+        assert d["mesh_index"] == {}
         assert d["scene_hierarchy"] is None
 
     def test_root_is_included_alongside_definitions(self) -> None:
@@ -402,6 +408,99 @@ class TestJsonExport:
         model.layers.append(Layer(name="Furniture", hidden=True))
         d = to_dict(model)
         assert d["layers"][0]["hidden"] is True
+
+    def test_layer_and_material_color_are_nested_objects(self) -> None:
+        # Matches TypeScript's convention (this schema's canonical shape)
+        # rather than Python's old flat color_r/color_g/color_b keys for
+        # layers or a positional [r, g, b, a] list for materials.
+        from openskp.model import Layer, Material, SkpModel
+        from openskp.export.json_export import to_dict
+
+        model = SkpModel()
+        model.layers.append(Layer(name="Furniture", color_r=10, color_g=20, color_b=30))
+        model.materials.append(Material(name="Brick", color=(1, 2, 3, 4)))
+        d = to_dict(model)
+        assert d["layers"][0]["color"] == {"r": 10, "g": 20, "b": 30}
+        assert d["materials"][0]["color"] == {"r": 1, "g": 2, "b": 3, "a": 4}
+
+    def test_definition_includes_full_edges_and_faces(self) -> None:
+        # Regression: this used to only include vertex/edge/face *counts*
+        # and a flat vertices array - TypeScript's toJSON always included
+        # full edges/faces arrays too, so switching ports meant a
+        # genuinely different (not just differently-named) shape.
+        from openskp.model import Definition, Edge, Face, SkpModel, Vertex
+
+        from openskp.export.json_export import to_dict
+
+        model = SkpModel()
+        model.root = Definition(id=0, guid="ROOT", name="ROOT_MODEL")
+        model.root.vertices[1] = Vertex(id=1, x=1.0, y=2.0, z=3.0)
+        model.root.vertices[2] = Vertex(id=2, x=4.0, y=5.0, z=6.0)
+        model.root.edges[10] = Edge(id=10, v1_id=1, v2_id=2)
+        model.root.faces[100] = Face(
+            id=100, loops=[[(10, 1)]], normal=(0.0, 0.0, 1.0), material_id=5,
+        )
+        d = to_dict(model)
+        assert d["root"]["edges"] == [{"id": 10, "v1_id": 1, "v2_id": 2}]
+        assert d["root"]["faces"] == [
+            {"id": 100, "loops": [[{"edge_id": 10, "orientation": 1}]], "normal": [0.0, 0.0, 1.0]}
+        ]
+
+    def test_instance_does_not_include_dead_layer_properties_children_fields(self) -> None:
+        # Instance.layer/Instance.properties/Instance.children are all
+        # declared but never assigned during parsing (always "" / {} / []
+        # defaults) - see item 17. Encoding them here would present
+        # known-dead data as if it were meaningful. The resolved,
+        # genuinely nested tree with correct layer/properties is
+        # available via scene_hierarchy instead.
+        from openskp.model import Definition, Instance, SkpModel
+        from openskp.export.json_export import to_dict
+
+        model = SkpModel()
+        model.root = Definition(id=0, guid="ROOT", name="ROOT_MODEL")
+        model.root.instances.append(Instance(name="child", ref_idx=1))
+        d = to_dict(model)
+        inst = d["root"]["instances"][0]
+        assert "layer" not in inst
+        assert "properties" not in inst
+        assert "children" not in inst
+        assert inst["name"] == "child"
+        assert inst["ref_idx"] == 1
+
+    def test_real_file_matches_ground_truth(self) -> None:
+        # Cross-checked directly against the TypeScript port's toJSON()
+        # on this same fixture - the schema is meant to match exactly.
+        import pathlib as _pathlib
+
+        import pytest as _pytest
+        from openskp.model import SkpFile
+        from openskp.export.json_export import to_dict
+
+        fixture = _pathlib.Path(__file__).parent / "fixtures" / "capilla_quiroz_v17.skp"
+        if not fixture.exists():
+            _pytest.skip("legacy fixture not present")
+
+        skp = SkpFile.open(str(fixture))
+        model = skp.parse()
+        d = to_dict(model)
+
+        assert d["total_definitions"] == 2
+        assert d["total_layers"] == 1
+        assert d["root"]["vertex_count"] == 251
+        assert d["root"]["edge_count"] == 390
+        assert d["root"]["face_count"] == 146
+        assert len(d["root"]["instances"]) == 3
+
+        puerta = next(v for v in d["definitions"].values() if v["name"] == "puerta")
+        assert puerta["id"] == 40
+        assert puerta["vertex_count"] == 64
+        assert puerta["edge_count"] == 95
+        assert puerta["face_count"] == 24
+        assert len(puerta["edges"]) == 95
+        assert len(puerta["faces"]) == 24
+        assert set(d["root"]["instances"][0].keys()) == {
+            "name", "ref_idx", "guid", "matrix",
+        }
 
 
 # ── SkpFile tests ────────────────────────────────────────────────────────

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -19,7 +19,10 @@ import {
   Style,
   Material,
   Texture,
+  Instance,
+  Definition,
   InstanceNode,
+  MeshMetadata,
   ParsedRawData,
   buildModelFromParsed,
   buildSceneFromParsed,
@@ -519,6 +522,28 @@ export function toGLB(scene: SkpScene): Uint8Array {
 }
 
 /**
+ * openskp's canonical JSON export schema, shared with the Python port's
+ * `to_dict` (and, from there, Dart/.NET/C++). It used to diverge from
+ * Python's in two real ways: this function never included `root` or any
+ * per-definition `instances` tree at all, while Python kept only
+ * vertex/edge/face *counts*, dropping the full `edges`/`faces` arrays
+ * this function always included - so a consumer switching between the
+ * two ports got a genuinely different shape, not just missing/extra
+ * fields. Both now match this one schema (snake_case keys throughout,
+ * including `scene_hierarchy`/`mesh_index` entries, which this function
+ * used to emit in TS's own camelCase instead).
+ *
+ * Note `Instance.layer`/`Instance.properties`/`Instance.children` on the
+ * *raw* (pre-bake) `instances` list are deliberately not part of this
+ * schema at all - TypeScript's `Instance` type doesn't declare any of
+ * them (a definition's placed instances are always a flat list at parse
+ * time here), and they're always empty defaults in Python's/Dart's/
+ * .NET's parsed model too (never assigned during parsing; only C++
+ * actually populates layer/properties - see item 17). The *resolved*,
+ * genuinely nested per-instance tree (with correct layer/properties) is
+ * available via `scene_hierarchy` (pass the result of {@link buildScene}
+ * as `scene`).
+ *
  * Export a parsed SkpModel to a metadata JSON object. Pass the result of
  * {@link buildScene} as `scene` to also include mesh/scene-hierarchy data;
  * omit it for a lighter summary covering just the raw model.
@@ -528,30 +553,41 @@ export function toGLB(scene: SkpScene): Uint8Array {
  * @returns Metadata object
  */
 export function toJSON(model: SkpModel, scene?: SkpScene): Record<string, unknown> {
+  const serializeInstance = (inst: Instance): any => ({
+    name: inst.name,
+    ref_idx: inst.refIdx,
+    guid: inst.guid,
+    matrix: inst.matrix,
+  });
+
+  const serializeDefinition = (defn: Definition): any => ({
+    id: defn.id,
+    guid: defn.guid,
+    name: defn.name,
+    vertex_count: defn.vertices.length,
+    edge_count: defn.edges.length,
+    face_count: defn.faces.length,
+    vertices: defn.vertices.map((v) => ({ id: v.id, x: v.x, y: v.y, z: v.z })),
+    edges: defn.edges.map((e) => ({ id: e.id, v1_id: e.v1Id, v2_id: e.v2Id })),
+    faces: defn.faces.map((f) => ({
+      id: f.id,
+      loops: f.loops.map((loop) =>
+        loop.map((ce) => ({ edge_id: ce.edgeId, orientation: ce.orientation }))
+      ),
+      normal: f.normal,
+    })),
+    instances: defn.instances.map(serializeInstance),
+  });
+
   const definitionsObj: Record<string, any> = {};
   for (const [id, defn] of model.definitions.entries()) {
-    definitionsObj[id] = {
-      id: defn.id,
-      guid: defn.guid,
-      name: defn.name,
-      vertex_count: defn.vertices.length,
-      edge_count: defn.edges.length,
-      face_count: defn.faces.length,
-      vertices: defn.vertices.map((v) => ({ id: v.id, x: v.x, y: v.y, z: v.z })),
-      edges: defn.edges.map((e) => ({ id: e.id, v1_id: e.v1Id, v2_id: e.v2Id })),
-      faces: defn.faces.map((f) => ({
-        id: f.id,
-        loops: f.loops.map((loop) =>
-          loop.map((ce) => ({ edge_id: ce.edgeId, orientation: ce.orientation }))
-        ),
-        normal: f.normal,
-      })),
-    };
+    definitionsObj[id] = serializeDefinition(defn);
   }
 
   const layersList = model.layers.map((l) => ({
     name: l.name,
     color: l.color,
+    hidden: l.hidden,
   }));
 
   const materialsList = model.materials.map((m) => ({
@@ -563,25 +599,43 @@ export function toJSON(model: SkpModel, scene?: SkpScene): Record<string, unknow
   const serializeInstanceNode = (node: InstanceNode): any => {
     return {
       name: node.name,
-      definitionName: node.definitionName,
+      definition_name: node.definitionName,
       layer: node.layer,
-      positionMm: node.positionMm,
+      position_mm: node.positionMm,
       properties: node.properties,
       children: node.children.map(serializeInstanceNode),
     };
   };
 
+  const serializeMeshMetadata = (m: MeshMetadata): any => ({
+    name: m.name,
+    definition_name: m.definitionName,
+    layer: m.layer,
+    position_mm: m.positionMm,
+    properties: m.properties,
+    path: m.path,
+  });
+
+  const meshIndexObj: Record<string, any> = {};
+  if (scene) {
+    for (const [name, m] of Object.entries(scene.meshIndex)) {
+      meshIndexObj[name] = serializeMeshMetadata(m);
+    }
+  }
+
   return {
     format_version: '1.0',
     sketchup_version: model.version,
+    units: model.units,
     total_definitions: model.definitions.size,
-    total_meshes: scene ? Object.keys(scene.meshIndex).length : 0,
     total_layers: model.layers.length,
+    total_meshes: scene ? Object.keys(scene.meshIndex).length : 0,
+    root: serializeDefinition(model.root),
+    definitions: definitionsObj,
     layers: layersList,
     materials: materialsList,
-    mesh_index: scene ? scene.meshIndex : {},
+    mesh_index: meshIndexObj,
     scene_hierarchy: scene ? serializeInstanceNode(scene.sceneHierarchy) : null,
-    definitions: definitionsObj,
   };
 }
 

--- a/packages/typescript/tests/json-export.test.ts
+++ b/packages/typescript/tests/json-export.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseSkp, buildScene, toJSON, SkpModel } from '../src/index';
+
+/**
+ * Real-file regression test for toJSON() - openskp's canonical JSON
+ * export schema, shared with the Python port's to_dict(). Every
+ * assertion here was cross-checked directly against Python's
+ * to_dict() on this exact fixture.
+ */
+describe('toJSON', () => {
+  const filePath = path.join(__dirname, 'fixtures', 'capilla_quiroz_v17.skp');
+  const buf = fs.readFileSync(filePath);
+  const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+
+  it('matches Python to_dict() ground truth on a real file', () => {
+    const model = parseSkp(arrayBuffer);
+    const d = toJSON(model) as any;
+
+    expect(d.format_version).toBe('1.0');
+    expect(d.sketchup_version).toBe('{17.0.18899}');
+    expect(d.total_definitions).toBe(2);
+    expect(d.total_layers).toBe(1);
+    expect(d.total_meshes).toBe(0); // no scene passed
+
+    expect(d.root.vertex_count).toBe(251);
+    expect(d.root.edge_count).toBe(390);
+    expect(d.root.face_count).toBe(146);
+    expect(d.root.instances.length).toBe(3);
+    // The raw (pre-bake) instance shape is flat, matching TS's own
+    // Instance type - no layer/properties/children (see item 17: those
+    // are dead fields at parse time in every language except C++, and
+    // TS's Instance type doesn't declare them at all).
+    expect(Object.keys(d.root.instances[0]).sort()).toEqual(
+      ['guid', 'matrix', 'name', 'ref_idx'].sort()
+    );
+
+    const puerta = Object.values(d.definitions).find((v: any) => v.name === 'puerta') as any;
+    expect(puerta.id).toBe(40);
+    expect(puerta.vertex_count).toBe(64);
+    expect(puerta.edge_count).toBe(95);
+    expect(puerta.face_count).toBe(24);
+    expect(puerta.edges.length).toBe(95);
+    expect(puerta.faces.length).toBe(24);
+
+    // Layer/material colors are nested {r,g,b[,a]} objects, not a flat
+    // color_r/g/b or a positional [r,g,b,a] list.
+    expect(d.layers[0].color).toEqual({ r: 255, g: 84, b: 84 });
+    expect(typeof d.materials[0].color.r).toBe('number');
+    expect(typeof d.materials[0].color.a).toBe('number');
+
+    expect(d.mesh_index).toEqual({});
+    expect(d.scene_hierarchy).toBeNull();
+  });
+
+  it('includes scene_hierarchy/mesh_index with snake_case keys when a scene is passed', () => {
+    const model = parseSkp(arrayBuffer);
+    const scene = buildScene(arrayBuffer);
+    const d = toJSON(model, scene) as any;
+
+    expect(d.total_meshes).toBe(Object.keys(scene.meshIndex).length);
+    expect(d.scene_hierarchy.name).toBe('ROOT');
+    // Snake_case, matching the rest of the schema - this function used
+    // to emit definitionName/positionMm here instead.
+    expect(d.scene_hierarchy).toHaveProperty('definition_name');
+    expect(d.scene_hierarchy).toHaveProperty('position_mm');
+    expect(d.scene_hierarchy).not.toHaveProperty('definitionName');
+
+    const firstMesh = Object.values(d.mesh_index)[0] as any;
+    expect(firstMesh).toHaveProperty('definition_name');
+    expect(firstMesh).toHaveProperty('position_mm');
+  });
+
+  it('produces JSON-serializable output with no undefined/circular values', () => {
+    const model = parseSkp(arrayBuffer);
+    const scene = buildScene(arrayBuffer);
+    const d = toJSON(model, scene);
+    expect(() => JSON.stringify(d)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

First step of item 16. Python's `export.json_export.to_dict()` and TypeScript's `toJSON()` were the only two languages with a JSON export, and their schemas were genuinely incompatible, not just differently-scoped: Python kept `root` + a recursive-looking `instances` tree per definition, but only vertex/edge/face *counts* (no full `edges`/`faces` arrays); TypeScript always included full `edges`/`faces` arrays, but never included `root` or any `instances` list at all. A consumer switching between the two ports got a different shape, not just missing fields.

This defines one canonical schema both now implement identically - the reference for porting to Dart/.NET/C++ in follow-up PRs:

- Every definition (root included) carries full `vertex_count`/`edge_count`/`face_count` *and* full `vertices`/`edges`/`faces` arrays, plus its raw (pre-bake) `instances` list.
- Top-level gains `format_version`/`units`/`total_definitions`/`total_layers`/`total_meshes`/`mesh_index`/`root` - fields only one side (or neither) had.
- Layer and material colors are nested `{r,g,b[,a]}` objects everywhere - Python used to emit layers as flat `color_r`/`color_g`/`color_b` keys and materials as a positional `[r,g,b,a]` list; TypeScript already used nested objects for materials but omitted `hidden` from layers entirely.
- `scene_hierarchy`/`mesh_index` entries are snake_case throughout - TypeScript's `toJSON` used to emit `definitionName`/`positionMm` (camelCase) here specifically, inconsistent with every other key in its own output.

## A design choice worth flagging

The raw (pre-bake) per-definition `instances` list is intentionally **flat**, with no `layer`/`properties`/`children` fields, in both languages now - not an arbitrary simplification. `Instance.children` turned out to be exactly the same class of bug as item 17's already-known `layer`/`properties` finding: declared on Python's (and Dart's/.NET's) `Instance` dataclass, but never assigned during parsing (confirmed directly in `model.py`'s live `Instance(...)` construction, which passes `name`/`ref_idx`/`guid`/`matrix`/`material_id`/`hidden` and nothing else) - a definition's placed instances are always flat at parse time. TypeScript's own `Instance` interface doesn't declare `layer`/`properties`/`children` at all, which is the more honest of the two. Encoding any of the three into a schema meant to be identical across languages would have baked a known inconsistency into brand-new API surface. The resolved, genuinely nested tree (with correct layer/properties) is already available via `scene_hierarchy` (pass `build_scene()`'s/`buildScene()`'s result as `scene`).

## Verification

Added `TestJsonExport` unit tests plus a real-fixture ground-truth test in Python (`capilla_quiroz_v17.skp`: total_definitions, root/puerta vertex/edge/face counts, nested layer/material colors, flat instance shape). Added TypeScript's first `toJSON` test coverage at all (`tests/json-export.test.ts`) against the same fixture, cross-checking the exact same values - including the literal layer color `{r:255,g:84,b:84}` matching between both languages' independent parses of the same file.

- Python: 128/128 tests passing, `ruff check` clean.
- TypeScript: 69/69 tests passing, `tsc --noEmit` clean, build succeeds.

## Test plan

- [x] Python: pytest 128/128, ruff clean
- [x] TypeScript: vitest 69/69, typecheck clean, build succeeds
- [x] Cross-checked identical real-fixture values between both languages' independent parses