### PR TITLE
fix(python): set newline='' in DXF export() to prevent Windows double CRLF corruption

### DIFF
--- a/packages/python/src/openskp/export/dxf.py
+++ b/packages/python/src/openskp/export/dxf.py
@@ -268,7 +268,7 @@ def export(
     out.parent.mkdir(parents=True, exist_ok=True)
 
     text = to_dxf(scene, scale=scale, mode=mode)
-    with open(out, "w", encoding="utf-8") as fp:
+    with open(out, "w", encoding="utf-8", newline="") as fp:
         fp.write(text)
 
 


### PR DESCRIPTION
Fixes an issue where open() without newline='' on Windows transformed \r\n into \r\r\n (double carriage returns), causing CAD viewers to reject 3DFACE DXF files. Explicitly setting newline='' guarantees clean standard line endings.