### PR TITLE
Fix TS's SkpFile.open/parseToRaw validation gaps

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -50,6 +50,15 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
   const data = new Uint8Array(buffer);
   emitLog(options, 'info', `Parsing buffer (${data.length} bytes)`);
 
+  // Both the legacy (pre-2021 MFC) and modern (VFF/ZIP) containers share
+  // this 4-byte magic - checked upfront, matching every other port, so a
+  // file that isn't a SketchUp file at all fails here with stage: 'header'
+  // instead of falling through to the ZIP extractor and getting mislabeled
+  // stage: 'zip_extract' for a problem that has nothing to do with ZIP.
+  if (!(data.length >= 4 && data[0] === 0xff && data[1] === 0xfe && data[2] === 0xff && data[3] === 0x0e)) {
+    throw new SkpParseError('Not a valid SketchUp file (bad header magic)', { stage: 'header' });
+  }
+
   if (isLegacy(data)) {
     emitLog(options, 'debug', 'Detected legacy MFC container; routing to legacy walker');
     return parseLegacyToRaw(data, options);
@@ -656,6 +665,14 @@ export class SkpFile {
   static open(filePath: string): SkpFile {
     if (typeof process !== 'undefined' && process.versions && process.versions.node) {
       const fs = require('fs');
+      const path = require('path');
+      if (!fs.existsSync(filePath)) {
+        throw new Error(`File not found: ${filePath}`);
+      }
+      const ext = path.extname(filePath);
+      if (ext.toLowerCase() !== '.skp') {
+        throw new Error(`Expected a .skp file, got: ${ext}`);
+      }
       const buffer = fs.readFileSync(filePath);
       const arrayBuffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength);
       return new SkpFile(arrayBuffer);

--- a/packages/typescript/tests/observability.test.ts
+++ b/packages/typescript/tests/observability.test.ts
@@ -41,11 +41,28 @@ describe('Observability: progress callbacks + structured error context', () => {
     expect(messages.some((m) => m.message.includes('Scene build complete'))).toBe(true);
   });
 
-  it('raises SkpParseError with stage="zip_extract" for a corrupt file', () => {
+  it('raises SkpParseError with stage="header" for a file with no valid SketchUp magic', () => {
     const bad = new Uint8Array(200).fill(0x41); // "AAAA..." - not a valid header
     const badBuffer = bad.buffer;
 
     expect(() => parseSkp(badBuffer)).toThrow(SkpParseError);
+    try {
+      parseSkp(badBuffer);
+      expect.fail('expected parseSkp to throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(SkpParseError);
+      expect((e as SkpParseError).stage).toBe('header');
+    }
+  });
+
+  it('raises SkpParseError with stage="zip_extract" for a file with a valid header but corrupt ZIP data', () => {
+    // Real SketchUp magic (shared by both legacy and modern containers),
+    // but garbage after it - passes the header check, fails at actual ZIP
+    // extraction, matching what stage: 'zip_extract' is meant to describe.
+    const bad = new Uint8Array(200).fill(0x41);
+    bad.set([0xff, 0xfe, 0xff, 0x0e], 0);
+    const badBuffer = bad.buffer;
+
     try {
       parseSkp(badBuffer);
       expect.fail('expected parseSkp to throw');

--- a/packages/typescript/tests/skpfile-open.test.ts
+++ b/packages/typescript/tests/skpfile-open.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { SkpFile } from '../src/index';
+
+/**
+ * SkpFile.open() validation - matches the same file-not-found/wrong-
+ * extension checks already present in every other port (Python: raises
+ * FileNotFoundError/ValueError; Dart: FileSystemException/ArgumentError;
+ * .NET: FileNotFoundException/ArgumentException; C++:
+ * std::filesystem::filesystem_error/std::invalid_argument). This port
+ * previously had neither check at all - a missing file surfaced as
+ * Node's own bare ENOENT, and a non-.skp path was accepted and handed
+ * straight to the parser.
+ */
+describe('SkpFile.open validation', () => {
+  it('throws for a missing file', () => {
+    const missing = path.join(__dirname, 'fixtures', 'does-not-exist.skp');
+    expect(() => SkpFile.open(missing)).toThrow(/File not found/);
+  });
+
+  it('throws for a file without a .skp extension', () => {
+    const tmpPath = path.join(os.tmpdir(), `openskp-test-${Date.now()}.txt`);
+    fs.writeFileSync(tmpPath, 'not a skp file');
+    try {
+      expect(() => SkpFile.open(tmpPath)).toThrow(/Expected a \.skp file/);
+    } finally {
+      fs.unlinkSync(tmpPath);
+    }
+  });
+
+  it('extension check is case-insensitive', () => {
+    // Copied to a tmpdir (not alongside the real fixture) - on a
+    // case-insensitive filesystem (Windows, default macOS),
+    // 'Untitled.SKP' and 'Untitled.skp' name the same file, so cleaning
+    // up the uppercase copy in-place would delete the real fixture out
+    // from under every other test.
+    const filePath = path.join(os.tmpdir(), `openskp-test-${Date.now()}.SKP`);
+    fs.copyFileSync(path.join(__dirname, 'fixtures', 'Untitled.skp'), filePath);
+    try {
+      expect(() => SkpFile.open(filePath)).not.toThrow();
+    } finally {
+      fs.unlinkSync(filePath);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes item 21. Two real gaps, both matching checks every other port (Python/Dart/.NET/C++) already had:

1. **`SkpFile.open()` had no file-existence or extension check at all** - a missing path surfaced as Node's bare ENOENT instead of a clear error, and a non-`.skp` path was silently accepted and handed straight to the parser. Added the same two checks the other 4 languages use (file-not-found, case-insensitive `.skp` extension), raising plain `Error` with the same message shape Python/Dart/.NET use.

2. **`parseToRaw()` had no upfront header-magic check.** Both the legacy (pre-2021 MFC) and modern (VFF/ZIP) containers share the same 4-byte magic - Python/Dart/.NET/C++ all check it first and raise `stage: 'header'` for anything that fails it. TS instead fell through unconditionally to the ZIP extractor whenever `isLegacy()` returned false (which it does for any non-matching input, not just "valid modern file"), so a file that wasn't SketchUp data at all got mislabeled `stage: 'zip_extract'`.

   This was concretely wrong, not just a doc nit: an existing test in `observability.test.ts` fed 200 bytes of `0x41` ("not a valid header", per its own comment) and asserted `stage: 'zip_extract'`. Fixed the check, updated that test to assert the correct `stage: 'header'`, and added a new test using real SketchUp magic bytes followed by garbage to confirm `stage: 'zip_extract'` still fires for what it's actually meant to describe (valid header, corrupt ZIP data after it).

## A bug caught while testing

The first version of the case-insensitive-extension test copied the `Untitled.skp` fixture to `Untitled.SKP` in the same directory and deleted it in a `finally` block - on a case-insensitive filesystem (Windows, default macOS) those are the same file, so the cleanup step deleted the real fixture out from under every other test depending on it. Rewritten to copy into a tmpdir instead.

## Verification

Full suite 73/73 passing (3 new `SkpFile.open` tests, 1 new `stage='zip_extract'` regression test, 1 existing test corrected to its right expected value), `tsc --noEmit` clean, `eslint` clean, build succeeds.

## Test plan

- [x] vitest 73/73 passing
- [x] `tsc --noEmit` clean
- [x] `eslint src/` clean
- [x] `npm run build` succeeds