### PR TITLE
chore: add TLV tag comments, C# SkpFile.Parse null check, and clean up Python dead fields

### DIFF
--- a/packages/cpp/src/geometry.cpp
+++ b/packages/cpp/src/geometry.cpp
@@ -95,6 +95,9 @@ static std::pair<std::optional<std::array<double, 9>>, std::optional<std::array<
   return {side("1127"), side("1227")};
 }
 
+// Extract Dynamic Component key/value pairs from a DC05 payload.
+// B636 = property key string tag; AD38 = property value string tag;
+// DD05, B536, B136, B236, B336, B036, A438 = property container tags.
 static void scan_properties(const ByteBuffer& p, std::map<std::string, std::string>& out) {
   std::string key;
   std::function<void(size_t, size_t)> walk = [&](size_t a, size_t z) {
@@ -108,12 +111,15 @@ static void scan_properties(const ByteBuffer& p, std::map<std::string, std::stri
       t += h[p[a + 1] >> 4];
       t += h[p[a + 1] & 15];
       if (t == "B636")
+        // Property key name (UTF-8 string)
         key = std::string(reinterpret_cast<const char*>(p.data() + a + 6), n);
       else if (t == "AD38" && !key.empty()) {
+        // Property value (UTF-8 string) matching preceding key
         out[key] = std::string(reinterpret_cast<const char*>(p.data() + a + 6), n);
         key.clear();
       } else if (t == "DD05" || t == "B536" || t == "B136" || t == "B236" || t == "B336" ||
                  t == "B036" || t == "A438")
+        // Recurse into property sub-container tag
         walk(a + 6, a + 6 + n);
       a += 6 + n;
     }

--- a/packages/cpp/src/tlv.cpp
+++ b/packages/cpp/src/tlv.cpp
@@ -52,6 +52,10 @@ static std::string tag_at(const ByteBuffer& d, std::size_t o) {
   return s;
 }
 
+// VFF (2021+) model.dat binary structure uses Type-Length-Value (TLV) records.
+// Most TLV tags carry raw leaf binary/string payloads, but container tags contain
+// nested sub-TLV nodes (e.g. definitions, drawing elements, component instances).
+// containers lists every tag hex ID that the TLV parser must recursively traverse.
 static const std::set<std::string> containers = {
     "F401", "F701", "D430", "D530", "C832", "7C15", "8813", "8913", "8A13", "8B13", "8C13", "8D13",
     "4C1D", "6419", "F901", "7017", "7117", "D007", "C409", "9411", "9511", "0F01", "384A", "B80B",

--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -208,8 +208,10 @@ class Geometry {
     void extractProps(List<TlvNode> nodes) {
       for (final n in nodes) {
         if (n.tag == 'B636') {
+          // Property key name (UTF-8 string)
           currentKey = utf8.decode(n.payload, allowMalformed: true);
         } else if (n.tag == 'AD38' && currentKey != null) {
+          // Property value (UTF-8 string) matching preceding key
           properties[currentKey!] = utf8.decode(n.payload, allowMalformed: true);
           currentKey = null;
         }

--- a/packages/dart/lib/src/tlv.dart
+++ b/packages/dart/lib/src/tlv.dart
@@ -22,6 +22,10 @@ class TlvNode {
 /// Low-level TLV (Tag-Length-Value) binary parsing helpers, ported from
 /// Python's _core.py. All multi-byte reads are explicitly little-endian.
 class Tlv {
+  /// VFF (2021+) model.dat binary structure uses Type-Length-Value (TLV) records.
+  /// Most TLV tags carry raw leaf binary/string payloads, but container tags contain
+  /// nested sub-TLV nodes (e.g. definitions, drawing elements, component instances).
+  /// [containerTags] lists every tag hex ID that the TLV parser must recursively traverse.
   static const Set<String> containerTags = {
     'F401', 'F701', 'D430', 'D530', 'C832',
     '7C15', '8813', '8913', '8A13', '8B13', '8C13', '8D13', '4C1D', '6419',

--- a/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/IntegrationTests.cs
@@ -169,5 +169,13 @@ namespace OpenSkp.Tests
             Assert.Single(scene.MeshIndex);
             Assert.Equal("ROOT_MODEL", scene.MeshIndex.Values.First().DefinitionName);
         }
+
+        [Fact]
+        public void NullBufferThrowsArgumentNullException()
+        {
+            byte[] nullBuffer = null!;
+            Assert.Throws<ArgumentNullException>(() => SkpFile.Parse(nullBuffer));
+            Assert.Throws<ArgumentNullException>(() => SkpFile.BuildScene(nullBuffer));
+        }
     }
 }

--- a/packages/dotnet/OpenSkp/Geometry.cs
+++ b/packages/dotnet/OpenSkp/Geometry.cs
@@ -177,10 +177,12 @@ namespace OpenSkp
                 {
                     if (n.Tag == "B636")
                     {
+                        // Property key name (UTF-8 string)
                         currentKey = Encoding.UTF8.GetString(n.Payload);
                     }
                     else if (n.Tag == "AD38" && currentKey != null)
                     {
+                        // Property value (UTF-8 string) matching preceding key
                         properties[currentKey] = Encoding.UTF8.GetString(n.Payload);
                         currentKey = null;
                     }

--- a/packages/dotnet/OpenSkp/Parser.cs
+++ b/packages/dotnet/OpenSkp/Parser.cs
@@ -17,6 +17,11 @@ namespace OpenSkp
     {
         public static SkpModel Parse(byte[] buffer, SkpParseOptions? options = null)
         {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer), "Buffer cannot be null.");
+            }
+
             var parsed = Core.FullParse(buffer, options);
 
             var model = new SkpModel { Version = parsed.Version, Units = parsed.Units };
@@ -173,6 +178,11 @@ namespace OpenSkp
         /// isn't part of Parse().</summary>
         public static Scene BuildScene(byte[] buffer, SkpParseOptions? options = null)
         {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer), "Buffer cannot be null.");
+            }
+
             var parsed = Core.FullParse(buffer, options);
             return SceneBuilder.Build(parsed, options);
         }

--- a/packages/dotnet/OpenSkp/Tlv.cs
+++ b/packages/dotnet/OpenSkp/Tlv.cs
@@ -21,6 +21,10 @@ namespace OpenSkp
     /// little-endian regardless of host platform endianness.</summary>
     internal static class Tlv
     {
+        /// <summary>VFF (2021+) model.dat binary structure uses Type-Length-Value (TLV) records.
+        /// Most TLV tags carry raw leaf binary/string payloads, but container tags contain
+        /// nested sub-TLV nodes (e.g. definitions, drawing elements, component instances).
+        /// ContainerTags lists every tag hex ID that the TLV parser must recursively traverse.</summary>
         public static readonly HashSet<string> ContainerTags = new HashSet<string>
         {
             "F401", "F701", "D430", "D530", "C832",

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -57,6 +57,10 @@ def parse_var_int(data: bytes, offset: int, length: int) -> int:
         val |= data[offset + i] << (8 * i)
     return val
 
+# VFF (2021+) model.dat binary structure uses Type-Length-Value (TLV) records.
+# Most TLV tags carry raw leaf binary/string payloads, but container tags contain
+# nested sub-TLV nodes (e.g. definitions, drawing elements, component instances).
+# CONTAINER_TAGS lists every tag hex ID that the TLV parser must recursively traverse.
 CONTAINER_TAGS = {
     'F401', 'F701', 'D430', 'D530', 'C832',
     '7C15', '8813', '8913', '8A13', '8B13', '8C13', '8D13', '4C1D', '6419',
@@ -549,9 +553,17 @@ def multiply_matrices(parent, child):
 # ── Dynamic properties ───────────────────────────────────────────────────
 
 def extract_dynamic_properties(d007):
+    """Extract Dynamic Component attribute key-value pairs from a D007 container node.
+
+    Dynamic properties are stored in a nested TLV hierarchy under the DC05 tag:
+    - Container tags (DD05, B536, B136, B236, B336, B036, A438) wrap property sub-trees.
+    - Tag B636 contains the attribute key name (UTF-8 string).
+    - Tag AD38 contains the attribute value (UTF-8 string).
+    """
     dc05 = next((c for c in d007['children'] if c['tag'] == 'DC05'), None)
     if not dc05:
         return {}
+    # TLV container tags nesting the dynamic property key/value nodes
     prop_container_tags = ['DD05', 'B536', 'B136', 'B236', 'B336', 'B036', 'A438']
     prop_elements = parse_tlv_recursive(dc05['payload'], 0, len(dc05['payload']), prop_container_tags)
     properties = {}
@@ -561,8 +573,10 @@ def extract_dynamic_properties(d007):
         for n in nodes:
             tag = n['tag']
             if tag == 'B636':
+                # Property key name (UTF-8 string)
                 current_key = n['payload'].decode('utf-8', errors='replace')
             elif tag == 'AD38' and current_key:
+                # Property value (UTF-8 string) matching preceding key
                 val = n['payload'].decode('utf-8', errors='replace')
                 properties[current_key] = val
                 current_key = None

--- a/packages/python/src/openskp/export/glb.py
+++ b/packages/python/src/openskp/export/glb.py
@@ -148,7 +148,7 @@ def export(
 
     from .. import scene as _scene_mod
 
-    if not hasattr(skp_file, '_parsed') or skp_file._parsed is None:
+    if skp_file._parsed is None:
         raise RuntimeError(
             "SkpFile must be parsed before exporting. Call skp_file.parse() first."
         )

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import pathlib
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 if TYPE_CHECKING:
     from . import scene
@@ -404,9 +404,7 @@ class SkpFile:
 
     def __init__(self, path: pathlib.Path) -> None:
         self.path: pathlib.Path = path
-        self._raw_data: Optional[bytes] = None
-        self._model_data: Optional[bytes] = None
-        self._material_files: Dict[str, bytes] = {}
+        self._parsed: Optional[Dict[str, Any]] = None
 
     # ── Construction ──────────────────────────────────────────────────
 

--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -447,6 +447,7 @@ export function collectDefs(
           while (pos <= pl.length - 6) {
             const subSize = readU32(pl, pos + 2);
             if (pos + 6 + subSize > pl.length) break;
+            // Tag 0x5d 0x1b contains component definition flags (1 = always faces camera)
             if (pl[pos] === 0x5d && pl[pos + 1] === 0x1b && subSize >= 1) {
               facesCamera = parseVarInt(pl, pos + 6, subSize) === 1;
             }
@@ -474,11 +475,20 @@ export function collectDefs(
   return defsDict;
 }
 
+/**
+ * Extract Dynamic Component attribute key-value pairs from a D007 container node.
+ *
+ * Dynamic properties are stored in a nested TLV hierarchy under the DC05 tag:
+ * - Container tags (DD05, B536, B136, B236, B336, B036, A438) wrap property sub-trees.
+ * - Tag B636 contains the attribute key name (UTF-8 string).
+ * - Tag AD38 contains the attribute value (UTF-8 string).
+ */
 export function extractDynamicProperties(d007: TlvNode, options?: ParseOptions): Record<string, string> {
   const dc05 = d007.children.find((c) => c.tag === 'DC05');
   if (!dc05) {
     return {};
   }
+  // TLV container tags nesting the dynamic property key/value nodes
   const propContainerTags = new Set<string>([
     'DD05',
     'B536',
@@ -501,6 +511,7 @@ export function extractDynamicProperties(d007: TlvNode, options?: ParseOptions):
     for (const n of nodes) {
       const tag = n.tag;
       if (tag === 'B636') {
+        // Property key name (UTF-8 string)
         try {
           const decoder = new TextDecoder('utf-8');
           currentKey = decoder.decode(n.payload).replace(/\0/g, '').trim();
@@ -509,6 +520,7 @@ export function extractDynamicProperties(d007: TlvNode, options?: ParseOptions):
           emitLog(options, 'debug', `Failed to decode dynamic property key: ${(e as Error).message}`);
         }
       } else if (tag === 'AD38' && currentKey) {
+        // Property value (UTF-8 string) matching preceding key
         try {
           const decoder = new TextDecoder('utf-8');
           const val = decoder.decode(n.payload).replace(/\0/g, '').trim();

--- a/packages/typescript/src/parser.ts
+++ b/packages/typescript/src/parser.ts
@@ -6,6 +6,12 @@ export interface TlvNode {
   payload: Uint8Array;
 }
 
+/**
+ * VFF (2021+) model.dat binary structure uses Type-Length-Value (TLV) records.
+ * Most TLV tags carry raw leaf binary/string payloads, but container tags contain
+ * nested sub-TLV nodes (e.g. definitions, drawing elements, component instances).
+ * CONTAINER_TAGS lists every tag hex ID that the TLV parser must recursively traverse.
+ */
 export const CONTAINER_TAGS = new Set<string>([
   'F401', 'F701', 'D430', 'D530', 'C832',
   '7C15', '8813', '8913', '8A13', '8B13', '8C13', '8D13', '4C1D', '6419',


### PR DESCRIPTION
## Summary

Completes Tier 8 of the audit checklist (Items 23, 24, 25):

1. **Item 23 — Add explanatory comments to TLV tag tables (All 5 languages)**:
   - Documented \CONTAINER_TAGS\ (VFF top-level container tags in \model.dat\ wrapping nested sub-entities) and dynamic component attribute tags (\DC05\ payload tags: \DD05\, \B536\, \B136\, \B236\, \B336\, \B036\, \A438\), UTF-8 key/value tags (\B636\ key, \AD38\ value), and definition camera-facing flags (\5D1B\) across Python, TypeScript, Dart, C#, and C++.

2. **Item 24 — C# boundary null-check (\Parser.cs\)**:
   - Added explicit \if (buffer == null) throw new ArgumentNullException(...)\ at the entry point of \SkpFile.Parse(byte[], ...)\ and \SkpFile.BuildScene(byte[], ...)\.
   - Added unit test coverage in \IntegrationTests.cs\.

3. **Item 25 — Clean up Python dead fields (\model.py\ / \glb.py\)**:
   - Removed unused fields \_raw_data\, \_model_data\, and \_material_files\ from \SkpFile.__init__\.
   - Declared \self._parsed: Optional[Dict[str, Any]] = None\ in \SkpFile.__init__\.
   - Simplified \export/glb.py\'s check to \if skp_file._parsed is None:\.

## Verification

- **Python**: \pytest\ (129 passed), \uff check\ (clean)
- **TypeScript**: \	ypecheck\ (clean), \uild\ (clean), \lint\ (clean), \itest\ (73 passed)
- **Dart**: \dart analyze\ (0 issues), \dart test\ (all passed)
- **C# / .NET**: \dotnet build\ (0 warnings/errors), \dotnet test\ (51 passed), \dotnet format\ (clean), \dotnet build -warnaserror\ (clean)
- **C++**: Comments added; verified via CI build matrix.