### PR TITLE
Widen Python's ruff scope to tests/; add .NET CI format/analyzer gate

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.cs]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -32,3 +32,27 @@ jobs:
 
       - name: Test
         run: dotnet test packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj --no-build --configuration Release
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0'
+
+      - name: Restore
+        run: |
+          dotnet restore packages/dotnet/OpenSkp/OpenSkp.csproj
+          dotnet restore packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj
+
+      - name: Verify formatting (.editorconfig)
+        run: |
+          dotnet format packages/dotnet/OpenSkp/OpenSkp.csproj --verify-no-changes
+          dotnet format packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj --verify-no-changes
+
+      - name: Build with analyzers as errors
+        run: |
+          dotnet build packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj --no-restore --configuration Release -warnaserror

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -52,4 +52,4 @@ jobs:
         run: pip install ruff==0.15.13
 
       - name: Lint
-        run: ruff check packages/python/src/
+        run: ruff check packages/python/src/ packages/python/tests/

--- a/packages/dotnet/Directory.Build.props
+++ b/packages/dotnet/Directory.Build.props
@@ -1,0 +1,12 @@
+<Project>
+  <PropertyGroup>
+    <!-- Shared analyzer/code-style settings for every project under
+         packages/dotnet/ - the built-in Roslyn analyzers plus
+         .editorconfig-based style rules, enforced as build warnings
+         (matching Dart's `dart analyze` and C++'s clang-format CI gates;
+         see item 19). -->
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+</Project>

--- a/packages/dotnet/OpenSkp/JsonExport.cs
+++ b/packages/dotnet/OpenSkp/JsonExport.cs
@@ -33,12 +33,17 @@ namespace OpenSkp
 
         private static Dictionary<string, object?> VertexToJson(Vertex v) => new Dictionary<string, object?>
         {
-            ["id"] = v.Id, ["x"] = v.X, ["y"] = v.Y, ["z"] = v.Z,
+            ["id"] = v.Id,
+            ["x"] = v.X,
+            ["y"] = v.Y,
+            ["z"] = v.Z,
         };
 
         private static Dictionary<string, object?> EdgeToJson(Edge e) => new Dictionary<string, object?>
         {
-            ["id"] = e.Id, ["v1_id"] = e.V1Id, ["v2_id"] = e.V2Id,
+            ["id"] = e.Id,
+            ["v1_id"] = e.V1Id,
+            ["v2_id"] = e.V2Id,
         };
 
         private static Dictionary<string, object?> FaceToJson(Face f)
@@ -119,7 +124,10 @@ namespace OpenSkp
                 ["name"] = m.Name,
                 ["color"] = new Dictionary<string, object?>
                 {
-                    ["r"] = m.Color.R, ["g"] = m.Color.G, ["b"] = m.Color.B, ["a"] = m.Color.A,
+                    ["r"] = m.Color.R,
+                    ["g"] = m.Color.G,
+                    ["b"] = m.Color.B,
+                    ["a"] = m.Color.A,
                 },
                 ["transparency"] = m.Transparency,
             }).ToList();


### PR DESCRIPTION
## Summary

Combines items 19 and 20 (Tier 7 CI hardening), per request to batch smaller items into fewer PRs.

**Item 20**: `ruff check` in `ci-python.yml`'s lint job only ever covered `packages/python/src/`, not `tests/` - this exact gap already let 5 lint issues sit unnoticed in `tests/` until an earlier cleanup pass this session. Widened to check both directories. Currently clean (0 issues) at the pinned ruff 0.15.13.

**Item 19**: .NET's CI had no format-verification step and no analyzer settings at all, unlike Dart's `dart analyze --fatal-infos` and C++'s dedicated clang-format job.

- Added a repo-root `.editorconfig` (charset/indent/line-ending basics, plus a `[*.cs]` section) - `dotnet format` has no rules to check without one.
- Added `packages/dotnet/Directory.Build.props` enabling the built-in Roslyn analyzers (`EnableNETAnalyzers`, `AnalysisLevel=latest`) and `.editorconfig`-based style enforcement (`EnforceCodeStyleInBuild`) for every project under `packages/dotnet/`.
- Added a new `format` job to `ci-dotnet.yml` (mirroring `ci-cpp.yml`'s dedicated `format` job, separate from the OS build/test matrix): `dotnet format --verify-no-changes` on both projects, then a build with `-warnaserror` so analyzer/style findings actually fail CI instead of being silently reported.

Running `dotnet format` for the first time surfaced one real style issue: `JsonExport.cs`'s object-initializer entries were packed multiple-per-line, inconsistent with this project's established one-member-per-line convention elsewhere. Fixed by accepting the formatter's split.

Note: `dotnet format` also silently normalized a handful of files whose *local working-copy* line endings had drifted from git's stored LF (a checkout-time Windows/autocrlf artifact on this machine, not a real repository inconsistency - confirmed via `git diff` showing zero content difference for every one of them). None of those are included in this commit since there was nothing real to commit.

## Verification

- `ruff check src/ tests/`: clean at the pinned CI version.
- `dotnet format --verify-no-changes`: clean on both projects.
- `dotnet build -warnaserror`: clean (0 warnings) on both, including a from-scratch `--no-incremental` rebuild to force analyzers to actually run rather than reuse a cached result.
- Full .NET test suite: 50/50 passing after the `JsonExport.cs` reformat.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `dotnet format --verify-no-changes` clean on both projects
- [x] `dotnet build -warnaserror` clean, verified via forced clean rebuild
- [x] `dotnet test` 50/50 passing