### PR TITLE
Populate Instance.layer/properties, remove dead Instance.children

### DIFF
--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -100,9 +100,15 @@ struct Instance {
   std::optional<EntityId> ref_idx;
   std::string guid;
   std::vector<double> matrix;
+  // This instance's own explicit layer override, or "" when it has
+  // none. An instance without an explicit override inherits its
+  // *placement's* layer, which can only be resolved once the scene
+  // graph is flattened - see build_scene()'s InstanceNode::layer for
+  // that resolved value.
   std::string layer;
+  // Arbitrary key/value dynamic attributes attached directly to this
+  // instance (SketchUp's Dynamic Components).
   std::map<std::string, std::string> properties;
-  std::vector<Instance> children;
   std::optional<EntityId> material_id;
   // Whether the instance itself is hidden (SketchUp's "Hide" on this
   // specific component/group placement, not a layer/tag visibility

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -55,15 +55,8 @@ static Definition definition(EntityId id, RawDefinition&& r) {
     d.faces.emplace(f.first, std::move(x));
   }
   for (auto& i : r.builder.instances)
-    d.instances.push_back({std::move(i.name),
-                           i.ref_idx,
-                           std::move(i.ref_guid),
-                           std::move(i.matrix),
-                           std::move(i.layer),
-                           std::move(i.properties),
-                           {},
-                           i.material_id,
-                           i.hidden});
+    d.instances.push_back({std::move(i.name), i.ref_idx, std::move(i.ref_guid), std::move(i.matrix),
+                           std::move(i.layer), std::move(i.properties), i.material_id, i.hidden});
   return d;
 }
 

--- a/packages/cpp/tests/parser_test.cpp
+++ b/packages/cpp/tests/parser_test.cpp
@@ -83,6 +83,23 @@ TEST(Parser, ModernUntitled) {
   EXPECT_EQ(model.styles[0].name, "[Construction Documentation Style]");
   EXPECT_EQ(model.styles[0].front_color, (Color3{255, 255, 255}));
   EXPECT_EQ(model.styles[0].back_color, (Color3{208, 209, 189}));
+
+  // Instance layer/properties (item 17): populated from each instance's
+  // own D207 (layer override)/DC05 (dynamic properties) TLV children -
+  // C++ was already correct here (the reference the other 4 languages
+  // were ported to match). Cross-checked directly against Python's/
+  // Dart's/.NET's independent parses of this same fixture.
+  const auto batten =
+      std::find_if(model.root().instances.begin(), model.root().instances.end(),
+                   [](const Instance& i) { return i.name == "BattenHatSection_1"; });
+  ASSERT_NE(batten, model.root().instances.end());
+  EXPECT_EQ(batten->layer, "Hat Sections");
+
+  const auto w1 = std::find_if(model.root().instances.begin(), model.root().instances.end(),
+                               [](const Instance& i) { return i.name == "W1"; });
+  ASSERT_NE(w1, model.root().instances.end());
+  EXPECT_EQ(w1->properties.at("generator"), "SteelFramer::Engine::PanelGenerator");
+  EXPECT_EQ(w1->properties.at("profile"), "362S200-43");
 }
 
 TEST(Parser, ModernRootOnly) {

--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -28,10 +28,16 @@ class GeometryBuilderInstance {
   int? materialId;
   bool hidden = false;
   List<TlvNode> children = const [];
-  /// Dynamic Component properties precomputed for legacy (pre-2021 MFC)
-  /// instances (see legacy.dart's extractLegacyDynamicProperties) - VFF
-  /// instances don't set this, since their properties come from a lazy
-  /// D007/DC05 TLV walk over [children] instead (see scene.dart).
+  /// This instance's own explicit layer override (unresolved numeric
+  /// TLV ID), or null when it has none - an instance without one
+  /// inherits its *placement's* layer, only resolvable once the scene
+  /// graph is flattened (see scene.dart's InstanceNode.layer).
+  int? layerId;
+  /// Dynamic Component key/value properties attached directly to this
+  /// instance - populated eagerly here for both legacy (pre-2021 MFC,
+  /// via legacy.dart's extractLegacyDynamicProperties) and VFF
+  /// instances (via extractDynamicProperties on this instance's own
+  /// D007/DC05 children).
   Map<String, String>? properties;
 }
 
@@ -371,6 +377,8 @@ class Geometry {
 
         int? instMatId;
         var instHidden = false;
+        int? instLayerId;
+        Map<String, String>? instProperties;
         final instD007 = el.children.where((c) => c.tag == 'D007').firstOrNull;
         if (instD007 != null) {
           final d107 =
@@ -378,6 +386,12 @@ class Geometry {
           if (d107 != null) {
             instMatId = Tlv.parseVarInt(d107.payload, 0, d107.payload.length);
           }
+          final d207 =
+              instD007.children.where((c) => c.tag == 'D207').firstOrNull;
+          if (d207 != null && d207.payload.isNotEmpty) {
+            instLayerId = Tlv.parseVarInt(d207.payload, 0, d207.payload.length);
+          }
+          instProperties = extractDynamicProperties(instD007);
           // D307 = display flags, same record edges/faces already read
           // (base 0x06, +0x01 hidden).
           final instD307 =
@@ -395,6 +409,8 @@ class Geometry {
           ..matrix = matrix
           ..materialId = instMatId
           ..hidden = instHidden
+          ..layerId = instLayerId
+          ..properties = instProperties
           ..children = el.children);
       } else if (el.children.isNotEmpty) {
         extractGeometryFromNodes(el.children, builder);

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -1211,6 +1211,7 @@ class Legacy {
           ..matrix = List<double>.from(v.xf)
           ..materialId = v.db.mat != 0 ? v.db.mat : null
           ..hidden = v.db.hidden != 0
+          ..layerId = v.db.layer != 0 ? v.db.layer : null
           ..children = const []
           ..properties = LegacyReaders.extractLegacyDynamicProperties(v.attrs));
       }

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -142,9 +142,16 @@ class Instance {
   /// (empty when the entity carried none).
   final List<double> matrix;
 
+  /// This instance's own explicit layer override, or "" when it has
+  /// none. An instance without an explicit override inherits its
+  /// *placement's* layer, which can only be resolved once the scene
+  /// graph is flattened - see SkpFile.buildScene()'s InstanceNode.layer
+  /// for that resolved value.
   final String layer;
+
+  /// Arbitrary key/value dynamic attributes attached directly to this
+  /// instance (SketchUp's Dynamic Components).
   final Map<String, String> properties;
-  final List<Instance> children;
   final int? materialId;
 
   /// Whether the instance itself is hidden (SketchUp's "Hide" on this
@@ -159,7 +166,6 @@ class Instance {
     this.matrix = const [],
     this.layer = '',
     this.properties = const {},
-    this.children = const [],
     this.materialId,
     this.hidden = false,
   });

--- a/packages/dart/lib/src/parser.dart
+++ b/packages/dart/lib/src/parser.dart
@@ -67,9 +67,10 @@ class SkpFile {
       ..units = parsed.units;
 
     for (final entry in parsed.defsDict.entries) {
-      model.definitions[entry.key] = _buildDefinition(entry.key, entry.value);
+      model.definitions[entry.key] =
+          _buildDefinition(entry.key, entry.value, parsed.layerIdToName);
     }
-    model.root = _buildDefinition(0, parsed.root);
+    model.root = _buildDefinition(0, parsed.root, parsed.layerIdToName);
 
     for (final entry in parsed.layerColors.entries) {
       final (r, g, b) = entry.value;
@@ -119,7 +120,8 @@ class SkpFile {
     return model;
   }
 
-  static Definition _buildDefinition(int defId, RawDefinition d) {
+  static Definition _buildDefinition(
+      int defId, RawDefinition d, Map<int, String> layerIdToName) {
     final defn = Definition(
       id: defId,
       guid: d.guid ?? '',
@@ -163,6 +165,7 @@ class SkpFile {
     }
 
     for (final inst in d.builder.instances) {
+      final layerId = inst.layerId;
       defn.instances.add(Instance(
         name: inst.name ?? '',
         refIdx: inst.refIdx,
@@ -170,6 +173,8 @@ class SkpFile {
         matrix: inst.matrix,
         materialId: inst.materialId,
         hidden: inst.hidden,
+        layer: layerId != null ? (layerIdToName[layerId] ?? '') : '',
+        properties: inst.properties ?? const {},
       ));
     }
 

--- a/packages/dart/test/integration_test.dart
+++ b/packages/dart/test/integration_test.dart
@@ -104,6 +104,20 @@ void main() {
     expect(firstEdge.smooth, isFalse);
     expect(firstEdge.hidden, isFalse);
 
+    // Instance layer/properties (item 17): previously always "" / {} -
+    // declared but never assigned. Now genuinely populated from each
+    // instance's own D207 (layer override)/DC05 (dynamic properties)
+    // TLV children, matching C++'s existing behavior. Cross-checked
+    // directly against Python's independent parse of this same fixture.
+    final battens =
+        model.root.instances.where((i) => i.name == 'BattenHatSection_1');
+    expect(battens, isNotEmpty);
+    expect(battens.first.layer, 'Hat Sections');
+    final w1 = model.root.instances.where((i) => i.name == 'W1');
+    expect(w1, isNotEmpty);
+    expect(w1.first.properties['generator'], 'SteelFramer::Engine::PanelGenerator');
+    expect(w1.first.properties['profile'], '362S200-43');
+
     expect(def66.isImage, isFalse);
     expect(def66.alwaysFacesCamera, isFalse);
 

--- a/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
@@ -93,6 +93,20 @@ namespace OpenSkp.Tests
             Assert.False(firstEdge.Smooth);
             Assert.False(firstEdge.Hidden);
 
+            // Instance Layer/Properties (item 17): previously always ""
+            // / {} - declared but never assigned. Now genuinely
+            // populated from each instance's own D207 (layer
+            // override)/DC05 (dynamic properties) TLV children, matching
+            // C++'s existing behavior. Cross-checked directly against
+            // Python's independent parse of this same fixture.
+            var battens = model.Root.Instances.Where(i => i.Name == "BattenHatSection_1").ToList();
+            Assert.NotEmpty(battens);
+            Assert.Equal("Hat Sections", battens[0].Layer);
+            var w1 = model.Root.Instances.Where(i => i.Name == "W1").ToList();
+            Assert.NotEmpty(w1);
+            Assert.Equal("SteelFramer::Engine::PanelGenerator", w1[0].Properties["generator"]);
+            Assert.Equal("362S200-43", w1[0].Properties["profile"]);
+
             Assert.False(def66.IsImage);
             Assert.False(def66.AlwaysFacesCamera);
 

--- a/packages/dotnet/OpenSkp/Geometry.cs
+++ b/packages/dotnet/OpenSkp/Geometry.cs
@@ -30,11 +30,16 @@ namespace OpenSkp
         public long? MaterialId;
         public bool Hidden;
         public List<TlvNode> Children = new List<TlvNode>();
-        /// <summary>Dynamic Component properties precomputed for legacy
-        /// (pre-2021 MFC) instances (see Legacy.ExtractLegacyDynamicProperties)
-        /// - VFF instances don't set this, since their properties come from a
-        /// lazy D007/DC05 TLV walk over <see cref="Children"/> instead (see
-        /// Scene.cs).</summary>
+        /// <summary>This instance's own explicit layer override (unresolved
+        /// numeric TLV ID), or null when it has none - an instance without
+        /// one inherits its *placement's* layer, only resolvable once the
+        /// scene graph is flattened (see Scene.cs's InstanceNode.Layer).</summary>
+        public long? LayerId;
+        /// <summary>Dynamic Component key/value properties attached directly
+        /// to this instance - populated eagerly for both legacy (pre-2021
+        /// MFC, via Legacy.ExtractLegacyDynamicProperties) and VFF instances
+        /// (via ExtractDynamicProperties on this instance's own D007/DC05
+        /// children).</summary>
         public Dictionary<string, string>? Properties;
     }
 
@@ -357,6 +362,8 @@ namespace OpenSkp
 
                     long? instMatId = null;
                     bool instHidden = false;
+                    long? instLayerId = null;
+                    Dictionary<string, string>? instProperties = null;
                     var instD007 = el.Children.FirstOrDefault(c => c.Tag == "D007");
                     if (instD007 != null)
                     {
@@ -365,6 +372,12 @@ namespace OpenSkp
                         {
                             instMatId = Tlv.ParseVarInt(d107.Payload, 0, d107.Payload.Length);
                         }
+                        var d207 = instD007.Children.FirstOrDefault(c => c.Tag == "D207");
+                        if (d207 != null && d207.Payload.Length > 0)
+                        {
+                            instLayerId = Tlv.ParseVarInt(d207.Payload, 0, d207.Payload.Length);
+                        }
+                        instProperties = ExtractDynamicProperties(instD007);
                         // D307 = display flags, same record edges/faces already
                         // read (base 0x06, +0x01 hidden).
                         var instD307 = instD007.Children.FirstOrDefault(c => c.Tag == "D307");
@@ -383,6 +396,8 @@ namespace OpenSkp
                         Matrix = matrix,
                         MaterialId = instMatId,
                         Hidden = instHidden,
+                        LayerId = instLayerId,
+                        Properties = instProperties,
                         Children = el.Children,
                     });
                 }

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -1289,6 +1289,7 @@ namespace OpenSkp
                         Matrix = instRec.Xf.ToList(),
                         MaterialId = instRec.Db.Mat != 0 ? instRec.Db.Mat : (long?)null,
                         Hidden = instRec.Db.Hidden != 0,
+                        LayerId = instRec.Db.Layer != 0 ? instRec.Db.Layer : (long?)null,
                         Children = new List<TlvNode>(),
                         Properties = LegacyReaders.ExtractLegacyDynamicProperties(instRec.Attrs),
                     });

--- a/packages/dotnet/OpenSkp/Model.cs
+++ b/packages/dotnet/OpenSkp/Model.cs
@@ -119,9 +119,17 @@ namespace OpenSkp
         /// column-major order (empty when the entity carried none).</summary>
         public List<double> Matrix { get; set; } = new List<double>();
 
+        /// <summary>This instance's own explicit layer override, or ""
+        /// when it has none. An instance without an explicit override
+        /// inherits its *placement's* layer, which can only be resolved
+        /// once the scene graph is flattened - see
+        /// SkpFile.BuildScene()'s InstanceNode.Layer for that resolved
+        /// value.</summary>
         public string Layer { get; set; } = "";
+
+        /// <summary>Arbitrary key/value dynamic attributes attached
+        /// directly to this instance (SketchUp's Dynamic Components).</summary>
         public Dictionary<string, string> Properties { get; set; } = new Dictionary<string, string>();
-        public List<Instance> Children { get; set; } = new List<Instance>();
         public long? MaterialId { get; set; }
 
         /// <summary>Whether the instance itself is hidden (SketchUp's "Hide"

--- a/packages/dotnet/OpenSkp/Parser.cs
+++ b/packages/dotnet/OpenSkp/Parser.cs
@@ -23,9 +23,9 @@ namespace OpenSkp
 
             foreach (var kv in parsed.DefsDict)
             {
-                model.Definitions[kv.Key] = BuildDefinition(kv.Key, kv.Value);
+                model.Definitions[kv.Key] = BuildDefinition(kv.Key, kv.Value, parsed.LayerIdToName);
             }
-            model.Root = BuildDefinition(0, parsed.Root);
+            model.Root = BuildDefinition(0, parsed.Root, parsed.LayerIdToName);
 
             foreach (var kv in parsed.LayerColors)
             {
@@ -79,7 +79,7 @@ namespace OpenSkp
             return model;
         }
 
-        private static Definition BuildDefinition(long defId, Geometry.RawDefinition d)
+        private static Definition BuildDefinition(long defId, Geometry.RawDefinition d, Dictionary<long, string> layerIdToName)
         {
             var defn = new Definition
             {
@@ -131,6 +131,12 @@ namespace OpenSkp
 
             foreach (var inst in d.Builder.Instances)
             {
+                string layer = "";
+                if (inst.LayerId is long layerId)
+                {
+                    layerIdToName.TryGetValue(layerId, out var layerName);
+                    layer = layerName ?? "";
+                }
                 defn.Instances.Add(new Instance
                 {
                     Name = inst.Name ?? "",
@@ -139,6 +145,8 @@ namespace OpenSkp
                     Matrix = inst.Matrix,
                     MaterialId = inst.MaterialId,
                     Hidden = inst.Hidden,
+                    Layer = layer,
+                    Properties = inst.Properties ?? new Dictionary<string, string>(),
                 });
             }
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -456,6 +456,16 @@ def _extract_geometry_from_nodes(elements, builder):
             # exporting, so consumers need the raw value to do the same.
             inst_mat_id = None
             inst_hidden = False
+            # Unresolved layer ID (as a string) - the raw model has no
+            # layer_id_to_name mapping in scope here, so resolution to a
+            # name happens later in model.py, where that mapping is
+            # already available. Only the instance's own explicit layer
+            # override is captured this way - an instance that doesn't
+            # specify one inherits its *placement's* layer, which is only
+            # knowable once the scene graph is actually flattened (see
+            # SkpFile.build_scene()'s InstanceNode.layer for that).
+            inst_layer_id = None
+            inst_properties = {}
             d007 = next((c for c in el['children'] if c['tag'] == 'D007'),
                         None)
             if d007:
@@ -464,6 +474,12 @@ def _extract_geometry_from_nodes(elements, builder):
                 if d107:
                     inst_mat_id = parse_var_int(
                         d107['payload'], 0, len(d107['payload']))
+                d207 = next((c for c in d007['children']
+                             if c['tag'] == 'D207'), None)
+                if d207 and d207['payload']:
+                    inst_layer_id = parse_var_int(
+                        d207['payload'], 0, len(d207['payload']))
+                inst_properties = extract_dynamic_properties(d007)
                 # D307 = display flags, same record edges/faces already
                 # read (base 0x06, +0x01 hidden).
                 d307 = next((c for c in d007['children']
@@ -479,6 +495,8 @@ def _extract_geometry_from_nodes(elements, builder):
                 'matrix': matrix,
                 'material_id': inst_mat_id,
                 'hidden': inst_hidden,
+                'layer_id': inst_layer_id,
+                'properties': inst_properties,
                 'children': el['children']
             })
 

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -272,9 +272,14 @@ class Instance:
         guid: Globally-unique identifier string.
         matrix: 4×4 transformation matrix stored as a flat 16-element list
             in **column-major** order.
-        layer: Layer name this instance belongs to.
-        properties: Arbitrary key/value dynamic attributes.
-        children: Nested child instances forming a subtree.
+        layer: This instance's own explicit layer override, or ``""``
+            when it has none. An instance without an explicit override
+            inherits its *placement's* layer, which can only be resolved
+            once the scene graph is flattened - see
+            :meth:`SkpFile.build_scene`'s ``InstanceNode.layer`` for that
+            resolved value.
+        properties: Arbitrary key/value dynamic attributes attached
+            directly to this instance (SketchUp's Dynamic Components).
         material_id: Numeric material ID painted onto the instance itself
             (SketchUp's "paint the component"), or ``None``.  Faces inside
             the placed definition whose own :attr:`Face.material_id` is
@@ -296,7 +301,6 @@ class Instance:
     ])
     layer: str = ""
     properties: Dict[str, str] = field(default_factory=dict)
-    children: List["Instance"] = field(default_factory=list)
     material_id: Optional[int] = None
     hidden: bool = False
 
@@ -455,6 +459,8 @@ class SkpFile:
         model.version = parsed.get("version", "unknown")
         model.units = parsed.get("units")
 
+        layer_id_to_name = parsed.get("layer_id_to_name", {})
+
         # Convert defs_dict to Definition dataclasses
         for def_id, d in parsed["defs_dict"].items():
             builder = d["builder"]
@@ -492,6 +498,7 @@ class SkpFile:
                 )
             # Populate instances
             for inst in builder.instances:
+                layer_id = inst.get("layer_id")
                 defn.instances.append(Instance(
                     name=inst.get("name", "") or "",
                     ref_idx=inst.get("ref_idx"),
@@ -499,6 +506,8 @@ class SkpFile:
                     matrix=inst.get("matrix", []),
                     material_id=inst.get("material_id"),
                     hidden=inst.get("hidden", False),
+                    layer=layer_id_to_name.get(layer_id, "") if layer_id is not None else "",
+                    properties=inst.get("properties", {}),
                 ))
             if def_id == "ROOT":
                 model.root = defn

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -154,6 +154,21 @@ class TestDataModel:
         assert inst.matrix[0] == 1.0
         assert inst.matrix[5] == 1.0
 
+    def test_instance_has_no_children_field(self) -> None:
+        # Item 17: Instance.children was declared but never assigned
+        # during parsing anywhere (confirmed the same in Dart/.NET/C++ -
+        # a definition's placed instances are always a flat list at
+        # parse time; nesting only exists in the resolved scene graph),
+        # so it was removed outright rather than left as a permanently-
+        # empty field.
+        from openskp.model import Instance
+        import dataclasses
+
+        field_names = {f.name for f in dataclasses.fields(Instance)}
+        assert "children" not in field_names
+        assert "layer" in field_names
+        assert "properties" in field_names
+
     def test_skp_model_defaults(self) -> None:
         from openskp.model import SkpModel
 
@@ -1660,6 +1675,18 @@ class TestModernRealFile:
         assert joined.name == "*"
         assert joined in model.materials
         assert joined.id == 26180
+
+        # 3b. Instance layer/properties (item 17): previously always ""
+        # / {} - declared but never assigned. Now genuinely populated
+        # from each instance's own D207 (layer override)/DC05 (dynamic
+        # properties) TLV children, matching C++'s existing behavior.
+        battens = [i for i in model.root.instances if i.name == "BattenHatSection_1"]
+        assert battens
+        assert battens[0].layer == "Hat Sections"
+        w1 = [i for i in model.root.instances if i.name == "W1"]
+        assert w1
+        assert w1[0].properties["generator"] == "SteelFramer::Engine::PanelGenerator"
+        assert w1[0].properties["profile"] == "362S200-43"
 
         # 4. Definitions
         assert len(model.definitions) == 46


### PR DESCRIPTION
## Summary

Fixes item 17. `Instance.layer`/`Instance.properties` were declared on Python's, Dart's, and .NET's `Instance` type but never assigned during parsing - always `""` / `{}` regardless of what the file actually contained. Investigating C++'s already-correct behavior (the only language that populated them) showed why: both are read directly from an instance's own `D007` children during the existing single-pass geometry-extraction walk (`D207` = layer-ID reference, `DC05` = dynamic properties, the same `DC05` walk `extract_dynamic_properties()`/`ExtractDynamicProperties()`/`extractDynamicProperties()` already implement for scene-baking) - no scene-graph recursion needed, just a few missing lines in a walk that was already there. Python's and Dart's legacy (pre-2021 MFC) parsing paths already had this correct from earlier work; only the VFF path and model-assembly step (resolving the raw layer ID to a name via `layer_id_to_name`) were missing it in Python, and only .NET was missing both layer AND properties on its VFF path.

**Layer resolution note**: only an instance's own explicit `D207` override is captured this way - an instance without one inherits its *placement's* layer, which needs the scene graph flattened to know (already available via `build_scene()`'s `InstanceNode.layer`). This matches C++'s existing semantics exactly, not a new invented behavior.

While tracing this, found `Instance.children` is the exact same class of bug, in **all 5 languages including C++**: declared, always empty. SketchUp's raw per-definition instance list has no concept of an instance directly containing child instances (nesting only happens via `ref_idx` -> `Definition` -> `Instance` chains) - C++'s own `model.cpp` confirms this, initializing the field to `{}` unconditionally rather than reading real data. Removed outright everywhere rather than leaving permanently-dead API surface; TS's `Instance` type never declared it, matching the design this converges on.

## Per-language notes

- **Python**: `_extract_geometry_from_nodes` (`_core.py`) now reads `D207`/calls `extract_dynamic_properties()` eagerly per instance; `model.py` resolves the layer ID via `layer_id_to_name` and passes properties through; `Instance.children` field removed.
- **Dart**: `geometry.dart`'s `extractGeometryFromNodes` and `legacy.dart` both gained the same `D207`/`DC05` reads (legacy already had properties, not `layerId`); `parser.dart` resolves layer via `layerIdToName`; `Instance.children` removed from `model.dart`.
- **.NET**: `Geometry.cs` and `Legacy.cs` gained the same reads; `Parser.cs` resolves layer via `LayerIdToName`; `Instance.Children` removed from `Model.cs`.
- **C++**: no logic changes needed (already correct in both `geometry.cpp` and `legacy.cpp`) - only removed the dead `Instance.children` field from `model.hpp`/`model.cpp` (a `{}` placeholder in the aggregate-init list).
- **TypeScript**: no changes - its `Instance` type never declared `layer`/`properties`/`children` in the first place.

## Verification

All three real-fixture assertions (Python/Dart/.NET, plus a C++ test though it can't be run locally) check the exact same values on `Untitled.skp` - `BattenHatSection_1`'s layer resolves to `"Hat Sections"`, `W1`'s properties include `generator="SteelFramer::Engine::PanelGenerator"` and `profile="362S200-43"` - cross-checked directly against each other, not copied blind.

- Python: 129/129 tests passing, `ruff check` clean.
- Dart: `dart analyze` clean, 52/52 tests passing.
- .NET: `dotnet build` 0 warnings/errors, 50/50 tests passing.
- C++: cannot be built locally (no toolchain in this environment) - relies on CI; `clang-format` clean on all touched files.

## Test plan

- [x] Python: pytest 129/129, ruff clean
- [x] Dart: analyze + test all green
- [x] .NET: build + test all green
- [ ] C++: CI compiles and passes (cannot verify locally)