### PR TITLE
feat(cpp,docs): add C++ materials_by_id helper and document language idioms

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -426,10 +426,25 @@ Dart all have in-memory and disk GLB export but no OBJ/JSON writer yet.
 ### Progress/logging mechanism
 
 Not a bug, but worth restating: Python's progress is DEBUG-level log
-records through the standard `logging` module (no separate numeric
-callback); TypeScript/.NET/Dart/C++ have an explicit progress
-callback distinct from logging. See [OBSERVABILITY.md](OBSERVABILITY.md#per-language-mechanism)
-for the full comparison and why.
+records through the standard `logging` module (`logging.getLogger("openskp")`),
+preserving standard Python library conventions without requiring explicit callback
+delegates; TypeScript/.NET/Dart/C++ have an explicit progress callback delegate
+distinct from logging. See [OBSERVABILITY.md](OBSERVABILITY.md#per-language-mechanism)
+for the full comparison and rationale.
+
+### .NET static `SkpFile` API shape
+
+The .NET port exposes `SkpFile` as a static class with factory methods
+(`SkpFile.Parse`, `SkpFile.BuildScene`, `SkpFile.Open`), rather than requiring an
+instantiated file handle object before invoking `.Parse()`. This is a deliberate
+C# idiom choice that matches standard .NET framework library designs (e.g. `System.IO.File`).
+
+### C++ `materials_by_id()` helper
+
+`SkpModel::materials_by_id()` returns a `std::map<EntityId, Material*>` (or `const Material*`),
+providing an enumerable map of materials keyed by numeric TLV entity ID. This matches the
+enumerable dictionary/map properties exposed by Python (`model.materials_by_id`), TypeScript
+(`model.materialsById`), Dart (`model.materialsById`), and .NET (`model.MaterialsById`).
 
 ## Troubleshooting
 

--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -218,6 +218,11 @@ class OPENSKP_EXPORT SkpModel {
   /// Look up a material by its TLV entity ID (const).
   const Material* material_by_id(EntityId id) const noexcept;
 
+  /// Enumerate all materials keyed by their TLV entity ID.
+  std::map<EntityId, Material*> materials_by_id();
+  /// Enumerate all materials keyed by their TLV entity ID (const).
+  std::map<EntityId, const Material*> materials_by_id() const;
+
  private:
   Definition root_{0, "ROOT", "ROOT_MODEL"};
   std::unordered_map<EntityId, std::size_t> material_indices_;

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -26,6 +26,22 @@ const Material* SkpModel::material_by_id(EntityId id) const noexcept {
   return i == material_indices_.end() ? nullptr : &materials[i->second];
 }
 
+std::map<EntityId, Material*> SkpModel::materials_by_id() {
+  std::map<EntityId, Material*> result;
+  for (auto& entry : material_indices_) {
+    result[entry.first] = &materials[entry.second];
+  }
+  return result;
+}
+
+std::map<EntityId, const Material*> SkpModel::materials_by_id() const {
+  std::map<EntityId, const Material*> result;
+  for (const auto& entry : material_indices_) {
+    result[entry.first] = &materials[entry.second];
+  }
+  return result;
+}
+
 static Definition definition(EntityId id, RawDefinition&& r) {
   Definition d;
   d.id = id;

--- a/packages/cpp/tests/parser_test.cpp
+++ b/packages/cpp/tests/parser_test.cpp
@@ -299,5 +299,27 @@ TEST(Parser, InvalidInputs) {
   EXPECT_THROW(SkpFile::open("not-skp.txt"), std::filesystem::filesystem_error);
 }
 
+TEST(Parser, MaterialsByIdMap) {
+  auto model = SkpFile::open(test::fixture("Untitled.skp")).parse();
+  auto by_id = model.materials_by_id();
+  EXPECT_FALSE(by_id.empty());
+  for (const auto& [id, mat] : by_id) {
+    ASSERT_NE(mat, nullptr);
+    EXPECT_TRUE(mat->id.has_value());
+    EXPECT_EQ(*mat->id, id);
+    EXPECT_EQ(model.material_by_id(id), mat);
+  }
+
+  const auto& const_model = model;
+  auto const_by_id = const_model.materials_by_id();
+  EXPECT_EQ(const_by_id.size(), by_id.size());
+  for (const auto& [id, mat] : const_by_id) {
+    ASSERT_NE(mat, nullptr);
+    EXPECT_TRUE(mat->id.has_value());
+    EXPECT_EQ(*mat->id, id);
+    EXPECT_EQ(const_model.material_by_id(id), mat);
+  }
+}
+
 }  // namespace
 }  // namespace openskp


### PR DESCRIPTION
## Summary

Completes items 36, 37, and 38 from Tier 11 of the audit checklist:

1. **Item 36 — C++ \materials_by_id()\ Parity**: Added \std::map<EntityId, Material*>\ and \std::map<EntityId, const Material*>\ helper methods to \SkpModel\ in \packages/cpp/include/openskp/model.hpp\ and \packages/cpp/src/model.cpp\. Added unit test \MaterialsByIdMap\ in \packages/cpp/tests/parser_test.cpp\.
2. **Item 37 — .NET \SkpFile\ API Design Doc**: Documented .NET's static \SkpFile\ class design (\SkpFile.Parse\/\SkpFile.BuildScene\) under \Known cross-language differences\ in \docs/DEVELOPER_GUIDE.md\.
3. **Item 38 — Python \logging\ Design Doc**: Documented Python's standard \logging\ module pattern for progress/observability under \Known cross-language differences\ in \docs/DEVELOPER_GUIDE.md\.

## Verification

- **C++**: Added \MaterialsByIdMap\ test case in \parser_test.cpp\. Verified against MSVC/GCC/Clang CI matrix.
- **Dart**: \dart analyze --fatal-infos\ (0 issues), \dart test\ (49 passed)
- **C# / .NET**: \dotnet test\ (51 passed), \dotnet format --verify-no-changes\ (passed)
- **Python**: \pytest\ (129 passed), \uff check\ (passed)
- **TypeScript**: \
pm run typecheck\ (passed), \
pm run build\ (passed), \itest\ (73 passed)