### PR TITLE
feat(dxf): Default DXF exporter to AutoCAD Polyface Mesh mode across all 5 language ports

### DIFF
--- a/packages/cpp/include/openskp/dxf_export.hpp
+++ b/packages/cpp/include/openskp/dxf_export.hpp
@@ -22,7 +22,7 @@ constexpr double METRES_TO_INCHES = 39.37007874015748;
  * @return Formatted ASCII DXF text string.
  */
 std::string to_dxf(const Scene& scene, double scale = METRES_TO_INCHES,
-                   const std::string& mode = "3dface");
+                   const std::string& mode = "polyface");
 
 /**
  * Export a baked Scene directly to an AutoCAD R2000 3D DXF file.
@@ -30,10 +30,10 @@ std::string to_dxf(const Scene& scene, double scale = METRES_TO_INCHES,
  * @param scene The baked scene returned by SkpFile::build_scene()
  * @param path Destination file path (.dxf)
  * @param scale Scale factor for vertex coordinates (default: METRES_TO_INCHES)
- * @param mode Export mode ("3dface" or "polyface", default: "3dface")
+ * @param mode Export mode ("3dface" or "polyface", default: "polyface")
  */
 void export_dxf(const Scene& scene, const std::filesystem::path& path,
-                double scale = METRES_TO_INCHES, const std::string& mode = "3dface");
+                double scale = METRES_TO_INCHES, const std::string& mode = "polyface");
 
 }  // namespace openskp
 

--- a/packages/cpp/tests/dxf_export_test.cpp
+++ b/packages/cpp/tests/dxf_export_test.cpp
@@ -16,13 +16,17 @@ TEST(DxfExport, SerializesSceneTo3DxfText) {
   prim.indices = {0, 1, 2};
   scene.glb_primitives.push_back(prim);
 
-  std::string dxf_text = to_dxf(scene, METRES_TO_INCHES, "polyface");
+  std::string dxf_text = to_dxf(scene);
   EXPECT_NE(dxf_text.find("$ACADVER"), std::string::npos);
   EXPECT_NE(dxf_text.find("AC1015"), std::string::npos);
   EXPECT_NE(dxf_text.find("POLYLINE"), std::string::npos);
   EXPECT_NE(dxf_text.find("AcDbPolyFaceMesh"), std::string::npos);
   EXPECT_NE(dxf_text.find("Walls"), std::string::npos);
   EXPECT_NE(dxf_text.find("EOF"), std::string::npos);
+
+  std::string dxf_3d = to_dxf(scene, METRES_TO_INCHES, "3dface");
+  EXPECT_NE(dxf_3d.find("3DFACE"), std::string::npos);
+  EXPECT_NE(dxf_3d.find("AcDbFace"), std::string::npos);
 }
 
 }  // namespace

--- a/packages/dart/lib/src/dxf_export.dart
+++ b/packages/dart/lib/src/dxf_export.dart
@@ -67,7 +67,7 @@ List<int> getPrimRgb(Scene scene, GlbPrimitive prim) {
 String toDxf(
   Scene scene, {
   double scale = metresToInches,
-  String mode = '3dface',
+  String mode = 'polyface',
 }) {
   final layerColors = <String, List<int>>{};
   for (final prim in scene.glbPrimitives) {
@@ -181,31 +181,62 @@ String toDxf(
     final rgb = getPrimRgb(scene, prim);
     final aci = rgbToAci(rgb[0], rgb[1], rgb[2]);
 
-    for (int i = 0; i < triCount; i++) {
-      final i0 = prim.indices[i * 3];
-      final i1 = prim.indices[i * 3 + 1];
-      final i2 = prim.indices[i * 3 + 2];
-
-      final v0x = (prim.positions[i0 * 3] * scale).toStringAsFixed(6);
-      final v0y = (prim.positions[i0 * 3 + 1] * scale).toStringAsFixed(6);
-      final v0z = (prim.positions[i0 * 3 + 2] * scale).toStringAsFixed(6);
-
-      final v1x = (prim.positions[i1 * 3] * scale).toStringAsFixed(6);
-      final v1y = (prim.positions[i1 * 3 + 1] * scale).toStringAsFixed(6);
-      final v1z = (prim.positions[i1 * 3 + 2] * scale).toStringAsFixed(6);
-
-      final v2x = (prim.positions[i2 * 3] * scale).toStringAsFixed(6);
-      final v2y = (prim.positions[i2 * 3 + 1] * scale).toStringAsFixed(6);
-      final v2z = (prim.positions[i2 * 3 + 2] * scale).toStringAsFixed(6);
-
+    if (mode == 'polyface') {
+      final vCount = prim.positions.length ~/ 3;
       lines.addAll([
-        '  0', '3DFACE', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
-        ' 62', aci.toString(), '100', 'AcDbFace',
-        ' 10', v0x, ' 20', v0y, ' 30', v0z,
-        ' 11', v1x, ' 21', v1y, ' 31', v1z,
-        ' 12', v2x, ' 22', v2y, ' 32', v2z,
-        ' 13', v2x, ' 23', v2y, ' 33', v2z
+        '  0', 'POLYLINE', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
+        ' 62', aci.toString(), '100', 'AcDbPolyFaceMesh', ' 66', '1',
+        ' 10', '0.0', ' 20', '0.0', ' 30', '0.0',
+        ' 70', '64', ' 71', vCount.toString(), ' 72', triCount.toString()
       ]);
+      for (int i = 0; i < vCount; i++) {
+        final vx = (prim.positions[i * 3] * scale).toStringAsFixed(6);
+        final vy = (prim.positions[i * 3 + 1] * scale).toStringAsFixed(6);
+        final vz = (prim.positions[i * 3 + 2] * scale).toStringAsFixed(6);
+        lines.addAll([
+          '  0', 'VERTEX', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
+          '100', 'AcDbVertex', '100', 'AcDbPolyFaceMeshVertex',
+          ' 10', vx, ' 20', vy, ' 30', vz, ' 70', '192'
+        ]);
+      }
+      for (int i = 0; i < triCount; i++) {
+        final idx0 = prim.indices[i * 3] + 1;
+        final idx1 = prim.indices[i * 3 + 1] + 1;
+        final idx2 = prim.indices[i * 3 + 2] + 1;
+        lines.addAll([
+          '  0', 'VERTEX', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
+          '100', 'AcDbVertex', '100', 'AcDbFaceRecord', ' 70', '128',
+          ' 71', idx0.toString(), ' 72', idx1.toString(), ' 73', idx2.toString(), ' 74', '0'
+        ]);
+      }
+      lines.addAll(['  0', 'SEQEND', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName]);
+    } else {
+      for (int i = 0; i < triCount; i++) {
+        final i0 = prim.indices[i * 3];
+        final i1 = prim.indices[i * 3 + 1];
+        final i2 = prim.indices[i * 3 + 2];
+
+        final v0x = (prim.positions[i0 * 3] * scale).toStringAsFixed(6);
+        final v0y = (prim.positions[i0 * 3 + 1] * scale).toStringAsFixed(6);
+        final v0z = (prim.positions[i0 * 3 + 2] * scale).toStringAsFixed(6);
+
+        final v1x = (prim.positions[i1 * 3] * scale).toStringAsFixed(6);
+        final v1y = (prim.positions[i1 * 3 + 1] * scale).toStringAsFixed(6);
+        final v1z = (prim.positions[i1 * 3 + 2] * scale).toStringAsFixed(6);
+
+        final v2x = (prim.positions[i2 * 3] * scale).toStringAsFixed(6);
+        final v2y = (prim.positions[i2 * 3 + 1] * scale).toStringAsFixed(6);
+        final v2z = (prim.positions[i2 * 3 + 2] * scale).toStringAsFixed(6);
+
+        lines.addAll([
+          '  0', '3DFACE', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
+          ' 62', aci.toString(), '100', 'AcDbFace',
+          ' 10', v0x, ' 20', v0y, ' 30', v0z,
+          ' 11', v1x, ' 21', v1y, ' 31', v1z,
+          ' 12', v2x, ' 22', v2y, ' 32', v2z,
+          ' 13', v2x, ' 23', v2y, ' 33', v2z
+        ]);
+      }
     }
   }
 
@@ -251,7 +282,7 @@ void exportDxf(
   Scene scene,
   String outputPath, {
   double scale = metresToInches,
-  String mode = '3dface',
+  String mode = 'polyface',
 }) {
   final file = File(outputPath);
   file.parent.createSync(recursive: true);

--- a/packages/dart/test/dxf_export_test.dart
+++ b/packages/dart/test/dxf_export_test.dart
@@ -31,9 +31,14 @@ void main() {
       final dxfText = toDxf(scene);
       expect(dxfText, contains('\$ACADVER'));
       expect(dxfText, contains('AC1015'));
-      expect(dxfText, contains('3DFACE'));
+      expect(dxfText, contains('POLYLINE'));
+      expect(dxfText, contains('AcDbPolyFaceMesh'));
       expect(dxfText, contains('Walls'));
       expect(dxfText, contains('EOF'));
+
+      final dxf3d = toDxf(scene, mode: '3dface');
+      expect(dxf3d, contains('3DFACE'));
+      expect(dxf3d, contains('AcDbFace'));
     });
   });
 }

--- a/packages/dotnet/OpenSkp.Tests/DxfExportTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/DxfExportTests.cs
@@ -29,9 +29,14 @@ namespace OpenSkp.Tests
             string dxfText = DxfExport.ToDxf(scene);
             Assert.Contains("$ACADVER", dxfText);
             Assert.Contains("AC1015", dxfText);
-            Assert.Contains("3DFACE", dxfText);
+            Assert.Contains("POLYLINE", dxfText);
+            Assert.Contains("AcDbPolyFaceMesh", dxfText);
             Assert.Contains("Walls", dxfText);
             Assert.Contains("EOF", dxfText);
+
+            string dxf3d = DxfExport.ToDxf(scene, mode: "3dface");
+            Assert.Contains("3DFACE", dxf3d);
+            Assert.Contains("AcDbFace", dxf3d);
         }
     }
 }

--- a/packages/dotnet/OpenSkp/DxfExport.cs
+++ b/packages/dotnet/OpenSkp/DxfExport.cs
@@ -76,7 +76,7 @@ namespace OpenSkp
         /// <summary>
         /// Serializes a baked <see cref="Scene"/> to AutoCAD R2000 (AC1015) 3D ASCII DXF format.
         /// </summary>
-        public static string ToDxf(Scene scene, double scale = MetresToInches, string mode = "3dface")
+        public static string ToDxf(Scene scene, double scale = MetresToInches, string mode = "polyface")
         {
             if (scene == null || scene.GlbPrimitives == null)
             {
@@ -188,7 +188,7 @@ namespace OpenSkp
                 "  0", "BLOCK", "  5", "18", "330", "17", "100", "AcDbEntity", "  8", "0", "100", "AcDbBlockBegin", "  2", "*Model_Space", " 70", "0", " 10", "0.0", " 20", "0.0", " 30", "0.0", "  3", "*Model_Space", "  1", "",
                 "  0", "ENDBLK", "  5", "19", "330", "17", "100", "AcDbEntity", "  8", "0", "100", "AcDbBlockEnd",
                 "  0", "BLOCK", "  5", "1C", "330", "1B", "100", "AcDbEntity", "  8", "0", "100", "AcDbBlockBegin", "  2", "*Paper_Space", " 70", "0", " 10", "0.0", " 20", "0.0", " 30", "0.0", "  3", "*Paper_Space", "  1", "",
-                "  0", "ENDBLK", "  5", "1D", "330", "1B", "100", "AcDbEntity", "  8", "0", "100", "AcDbBlockEnd",
+                "  0", "ENDBLK", "  5", "1D", "330", "1B", "100", "AcDbBlockEnd",
                 "  0", "ENDSEC",
                 "  0", "SECTION", "  2", "ENTITIES"
             });
@@ -202,33 +202,78 @@ namespace OpenSkp
                 var (pr, pg, pb) = GetPrimRgb(scene, prim);
                 int aci = RgbToAci(pr, pg, pb);
 
-                for (int i = 0; i < triCount; i++)
+                if (string.Equals(mode, "polyface", StringComparison.OrdinalIgnoreCase))
                 {
-                    int i0 = (int)prim.Indices[i * 3];
-                    int i1 = (int)prim.Indices[i * 3 + 1];
-                    int i2 = (int)prim.Indices[i * 3 + 2];
+                    int vCount = prim.Positions.Length / 3;
+                    lines.AddRange(new[]
+                    {
+                        "  0", "POLYLINE", "  5", NextHandle(), "330", "17", "100", "AcDbEntity", "  8", lName,
+                        " 62", aci.ToString(CultureInfo.InvariantCulture), "100", "AcDbPolyFaceMesh", " 66", "1",
+                        " 10", "0.0", " 20", "0.0", " 30", "0.0",
+                        " 70", "64", " 71", vCount.ToString(CultureInfo.InvariantCulture), " 72", triCount.ToString(CultureInfo.InvariantCulture)
+                    });
 
-                    string v0x = (prim.Positions[i0 * 3] * scale).ToString("F6", CultureInfo.InvariantCulture);
-                    string v0y = (prim.Positions[i0 * 3 + 1] * scale).ToString("F6", CultureInfo.InvariantCulture);
-                    string v0z = (prim.Positions[i0 * 3 + 2] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                    for (int i = 0; i < vCount; i++)
+                    {
+                        string vx = (prim.Positions[i * 3] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        string vy = (prim.Positions[i * 3 + 1] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        string vz = (prim.Positions[i * 3 + 2] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        lines.AddRange(new[]
+                        {
+                            "  0", "VERTEX", "  5", NextHandle(), "330", "17", "100", "AcDbEntity", "  8", lName,
+                            "100", "AcDbVertex", "100", "AcDbPolyFaceMeshVertex",
+                            " 10", vx, " 20", vy, " 30", vz, " 70", "192"
+                        });
+                    }
 
-                    string v1x = (prim.Positions[i1 * 3] * scale).ToString("F6", CultureInfo.InvariantCulture);
-                    string v1y = (prim.Positions[i1 * 3 + 1] * scale).ToString("F6", CultureInfo.InvariantCulture);
-                    string v1z = (prim.Positions[i1 * 3 + 2] * scale).ToString("F6", CultureInfo.InvariantCulture);
-
-                    string v2x = (prim.Positions[i2 * 3] * scale).ToString("F6", CultureInfo.InvariantCulture);
-                    string v2y = (prim.Positions[i2 * 3 + 1] * scale).ToString("F6", CultureInfo.InvariantCulture);
-                    string v2z = (prim.Positions[i2 * 3 + 2] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                    for (int i = 0; i < triCount; i++)
+                    {
+                        uint idx0 = prim.Indices[i * 3] + 1;
+                        uint idx1 = prim.Indices[i * 3 + 1] + 1;
+                        uint idx2 = prim.Indices[i * 3 + 2] + 1;
+                        lines.AddRange(new[]
+                        {
+                            "  0", "VERTEX", "  5", NextHandle(), "330", "17", "100", "AcDbEntity", "  8", lName,
+                            "100", "AcDbVertex", "100", "AcDbFaceRecord", " 70", "128",
+                            " 71", idx0.ToString(CultureInfo.InvariantCulture), " 72", idx1.ToString(CultureInfo.InvariantCulture), " 73", idx2.ToString(CultureInfo.InvariantCulture), " 74", "0"
+                        });
+                    }
 
                     lines.AddRange(new[]
                     {
-                        "  0", "3DFACE", "  5", NextHandle(), "330", "17", "100", "AcDbEntity", "  8", lName,
-                        " 62", aci.ToString(CultureInfo.InvariantCulture), "100", "AcDbFace",
-                        " 10", v0x, " 20", v0y, " 30", v0z,
-                        " 11", v1x, " 21", v1y, " 31", v1z,
-                        " 12", v2x, " 22", v2y, " 32", v2z,
-                        " 13", v2x, " 23", v2y, " 33", v2z
+                        "  0", "SEQEND", "  5", NextHandle(), "330", "17", "100", "AcDbEntity", "  8", lName
                     });
+                }
+                else
+                {
+                    for (int i = 0; i < triCount; i++)
+                    {
+                        int i0 = (int)prim.Indices[i * 3];
+                        int i1 = (int)prim.Indices[i * 3 + 1];
+                        int i2 = (int)prim.Indices[i * 3 + 2];
+
+                        string v0x = (prim.Positions[i0 * 3] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        string v0y = (prim.Positions[i0 * 3 + 1] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        string v0z = (prim.Positions[i0 * 3 + 2] * scale).ToString("F6", CultureInfo.InvariantCulture);
+
+                        string v1x = (prim.Positions[i1 * 3] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        string v1y = (prim.Positions[i1 * 3 + 1] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        string v1z = (prim.Positions[i1 * 3 + 2] * scale).ToString("F6", CultureInfo.InvariantCulture);
+
+                        string v2x = (prim.Positions[i2 * 3] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        string v2y = (prim.Positions[i2 * 3 + 1] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                        string v2z = (prim.Positions[i2 * 3 + 2] * scale).ToString("F6", CultureInfo.InvariantCulture);
+
+                        lines.AddRange(new[]
+                        {
+                            "  0", "3DFACE", "  5", NextHandle(), "330", "17", "100", "AcDbEntity", "  8", lName,
+                            " 62", aci.ToString(CultureInfo.InvariantCulture), "100", "AcDbFace",
+                            " 10", v0x, " 20", v0y, " 30", v0z,
+                            " 11", v1x, " 21", v1y, " 31", v1z,
+                            " 12", v2x, " 22", v2y, " 32", v2z,
+                            " 13", v2x, " 23", v2y, " 33", v2z
+                        });
+                    }
                 }
             }
 
@@ -274,7 +319,7 @@ namespace OpenSkp
         /// <summary>
         /// Exports a baked <see cref="Scene"/> directly to an AutoCAD R2000 3D DXF file using UTF-8 without BOM.
         /// </summary>
-        public static void ExportDxf(Scene scene, string outputPath, double scale = MetresToInches, string mode = "3dface")
+        public static void ExportDxf(Scene scene, string outputPath, double scale = MetresToInches, string mode = "polyface")
         {
             if (scene == null)
             {

--- a/packages/python/src/openskp/export/dxf.py
+++ b/packages/python/src/openskp/export/dxf.py
@@ -67,7 +67,7 @@ def _get_prim_rgb(scene: Scene, prim: any) -> tuple[int, int, int]:
 def to_dxf(
     scene: Scene,
     scale: float = METRES_TO_INCHES,
-    mode: Literal["3dface", "polyface"] = "3dface",
+    mode: Literal["3dface", "polyface"] = "polyface",
 ) -> str:
     """Serialize a baked scene to AutoCAD R2000 (AC1015) 3D ASCII DXF format.
 
@@ -145,7 +145,7 @@ def to_dxf(
         doc.write(stream)
         return stream.getvalue()
 
-    # Zero-dependency native R2000 3DFACE exporter with 100% AutoCAD parity
+    # Zero-dependency native R2000 DXF exporter with 100% AutoCAD parity
     layer_colors: dict[str, tuple[int, int, int]] = {}
     for prim in scene.glb_primitives:
         layer_name = _sanitize_layer_name(prim.geom_name or "0")
@@ -213,31 +213,61 @@ def to_dxf(
         r, g, b = layer_colors.get(layer_name, (200, 200, 200))
         aci = _rgb_to_aci(r, g, b)
 
-        for i in range(tri_count):
-            i0 = prim.indices[i * 3]
-            i1 = prim.indices[i * 3 + 1]
-            i2 = prim.indices[i * 3 + 2]
-
-            v0x = f"{prim.positions[i0 * 3] * scale:.6f}"
-            v0y = f"{prim.positions[i0 * 3 + 1] * scale:.6f}"
-            v0z = f"{prim.positions[i0 * 3 + 2] * scale:.6f}"
-
-            v1x = f"{prim.positions[i1 * 3] * scale:.6f}"
-            v1y = f"{prim.positions[i1 * 3 + 1] * scale:.6f}"
-            v1z = f"{prim.positions[i1 * 3 + 2] * scale:.6f}"
-
-            v2x = f"{prim.positions[i2 * 3] * scale:.6f}"
-            v2y = f"{prim.positions[i2 * 3 + 1] * scale:.6f}"
-            v2z = f"{prim.positions[i2 * 3 + 2] * scale:.6f}"
-
+        if mode == "polyface":
+            v_count = len(prim.positions) // 3
             lines.extend([
-                "  0", "3DFACE", "  5", next_handle(), "330", "17", "100", "AcDbEntity", "  8", layer_name,
-                " 62", str(aci), "100", "AcDbFace",
-                " 10", v0x, " 20", v0y, " 30", v0z,
-                " 11", v1x, " 21", v1y, " 31", v1z,
-                " 12", v2x, " 22", v2y, " 32", v2z,
-                " 13", v2x, " 23", v2y, " 33", v2z
+                "  0", "POLYLINE", "  5", next_handle(), "330", "17", "100", "AcDbEntity", "  8", layer_name,
+                " 62", str(aci), "100", "AcDbPolyFaceMesh", " 66", "1",
+                " 10", "0.0", " 20", "0.0", " 30", "0.0",
+                " 70", "64", " 71", str(v_count), " 72", str(tri_count)
             ])
+            for i in range(v_count):
+                vx = f"{prim.positions[i * 3] * scale:.6f}"
+                vy = f"{prim.positions[i * 3 + 1] * scale:.6f}"
+                vz = f"{prim.positions[i * 3 + 2] * scale:.6f}"
+                lines.extend([
+                    "  0", "VERTEX", "  5", next_handle(), "330", "17", "100", "AcDbEntity", "  8", layer_name,
+                    "100", "AcDbVertex", "100", "AcDbPolyFaceMeshVertex",
+                    " 10", vx, " 20", vy, " 30", vz, " 70", "192"
+                ])
+            for i in range(tri_count):
+                idx0 = prim.indices[i * 3] + 1
+                idx1 = prim.indices[i * 3 + 1] + 1
+                idx2 = prim.indices[i * 3 + 2] + 1
+                lines.extend([
+                    "  0", "VERTEX", "  5", next_handle(), "330", "17", "100", "AcDbEntity", "  8", layer_name,
+                    "100", "AcDbVertex", "100", "AcDbFaceRecord", " 70", "128",
+                    " 71", str(idx0), " 72", str(idx1), " 73", str(idx2), " 74", "0"
+                ])
+            lines.extend([
+                "  0", "SEQEND", "  5", next_handle(), "330", "17", "100", "AcDbEntity", "  8", layer_name
+            ])
+        else:
+            for i in range(tri_count):
+                i0 = prim.indices[i * 3]
+                i1 = prim.indices[i * 3 + 1]
+                i2 = prim.indices[i * 3 + 2]
+
+                v0x = f"{prim.positions[i0 * 3] * scale:.6f}"
+                v0y = f"{prim.positions[i0 * 3 + 1] * scale:.6f}"
+                v0z = f"{prim.positions[i0 * 3 + 2] * scale:.6f}"
+
+                v1x = f"{prim.positions[i1 * 3] * scale:.6f}"
+                v1y = f"{prim.positions[i1 * 3 + 1] * scale:.6f}"
+                v1z = f"{prim.positions[i1 * 3 + 2] * scale:.6f}"
+
+                v2x = f"{prim.positions[i2 * 3] * scale:.6f}"
+                v2y = f"{prim.positions[i2 * 3 + 1] * scale:.6f}"
+                v2z = f"{prim.positions[i2 * 3 + 2] * scale:.6f}"
+
+                lines.extend([
+                    "  0", "3DFACE", "  5", next_handle(), "330", "17", "100", "AcDbEntity", "  8", layer_name,
+                    " 62", str(aci), "100", "AcDbFace",
+                    " 10", v0x, " 20", v0y, " 30", v0z,
+                    " 11", v1x, " 21", v1y, " 31", v1z,
+                    " 12", v2x, " 22", v2y, " 32", v2z,
+                    " 13", v2x, " 23", v2y, " 33", v2z
+                ])
 
     lines.extend([
         "  0", "ENDSEC", "  0", "SECTION", "  2", "OBJECTS", "  0", "DICTIONARY", "  5", "C", "330", "0",
@@ -251,7 +281,7 @@ def export(
     scene: Scene,
     output_path: Union[str, pathlib.Path],
     scale: float = METRES_TO_INCHES,
-    mode: Literal["3dface", "polyface"] = "3dface",
+    mode: Literal["3dface", "polyface"] = "polyface",
 ) -> None:
     """Export a baked scene to an AutoCAD R2000 3D DXF file.
 

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -1437,12 +1437,15 @@ class TestDxfExporter:
             indices=array("I", [0, 1, 2]),
         )
         scene = Scene(glb_primitives=[prim])
-        dxf_text = to_dxf(scene, mode="polyface")
+        dxf_text = to_dxf(scene)
         assert "$ACADVER" in dxf_text
         assert "AC1015" in dxf_text
-        assert "3DFACE" in dxf_text or "POLYLINE" in dxf_text
+        assert "POLYLINE" in dxf_text or "3DFACE" in dxf_text
         assert "Walls" in dxf_text
         assert "EOF" in dxf_text
+
+        dxf_poly = to_dxf(scene, mode="polyface")
+        assert "POLYLINE" in dxf_poly or "AcDbPolyFaceMesh" in dxf_poly
 
         dxf_3d = to_dxf(scene, mode="3dface")
         assert "3DFACE" in dxf_3d

--- a/packages/typescript/src/dxf.ts
+++ b/packages/typescript/src/dxf.ts
@@ -72,7 +72,7 @@ function getPrimRgb(scene: SkpScene, prim: any): [number, number, number] {
 export function toDXF(
   scene: SkpScene,
   scale: number = METRES_TO_INCHES,
-  _mode: '3dface' | 'polyface' = '3dface'
+  mode: '3dface' | 'polyface' = 'polyface'
 ): string {
   if (!scene || !scene.glbPrimitives) {
     throw new Error('toDXF requires a valid SkpScene instance');
@@ -187,31 +187,62 @@ export function toDXF(
     const [pr, pg, pb] = getPrimRgb(scene, prim);
     const aci = rgbToAci(pr, pg, pb);
 
-    for (let i = 0; i < triCount; i++) {
-      const i0 = prim.indices[i * 3];
-      const i1 = prim.indices[i * 3 + 1];
-      const i2 = prim.indices[i * 3 + 2];
-
-      const v0x = (prim.positions[i0 * 3] * scale).toFixed(6);
-      const v0y = (prim.positions[i0 * 3 + 1] * scale).toFixed(6);
-      const v0z = (prim.positions[i0 * 3 + 2] * scale).toFixed(6);
-
-      const v1x = (prim.positions[i1 * 3] * scale).toFixed(6);
-      const v1y = (prim.positions[i1 * 3 + 1] * scale).toFixed(6);
-      const v1z = (prim.positions[i1 * 3 + 2] * scale).toFixed(6);
-
-      const v2x = (prim.positions[i2 * 3] * scale).toFixed(6);
-      const v2y = (prim.positions[i2 * 3 + 1] * scale).toFixed(6);
-      const v2z = (prim.positions[i2 * 3 + 2] * scale).toFixed(6);
-
+    if (mode === 'polyface') {
+      const vCount = Math.floor(prim.positions.length / 3);
       lines.push(
-        '  0', '3DFACE', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
-        ' 62', aci.toString(), '100', 'AcDbFace',
-        ' 10', v0x, ' 20', v0y, ' 30', v0z,
-        ' 11', v1x, ' 21', v1y, ' 31', v1z,
-        ' 12', v2x, ' 22', v2y, ' 32', v2z,
-        ' 13', v2x, ' 23', v2y, ' 33', v2z
+        '  0', 'POLYLINE', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
+        ' 62', aci.toString(), '100', 'AcDbPolyFaceMesh', ' 66', '1',
+        ' 10', '0.0', ' 20', '0.0', ' 30', '0.0',
+        ' 70', '64', ' 71', vCount.toString(), ' 72', triCount.toString()
       );
+      for (let i = 0; i < vCount; i++) {
+        const vx = (prim.positions[i * 3] * scale).toFixed(6);
+        const vy = (prim.positions[i * 3 + 1] * scale).toFixed(6);
+        const vz = (prim.positions[i * 3 + 2] * scale).toFixed(6);
+        lines.push(
+          '  0', 'VERTEX', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
+          '100', 'AcDbVertex', '100', 'AcDbPolyFaceMeshVertex',
+          ' 10', vx, ' 20', vy, ' 30', vz, ' 70', '192'
+        );
+      }
+      for (let i = 0; i < triCount; i++) {
+        const idx0 = prim.indices[i * 3] + 1;
+        const idx1 = prim.indices[i * 3 + 1] + 1;
+        const idx2 = prim.indices[i * 3 + 2] + 1;
+        lines.push(
+          '  0', 'VERTEX', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
+          '100', 'AcDbVertex', '100', 'AcDbFaceRecord', ' 70', '128',
+          ' 71', idx0.toString(), ' 72', idx1.toString(), ' 73', idx2.toString(), ' 74', '0'
+        );
+      }
+      lines.push('  0', 'SEQEND', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName);
+    } else {
+      for (let i = 0; i < triCount; i++) {
+        const i0 = prim.indices[i * 3];
+        const i1 = prim.indices[i * 3 + 1];
+        const i2 = prim.indices[i * 3 + 2];
+
+        const v0x = (prim.positions[i0 * 3] * scale).toFixed(6);
+        const v0y = (prim.positions[i0 * 3 + 1] * scale).toFixed(6);
+        const v0z = (prim.positions[i0 * 3 + 2] * scale).toFixed(6);
+
+        const v1x = (prim.positions[i1 * 3] * scale).toFixed(6);
+        const v1y = (prim.positions[i1 * 3 + 1] * scale).toFixed(6);
+        const v1z = (prim.positions[i1 * 3 + 2] * scale).toFixed(6);
+
+        const v2x = (prim.positions[i2 * 3] * scale).toFixed(6);
+        const v2y = (prim.positions[i2 * 3 + 1] * scale).toFixed(6);
+        const v2z = (prim.positions[i2 * 3 + 2] * scale).toFixed(6);
+
+        lines.push(
+          '  0', '3DFACE', '  5', nextHandle(), '330', '17', '100', 'AcDbEntity', '  8', layerName,
+          ' 62', aci.toString(), '100', 'AcDbFace',
+          ' 10', v0x, ' 20', v0y, ' 30', v0z,
+          ' 11', v1x, ' 21', v1y, ' 31', v1z,
+          ' 12', v2x, ' 22', v2y, ' 32', v2z,
+          ' 13', v2x, ' 23', v2y, ' 33', v2z
+        );
+      }
     }
   }
 
@@ -260,13 +291,13 @@ export function toDXF(
  * @param scene The result of SkpFile.buildScene()
  * @param outputPath Destination file path (.dxf)
  * @param scale Scale factor for vertex coordinates (default: METRES_TO_INCHES)
- * @param mode Export mode ('3dface' or 'polyface', default: '3dface')
+ * @param mode Export mode ('3dface' or 'polyface', default: 'polyface')
  */
 export function exportDXF(
   scene: SkpScene,
   outputPath: string,
   scale: number = METRES_TO_INCHES,
-  mode: '3dface' | 'polyface' = '3dface'
+  mode: '3dface' | 'polyface' = 'polyface'
 ): void {
   if (typeof process !== 'undefined' && process.versions && process.versions.node) {
     const fs = require('fs');

--- a/packages/typescript/tests/dxf.test.ts
+++ b/packages/typescript/tests/dxf.test.ts
@@ -26,13 +26,21 @@ describe('DXF 3D Exporter', () => {
     gltfMaterials: [],
   });
 
-  it('serializes SkpScene to 3D DXF format', () => {
+  it('serializes SkpScene to 3D DXF format in polyface mode by default', () => {
     const scene = createMockScene();
-    const dxfText = toDXF(scene, METRES_TO_INCHES, 'polyface');
+    const dxfText = toDXF(scene);
     expect(dxfText).toContain('$ACADVER');
     expect(dxfText).toContain('AC1015');
-    expect(dxfText).toContain('3DFACE');
+    expect(dxfText).toContain('POLYLINE');
+    expect(dxfText).toContain('AcDbPolyFaceMesh');
     expect(dxfText).toContain('Walls');
     expect(dxfText).toContain('EOF');
+  });
+
+  it('serializes SkpScene to 3DFACE format when mode is 3dface', () => {
+    const scene = createMockScene();
+    const dxfText = toDXF(scene, METRES_TO_INCHES, '3dface');
+    expect(dxfText).toContain('3DFACE');
+    expect(dxfText).toContain('AcDbFace');
   });
 });


### PR DESCRIPTION
## Summary of Changes
- **DXF Default Mode Update**: Updated the DXF exporter default \mode\ from \3dface\ to \polyface\ across all 5 language ports (Python, TypeScript, Dart, C# / .NET, C++).
- **Polyface Mesh Generation**: Implemented native AutoCAD Polyface Mesh generation (\POLYLINE\ type 64, \VERTEX\ points, \VERTEX\ face records, \SEQEND\) in TypeScript, Dart, and C# / .NET.
- **Unit Test Parity**: Updated test suites across Python, TypeScript, Dart, .NET, and C++ to assert default \polyface\ mesh output as well as explicit \3dface\ mode fallback.