### PR TITLE
Route silently-swallowed exceptions through existing debug-logging plumbing

### DIFF
--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include <openskp/export.hpp>
+#include <openskp/observability.hpp>
 
 namespace openskp {
 
@@ -150,6 +151,6 @@ class OPENSKP_EXPORT SkpModel {
  private:
   Definition root_{0, "ROOT", "ROOT_MODEL"};
   std::unordered_map<EntityId, std::size_t> material_indices_;
-  friend SkpModel build_model(struct RawParsed&&);
+  friend SkpModel build_model(struct RawParsed&&, const ParseOptions&);
 };
 }  // namespace openskp

--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -277,6 +277,7 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
     if (auto meta = zip.get("meta/meta.dat")) p.units = read_meta_units(*meta);
   } catch (...) {
     p.units = std::nullopt;
+    emit_log(o, LogLevel::debug, "Failed to read units from meta/meta.dat");
   }
   if (!p.layer_id_to_name.count(1)) p.layer_id_to_name[1] = "Layer0";
   if (!p.layer_colors.count("Layer0")) p.layer_colors["Layer0"] = {136, 136, 136};

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -126,7 +126,7 @@ void collect_geometry(const std::vector<TlvNode>&, GeometryBuilder&);
 void collect_layers(const std::vector<TlvNode>&, std::map<EntityId, std::string>&);
 void collect_material_ids(const std::vector<TlvNode>&, std::map<EntityId, std::string>&);
 void collect_definitions(const std::vector<TlvNode>&, std::map<EntityId, RawDefinition>&);
-SkpModel build_model(RawParsed&&);
+SkpModel build_model(RawParsed&&, const ParseOptions& = {});
 Scene build_scene_raw(RawParsed&&, const ParseOptions&);
 std::array<double, 3> transform_point(const std::vector<double>&, const std::array<double, 3>&);
 std::array<double, 3> transform_normal(const std::vector<double>&, const std::array<double, 3>&);

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -60,7 +60,7 @@ static Definition definition(EntityId id, RawDefinition&& r) {
   return d;
 }
 
-SkpModel build_model(RawParsed&& p) {
+SkpModel build_model(RawParsed&& p, const ParseOptions& o) {
   SkpModel m;
   m.version = std::move(p.version);
   m.units = std::move(p.units);
@@ -70,6 +70,7 @@ SkpModel build_model(RawParsed&& p) {
           auto l = p.layer_id_to_name.find(std::stoll(i.layer));
           if (l != p.layer_id_to_name.end()) i.layer = l->second;
         } catch (...) {
+          emit_log(o, LogLevel::debug, "Failed to resolve layer id '" + i.layer + "' to a name");
         };
   };
   for (auto& d : p.definitions) {

--- a/packages/cpp/src/parser.cpp
+++ b/packages/cpp/src/parser.cpp
@@ -30,7 +30,7 @@ SkpModel SkpFile::parse(const ParseOptions& o) const { return parse_skp(data_, o
 
 Scene SkpFile::build_scene(const ParseOptions& o) const { return openskp::build_scene(data_, o); }
 
-SkpModel parse_skp(ByteBuffer b, const ParseOptions& o) { return build_model(full_parse(b, o)); }
+SkpModel parse_skp(ByteBuffer b, const ParseOptions& o) { return build_model(full_parse(b, o), o); }
 
 Scene build_scene(ByteBuffer b, const ParseOptions& o) {
   return build_scene_raw(full_parse(b, o), o);

--- a/packages/cpp/src/scene.cpp
+++ b/packages/cpp/src/scene.cpp
@@ -281,6 +281,7 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
           if (li != p.layer_id_to_name.end()) child_layer = li->second;
         } catch (...) {
           child_layer = i.layer;
+          emit_log(o, LogLevel::debug, "Failed to resolve layer id '" + i.layer + "' to a name");
         }
       }
       auto child_color = inherited;

--- a/packages/dart/lib/src/core.dart
+++ b/packages/dart/lib/src/core.dart
@@ -72,9 +72,10 @@ class Core {
         Vff.validateEntrySize(entry);
         RawMaterial? mat;
         try {
-          mat = Geometry.parseMaterialXml(zip, name, entry.content);
-        } catch (_) {
+          mat = Geometry.parseMaterialXml(zip, name, entry.content, options);
+        } catch (e) {
           mat = null;
+          emitLog(options, SkpLogLevel.debug, 'Failed to parse material.xml $name: $e');
         }
         if (mat != null) {
           final parts = name.split('/');
@@ -98,7 +99,7 @@ class Core {
         continue;
       }
       Vff.validateEntrySize(entry);
-      final style = Geometry.parseStyleXml(entry.content);
+      final style = Geometry.parseStyleXml(entry.content, name, options);
       if (style != null) {
         styles.add(style);
       }

--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:archive/archive.dart';
 import 'package:xml/xml.dart';
 
+import 'observability.dart';
 import 'tlv.dart';
 import 'vff.dart';
 
@@ -516,11 +517,12 @@ class Geometry {
   /// archive path (e.g. "materials/Wood/material.xml"), used to resolve
   /// sibling texture image files.
   static RawMaterial? parseMaterialXml(
-      Archive zip, String xmlName, Uint8List xmlData) {
+      Archive zip, String xmlName, Uint8List xmlData, [ParseOptions? options]) {
     XmlDocument doc;
     try {
       doc = XmlDocument.parse(utf8.decode(xmlData));
-    } catch (_) {
+    } catch (e) {
+      emitLog(options, SkpLogLevel.debug, 'Failed to parse material.xml $xmlName: $e');
       return null;
     }
 
@@ -631,11 +633,12 @@ class Geometry {
     return s.substring(i);
   }
 
-  static RawStyle? parseStyleXml(Uint8List xmlData) {
+  static RawStyle? parseStyleXml(Uint8List xmlData, [String xmlName = '', ParseOptions? options]) {
     XmlDocument doc;
     try {
       doc = XmlDocument.parse(utf8.decode(xmlData));
-    } catch (_) {
+    } catch (e) {
+      emitLog(options, SkpLogLevel.debug, 'Failed to parse style.xml $xmlName: $e');
       return null;
     }
 

--- a/packages/dart/lib/src/scene.dart
+++ b/packages/dart/lib/src/scene.dart
@@ -503,8 +503,11 @@ class SceneBuilder {
           }
           try {
             properties = Geometry.extractDynamicProperties(d007);
-          } catch (_) {
-            // Ignore
+          } catch (e) {
+            emitLog(
+              options, SkpLogLevel.debug,
+              'Failed to extract dynamic properties for instance ${inst.name} (refIdx=$refIdx): $e',
+            );
           }
         }
 

--- a/packages/dotnet/OpenSkp/Core.cs
+++ b/packages/dotnet/OpenSkp/Core.cs
@@ -86,11 +86,12 @@ namespace OpenSkp
                     Geometry.RawMaterial? mat;
                     try
                     {
-                        mat = Geometry.ParseMaterialXml(zip, name, xmlData);
+                        mat = Geometry.ParseMaterialXml(zip, name, xmlData, options);
                     }
-                    catch
+                    catch (Exception e)
                     {
                         mat = null;
+                        Observability.Log(options, SkpLogLevel.Debug, $"Failed to parse material.xml {name}: {e.Message}");
                     }
                     if (mat != null)
                     {
@@ -126,7 +127,7 @@ namespace OpenSkp
                     s.CopyTo(ms);
                     xmlData = ms.ToArray();
                 }
-                var style = Geometry.ParseStyleXml(xmlData);
+                var style = Geometry.ParseStyleXml(xmlData, name, options);
                 if (style != null)
                 {
                     styles.Add(style);
@@ -222,9 +223,10 @@ namespace OpenSkp
                     }
                     units = Vff.ReadMetaUnits(metaData);
                 }
-                catch
+                catch (Exception e)
                 {
                     units = null;
+                    Observability.Log(options, SkpLogLevel.Debug, $"Failed to read units from meta/meta.dat: {e.Message}");
                 }
             }
 

--- a/packages/dotnet/OpenSkp/Geometry.cs
+++ b/packages/dotnet/OpenSkp/Geometry.cs
@@ -557,15 +557,16 @@ namespace OpenSkp
         /// <summary>Parse one materials/&lt;folder&gt;/material.xml entry.
         /// xmlName is the archive path (e.g. "materials/Wood/material.xml"),
         /// used to resolve sibling texture image files.</summary>
-        public static RawMaterial? ParseMaterialXml(ZipArchive zip, string xmlName, byte[] xmlData)
+        public static RawMaterial? ParseMaterialXml(ZipArchive zip, string xmlName, byte[] xmlData, SkpParseOptions? options = null)
         {
             XElement root;
             try
             {
                 root = XDocument.Parse(Encoding.UTF8.GetString(xmlData)).Root!;
             }
-            catch
+            catch (Exception e)
             {
+                Observability.Log(options, SkpLogLevel.Debug, $"Failed to parse material.xml {xmlName}: {e.Message}");
                 return null;
             }
 
@@ -693,15 +694,16 @@ namespace OpenSkp
             return ms.ToArray();
         }
 
-        public static RawStyle? ParseStyleXml(byte[] xmlData)
+        public static RawStyle? ParseStyleXml(byte[] xmlData, string xmlName = "", SkpParseOptions? options = null)
         {
             XElement root;
             try
             {
                 root = XDocument.Parse(Encoding.UTF8.GetString(xmlData)).Root!;
             }
-            catch
+            catch (Exception e)
             {
+                Observability.Log(options, SkpLogLevel.Debug, $"Failed to parse style.xml {xmlName}: {e.Message}");
                 return null;
             }
 

--- a/packages/dotnet/OpenSkp/Scene.cs
+++ b/packages/dotnet/OpenSkp/Scene.cs
@@ -525,9 +525,11 @@ namespace OpenSkp
                         {
                             properties = Geometry.ExtractDynamicProperties(d007);
                         }
-                        catch
+                        catch (Exception e)
                         {
-                            // Ignore
+                            Observability.Log(
+                                options, SkpLogLevel.Debug,
+                                $"Failed to extract dynamic properties for instance {inst.Name} (refIdx={refIdx}): {e.Message}");
                         }
                     }
 

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -830,7 +830,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
                         layer_colors[mat_name[6:]] = (r, g, b)
                         layer_hidden[mat_name[6:]] = False
             except Exception:
-                pass
+                logger.debug("Failed to parse material.xml %r", name, exc_info=True)
 
     # Thumbnail
     thumbnail_data = None
@@ -847,6 +847,7 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
             units = _read_meta_units(zf.read('meta/meta.dat'))
         except Exception:
             units = None
+            logger.debug("Failed to read units from meta/meta.dat", exc_info=True)
 
     # Styles: face colors live in styles/*/style.xml as signed-int32 ARGB
     # variants — item id 4000 is the front (default) face color, 4001 the

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -506,7 +506,10 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
                 try:
                     properties = _core.extract_dynamic_properties(d007)
                 except Exception:
-                    pass
+                    logger.debug(
+                        "Failed to extract dynamic properties for instance %r (ref_idx=%r)",
+                        inst.get("name"), ref_idx, exc_info=True,
+                    )
 
             inst_name = inst["name"] or f"Component_{ref_idx}"
             full_path_name = f"{path_name} / {inst_name}"

--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -1,4 +1,5 @@
 import { TlvNode, readF64, readU32, parseVarInt, parseTlvRecursive } from './parser';
+import { ParseOptions, emitLog } from './observability';
 
 export interface GeometryBuilderInstance {
   offset: number;
@@ -162,7 +163,8 @@ export function extractUvTransforms(
 
 export function extractGeometryFromNodes(
   elements: TlvNode[],
-  builder: GeometryBuilder
+  builder: GeometryBuilder,
+  options?: ParseOptions
 ): void {
   for (const el of elements) {
     const tag = el.tag;
@@ -310,8 +312,9 @@ export function extractGeometryFromNodes(
         try {
           const decoder = new TextDecoder('utf-8');
           name = decoder.decode(nameNode.payload).replace(/\0/g, '').trim();
-        } catch {
+        } catch (e) {
           name = '';
+          emitLog(options, 'debug', `Failed to decode instance name: ${(e as Error).message}`);
         }
       }
 
@@ -360,14 +363,15 @@ export function extractGeometryFromNodes(
         children: el.children,
       });
     } else if (el.children && el.children.length > 0) {
-      extractGeometryFromNodes(el.children, builder);
+      extractGeometryFromNodes(el.children, builder, options);
     }
   }
 }
 
 export function collectLayers(
   nodes: TlvNode[],
-  layerIdToName: Map<number, string> = new Map()
+  layerIdToName: Map<number, string> = new Map(),
+  options?: ParseOptions
 ): Map<number, string> {
   for (const el of nodes) {
     if (el.tag === '993A') {
@@ -388,8 +392,8 @@ export function collectLayers(
             try {
               const decoder = new TextDecoder('utf-8');
               lName = decoder.decode(nameNode.payload).replace(/\0/g, '').trim();
-            } catch {
-              // Ignore
+            } catch (e) {
+              emitLog(options, 'debug', `Failed to decode layer name for id ${lId}: ${(e as Error).message}`);
             }
             layerIdToName.set(lId, lName);
           }
@@ -397,7 +401,7 @@ export function collectLayers(
       }
     }
     if (el.children && el.children.length > 0) {
-      collectLayers(el.children, layerIdToName);
+      collectLayers(el.children, layerIdToName, options);
     }
   }
   return layerIdToName;
@@ -405,7 +409,8 @@ export function collectLayers(
 
 export function collectDefs(
   nodes: TlvNode[],
-  defsDict: Map<number | string, ParsedDefinition> = new Map()
+  defsDict: Map<number | string, ParsedDefinition> = new Map(),
+  options?: ParseOptions
 ): Map<number | string, ParsedDefinition> {
   for (const el of nodes) {
     if (el.tag === '7C15') {
@@ -425,8 +430,9 @@ export function collectDefs(
           try {
             const decoder = new TextDecoder('utf-8');
             name = decoder.decode(child.payload).replace(/\0/g, '').trim();
-          } catch {
+          } catch (e) {
             name = '';
+            emitLog(options, 'debug', `Failed to decode definition name: ${(e as Error).message}`);
           }
         } else if (child.tag === '8315' && child.payload.length > 0) {
           // Definition kind: observed 0/1 for ordinary component/group
@@ -451,7 +457,7 @@ export function collectDefs(
       const entId = extractEntityId(el);
       if (entId !== null) {
         const builder = new GeometryBuilder();
-        extractGeometryFromNodes(el.children, builder);
+        extractGeometryFromNodes(el.children, builder, options);
         defsDict.set(entId, {
           guid: guid || '',
           name: name || '',
@@ -462,13 +468,13 @@ export function collectDefs(
       }
     }
     if (el.children && el.children.length > 0) {
-      collectDefs(el.children, defsDict);
+      collectDefs(el.children, defsDict, options);
     }
   }
   return defsDict;
 }
 
-export function extractDynamicProperties(d007: TlvNode): Record<string, string> {
+export function extractDynamicProperties(d007: TlvNode, options?: ParseOptions): Record<string, string> {
   const dc05 = d007.children.find((c) => c.tag === 'DC05');
   if (!dc05) {
     return {};
@@ -498,16 +504,20 @@ export function extractDynamicProperties(d007: TlvNode): Record<string, string> 
         try {
           const decoder = new TextDecoder('utf-8');
           currentKey = decoder.decode(n.payload).replace(/\0/g, '').trim();
-        } catch {
+        } catch (e) {
           currentKey = null;
+          emitLog(options, 'debug', `Failed to decode dynamic property key: ${(e as Error).message}`);
         }
       } else if (tag === 'AD38' && currentKey) {
         try {
           const decoder = new TextDecoder('utf-8');
           const val = decoder.decode(n.payload).replace(/\0/g, '').trim();
           properties[currentKey] = val;
-        } catch {
-          // Ignore
+        } catch (e) {
+          emitLog(
+            options, 'debug',
+            `Failed to decode dynamic property value for key ${currentKey}: ${(e as Error).message}`
+          );
         }
         currentKey = null;
       }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -67,7 +67,7 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
   // 1. Extract SKP contents from VFF/ZIP container
   let contents;
   try {
-    contents = extractSkpContents(data);
+    contents = extractSkpContents(data, options);
   } catch (e) {
     throw new SkpParseError(`Failed to extract SKP contents: ${(e as Error).message}`, {
       stage: 'zip_extract',
@@ -140,8 +140,8 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
             layerHidden.set(parsedMat.name.slice(6), false);
           }
         }
-      } catch {
-        // Ignore XML errors
+      } catch (e) {
+        emitLog(options, 'debug', `Failed to parse material.xml ${name}: ${(e as Error).message}`);
       }
     }
   }
@@ -163,8 +163,8 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
             backColor: parsedStyle.backColor,
           });
         }
-      } catch {
-        // Ignore XML errors
+      } catch (e) {
+        emitLog(options, 'debug', `Failed to parse style.xml ${name}: ${(e as Error).message}`);
       }
     }
   }
@@ -196,8 +196,8 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
           try {
             const decoder = new TextDecoder('utf-8');
             mName = decoder.decode(nameNode.payload);
-          } catch {
-            // Ignore
+          } catch (e) {
+            emitLog(options, 'debug', `Failed to decode material name for id ${mId}: ${(e as Error).message}`);
           }
           materialIdToName.set(mId, mName);
         }
@@ -215,11 +215,11 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
 
   for (const { index, total, node: el } of iterTopLevelLazy(modelData, 0, modelData.length)) {
     try {
-      collectLayers([el], layerIdToName);
+      collectLayers([el], layerIdToName, options);
       collectMaterialIds([el]);
-      collectDefs([el], defsDict);
+      collectDefs([el], defsDict, options);
       if (el.tag === 'F601') {
-        extractGeometryFromNodes(el.children, rootBuilder);
+        extractGeometryFromNodes(el.children, rootBuilder, options);
       }
     } catch (e) {
       throw new SkpParseError(`Failed while processing top-level record: ${(e as Error).message}`, {

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -746,9 +746,12 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
       const d007 = inst.children.find((c) => c.tag === 'D007');
       if (d007) {
         try {
-          properties = extractDynamicProperties(d007);
-        } catch {
-          // Ignore
+          properties = extractDynamicProperties(d007, options);
+        } catch (e) {
+          emitLog(
+            options, 'debug',
+            `Failed to extract dynamic properties for instance ${inst.name ?? ''} (refIdx=${refIdx}): ${(e as Error).message}`
+          );
         }
       }
 

--- a/packages/typescript/src/vff.ts
+++ b/packages/typescript/src/vff.ts
@@ -1,4 +1,5 @@
 import { unzipSync, UnzipFileInfo } from 'fflate';
+import { ParseOptions, emitLog } from './observability';
 
 export interface SkpContents {
   version: string;
@@ -38,7 +39,7 @@ export function validateHeader(data: Uint8Array): boolean {
   );
 }
 
-export function readVersion(data: Uint8Array): string {
+export function readVersion(data: Uint8Array, options?: ParseOptions): string {
   if (data.length < 16) return 'unknown';
 
   // Find second FF FE FF marker after the initial one at offset 0
@@ -56,8 +57,8 @@ export function readVersion(data: Uint8Array): string {
           return verText.slice(braceStart, braceEnd + 1);
         }
       }
-    } catch {
-      // Ignore decoder errors
+    } catch (e) {
+      emitLog(options, 'debug', `Failed to decode version string: ${(e as Error).message}`);
     }
   }
 
@@ -138,7 +139,7 @@ function validateEntrySize(file: UnzipFileInfo): void {
   }
 }
 
-export function extractSkpContents(data: Uint8Array): SkpContents {
+export function extractSkpContents(data: Uint8Array, options?: ParseOptions): SkpContents {
   // Allow both VFF-wrapped and bare ZIP (some exporters omit the header)
   if (!validateHeader(data)) {
     const zipInHeader = findSequence(data.subarray(0, Math.min(64, data.length)), ZIP_LOCAL_HEADER) >= 0;
@@ -147,7 +148,7 @@ export function extractSkpContents(data: Uint8Array): SkpContents {
     }
   }
 
-  const version = readVersion(data);
+  const version = readVersion(data, options);
   const zipOffset = findZipOffset(data);
   const zipBytes = data.subarray(zipOffset);
 


### PR DESCRIPTION
## Summary

Fixes item 22, all 5 languages. Dynamic-property extraction, layer-ID resolution, material.xml/style.xml parsing, and units decoding all had bare catch-and-continue blocks sitting right next to code in the same function that already raises a fully-staged `SkpParseError` for other kinds of failure. Every port already has the logging plumbing (`logger.debug` in Python, `emitLog`/`ParseOptions` in TS/Dart/.NET, `emit_log`/`ParseOptions` in C++) - these sites just weren't using it, so a corrupted `material.xml` or a malformed dynamic-property blob failed completely silently instead of leaving a debug-level trace of what actually went wrong and where.

## Per language

- **Python**: `scene.py`'s dynamic-property extraction (the canonical example - a bare `except Exception: pass` right next to `build_scene`'s own `SkpParseError` raises), `_core.py`'s material.xml/layer-color parsing and `meta/meta.dat` units parsing. `legacy.py` was already clean - every catch there already re-raises as a staged error.
- **TypeScript**: `model.ts`'s dynamic-property extraction, plus material.xml/style.xml parsing and instance-name decoding in `index.ts`. Threading `options` through to the sites that needed it (`geometry.ts`'s `extractGeometryFromNodes`/`extractDynamicProperties`/`collectLayers`/`collectDefs`, `vff.ts`'s `readVersion`/`extractSkpContents`) meant giving each an optional `options?: ParseOptions` parameter and updating their call sites. `legacy.ts` was already clean.
- **Dart**: `scene.dart`'s dynamic-property extraction, `core.dart`'s material.xml/style.xml parsing (both the outer catch-and-continue and the inner `XmlDocument.parse` failure, which needed the same options threading as TS). `legacy.dart` was already clean.
- **.NET**: `Scene.cs`'s dynamic-property extraction, `Core.cs`'s material.xml/style.xml parsing and units parsing, `Geometry.cs`'s `ParseMaterialXml`/`ParseStyleXml`. `Legacy.cs` was already clean.
- **C++**: two sites, both layer-ID-string resolution (`std::stoll(i.layer)`) in `build_model()` (`model.cpp`) and `build_scene_raw()` (`scene.cpp`). material.xml/style.xml parsing use regex rather than a real XML parser here and simply can't throw, so there's nothing to route for those; `core.cpp`'s units-parsing swallow was already routed. Threading `ParseOptions` into `build_model()` required updating its declaration (`internal.hpp`), its friend declaration (`model.hpp`, needed a new `observability.hpp` include), its definition (`model.cpp`), and its one call site (`parser.cpp`) - given a default value so the two tests that call `build_model()` directly with a synthetic `RawParsed` and no options keep compiling unchanged. `legacy.cpp` was already clean.

## Deliberately left alone (same judgment across all 5 languages)

- Retry/fallback control-flow catches that already re-raise or deliberately break out of a loop (e.g. the legacy "over-declared root count" pattern in every port) - not silent, documented control flow.
- Tiny attribute-parsing fallbacks (x_scale/y_scale/colorizeType defaulting to 0 on a bad numeric attribute) - too fine-grained to be worth a log line each.
- Python's `geometry.py`/`metadata.py`/`materials.py` modules: confirmed entirely unreachable from the public API (never imported by `__init__.py`, `model.py`, or `scene.py`) and built around a TLV tag scheme that doesn't match the live parser's actual tags at all - polishing orphaned, seemingly-never-correct code isn't worth it here. Worth a follow-up item to just delete them.

## Verification

- Python: 129/129 tests, ruff clean.
- TypeScript: 73/73 tests, `tsc --noEmit` clean, eslint clean.
- Dart: `dart analyze` clean, 52/52 tests.
- .NET: `dotnet build` 0 warnings/errors (including a forced `--no-incremental` rebuild with `-warnaserror`), `dotnet test` 50/50, `dotnet format --verify-no-changes` clean on both projects.
- C++: cannot be built locally (no toolchain in this environment) - relies on CI; `clang-format` clean on all touched files; every edited site checked by hand against the real struct/function signatures.

## Test plan

- [x] Python: pytest 129/129, ruff clean
- [x] TypeScript: vitest 73/73, typecheck clean, eslint clean
- [x] Dart: analyze + test all green
- [x] .NET: build (incl. -warnaserror) + test + format all green
- [ ] C++: CI compiles and passes (cannot verify locally)