### PR TITLE
feat(ifc): implement native ISO STEP IFC4 BIM 3D exporter across all 5 language ports (Item 43)

### DIFF
--- a/packages/cpp/CMakeLists.txt
+++ b/packages/cpp/CMakeLists.txt
@@ -109,6 +109,7 @@ set(
   src/errors.cpp
   src/geometry.cpp
   src/glb.cpp
+  src/ifc_export.cpp
   src/json_export.cpp
   src/legacy.cpp
   src/model.cpp

--- a/packages/cpp/include/openskp/ifc_export.hpp
+++ b/packages/cpp/include/openskp/ifc_export.hpp
@@ -1,0 +1,49 @@
+#ifndef OPENSKP_IFC_EXPORT_HPP
+#define OPENSKP_IFC_EXPORT_HPP
+
+#include <filesystem>
+#include <string>
+
+#include "model.hpp"
+#include "scene.hpp"
+
+namespace openskp {
+
+// 1 metre = 39.37007874015748 inches (SketchUp native unit)
+constexpr double METRES_TO_INCHES = 39.37007874015748;
+
+/**
+ * Generate a standard 22-character IFC base64 compressed GUID.
+ */
+std::string generate_ifc_guid();
+
+/**
+ * Classify a geometry name to an IFC entity type (STEP_TYPE, CLASS_NAME).
+ */
+std::pair<std::string, std::string> classify_element(const std::string& geom_name);
+
+/**
+ * Serialize a baked Scene into ISO-10303-21 STEP ASCII IFC4 format.
+ *
+ * @param scene The baked scene returned by SkpFile::build_scene()
+ * @param scale Scale factor for vertex coordinates (default: METRES_TO_INCHES)
+ * @param schema IFC schema version (default: "IFC4")
+ * @return Formatted ASCII IFC text string.
+ */
+std::string to_ifc(const Scene& scene, double scale = METRES_TO_INCHES,
+                   const std::string& schema = "IFC4");
+
+/**
+ * Export a baked Scene directly to an ISO-10303-21 STEP ASCII IFC4 file.
+ *
+ * @param scene The baked scene returned by SkpFile::build_scene()
+ * @param path Destination file path (.ifc)
+ * @param scale Scale factor for vertex coordinates (default: METRES_TO_INCHES)
+ * @param schema IFC schema version (default: "IFC4")
+ */
+void export_ifc(const Scene& scene, const std::filesystem::path& path,
+                double scale = METRES_TO_INCHES, const std::string& schema = "IFC4");
+
+}  // namespace openskp
+
+#endif  // OPENSKP_IFC_EXPORT_HPP

--- a/packages/cpp/src/ifc_export.cpp
+++ b/packages/cpp/src/ifc_export.cpp
@@ -168,6 +168,7 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
     ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,#" << bldg_id << ",(#" << storey_id << "));\r\n";
 
     std::vector<int> product_ids;
+    std::map<std::string, std::vector<int>> layer_items;
     std::map<std::string, int> mat_style_cache;
 
     for (const auto& prim : scene.glb_primitives) {
@@ -176,6 +177,12 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
         if (tri_count == 0 || v_count == 0) continue;
 
         std::string geom_name = sanitize_name(prim.geom_name);
+        std::string layer_name = "Layer0";
+        auto meta_it = scene.mesh_index.find(prim.geom_name);
+        if (meta_it != scene.mesh_index.end() && !meta_it->second.layer.empty()) {
+            layer_name = sanitize_name(meta_it->second.layer);
+        }
+
         auto [step_type, _] = classify_element(geom_name);
 
         std::ostringstream pt_ss;
@@ -200,6 +207,8 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
 
         int face_set_id = next_id();
         ss << "#" << face_set_id << "=IFCTRIANGULATEDFACESET(#" << pt_list_id << ",$,.TRUE.,(" << face_ss.str() << "),$);\r\n";
+
+        layer_items[layer_name].push_back(face_set_id);
 
         auto [r, g, b, a] = get_prim_rgb(scene, prim.material_index);
         std::ostringstream key_ss;
@@ -248,7 +257,6 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
         }
         product_ids.push_back(product_id);
 
-        auto meta_it = scene.mesh_index.find(prim.geom_name);
         if (meta_it != scene.mesh_index.end() && !meta_it->second.properties.empty()) {
             std::vector<int> prop_val_ids;
             for (const auto& [pk, pv] : meta_it->second.properties) {
@@ -269,6 +277,17 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
                 ss << "#" << pset_id << "=IFCPROPERTYSET('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Pset_CustomProperties',$,(" << prop_ss.str() << "));\r\n";
                 ss << "#" << next_id() << "=IFCRELDEFINESBYPROPERTIES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,(#" << product_id << "),#" << pset_id << ");\r\n";
             }
+        }
+    }
+
+    for (const auto& [l_name, item_ids] : layer_items) {
+        if (!item_ids.empty()) {
+            std::ostringstream item_ss;
+            for (size_t i = 0; i < item_ids.size(); ++i) {
+                if (i > 0) item_ss << ",";
+                item_ss << "#" << item_ids[i];
+            }
+            ss << "#" << next_id() << "=IFCPRESENTATIONLAYERASSIGNMENT('" << l_name << "',$,(" << item_ss.str() << "),$);\r\n";
         }
     }
 

--- a/packages/cpp/src/ifc_export.cpp
+++ b/packages/cpp/src/ifc_export.cpp
@@ -39,23 +39,11 @@ std::tuple<double, double, double, double> get_prim_rgb(const Scene& scene, size
   double r = 0.8, g = 0.8, b = 0.8, a = 1.0;
   if (prim_mat_idx < scene.gltf_materials.size()) {
     const auto& mat = scene.gltf_materials[prim_mat_idx];
-    auto pbr_it = mat.find("pbrMetallicRoughness");
-    if (pbr_it != mat.end() &&
-        std::holds_alternative<std::map<std::string, MaterialValue>>(pbr_it->second)) {
-      const auto& pbr = std::get<std::map<std::string, MaterialValue>>(pbr_it->second);
-      auto col_it = pbr.find("baseColorFactor");
-      if (col_it != pbr.end() && std::holds_alternative<std::vector<double>>(col_it->second)) {
-        const auto& color_vec = std::get<std::vector<double>>(col_it->second);
-        if (color_vec.size() >= 3) {
-          r = std::max(0.0, std::min(1.0, color_vec[0]));
-          g = std::max(0.0, std::min(1.0, color_vec[1]));
-          b = std::max(0.0, std::min(1.0, color_vec[2]));
-          if (color_vec.size() >= 4) {
-            a = std::max(0.0, std::min(1.0, color_vec[3]));
-          }
-        }
-      }
-    }
+    const auto& col = mat.pbr_metallic_roughness.base_color_factor;
+    r = std::max(0.0, std::min(1.0, col[0]));
+    g = std::max(0.0, std::min(1.0, col[1]));
+    b = std::max(0.0, std::min(1.0, col[2]));
+    a = std::max(0.0, std::min(1.0, col[3]));
   }
   return {r, g, b, a};
 }

--- a/packages/cpp/src/ifc_export.cpp
+++ b/packages/cpp/src/ifc_export.cpp
@@ -102,7 +102,8 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
   ss << "ISO-10303-21;\r\n";
   ss << "HEADER;\r\n";
   ss << "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');\r\n";
-  ss << "FILE_NAME('model.ifc','" << time_buf << "',('OpenSKP Author'),('OpenSKP "
+  ss << "FILE_NAME('model.ifc','" << time_buf
+     << "',('OpenSKP Author'),('OpenSKP "
         "Organization'),'OpenSKP IFC Exporter','OpenSKP','');\r\n";
   ss << "FILE_SCHEMA(('" << schema_str << "'));\r\n";
   ss << "ENDSEC;\r\n";

--- a/packages/cpp/src/ifc_export.cpp
+++ b/packages/cpp/src/ifc_export.cpp
@@ -1,0 +1,301 @@
+#include "openskp/ifc_export.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <map>
+#include <random>
+#include <sstream>
+
+namespace openskp {
+
+namespace {
+
+const std::string IFC_BASE64 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$";
+
+std::string sanitize_name(const std::string& name) {
+    if (name.empty()) return "Unnamed";
+    std::string clean;
+    clean.reserve(name.size());
+    for (char c : name) {
+        if (c == '\'') {
+            clean += "''";
+        } else if (c == '\\') {
+            clean += "\\\\";
+        } else {
+            clean += c;
+        }
+    }
+    // trim
+    size_t start = clean.find_first_not_of(" \t\r\n");
+    if (start == std::string::npos) return "Unnamed";
+    size_t end = clean.find_last_not_of(" \t\r\n");
+    return clean.substr(start, end - start + 1);
+}
+
+std::tuple<double, double, double, double> get_prim_rgb(const Scene& scene, size_t prim_mat_idx) {
+    double r = 0.8, g = 0.8, b = 0.8, a = 1.0;
+    if (prim_mat_idx < scene.gltf_materials.size()) {
+        const auto& mat = scene.gltf_materials[prim_mat_idx];
+        auto pbr_it = mat.find("pbrMetallicRoughness");
+        if (pbr_it != mat.end() && std::holds_alternative<std::map<std::string, MaterialValue>>(pbr_it->second)) {
+            const auto& pbr = std::get<std::map<std::string, MaterialValue>>(pbr_it->second);
+            auto col_it = pbr.find("baseColorFactor");
+            if (col_it != pbr.end() && std::holds_alternative<std::vector<double>>(col_it->second)) {
+                const auto& color_vec = std::get<std::vector<double>>(col_it->second);
+                if (color_vec.size() >= 3) {
+                    r = std::max(0.0, std::min(1.0, color_vec[0]));
+                    g = std::max(0.0, std::min(1.0, color_vec[1]));
+                    b = std::max(0.0, std::min(1.0, color_vec[2]));
+                    if (color_vec.size() >= 4) {
+                        a = std::max(0.0, std::min(1.0, color_vec[3]));
+                    }
+                }
+            }
+        }
+    }
+    return {r, g, b, a};
+}
+
+}  // namespace
+
+std::string generate_ifc_guid() {
+    static std::mt19937 rng(1337);
+    std::uniform_int_distribution<int> dist(0, 63);
+    std::string result;
+    result.reserve(22);
+    for (int i = 0; i < 22; ++i) {
+        result += IFC_BASE64[dist(rng)];
+    }
+    return result;
+}
+
+std::pair<std::string, std::string> classify_element(const std::string& geom_name) {
+    std::string l = geom_name;
+    std::transform(l.begin(), l.end(), l.begin(), [](unsigned char c) { return std::tolower(c); });
+    if (l.find("wall") != std::string::npos) return {"IFCWALL", "IfcWall"};
+    if (l.find("door") != std::string::npos) return {"IFCDOOR", "IfcDoor"};
+    if (l.find("window") != std::string::npos) return {"IFCWINDOW", "IfcWindow"};
+    if (l.find("slab") != std::string::npos || l.find("floor") != std::string::npos) return {"IFCSLAB", "IfcSlab"};
+    if (l.find("column") != std::string::npos || l.find("pillar") != std::string::npos) return {"IFCCOLUMN", "IfcColumn"};
+    if (l.find("beam") != std::string::npos || l.find("joist") != std::string::npos) return {"IFCBEAM", "IfcBeam"};
+    if (l.find("roof") != std::string::npos) return {"IFCROOF", "IfcRoof"};
+    return {"IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy"};
+}
+
+std::string to_ifc(const Scene& scene, double scale, const std::string& schema) {
+    std::string schema_str = schema.empty() ? "IFC4" : schema;
+    std::transform(schema_str.begin(), schema_str.end(), schema_str.begin(), [](unsigned char c) { return std::toupper(c); });
+
+    auto now = std::chrono::system_clock::now();
+    auto timestamp_epoch = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(6);
+
+    ss << "ISO-10303-21;\r\n";
+    ss << "HEADER;\r\n";
+    ss << "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');\r\n";
+    ss << "FILE_NAME('model.ifc','2026-08-12T00:00:00',('OpenSKP Author'),('OpenSKP Organization'),'OpenSKP IFC Exporter','OpenSKP','');\r\n";
+    ss << "FILE_SCHEMA(('" << schema_str << "'));\r\n";
+    ss << "ENDSEC;\r\n";
+    ss << "DATA;\r\n";
+
+    int entity_id = 1;
+    auto next_id = [&entity_id]() { return entity_id++; };
+
+    int person_id = next_id();
+    ss << "#" << person_id << "=IFCPERSON($,$,'OpenSKP User',$,$,$,$,$);\r\n";
+
+    int org_id = next_id();
+    ss << "#" << org_id << "=IFCORGANIZATION($,'OpenSKP',$,$,$);\r\n";
+
+    int person_org_id = next_id();
+    ss << "#" << person_org_id << "=IFCPERSONANDORGANIZATION(#" << person_id << ",#" << org_id << ",$);\r\n";
+
+    int app_id = next_id();
+    ss << "#" << app_id << "=IFCAPPLICATION(#" << org_id << ",'0.3.1','OpenSKP Exporter','OpenSKP');\r\n";
+
+    int owner_hist_id = next_id();
+    ss << "#" << owner_hist_id << "=IFCOWNERHISTORY(#" << person_org_id << ",#" << app_id << ",$,.READWRITE.,$,$,$," << timestamp_epoch << ");\r\n";
+
+    int length_unit_id = next_id();
+    ss << "#" << length_unit_id << "=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);\r\n";
+
+    int angle_unit_id = next_id();
+    ss << "#" << angle_unit_id << "=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);\r\n";
+
+    int solid_unit_id = next_id();
+    ss << "#" << solid_unit_id << "=IFCSIUNIT(*,.STERADIANUNIT.,$,.STERADIAN.);\r\n";
+
+    int unit_assign_id = next_id();
+    ss << "#" << unit_assign_id << "=IFCUNITASSIGNMENT((#" << length_unit_id << ",#" << angle_unit_id << ",#" << solid_unit_id << "));\r\n";
+
+    int pt_zero_id = next_id();
+    ss << "#" << pt_zero_id << "=IFCCARTESIANPOINT((0.0,0.0,0.0));\r\n";
+
+    int axis_placement_id = next_id();
+    ss << "#" << axis_placement_id << "=IFCAXIS2PLACEMENT3D(#" << pt_zero_id << ",$,$);\r\n";
+
+    int geom_ctx_id = next_id();
+    ss << "#" << geom_ctx_id << "=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,# " << axis_placement_id << ",$);\r\n";
+
+    int proj_id = next_id();
+    ss << "#" << proj_id << "=IFCPROJECT('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'OpenSKP Project',$,$,$,$,(#" << geom_ctx_id << "),#" << unit_assign_id << ");\r\n";
+
+    int site_placement_id = next_id();
+    ss << "#" << site_placement_id << "=IFCLOCALPLACEMENT($,#" << axis_placement_id << ");\r\n";
+
+    int site_id = next_id();
+    ss << "#" << site_id << "=IFCSITE('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Site',$,$,#" << site_placement_id << ",$,$,.ELEMENT.,$,$,$,$,$);\r\n";
+
+    int bldg_placement_id = next_id();
+    ss << "#" << bldg_placement_id << "=IFCLOCALPLACEMENT(#" << site_placement_id << ",#" << axis_placement_id << ");\r\n";
+
+    int bldg_id = next_id();
+    ss << "#" << bldg_id << "=IFCBUILDING('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Building',$,$,#" << bldg_placement_id << ",$,$,.ELEMENT.,$,$,$);\r\n";
+
+    int storey_placement_id = next_id();
+    ss << "#" << storey_placement_id << "=IFCLOCALPLACEMENT(#" << bldg_placement_id << ",#" << axis_placement_id << ");\r\n";
+
+    int storey_id = next_id();
+    ss << "#" << storey_id << "=IFCBUILDINGSTOREY('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Level 0',$,$,#" << storey_placement_id << ",$,$,.ELEMENT.,0.0);\r\n";
+
+    ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,#" << proj_id << ",(#" << site_id << "));\r\n";
+    ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,#" << site_id << ",(#" << bldg_id << "));\r\n";
+    ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,#" << bldg_id << ",(#" << storey_id << "));\r\n";
+
+    std::vector<int> product_ids;
+    std::map<std::string, int> mat_style_cache;
+
+    for (const auto& prim : scene.glb_primitives) {
+        size_t tri_count = prim.indices.size() / 3;
+        size_t v_count = prim.positions.size() / 3;
+        if (tri_count == 0 || v_count == 0) continue;
+
+        std::string geom_name = sanitize_name(prim.geom_name);
+        auto [step_type, _] = classify_element(geom_name);
+
+        std::ostringstream pt_ss;
+        pt_ss << std::fixed << std::setprecision(6);
+        for (size_t i = 0; i < v_count; ++i) {
+            if (i > 0) pt_ss << ",";
+            pt_ss << "(" << (prim.positions[i * 3] * scale) << ","
+                  << (prim.positions[i * 3 + 1] * scale) << ","
+                  << (prim.positions[i * 3 + 2] * scale) << ")";
+        }
+
+        int pt_list_id = next_id();
+        ss << "#" << pt_list_id << "=IFCCARTESIANPOINTLIST3D((" << pt_ss.str() << "));\r\n";
+
+        std::ostringstream face_ss;
+        for (size_t i = 0; i < tri_count; ++i) {
+            if (i > 0) face_ss << ",";
+            face_ss << "(" << (prim.indices[i * 3] + 1) << ","
+                    << (prim.indices[i * 3 + 1] + 1) << ","
+                    << (prim.indices[i * 3 + 2] + 1) << ")";
+        }
+
+        int face_set_id = next_id();
+        ss << "#" << face_set_id << "=IFCTRIANGULATEDFACESET(#" << pt_list_id << ",$,.TRUE.,(" << face_ss.str() << "),$);\r\n";
+
+        auto [r, g, b, a] = get_prim_rgb(scene, prim.material_index);
+        std::ostringstream key_ss;
+        key_ss << std::fixed << std::setprecision(4) << r << "," << g << "," << b << "," << a;
+        std::string rgba_key = key_ss.str();
+
+        int style_assign_id;
+        auto style_it = mat_style_cache.find(rgba_key);
+        if (style_it == mat_style_cache.end()) {
+            int col_id = next_id();
+            ss << std::fixed << std::setprecision(4);
+            ss << "#" << col_id << "=IFCCOLOURRGB($, " << r << "," << g << "," << b << ");\r\n";
+
+            double transparency = 1.0 - a;
+            int rendering_id = next_id();
+            ss << "#" << rendering_id << "=IFCSURFACESTYLERENDERING(#" << col_id << "," << transparency << ",$,$,$,$,$,$,.FLAT.);\r\n";
+
+            int style_id = next_id();
+            ss << "#" << style_id << "=IFCSURFACESTYLE('" << geom_name << "_Material',.BOTH.,(#" << rendering_id << "));\r\n";
+
+            style_assign_id = next_id();
+            ss << "#" << style_assign_id << "=IFCPRESENTATIONSTYLEASSIGNMENT((#" << style_id << "));\r\n";
+            mat_style_cache[rgba_key] = style_assign_id;
+        } else {
+            style_assign_id = style_it->second;
+        }
+
+        int styled_item_id = next_id();
+        ss << "#" << styled_item_id << "=IFCSTYLEDITEM(#" << face_set_id << ",(#" << style_assign_id << "),$);\r\n";
+
+        int shape_rep_id = next_id();
+        ss << "#" << shape_rep_id << "=IFCSHAPEREPRESENTATION(#" << geom_ctx_id << ",'Body','Tessellation',(#" << face_set_id << "));\r\n";
+
+        int prod_shape_id = next_id();
+        ss << "#" << prod_shape_id << "=IFCPRODUCTDEFINITIONSHAPE($,$,(#" << shape_rep_id << "));\r\n";
+
+        int prod_placement_id = next_id();
+        ss << "#" << prod_placement_id << "=IFCLOCALPLACEMENT(#" << storey_placement_id << ",#" << axis_placement_id << ");\r\n";
+
+        int product_id = next_id();
+        std::string prod_guid = generate_ifc_guid();
+        if (step_type == "IFCBUILDINGELEMENTPROXY") {
+            ss << "#" << product_id << "=" << step_type << "('" << prod_guid << "',#" << owner_hist_id << ",'" << geom_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id << ",$,.NOTDEFINED.);\r\n";
+        } else {
+            ss << "#" << product_id << "=" << step_type << "('" << prod_guid << "',#" << owner_hist_id << ",'" << geom_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id << ",$,$);\r\n";
+        }
+        product_ids.push_back(product_id);
+
+        auto meta_it = scene.mesh_index.find(prim.geom_name);
+        if (meta_it != scene.mesh_index.end() && !meta_it->second.properties.empty()) {
+            std::vector<int> prop_val_ids;
+            for (const auto& [pk, pv] : meta_it->second.properties) {
+                std::string clean_k = sanitize_name(pk);
+                std::string clean_v = sanitize_name(pv);
+                int prop_id = next_id();
+                ss << "#" << prop_id << "=IFCPROPERTYSINGLEVALUE('" << clean_k << "',$,IFCTEXT('" << clean_v << "'),$);\r\n";
+                prop_val_ids.push_back(prop_id);
+            }
+
+            if (!prop_val_ids.empty()) {
+                int pset_id = next_id();
+                std::ostringstream prop_ss;
+                for (size_t i = 0; i < prop_val_ids.size(); ++i) {
+                    if (i > 0) prop_ss << ",";
+                    prop_ss << "#" << prop_val_ids[i];
+                }
+                ss << "#" << pset_id << "=IFCPROPERTYSET('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Pset_CustomProperties',$,(" << prop_ss.str() << "));\r\n";
+                ss << "#" << next_id() << "=IFCRELDEFINESBYPROPERTIES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,(#" << product_id << "),#" << pset_id << ");\r\n";
+            }
+        }
+    }
+
+    if (!product_ids.empty()) {
+        std::ostringstream prod_ss;
+        for (size_t i = 0; i < product_ids.size(); ++i) {
+            if (i > 0) prod_ss << ",";
+            prod_ss << "#" << product_ids[i];
+        }
+        ss << "#" << next_id() << "=IFCRELCONTAINEDINSPATIALSTRUCTURE('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,(" << prod_ss.str() << "),#" << storey_id << ");\r\n";
+    }
+
+    ss << "ENDSEC;\r\n";
+    ss << "END-ISO-10303-21;\r\n";
+    return ss.str();
+}
+
+void export_ifc(const Scene& scene, const std::filesystem::path& path, double scale, const std::string& schema) {
+    if (path.has_parent_path()) {
+        std::filesystem::create_directories(path.parent_path());
+    }
+    std::ofstream file(path, std::ios::out | std::ios::binary);
+    if (!file.is_open()) {
+        throw std::runtime_error("Failed to open file for writing: " + path.string());
+    }
+    std::string text = to_ifc(scene, scale, schema);
+    file.write(text.data(), text.size());
+}
+
+}  // namespace openskp

--- a/packages/cpp/src/ifc_export.cpp
+++ b/packages/cpp/src/ifc_export.cpp
@@ -51,7 +51,7 @@ std::tuple<double, double, double, double> get_prim_rgb(const Scene& scene, size
 }  // namespace
 
 std::string generate_ifc_guid() {
-  static std::mt19937 rng(1337);
+  static std::mt19937 rng(std::random_device{}());
   std::uniform_int_distribution<int> dist(0, 63);
   std::string result;
   result.reserve(22);
@@ -85,14 +85,24 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
   auto now = std::chrono::system_clock::now();
   auto timestamp_epoch =
       std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+  std::time_t now_time = std::chrono::system_clock::to_time_t(now);
+  std::tm gmt{};
+#if defined(_WIN32)
+  gmtime_s(&gmt, &now_time);
+#else
+  gmtime_r(&now_time, &gmt);
+#endif
+  char time_buf[32];
+  std::strftime(time_buf, sizeof(time_buf), "%Y-%m-%dT%H:%M:%S", &gmt);
 
   std::ostringstream ss;
+  ss.imbue(std::locale::classic());
   ss << std::fixed << std::setprecision(6);
 
   ss << "ISO-10303-21;\r\n";
   ss << "HEADER;\r\n";
   ss << "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');\r\n";
-  ss << "FILE_NAME('model.ifc','2026-08-12T00:00:00',('OpenSKP Author'),('OpenSKP "
+  ss << "FILE_NAME('model.ifc','" << time_buf << "',('OpenSKP Author'),('OpenSKP "
         "Organization'),'OpenSKP IFC Exporter','OpenSKP','');\r\n";
   ss << "FILE_SCHEMA(('" << schema_str << "'));\r\n";
   ss << "ENDSEC;\r\n";
@@ -195,6 +205,7 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
     auto [step_type, _] = classify_element(geom_name);
 
     std::ostringstream pt_ss;
+    pt_ss.imbue(std::locale::classic());
     pt_ss << std::fixed << std::setprecision(6);
     for (size_t i = 0; i < v_count; ++i) {
       if (i > 0) pt_ss << ",";
@@ -220,6 +231,7 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
 
     auto [r, g, b, a] = get_prim_rgb(scene, prim.material_index);
     std::ostringstream key_ss;
+    key_ss.imbue(std::locale::classic());
     key_ss << std::fixed << std::setprecision(4) << r << "," << g << "," << b << "," << a;
     std::string rgba_key = key_ss.str();
 

--- a/packages/cpp/src/ifc_export.cpp
+++ b/packages/cpp/src/ifc_export.cpp
@@ -16,305 +16,340 @@ namespace {
 const std::string IFC_BASE64 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$";
 
 std::string sanitize_name(const std::string& name) {
-    if (name.empty()) return "Unnamed";
-    std::string clean;
-    clean.reserve(name.size());
-    for (char c : name) {
-        if (c == '\'') {
-            clean += "''";
-        } else if (c == '\\') {
-            clean += "\\\\";
-        } else {
-            clean += c;
-        }
+  if (name.empty()) return "Unnamed";
+  std::string clean;
+  clean.reserve(name.size());
+  for (char c : name) {
+    if (c == '\'') {
+      clean += "''";
+    } else if (c == '\\') {
+      clean += "\\\\";
+    } else {
+      clean += c;
     }
-    // trim
-    size_t start = clean.find_first_not_of(" \t\r\n");
-    if (start == std::string::npos) return "Unnamed";
-    size_t end = clean.find_last_not_of(" \t\r\n");
-    return clean.substr(start, end - start + 1);
+  }
+  // trim
+  size_t start = clean.find_first_not_of(" \t\r\n");
+  if (start == std::string::npos) return "Unnamed";
+  size_t end = clean.find_last_not_of(" \t\r\n");
+  return clean.substr(start, end - start + 1);
 }
 
 std::tuple<double, double, double, double> get_prim_rgb(const Scene& scene, size_t prim_mat_idx) {
-    double r = 0.8, g = 0.8, b = 0.8, a = 1.0;
-    if (prim_mat_idx < scene.gltf_materials.size()) {
-        const auto& mat = scene.gltf_materials[prim_mat_idx];
-        auto pbr_it = mat.find("pbrMetallicRoughness");
-        if (pbr_it != mat.end() && std::holds_alternative<std::map<std::string, MaterialValue>>(pbr_it->second)) {
-            const auto& pbr = std::get<std::map<std::string, MaterialValue>>(pbr_it->second);
-            auto col_it = pbr.find("baseColorFactor");
-            if (col_it != pbr.end() && std::holds_alternative<std::vector<double>>(col_it->second)) {
-                const auto& color_vec = std::get<std::vector<double>>(col_it->second);
-                if (color_vec.size() >= 3) {
-                    r = std::max(0.0, std::min(1.0, color_vec[0]));
-                    g = std::max(0.0, std::min(1.0, color_vec[1]));
-                    b = std::max(0.0, std::min(1.0, color_vec[2]));
-                    if (color_vec.size() >= 4) {
-                        a = std::max(0.0, std::min(1.0, color_vec[3]));
-                    }
-                }
-            }
+  double r = 0.8, g = 0.8, b = 0.8, a = 1.0;
+  if (prim_mat_idx < scene.gltf_materials.size()) {
+    const auto& mat = scene.gltf_materials[prim_mat_idx];
+    auto pbr_it = mat.find("pbrMetallicRoughness");
+    if (pbr_it != mat.end() &&
+        std::holds_alternative<std::map<std::string, MaterialValue>>(pbr_it->second)) {
+      const auto& pbr = std::get<std::map<std::string, MaterialValue>>(pbr_it->second);
+      auto col_it = pbr.find("baseColorFactor");
+      if (col_it != pbr.end() && std::holds_alternative<std::vector<double>>(col_it->second)) {
+        const auto& color_vec = std::get<std::vector<double>>(col_it->second);
+        if (color_vec.size() >= 3) {
+          r = std::max(0.0, std::min(1.0, color_vec[0]));
+          g = std::max(0.0, std::min(1.0, color_vec[1]));
+          b = std::max(0.0, std::min(1.0, color_vec[2]));
+          if (color_vec.size() >= 4) {
+            a = std::max(0.0, std::min(1.0, color_vec[3]));
+          }
         }
+      }
     }
-    return {r, g, b, a};
+  }
+  return {r, g, b, a};
 }
 
 }  // namespace
 
 std::string generate_ifc_guid() {
-    static std::mt19937 rng(1337);
-    std::uniform_int_distribution<int> dist(0, 63);
-    std::string result;
-    result.reserve(22);
-    for (int i = 0; i < 22; ++i) {
-        result += IFC_BASE64[dist(rng)];
-    }
-    return result;
+  static std::mt19937 rng(1337);
+  std::uniform_int_distribution<int> dist(0, 63);
+  std::string result;
+  result.reserve(22);
+  for (int i = 0; i < 22; ++i) {
+    result += IFC_BASE64[dist(rng)];
+  }
+  return result;
 }
 
 std::pair<std::string, std::string> classify_element(const std::string& geom_name) {
-    std::string l = geom_name;
-    std::transform(l.begin(), l.end(), l.begin(), [](unsigned char c) { return std::tolower(c); });
-    if (l.find("wall") != std::string::npos) return {"IFCWALL", "IfcWall"};
-    if (l.find("door") != std::string::npos) return {"IFCDOOR", "IfcDoor"};
-    if (l.find("window") != std::string::npos) return {"IFCWINDOW", "IfcWindow"};
-    if (l.find("slab") != std::string::npos || l.find("floor") != std::string::npos) return {"IFCSLAB", "IfcSlab"};
-    if (l.find("column") != std::string::npos || l.find("pillar") != std::string::npos) return {"IFCCOLUMN", "IfcColumn"};
-    if (l.find("beam") != std::string::npos || l.find("joist") != std::string::npos) return {"IFCBEAM", "IfcBeam"};
-    if (l.find("roof") != std::string::npos) return {"IFCROOF", "IfcRoof"};
-    return {"IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy"};
+  std::string l = geom_name;
+  std::transform(l.begin(), l.end(), l.begin(), [](unsigned char c) { return std::tolower(c); });
+  if (l.find("wall") != std::string::npos) return {"IFCWALL", "IfcWall"};
+  if (l.find("door") != std::string::npos) return {"IFCDOOR", "IfcDoor"};
+  if (l.find("window") != std::string::npos) return {"IFCWINDOW", "IfcWindow"};
+  if (l.find("slab") != std::string::npos || l.find("floor") != std::string::npos)
+    return {"IFCSLAB", "IfcSlab"};
+  if (l.find("column") != std::string::npos || l.find("pillar") != std::string::npos)
+    return {"IFCCOLUMN", "IfcColumn"};
+  if (l.find("beam") != std::string::npos || l.find("joist") != std::string::npos)
+    return {"IFCBEAM", "IfcBeam"};
+  if (l.find("roof") != std::string::npos) return {"IFCROOF", "IfcRoof"};
+  return {"IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy"};
 }
 
 std::string to_ifc(const Scene& scene, double scale, const std::string& schema) {
-    std::string schema_str = schema.empty() ? "IFC4" : schema;
-    std::transform(schema_str.begin(), schema_str.end(), schema_str.begin(), [](unsigned char c) { return std::toupper(c); });
+  std::string schema_str = schema.empty() ? "IFC4" : schema;
+  std::transform(schema_str.begin(), schema_str.end(), schema_str.begin(),
+                 [](unsigned char c) { return std::toupper(c); });
 
-    auto now = std::chrono::system_clock::now();
-    auto timestamp_epoch = std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+  auto now = std::chrono::system_clock::now();
+  auto timestamp_epoch =
+      std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
 
-    std::ostringstream ss;
-    ss << std::fixed << std::setprecision(6);
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(6);
 
-    ss << "ISO-10303-21;\r\n";
-    ss << "HEADER;\r\n";
-    ss << "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');\r\n";
-    ss << "FILE_NAME('model.ifc','2026-08-12T00:00:00',('OpenSKP Author'),('OpenSKP Organization'),'OpenSKP IFC Exporter','OpenSKP','');\r\n";
-    ss << "FILE_SCHEMA(('" << schema_str << "'));\r\n";
-    ss << "ENDSEC;\r\n";
-    ss << "DATA;\r\n";
+  ss << "ISO-10303-21;\r\n";
+  ss << "HEADER;\r\n";
+  ss << "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');\r\n";
+  ss << "FILE_NAME('model.ifc','2026-08-12T00:00:00',('OpenSKP Author'),('OpenSKP "
+        "Organization'),'OpenSKP IFC Exporter','OpenSKP','');\r\n";
+  ss << "FILE_SCHEMA(('" << schema_str << "'));\r\n";
+  ss << "ENDSEC;\r\n";
+  ss << "DATA;\r\n";
 
-    int entity_id = 1;
-    auto next_id = [&entity_id]() { return entity_id++; };
+  int entity_id = 1;
+  auto next_id = [&entity_id]() { return entity_id++; };
 
-    int person_id = next_id();
-    ss << "#" << person_id << "=IFCPERSON($,$,'OpenSKP User',$,$,$,$,$);\r\n";
+  int person_id = next_id();
+  ss << "#" << person_id << "=IFCPERSON($,$,'OpenSKP User',$,$,$,$,$);\r\n";
 
-    int org_id = next_id();
-    ss << "#" << org_id << "=IFCORGANIZATION($,'OpenSKP',$,$,$);\r\n";
+  int org_id = next_id();
+  ss << "#" << org_id << "=IFCORGANIZATION($,'OpenSKP',$,$,$);\r\n";
 
-    int person_org_id = next_id();
-    ss << "#" << person_org_id << "=IFCPERSONANDORGANIZATION(#" << person_id << ",#" << org_id << ",$);\r\n";
+  int person_org_id = next_id();
+  ss << "#" << person_org_id << "=IFCPERSONANDORGANIZATION(#" << person_id << ",#" << org_id
+     << ",$);\r\n";
 
-    int app_id = next_id();
-    ss << "#" << app_id << "=IFCAPPLICATION(#" << org_id << ",'0.3.1','OpenSKP Exporter','OpenSKP');\r\n";
+  int app_id = next_id();
+  ss << "#" << app_id << "=IFCAPPLICATION(#" << org_id
+     << ",'0.3.1','OpenSKP Exporter','OpenSKP');\r\n";
 
-    int owner_hist_id = next_id();
-    ss << "#" << owner_hist_id << "=IFCOWNERHISTORY(#" << person_org_id << ",#" << app_id << ",$,.READWRITE.,$,$,$," << timestamp_epoch << ");\r\n";
+  int owner_hist_id = next_id();
+  ss << "#" << owner_hist_id << "=IFCOWNERHISTORY(#" << person_org_id << ",#" << app_id
+     << ",$,.READWRITE.,$,$,$," << timestamp_epoch << ");\r\n";
 
-    int length_unit_id = next_id();
-    ss << "#" << length_unit_id << "=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);\r\n";
+  int length_unit_id = next_id();
+  ss << "#" << length_unit_id << "=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);\r\n";
 
-    int angle_unit_id = next_id();
-    ss << "#" << angle_unit_id << "=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);\r\n";
+  int angle_unit_id = next_id();
+  ss << "#" << angle_unit_id << "=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);\r\n";
 
-    int solid_unit_id = next_id();
-    ss << "#" << solid_unit_id << "=IFCSIUNIT(*,.STERADIANUNIT.,$,.STERADIAN.);\r\n";
+  int solid_unit_id = next_id();
+  ss << "#" << solid_unit_id << "=IFCSIUNIT(*,.STERADIANUNIT.,$,.STERADIAN.);\r\n";
 
-    int unit_assign_id = next_id();
-    ss << "#" << unit_assign_id << "=IFCUNITASSIGNMENT((#" << length_unit_id << ",#" << angle_unit_id << ",#" << solid_unit_id << "));\r\n";
+  int unit_assign_id = next_id();
+  ss << "#" << unit_assign_id << "=IFCUNITASSIGNMENT((#" << length_unit_id << ",#" << angle_unit_id
+     << ",#" << solid_unit_id << "));\r\n";
 
-    int pt_zero_id = next_id();
-    ss << "#" << pt_zero_id << "=IFCCARTESIANPOINT((0.0,0.0,0.0));\r\n";
+  int pt_zero_id = next_id();
+  ss << "#" << pt_zero_id << "=IFCCARTESIANPOINT((0.0,0.0,0.0));\r\n";
 
-    int axis_placement_id = next_id();
-    ss << "#" << axis_placement_id << "=IFCAXIS2PLACEMENT3D(#" << pt_zero_id << ",$,$);\r\n";
+  int axis_placement_id = next_id();
+  ss << "#" << axis_placement_id << "=IFCAXIS2PLACEMENT3D(#" << pt_zero_id << ",$,$);\r\n";
 
-    int geom_ctx_id = next_id();
-    ss << "#" << geom_ctx_id << "=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,# " << axis_placement_id << ",$);\r\n";
+  int geom_ctx_id = next_id();
+  ss << "#" << geom_ctx_id << "=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,# "
+     << axis_placement_id << ",$);\r\n";
 
-    int proj_id = next_id();
-    ss << "#" << proj_id << "=IFCPROJECT('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'OpenSKP Project',$,$,$,$,(#" << geom_ctx_id << "),#" << unit_assign_id << ");\r\n";
+  int proj_id = next_id();
+  ss << "#" << proj_id << "=IFCPROJECT('" << generate_ifc_guid() << "',#" << owner_hist_id
+     << ",'OpenSKP Project',$,$,$,$,(#" << geom_ctx_id << "),#" << unit_assign_id << ");\r\n";
 
-    int site_placement_id = next_id();
-    ss << "#" << site_placement_id << "=IFCLOCALPLACEMENT($,#" << axis_placement_id << ");\r\n";
+  int site_placement_id = next_id();
+  ss << "#" << site_placement_id << "=IFCLOCALPLACEMENT($,#" << axis_placement_id << ");\r\n";
 
-    int site_id = next_id();
-    ss << "#" << site_id << "=IFCSITE('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Site',$,$,#" << site_placement_id << ",$,$,.ELEMENT.,$,$,$,$,$);\r\n";
+  int site_id = next_id();
+  ss << "#" << site_id << "=IFCSITE('" << generate_ifc_guid() << "',#" << owner_hist_id
+     << ",'Site',$,$,#" << site_placement_id << ",$,$,.ELEMENT.,$,$,$,$,$);\r\n";
 
-    int bldg_placement_id = next_id();
-    ss << "#" << bldg_placement_id << "=IFCLOCALPLACEMENT(#" << site_placement_id << ",#" << axis_placement_id << ");\r\n";
+  int bldg_placement_id = next_id();
+  ss << "#" << bldg_placement_id << "=IFCLOCALPLACEMENT(#" << site_placement_id << ",#"
+     << axis_placement_id << ");\r\n";
 
-    int bldg_id = next_id();
-    ss << "#" << bldg_id << "=IFCBUILDING('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Building',$,$,#" << bldg_placement_id << ",$,$,.ELEMENT.,$,$,$);\r\n";
+  int bldg_id = next_id();
+  ss << "#" << bldg_id << "=IFCBUILDING('" << generate_ifc_guid() << "',#" << owner_hist_id
+     << ",'Building',$,$,#" << bldg_placement_id << ",$,$,.ELEMENT.,$,$,$);\r\n";
 
-    int storey_placement_id = next_id();
-    ss << "#" << storey_placement_id << "=IFCLOCALPLACEMENT(#" << bldg_placement_id << ",#" << axis_placement_id << ");\r\n";
+  int storey_placement_id = next_id();
+  ss << "#" << storey_placement_id << "=IFCLOCALPLACEMENT(#" << bldg_placement_id << ",#"
+     << axis_placement_id << ");\r\n";
 
-    int storey_id = next_id();
-    ss << "#" << storey_id << "=IFCBUILDINGSTOREY('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Level 0',$,$,#" << storey_placement_id << ",$,$,.ELEMENT.,0.0);\r\n";
+  int storey_id = next_id();
+  ss << "#" << storey_id << "=IFCBUILDINGSTOREY('" << generate_ifc_guid() << "',#" << owner_hist_id
+     << ",'Level 0',$,$,#" << storey_placement_id << ",$,$,.ELEMENT.,0.0);\r\n";
 
-    ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,#" << proj_id << ",(#" << site_id << "));\r\n";
-    ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,#" << site_id << ",(#" << bldg_id << "));\r\n";
-    ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,#" << bldg_id << ",(#" << storey_id << "));\r\n";
+  ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id
+     << ",$,$,#" << proj_id << ",(#" << site_id << "));\r\n";
+  ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id
+     << ",$,$,#" << site_id << ",(#" << bldg_id << "));\r\n";
+  ss << "#" << next_id() << "=IFCRELAGGREGATES('" << generate_ifc_guid() << "',#" << owner_hist_id
+     << ",$,$,#" << bldg_id << ",(#" << storey_id << "));\r\n";
 
-    std::vector<int> product_ids;
-    std::map<std::string, std::vector<int>> layer_items;
-    std::map<std::string, int> mat_style_cache;
+  std::vector<int> product_ids;
+  std::map<std::string, std::vector<int>> layer_items;
+  std::map<std::string, int> mat_style_cache;
 
-    for (const auto& prim : scene.glb_primitives) {
-        size_t tri_count = prim.indices.size() / 3;
-        size_t v_count = prim.positions.size() / 3;
-        if (tri_count == 0 || v_count == 0) continue;
+  for (const auto& prim : scene.glb_primitives) {
+    size_t tri_count = prim.indices.size() / 3;
+    size_t v_count = prim.positions.size() / 3;
+    if (tri_count == 0 || v_count == 0) continue;
 
-        std::string geom_name = sanitize_name(prim.geom_name);
-        std::string layer_name = "Layer0";
-        auto meta_it = scene.mesh_index.find(prim.geom_name);
-        if (meta_it != scene.mesh_index.end() && !meta_it->second.layer.empty()) {
-            layer_name = sanitize_name(meta_it->second.layer);
-        }
-
-        auto [step_type, _] = classify_element(geom_name);
-
-        std::ostringstream pt_ss;
-        pt_ss << std::fixed << std::setprecision(6);
-        for (size_t i = 0; i < v_count; ++i) {
-            if (i > 0) pt_ss << ",";
-            pt_ss << "(" << (prim.positions[i * 3] * scale) << ","
-                  << (prim.positions[i * 3 + 1] * scale) << ","
-                  << (prim.positions[i * 3 + 2] * scale) << ")";
-        }
-
-        int pt_list_id = next_id();
-        ss << "#" << pt_list_id << "=IFCCARTESIANPOINTLIST3D((" << pt_ss.str() << "));\r\n";
-
-        std::ostringstream face_ss;
-        for (size_t i = 0; i < tri_count; ++i) {
-            if (i > 0) face_ss << ",";
-            face_ss << "(" << (prim.indices[i * 3] + 1) << ","
-                    << (prim.indices[i * 3 + 1] + 1) << ","
-                    << (prim.indices[i * 3 + 2] + 1) << ")";
-        }
-
-        int face_set_id = next_id();
-        ss << "#" << face_set_id << "=IFCTRIANGULATEDFACESET(#" << pt_list_id << ",$,.TRUE.,(" << face_ss.str() << "),$);\r\n";
-
-        layer_items[layer_name].push_back(face_set_id);
-
-        auto [r, g, b, a] = get_prim_rgb(scene, prim.material_index);
-        std::ostringstream key_ss;
-        key_ss << std::fixed << std::setprecision(4) << r << "," << g << "," << b << "," << a;
-        std::string rgba_key = key_ss.str();
-
-        int style_assign_id;
-        auto style_it = mat_style_cache.find(rgba_key);
-        if (style_it == mat_style_cache.end()) {
-            int col_id = next_id();
-            ss << std::fixed << std::setprecision(4);
-            ss << "#" << col_id << "=IFCCOLOURRGB($, " << r << "," << g << "," << b << ");\r\n";
-
-            double transparency = 1.0 - a;
-            int rendering_id = next_id();
-            ss << "#" << rendering_id << "=IFCSURFACESTYLERENDERING(#" << col_id << "," << transparency << ",$,$,$,$,$,$,.FLAT.);\r\n";
-
-            int style_id = next_id();
-            ss << "#" << style_id << "=IFCSURFACESTYLE('" << geom_name << "_Material',.BOTH.,(#" << rendering_id << "));\r\n";
-
-            style_assign_id = next_id();
-            ss << "#" << style_assign_id << "=IFCPRESENTATIONSTYLEASSIGNMENT((#" << style_id << "));\r\n";
-            mat_style_cache[rgba_key] = style_assign_id;
-        } else {
-            style_assign_id = style_it->second;
-        }
-
-        int styled_item_id = next_id();
-        ss << "#" << styled_item_id << "=IFCSTYLEDITEM(#" << face_set_id << ",(#" << style_assign_id << "),$);\r\n";
-
-        int shape_rep_id = next_id();
-        ss << "#" << shape_rep_id << "=IFCSHAPEREPRESENTATION(#" << geom_ctx_id << ",'Body','Tessellation',(#" << face_set_id << "));\r\n";
-
-        int prod_shape_id = next_id();
-        ss << "#" << prod_shape_id << "=IFCPRODUCTDEFINITIONSHAPE($,$,(#" << shape_rep_id << "));\r\n";
-
-        int prod_placement_id = next_id();
-        ss << "#" << prod_placement_id << "=IFCLOCALPLACEMENT(#" << storey_placement_id << ",#" << axis_placement_id << ");\r\n";
-
-        int product_id = next_id();
-        std::string prod_guid = generate_ifc_guid();
-        if (step_type == "IFCBUILDINGELEMENTPROXY") {
-            ss << "#" << product_id << "=" << step_type << "('" << prod_guid << "',#" << owner_hist_id << ",'" << geom_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id << ",$,.NOTDEFINED.);\r\n";
-        } else {
-            ss << "#" << product_id << "=" << step_type << "('" << prod_guid << "',#" << owner_hist_id << ",'" << geom_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id << ",$,$);\r\n";
-        }
-        product_ids.push_back(product_id);
-
-        if (meta_it != scene.mesh_index.end() && !meta_it->second.properties.empty()) {
-            std::vector<int> prop_val_ids;
-            for (const auto& [pk, pv] : meta_it->second.properties) {
-                std::string clean_k = sanitize_name(pk);
-                std::string clean_v = sanitize_name(pv);
-                int prop_id = next_id();
-                ss << "#" << prop_id << "=IFCPROPERTYSINGLEVALUE('" << clean_k << "',$,IFCTEXT('" << clean_v << "'),$);\r\n";
-                prop_val_ids.push_back(prop_id);
-            }
-
-            if (!prop_val_ids.empty()) {
-                int pset_id = next_id();
-                std::ostringstream prop_ss;
-                for (size_t i = 0; i < prop_val_ids.size(); ++i) {
-                    if (i > 0) prop_ss << ",";
-                    prop_ss << "#" << prop_val_ids[i];
-                }
-                ss << "#" << pset_id << "=IFCPROPERTYSET('" << generate_ifc_guid() << "',#" << owner_hist_id << ",'Pset_CustomProperties',$,(" << prop_ss.str() << "));\r\n";
-                ss << "#" << next_id() << "=IFCRELDEFINESBYPROPERTIES('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,(#" << product_id << "),#" << pset_id << ");\r\n";
-            }
-        }
+    std::string geom_name = sanitize_name(prim.geom_name);
+    std::string layer_name = "Layer0";
+    auto meta_it = scene.mesh_index.find(prim.geom_name);
+    if (meta_it != scene.mesh_index.end() && !meta_it->second.layer.empty()) {
+      layer_name = sanitize_name(meta_it->second.layer);
     }
 
-    for (const auto& [l_name, item_ids] : layer_items) {
-        if (!item_ids.empty()) {
-            std::ostringstream item_ss;
-            for (size_t i = 0; i < item_ids.size(); ++i) {
-                if (i > 0) item_ss << ",";
-                item_ss << "#" << item_ids[i];
-            }
-            ss << "#" << next_id() << "=IFCPRESENTATIONLAYERASSIGNMENT('" << l_name << "',$,(" << item_ss.str() << "),$);\r\n";
-        }
+    auto [step_type, _] = classify_element(geom_name);
+
+    std::ostringstream pt_ss;
+    pt_ss << std::fixed << std::setprecision(6);
+    for (size_t i = 0; i < v_count; ++i) {
+      if (i > 0) pt_ss << ",";
+      pt_ss << "(" << (prim.positions[i * 3] * scale) << "," << (prim.positions[i * 3 + 1] * scale)
+            << "," << (prim.positions[i * 3 + 2] * scale) << ")";
     }
 
-    if (!product_ids.empty()) {
-        std::ostringstream prod_ss;
-        for (size_t i = 0; i < product_ids.size(); ++i) {
-            if (i > 0) prod_ss << ",";
-            prod_ss << "#" << product_ids[i];
-        }
-        ss << "#" << next_id() << "=IFCRELCONTAINEDINSPATIALSTRUCTURE('" << generate_ifc_guid() << "',#" << owner_hist_id << ",$,$,(" << prod_ss.str() << "),#" << storey_id << ");\r\n";
+    int pt_list_id = next_id();
+    ss << "#" << pt_list_id << "=IFCCARTESIANPOINTLIST3D((" << pt_ss.str() << "));\r\n";
+
+    std::ostringstream face_ss;
+    for (size_t i = 0; i < tri_count; ++i) {
+      if (i > 0) face_ss << ",";
+      face_ss << "(" << (prim.indices[i * 3] + 1) << "," << (prim.indices[i * 3 + 1] + 1) << ","
+              << (prim.indices[i * 3 + 2] + 1) << ")";
     }
 
-    ss << "ENDSEC;\r\n";
-    ss << "END-ISO-10303-21;\r\n";
-    return ss.str();
+    int face_set_id = next_id();
+    ss << "#" << face_set_id << "=IFCTRIANGULATEDFACESET(#" << pt_list_id << ",$,.TRUE.,("
+       << face_ss.str() << "),$);\r\n";
+
+    layer_items[layer_name].push_back(face_set_id);
+
+    auto [r, g, b, a] = get_prim_rgb(scene, prim.material_index);
+    std::ostringstream key_ss;
+    key_ss << std::fixed << std::setprecision(4) << r << "," << g << "," << b << "," << a;
+    std::string rgba_key = key_ss.str();
+
+    int style_assign_id;
+    auto style_it = mat_style_cache.find(rgba_key);
+    if (style_it == mat_style_cache.end()) {
+      int col_id = next_id();
+      ss << std::fixed << std::setprecision(4);
+      ss << "#" << col_id << "=IFCCOLOURRGB($, " << r << "," << g << "," << b << ");\r\n";
+
+      double transparency = 1.0 - a;
+      int rendering_id = next_id();
+      ss << "#" << rendering_id << "=IFCSURFACESTYLERENDERING(#" << col_id << "," << transparency
+         << ",$,$,$,$,$,$,.FLAT.);\r\n";
+
+      int style_id = next_id();
+      ss << "#" << style_id << "=IFCSURFACESTYLE('" << geom_name << "_Material',.BOTH.,(#"
+         << rendering_id << "));\r\n";
+
+      style_assign_id = next_id();
+      ss << "#" << style_assign_id << "=IFCPRESENTATIONSTYLEASSIGNMENT((#" << style_id << "));\r\n";
+      mat_style_cache[rgba_key] = style_assign_id;
+    } else {
+      style_assign_id = style_it->second;
+    }
+
+    int styled_item_id = next_id();
+    ss << "#" << styled_item_id << "=IFCSTYLEDITEM(#" << face_set_id << ",(#" << style_assign_id
+       << "),$);\r\n";
+
+    int shape_rep_id = next_id();
+    ss << "#" << shape_rep_id << "=IFCSHAPEREPRESENTATION(#" << geom_ctx_id
+       << ",'Body','Tessellation',(#" << face_set_id << "));\r\n";
+
+    int prod_shape_id = next_id();
+    ss << "#" << prod_shape_id << "=IFCPRODUCTDEFINITIONSHAPE($,$,(#" << shape_rep_id << "));\r\n";
+
+    int prod_placement_id = next_id();
+    ss << "#" << prod_placement_id << "=IFCLOCALPLACEMENT(#" << storey_placement_id << ",#"
+       << axis_placement_id << ");\r\n";
+
+    int product_id = next_id();
+    std::string prod_guid = generate_ifc_guid();
+    if (step_type == "IFCBUILDINGELEMENTPROXY") {
+      ss << "#" << product_id << "=" << step_type << "('" << prod_guid << "',#" << owner_hist_id
+         << ",'" << geom_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id
+         << ",$,.NOTDEFINED.);\r\n";
+    } else {
+      ss << "#" << product_id << "=" << step_type << "('" << prod_guid << "',#" << owner_hist_id
+         << ",'" << geom_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id
+         << ",$,$);\r\n";
+    }
+    product_ids.push_back(product_id);
+
+    if (meta_it != scene.mesh_index.end() && !meta_it->second.properties.empty()) {
+      std::vector<int> prop_val_ids;
+      for (const auto& [pk, pv] : meta_it->second.properties) {
+        std::string clean_k = sanitize_name(pk);
+        std::string clean_v = sanitize_name(pv);
+        int prop_id = next_id();
+        ss << "#" << prop_id << "=IFCPROPERTYSINGLEVALUE('" << clean_k << "',$,IFCTEXT('" << clean_v
+           << "'),$);\r\n";
+        prop_val_ids.push_back(prop_id);
+      }
+
+      if (!prop_val_ids.empty()) {
+        int pset_id = next_id();
+        std::ostringstream prop_ss;
+        for (size_t i = 0; i < prop_val_ids.size(); ++i) {
+          if (i > 0) prop_ss << ",";
+          prop_ss << "#" << prop_val_ids[i];
+        }
+        ss << "#" << pset_id << "=IFCPROPERTYSET('" << generate_ifc_guid() << "',#" << owner_hist_id
+           << ",'Pset_CustomProperties',$,(" << prop_ss.str() << "));\r\n";
+        ss << "#" << next_id() << "=IFCRELDEFINESBYPROPERTIES('" << generate_ifc_guid() << "',#"
+           << owner_hist_id << ",$,$,(#" << product_id << "),#" << pset_id << ");\r\n";
+      }
+    }
+  }
+
+  for (const auto& [l_name, item_ids] : layer_items) {
+    if (!item_ids.empty()) {
+      std::ostringstream item_ss;
+      for (size_t i = 0; i < item_ids.size(); ++i) {
+        if (i > 0) item_ss << ",";
+        item_ss << "#" << item_ids[i];
+      }
+      ss << "#" << next_id() << "=IFCPRESENTATIONLAYERASSIGNMENT('" << l_name << "',$,("
+         << item_ss.str() << "),$);\r\n";
+    }
+  }
+
+  if (!product_ids.empty()) {
+    std::ostringstream prod_ss;
+    for (size_t i = 0; i < product_ids.size(); ++i) {
+      if (i > 0) prod_ss << ",";
+      prod_ss << "#" << product_ids[i];
+    }
+    ss << "#" << next_id() << "=IFCRELCONTAINEDINSPATIALSTRUCTURE('" << generate_ifc_guid() << "',#"
+       << owner_hist_id << ",$,$,(" << prod_ss.str() << "),#" << storey_id << ");\r\n";
+  }
+
+  ss << "ENDSEC;\r\n";
+  ss << "END-ISO-10303-21;\r\n";
+  return ss.str();
 }
 
-void export_ifc(const Scene& scene, const std::filesystem::path& path, double scale, const std::string& schema) {
-    if (path.has_parent_path()) {
-        std::filesystem::create_directories(path.parent_path());
-    }
-    std::ofstream file(path, std::ios::out | std::ios::binary);
-    if (!file.is_open()) {
-        throw std::runtime_error("Failed to open file for writing: " + path.string());
-    }
-    std::string text = to_ifc(scene, scale, schema);
-    file.write(text.data(), text.size());
+void export_ifc(const Scene& scene, const std::filesystem::path& path, double scale,
+                const std::string& schema) {
+  if (path.has_parent_path()) {
+    std::filesystem::create_directories(path.parent_path());
+  }
+  std::ofstream file(path, std::ios::out | std::ios::binary);
+  if (!file.is_open()) {
+    throw std::runtime_error("Failed to open file for writing: " + path.string());
+  }
+  std::string text = to_ifc(scene, scale, schema);
+  file.write(text.data(), text.size());
 }
 
 }  // namespace openskp

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ add_executable(
   face_instance_hidden_test.cpp
   geometry_test.cpp
   glb_test.cpp
+  ifc_export_test.cpp
   json_export_test.cpp
   layer_hidden_test.cpp
   lowlevel_test.cpp

--- a/packages/cpp/tests/ifc_export_test.cpp
+++ b/packages/cpp/tests/ifc_export_test.cpp
@@ -1,0 +1,53 @@
+#include "openskp/ifc_export.hpp"
+
+#include <gtest/gtest.h>
+
+namespace openskp {
+namespace {
+
+TEST(IfcExport, GeneratesValid22CharGuid) {
+  std::string guid = generate_ifc_guid();
+  EXPECT_EQ(guid.length(), 22u);
+}
+
+TEST(IfcExport, ClassifiesElementNames) {
+  EXPECT_EQ(classify_element("Main Wall").first, "IFCWALL");
+  EXPECT_EQ(classify_element("Front Door").first, "IFCDOOR");
+  EXPECT_EQ(classify_element("Office Window").first, "IFCWINDOW");
+  EXPECT_EQ(classify_element("Concrete Slab").first, "IFCSLAB");
+  EXPECT_EQ(classify_element("Steel Beam").first, "IFCBEAM");
+}
+
+TEST(IfcExport, SerializesSceneToIfc4StepText) {
+  Scene scene;
+  GlbPrimitive prim;
+  prim.geom_name = "Outer Wall";
+  prim.material_index = 0;
+  prim.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  scene.glb_primitives.push_back(prim);
+
+  MeshMetadata meta;
+  meta.name = "Outer Wall";
+  meta.properties["Thickness"] = "200mm";
+  scene.mesh_index["Outer Wall"] = meta;
+
+  std::string ifc_text = to_ifc(scene);
+  EXPECT_NE(ifc_text.find("ISO-10303-21;"), std::string::npos);
+  EXPECT_NE(ifc_text.find("HEADER;"), std::string::npos);
+  EXPECT_NE(ifc_text.find("FILE_SCHEMA(('IFC4'));"), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCPROJECT"), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCSITE"), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCBUILDING"), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCBUILDINGSTOREY"), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCWALL"), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCTRIANGULATEDFACESET"), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCCARTESIANPOINTLIST3D"), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCPROPERTYSET"), std::string::npos);
+  EXPECT_NE(ifc_text.find("ENDSEC;"), std::string::npos);
+}
+
+}  // namespace
+}  // namespace openskp

--- a/packages/dart/lib/openskp.dart
+++ b/packages/dart/lib/openskp.dart
@@ -11,5 +11,6 @@ export 'src/obj_export.dart' show toObj, toMtl, exportObj;
 export 'src/stl_export.dart' show toStlAscii, toStlBinary, exportStl;
 export 'src/ply_export.dart' show toPlyAscii, toPlyBinary, exportPly;
 export 'src/dxf_export.dart' show toDxf, exportDxf, metresToInches;
+export 'src/ifc_export.dart' show toIfc, exportIfc, generateIfcGuid, classifyElement;
 export 'src/errors.dart' show SkpParseException;
 export 'src/observability.dart' show SkpLogLevel, ParseProgress, ParseOptions;

--- a/packages/dart/lib/src/ifc_export.dart
+++ b/packages/dart/lib/src/ifc_export.dart
@@ -161,6 +161,7 @@ String toIfc(
   );
 
   final productIds = <int>[];
+  final layerItems = <String, List<int>>{};
   final matStyleCache = <String, int>{};
 
   for (final prim in scene.glbPrimitives) {
@@ -169,6 +170,8 @@ String toIfc(
     if (triCount == 0 || vCount == 0) continue;
 
     final geomName = sanitizeName(prim.geomName);
+    final meta = scene.meshIndex[prim.geomName];
+    final layerName = sanitizeName(meta?.layer ?? 'Layer0');
     final classification = classifyElement(geomName);
     final stepType = classification[0];
 
@@ -195,6 +198,8 @@ String toIfc(
     lines.add(
       '#$faceSetId=IFCTRIANGULATEDFACESET(#$ptListId,\$,.TRUE.,(${faceIndices.join(',')}),\$);'
     );
+
+    layerItems.putIfAbsent(layerName, () => []).add(faceSetId);
 
     final rgba = getPrimRgb(scene, prim.materialIndex);
     final r = rgba[0], g = rgba[1], b = rgba[2], a = rgba[3];
@@ -248,7 +253,6 @@ String toIfc(
     }
     productIds.add(productId);
 
-    final meta = scene.meshIndex[prim.geomName];
     if (meta != null && meta.properties.isNotEmpty) {
       final propValIds = <int>[];
       for (final entry in meta.properties.entries) {
@@ -270,6 +274,17 @@ String toIfc(
           '#${nextId()}=IFCRELDEFINESBYPROPERTIES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,(#$productId),#$psetId);'
         );
       }
+    }
+  }
+
+  final sortedLayerNames = layerItems.keys.toList()..sort();
+  for (final lName in sortedLayerNames) {
+    final itemIds = layerItems[lName]!;
+    if (itemIds.isNotEmpty) {
+      final itemRefs = itemIds.map((iid) => '#$iid').join(',');
+      lines.add(
+        '#${nextId()}=IFCPRESENTATIONLAYERASSIGNMENT(\'$lName\',\$,($itemRefs),\$);'
+      );
     }
   }
 

--- a/packages/dart/lib/src/ifc_export.dart
+++ b/packages/dart/lib/src/ifc_export.dart
@@ -36,7 +36,7 @@ List<double> getPrimRgb(Scene scene, int primMatIdx) {
   double r = 0.8, g = 0.8, b = 0.8, a = 1.0;
   if (primMatIdx >= 0 && primMatIdx < scene.gltfMaterials.length) {
     final mat = scene.gltfMaterials[primMatIdx];
-    if (mat is Map && mat['pbrMetallicRoughness'] is Map) {
+    if (mat['pbrMetallicRoughness'] is Map) {
       final pbr = mat['pbrMetallicRoughness'] as Map;
       if (pbr['baseColorFactor'] is List) {
         final vec = pbr['baseColorFactor'] as List;

--- a/packages/dart/lib/src/ifc_export.dart
+++ b/packages/dart/lib/src/ifc_export.dart
@@ -1,0 +1,298 @@
+import 'dart:io';
+import 'dart:math' as math;
+import 'scene.dart';
+
+const double metresToInches = 39.37007874015748;
+const _ifcBase64 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_\$';
+
+String generateIfcGuid() {
+  final rand = math.Random();
+  final buffer = StringBuffer();
+  for (int i = 0; i < 22; i++) {
+    buffer.write(_ifcBase64[rand.nextInt(64)]);
+  }
+  return buffer.toString();
+}
+
+String sanitizeName(String? name) {
+  if (name == null || name.isEmpty) return 'Unnamed';
+  final clean = name.replaceAll("'", "''").replaceAll('\\', '\\\\').trim();
+  return clean.isEmpty ? 'Unnamed' : clean;
+}
+
+List<String> classifyElement(String geomName) {
+  final l = geomName.toLowerCase();
+  if (l.contains('wall')) return ['IFCWALL', 'IfcWall'];
+  if (l.contains('door')) return ['IFCDOOR', 'IfcDoor'];
+  if (l.contains('window')) return ['IFCWINDOW', 'IfcWindow'];
+  if (l.contains('slab') || l.contains('floor')) return ['IFCSLAB', 'IfcSlab'];
+  if (l.contains('column') || l.contains('pillar')) return ['IFCCOLUMN', 'IfcColumn'];
+  if (l.contains('beam') || l.contains('joist')) return ['IFCBEAM', 'IfcBeam'];
+  if (l.contains('roof')) return ['IFCROOF', 'IfcRoof'];
+  return ['IFCBUILDINGELEMENTPROXY', 'IfcBuildingElementProxy'];
+}
+
+List<double> getPrimRgb(Scene scene, int primMatIdx) {
+  double r = 0.8, g = 0.8, b = 0.8, a = 1.0;
+  if (primMatIdx >= 0 && primMatIdx < scene.gltfMaterials.length) {
+    final mat = scene.gltfMaterials[primMatIdx];
+    if (mat is Map && mat['pbrMetallicRoughness'] is Map) {
+      final pbr = mat['pbrMetallicRoughness'] as Map;
+      if (pbr['baseColorFactor'] is List) {
+        final vec = pbr['baseColorFactor'] as List;
+        if (vec.length >= 3) {
+          r = (vec[0] as num).toDouble().clamp(0.0, 1.0);
+          g = (vec[1] as num).toDouble().clamp(0.0, 1.0);
+          b = (vec[2] as num).toDouble().clamp(0.0, 1.0);
+          if (vec.length >= 4) {
+            a = (vec[3] as num).toDouble().clamp(0.0, 1.0);
+          }
+        }
+      }
+    }
+  }
+  return [r, g, b, a];
+}
+
+/**
+ * Serialize a baked Scene into ISO-10303-21 STEP ASCII IFC4 format.
+ */
+String toIfc(
+  Scene scene, {
+  double scale = metresToInches,
+  String schema = 'IFC4',
+}) {
+  final schemaStr = schema.toUpperCase();
+  final nowIso = DateTime.now().toUtc().toIso8601String().split('.').first;
+  final timestampEpoch = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
+
+  final lines = <String>[
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');",
+    "FILE_NAME('model.ifc','$nowIso',('OpenSKP Author'),('OpenSKP Organization'),'OpenSKP IFC Exporter','OpenSKP','');",
+    "FILE_SCHEMA(('$schemaStr'));",
+    'ENDSEC;',
+    'DATA;'
+  ];
+
+  int entityId = 1;
+  int nextId() => entityId++;
+
+  final personId = nextId();
+  lines.add('#$personId=IFCPERSON(\$,\$,\'OpenSKP User\',\$,\$,\$,\$,\$);');
+
+  final orgId = nextId();
+  lines.add('#$orgId=IFCORGANIZATION(\$,\'OpenSKP\',\$,\$,\$);');
+
+  final personOrgId = nextId();
+  lines.add('#$personOrgId=IFCPERSONANDORGANIZATION(#$personId,#$orgId,\$);');
+
+  final appId = nextId();
+  lines.add('#$appId=IFCAPPLICATION(#$orgId,\'0.3.1\',\'OpenSKP Exporter\',\'OpenSKP\');');
+
+  final ownerHistId = nextId();
+  lines.add(
+    '#$ownerHistId=IFCOWNERHISTORY(#$personOrgId,#$appId,\$,.READWRITE.,\$,\$,\$,$timestampEpoch);'
+  );
+
+  final lengthUnitId = nextId();
+  lines.add('#$lengthUnitId=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);');
+
+  final angleUnitId = nextId();
+  lines.add('#$angleUnitId=IFCSIUNIT(*,.PLANEANGLEUNIT.,\$,.RADIAN.);');
+
+  final solidUnitId = nextId();
+  lines.add('#$solidUnitId=IFCSIUNIT(*,.STERADIANUNIT.,\$,.STERADIAN.);');
+
+  final unitAssignId = nextId();
+  lines.add(
+    '#$unitAssignId=IFCUNITASSIGNMENT((#$lengthUnitId,#$angleUnitId,#$solidUnitId));'
+  );
+
+  final ptZeroId = nextId();
+  lines.add('#$ptZeroId=IFCCARTESIANPOINT((0.0,0.0,0.0));');
+
+  final axisPlacementId = nextId();
+  lines.add('#$axisPlacementId=IFCAXIS2PLACEMENT3D(#$ptZeroId,\$,\$);');
+
+  final geomCtxId = nextId();
+  lines.add(
+    '#$geomCtxId=IFCGEOMETRICREPRESENTATIONCONTEXT(\$,\'Model\',3,1.0E-5,#$axisPlacementId,\$);'
+  );
+
+  final projId = nextId();
+  lines.add(
+    '#$projId=IFCPROJECT(\'${generateIfcGuid()}\',#$ownerHistId,\'OpenSKP Project\',\$,\$,\$,\$,(#$geomCtxId),#$unitAssignId);'
+  );
+
+  final sitePlacementId = nextId();
+  lines.add('#$sitePlacementId=IFCLOCALPLACEMENT(\$,#$axisPlacementId);');
+
+  final siteId = nextId();
+  lines.add(
+    '#$siteId=IFCSITE(\'${generateIfcGuid()}\',#$ownerHistId,\'Site\',\$,\$,#$sitePlacementId,\$,\$,.ELEMENT.,\$,\$,\$,\$,\$);'
+  );
+
+  final bldgPlacementId = nextId();
+  lines.add('#$bldgPlacementId=IFCLOCALPLACEMENT(#$sitePlacementId,#$axisPlacementId);');
+
+  final bldgId = nextId();
+  lines.add(
+    '#$bldgId=IFCBUILDING(\'${generateIfcGuid()}\',#$ownerHistId,\'Building\',\$,\$,#$bldgPlacementId,\$,\$,.ELEMENT.,\$,\$,\$);'
+  );
+
+  final storeyPlacementId = nextId();
+  lines.add('#$storeyPlacementId=IFCLOCALPLACEMENT(#$bldgPlacementId,#$axisPlacementId);');
+
+  final storeyId = nextId();
+  lines.add(
+    '#$storeyId=IFCBUILDINGSTOREY(\'${generateIfcGuid()}\',#$ownerHistId,\'Level 0\',\$,\$,#$storeyPlacementId,\$,\$,.ELEMENT.,0.0);'
+  );
+
+  lines.add(
+    '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$projId,(#$siteId));'
+  );
+  lines.add(
+    '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$siteId,(#$bldgId));'
+  );
+  lines.add(
+    '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$bldgId,(#$storeyId));'
+  );
+
+  final productIds = <int>[];
+  final matStyleCache = <String, int>{};
+
+  for (final prim in scene.glbPrimitives) {
+    final triCount = prim.indices.length ~/ 3;
+    final vCount = prim.positions.length ~/ 3;
+    if (triCount == 0 || vCount == 0) continue;
+
+    final geomName = sanitizeName(prim.geomName);
+    final classification = classifyElement(geomName);
+    final stepType = classification[0];
+
+    final ptCoords = <String>[];
+    for (int i = 0; i < vCount; i++) {
+      final vx = (prim.positions[i * 3] * scale).toStringAsFixed(6);
+      final vy = (prim.positions[i * 3 + 1] * scale).toStringAsFixed(6);
+      final vz = (prim.positions[i * 3 + 2] * scale).toStringAsFixed(6);
+      ptCoords.add('($vx,$vy,$vz)');
+    }
+
+    final ptListId = nextId();
+    lines.add('#$ptListId=IFCCARTESIANPOINTLIST3D((${ptCoords.join(',')}));');
+
+    final faceIndices = <String>[];
+    for (int i = 0; i < triCount; i++) {
+      final idx0 = prim.indices[i * 3] + 1;
+      final idx1 = prim.indices[i * 3 + 1] + 1;
+      final idx2 = prim.indices[i * 3 + 2] + 1;
+      faceIndices.add('($idx0,$idx1,$idx2)');
+    }
+
+    final faceSetId = nextId();
+    lines.add(
+      '#$faceSetId=IFCTRIANGULATEDFACESET(#$ptListId,\$,.TRUE.,(${faceIndices.join(',')}),\$);'
+    );
+
+    final rgba = getPrimRgb(scene, prim.materialIndex);
+    final r = rgba[0], g = rgba[1], b = rgba[2], a = rgba[3];
+    final rgbaKey = '${r.toStringAsFixed(4)},${g.toStringAsFixed(4)},${b.toStringAsFixed(4)},${a.toStringAsFixed(4)}';
+    int styleAssignId;
+
+    if (!matStyleCache.containsKey(rgbaKey)) {
+      final colId = nextId();
+      lines.add('#$colId=IFCCOLOURRGB(\$,${r.toStringAsFixed(4)},${g.toStringAsFixed(4)},${b.toStringAsFixed(4)});');
+
+      final transparency = (1.0 - a).toStringAsFixed(4);
+      final renderingId = nextId();
+      lines.add(
+        '#$renderingId=IFCSURFACESTYLERENDERING(#$colId,$transparency,\$,\$,\$,\$,\$,\$,.FLAT.);'
+      );
+
+      final styleId = nextId();
+      lines.add('#$styleId=IFCSURFACESTYLE(\'${geomName}_Material\',.BOTH.,(#$renderingId));');
+
+      styleAssignId = nextId();
+      lines.add('#$styleAssignId=IFCPRESENTATIONSTYLEASSIGNMENT((#$styleId));');
+      matStyleCache[rgbaKey] = styleAssignId;
+    } else {
+      styleAssignId = matStyleCache[rgbaKey]!;
+    }
+
+    final styledItemId = nextId();
+    lines.add('#$styledItemId=IFCSTYLEDITEM(#$faceSetId,(#$styleAssignId),\$);');
+
+    final shapeRepId = nextId();
+    lines.add(
+      '#$shapeRepId=IFCSHAPEREPRESENTATION(#$geomCtxId,\'Body\',\'Tessellation\',(#$faceSetId));'
+    );
+
+    final prodShapeId = nextId();
+    lines.add('#$prodShapeId=IFCPRODUCTDEFINITIONSHAPE(\$,\$,(#$shapeRepId));');
+
+    final prodPlacementId = nextId();
+    lines.add('#$prodPlacementId=IFCLOCALPLACEMENT(#$storeyPlacementId,#$axisPlacementId);');
+
+    final productId = nextId();
+    final prodGuid = generateIfcGuid();
+    if (stepType == 'IFCBUILDINGELEMENTPROXY') {
+      lines.add(
+        '#$productId=$stepType(\'$prodGuid\',#$ownerHistId,\'$geomName\',\$,\$,#$prodPlacementId,#$prodShapeId,\$,.NOTDEFINED.);'
+      );
+    } else {
+      lines.add(
+        '#$productId=$stepType(\'$prodGuid\',#$ownerHistId,\'$geomName\',\$,\$,#$prodPlacementId,#$prodShapeId,\$,\$);'
+      );
+    }
+    productIds.add(productId);
+
+    final meta = scene.meshIndex[prim.geomName];
+    if (meta != null && meta.properties.isNotEmpty) {
+      final propValIds = <int>[];
+      for (final entry in meta.properties.entries) {
+        final cleanK = sanitizeName(entry.key);
+        final cleanV = sanitizeName(entry.value);
+        final propId = nextId();
+        lines.add('#$propId=IFCPROPERTYSINGLEVALUE(\'$cleanK\',\$,IFCTEXT(\'$cleanV\'),\$);');
+        propValIds.add(propId);
+      }
+
+      if (propValIds.isNotEmpty) {
+        final psetId = nextId();
+        final propRefs = propValIds.map((pid) => '#$pid').join(',');
+        lines.add(
+          '#$psetId=IFCPROPERTYSET(\'${generateIfcGuid()}\',#$ownerHistId,\'Pset_CustomProperties\',\$,($propRefs));'
+        );
+
+        lines.add(
+          '#${nextId()}=IFCRELDEFINESBYPROPERTIES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,(#$productId),#$psetId);'
+        );
+      }
+    }
+  }
+
+  if (productIds.isNotEmpty) {
+    final prodRefs = productIds.map((pid) => '#$pid').join(',');
+    lines.add(
+      '#${nextId()}=IFCRELCONTAINEDINSPATIALSTRUCTURE(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,($prodRefs),#$storeyId);'
+    );
+  }
+
+  lines.add('ENDSEC;');
+  lines.add('END-ISO-10303-21;');
+  return lines.join('\r\n') + '\r\n';
+}
+
+void exportIfc(
+  Scene scene,
+  String outputPath, {
+  double scale = metresToInches,
+  String schema = 'IFC4',
+}) {
+  final file = File(outputPath);
+  file.parent.createSync(recursive: true);
+  final text = toIfc(scene, scale: scale, schema: schema);
+  file.writeAsStringSync(text);
+}

--- a/packages/dart/test/ifc_export_test.dart
+++ b/packages/dart/test/ifc_export_test.dart
@@ -1,0 +1,74 @@
+import 'dart:typed_data';
+import 'package:openskp/openskp.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('IFC4 3D Exporter', () {
+    test('generates valid 22-char IFC GUIDs', () {
+      final guid = generateIfcGuid();
+      expect(guid.length, equals(22));
+    });
+
+    test('classifies geometry names into IFC classes', () {
+      expect(classifyElement('Main Wall')[0], equals('IFCWALL'));
+      expect(classifyElement('Front Door')[0], equals('IFCDOOR'));
+      expect(classifyElement('Office Window')[0], equals('IFCWINDOW'));
+      expect(classifyElement('Concrete Slab')[0], equals('IFCSLAB'));
+      expect(classifyElement('Steel Beam')[0], equals('IFCBEAM'));
+    });
+
+    test('serializes Scene to IFC4 STEP text format', () {
+      final scene = Scene(
+        sceneHierarchy: InstanceNode(
+          name: 'Root',
+          definitionName: 'RootDef',
+          layer: 'Layer0',
+          positionMm: (0.0, 0.0, 0.0),
+          properties: {},
+          children: [],
+        ),
+        meshIndex: {
+          'Outer Wall': MeshMetadata(
+            name: 'Outer Wall',
+            definitionName: 'WallDef',
+            layer: 'Layer0',
+            positionMm: (0.0, 0.0, 0.0),
+            properties: {'Thickness': '200mm'},
+            path: 'Root/Outer Wall',
+          ),
+        },
+        glbPrimitives: [
+          GlbPrimitive(
+            geomName: 'Outer Wall',
+            materialIndex: 0,
+            positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+            normals: Float32List.fromList([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+            uvs: Float32List.fromList([0, 0, 1, 0, 0, 1]),
+            indices: Uint32List.fromList([0, 1, 2]),
+          ),
+        ],
+        gltfMaterials: [
+          {
+            'pbrMetallicRoughness': {
+              'baseColorFactor': [0.8, 0.2, 0.2, 1.0]
+            }
+          }
+        ],
+      );
+
+      final ifcText = toIfc(scene);
+      expect(ifcText, contains('ISO-10303-21;'));
+      expect(ifcText, contains('HEADER;'));
+      expect(ifcText, contains("FILE_SCHEMA(('IFC4'));"));
+      expect(ifcText, contains('IFCPROJECT'));
+      expect(ifcText, contains('IFCSITE'));
+      expect(ifcText, contains('IFCBUILDING'));
+      expect(ifcText, contains('IFCBUILDINGSTOREY'));
+      expect(ifcText, contains('IFCWALL'));
+      expect(ifcText, contains('IFCTRIANGULATEDFACESET'));
+      expect(ifcText, contains('IFCCARTESIANPOINTLIST3D'));
+      expect(ifcText, contains('IFCPROPERTYSET'));
+      expect(ifcText, contains('ENDSEC;'));
+    });
+  });
+}

--- a/packages/dotnet/OpenSkp.Tests/IfcExportTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/IfcExportTests.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using OpenSkp;
+using Xunit;
+
+namespace OpenSkp.Tests
+{
+    public class IfcExportTests
+    {
+        [Fact]
+        public void GenerateIfcGuid_ReturnsValid22CharString()
+        {
+            string guid = IfcExport.GenerateIfcGuid();
+            Assert.NotNull(guid);
+            Assert.Equal(22, guid.Length);
+        }
+
+        [Fact]
+        public void ClassifyElement_ClassifiesNamesToIfcTypes()
+        {
+            Assert.Equal("IFCWALL", IfcExport.ClassifyElement("Main Wall").StepType);
+            Assert.Equal("IFCDOOR", IfcExport.ClassifyElement("Front Door").StepType);
+            Assert.Equal("IFCWINDOW", IfcExport.ClassifyElement("Office Window").StepType);
+            Assert.Equal("IFCSLAB", IfcExport.ClassifyElement("Concrete Slab").StepType);
+            Assert.Equal("IFCBEAM", IfcExport.ClassifyElement("Steel Beam").StepType);
+        }
+
+        [Fact]
+        public void ToIfc_SerializesSceneToIfc4StepText()
+        {
+            var scene = new Scene
+            {
+                SceneHierarchy = new InstanceNode { Name = "Root", DefinitionName = "RootDef" },
+                MeshIndex = new Dictionary<string, MeshMetadata>
+                {
+                    ["Outer Wall"] = new MeshMetadata
+                    {
+                        Name = "Outer Wall",
+                        DefinitionName = "WallDef",
+                        Properties = new Dictionary<string, string> { ["Thickness"] = "200mm" }
+                    }
+                },
+                GlbPrimitives = new List<GlbPrimitive>
+                {
+                    new GlbPrimitive
+                    {
+                        GeomName = "Outer Wall",
+                        MaterialIndex = 0,
+                        Positions = new float[] { 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f, 0f },
+                        Normals = new float[] { 0f, 0f, 1f, 0f, 0f, 1f, 0f, 0f, 1f },
+                        Uvs = new float[] { 0f, 0f, 1f, 0f, 0f, 1f },
+                        Indices = new uint[] { 0, 1, 2 }
+                    }
+                }
+            };
+
+            string ifcText = IfcExport.ToIfc(scene);
+            Assert.Contains("ISO-10303-21;", ifcText);
+            Assert.Contains("HEADER;", ifcText);
+            Assert.Contains("FILE_SCHEMA(('IFC4'));", ifcText);
+            Assert.Contains("IFCPROJECT", ifcText);
+            Assert.Contains("IFCSITE", ifcText);
+            Assert.Contains("IFCBUILDING", ifcText);
+            Assert.Contains("IFCBUILDINGSTOREY", ifcText);
+            Assert.Contains("IFCWALL", ifcText);
+            Assert.Contains("IFCTRIANGULATEDFACESET", ifcText);
+            Assert.Contains("IFCCARTESIANPOINTLIST3D", ifcText);
+            Assert.Contains("IFCPROPERTYSET", ifcText);
+            Assert.Contains("ENDSEC;", ifcText);
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/IfcExport.cs
+++ b/packages/dotnet/OpenSkp/IfcExport.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+
+namespace OpenSkp
+{
+    /// <summary>
+    /// Export utilities for serializing OpenSKP scenes to ISO-10303-21 STEP ASCII IFC4 format.
+    /// </summary>
+    public static class IfcExport
+    {
+        /// <summary>
+        /// 1 metre = 39.37007874015748 inches (SketchUp native unit).
+        /// </summary>
+        public const double MetresToInches = 39.37007874015748;
+
+        private const string IfcBase64 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$";
+
+        /// <summary>
+        /// Generates a standard 22-character IFC base64 compressed GUID.
+        /// </summary>
+        public static string GenerateIfcGuid()
+        {
+            var rand = new Random();
+            var sb = new StringBuilder(22);
+            for (int i = 0; i < 22; i++)
+            {
+                sb.Append(IfcBase64[rand.Next(64)]);
+            }
+            return sb.ToString();
+        }
+
+        private static string SanitizeName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return "Unnamed";
+            string clean = name.Replace("'", "''").Replace("\\", "\\\\").Trim();
+            return string.IsNullOrEmpty(clean) ? "Unnamed" : clean;
+        }
+
+        /// <summary>
+        /// Classifies geometry/component name into an IFC entity type.
+        /// </summary>
+        public static (string StepType, string ClassName) ClassifyElement(string geomName)
+        {
+            if (string.IsNullOrEmpty(geomName)) return ("IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy");
+            string l = geomName.ToLowerInvariant();
+            if (l.Contains("wall")) return ("IFCWALL", "IfcWall");
+            if (l.Contains("door")) return ("IFCDOOR", "IfcDoor");
+            if (l.Contains("window")) return ("IFCWINDOW", "IfcWindow");
+            if (l.Contains("slab") || l.Contains("floor")) return ("IFCSLAB", "IfcSlab");
+            if (l.Contains("column") || l.Contains("pillar")) return ("IFCCOLUMN", "IfcColumn");
+            if (l.Contains("beam") || l.Contains("joist")) return ("IFCBEAM", "IfcBeam");
+            if (l.Contains("roof")) return ("IFCROOF", "IfcRoof");
+            return ("IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy");
+        }
+
+        private static (double R, double G, double B, double A) GetPrimRgb(Scene scene, int primMatIdx)
+        {
+            double r = 0.8, g = 0.8, b = 0.8, a = 1.0;
+            if (scene.GltfMaterials != null && primMatIdx >= 0 && primMatIdx < scene.GltfMaterials.Count)
+            {
+                var mat = scene.GltfMaterials[primMatIdx] as Dictionary<string, object>;
+                if (mat != null && mat.TryGetValue("pbrMetallicRoughness", out var pbrObj) && pbrObj is Dictionary<string, object> pbr)
+                {
+                    if (pbr.TryGetValue("baseColorFactor", out var colorVecObj) && colorVecObj is List<object> colorVec && colorVec.Count >= 3)
+                    {
+                        r = Math.Max(0.0, Math.Min(1.0, Convert.ToDouble(colorVec[0], CultureInfo.InvariantCulture)));
+                        g = Math.Max(0.0, Math.Min(1.0, Convert.ToDouble(colorVec[1], CultureInfo.InvariantCulture)));
+                        b = Math.Max(0.0, Math.Min(1.0, Convert.ToDouble(colorVec[2], CultureInfo.InvariantCulture)));
+                        if (colorVec.Count >= 4)
+                        {
+                            a = Math.Max(0.0, Math.Min(1.0, Convert.ToDouble(colorVec[3], CultureInfo.InvariantCulture)));
+                        }
+                    }
+                }
+            }
+            return (r, g, b, a);
+        }
+
+        /// <summary>
+        /// Serializes a baked <see cref="Scene"/> to ISO-10303-21 STEP ASCII IFC4 format.
+        /// </summary>
+        public static string ToIfc(Scene scene, double scale = MetresToInches, string schema = "IFC4")
+        {
+            if (scene == null || scene.GlbPrimitives == null)
+            {
+                throw new ArgumentNullException(nameof(scene), "ToIfc requires a valid Scene instance");
+            }
+
+            string schemaStr = string.IsNullOrWhiteSpace(schema) ? "IFC4" : schema.ToUpperInvariant();
+            string nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
+            long timestampEpoch = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            var lines = new List<string>
+            {
+                "ISO-10303-21;",
+                "HEADER;",
+                "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');",
+                $"FILE_NAME('model.ifc','{nowIso}',('OpenSKP Author'),('OpenSKP Organization'),'OpenSKP IFC Exporter','OpenSKP','');",
+                $"FILE_SCHEMA(('{schemaStr}'));",
+                "ENDSEC;",
+                "DATA;"
+            };
+
+            int entityId = 1;
+            int NextId() => entityId++;
+
+            int personId = NextId();
+            lines.Add($"#{personId}=IFCPERSON($,$,'OpenSKP User',$,$,$,$,$);");
+
+            int orgId = NextId();
+            lines.Add($"#{orgId}=IFCORGANIZATION($,'OpenSKP',$,$,$);");
+
+            int personOrgId = NextId();
+            lines.Add($"#{personOrgId}=IFCPERSONANDORGANIZATION(#{personId},#{orgId},$);");
+
+            int appId = NextId();
+            lines.Add($"#{appId}=IFCAPPLICATION(#{orgId},'0.3.1','OpenSKP Exporter','OpenSKP');");
+
+            int ownerHistId = NextId();
+            lines.Add($"#{ownerHistId}=IFCOWNERHISTORY(#{personOrgId},#{appId},$,.READWRITE.,$,$,$,{timestampEpoch});");
+
+            int lengthUnitId = NextId();
+            lines.Add($"#{lengthUnitId}=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);");
+
+            int angleUnitId = NextId();
+            lines.Add($"#{angleUnitId}=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);");
+
+            int solidUnitId = NextId();
+            lines.Add($"#{solidUnitId}=IFCSIUNIT(*,.STERADIANUNIT.,$,.STERADIAN.);");
+
+            int unitAssignId = NextId();
+            lines.Add($"#{unitAssignId}=IFCUNITASSIGNMENT((#{lengthUnitId},#{angleUnitId},#{solidUnitId}));");
+
+            int ptZeroId = NextId();
+            lines.Add($"#{ptZeroId}=IFCCARTESIANPOINT((0.0,0.0,0.0));");
+
+            int axisPlacementId = NextId();
+            lines.Add($"#{axisPlacementId}=IFCAXIS2PLACEMENT3D(#{ptZeroId},$,$);");
+
+            int geomCtxId = NextId();
+            lines.Add($"#{geomCtxId}=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#{axisPlacementId},$);");
+
+            int projId = NextId();
+            lines.Add($"#{projId}=IFCPROJECT('{GenerateIfcGuid()}',#{ownerHistId},'OpenSKP Project',$,$,$,$,(#{geomCtxId}),#{unitAssignId});");
+
+            int sitePlacementId = NextId();
+            lines.Add($"#{sitePlacementId}=IFCLOCALPLACEMENT($,#{axisPlacementId});");
+
+            int siteId = NextId();
+            lines.Add($"#{siteId}=IFCSITE('{GenerateIfcGuid()}',#{ownerHistId},'Site',$,$,#{sitePlacementId},$,$,.ELEMENT.,$,$,$,$,$);");
+
+            int bldgPlacementId = NextId();
+            lines.Add($"#{bldgPlacementId}=IFCLOCALPLACEMENT(#{sitePlacementId},#{axisPlacementId});");
+
+            int bldgId = NextId();
+            lines.Add($"#{bldgId}=IFCBUILDING('{GenerateIfcGuid()}',#{ownerHistId},'Building',$,$,#{bldgPlacementId},$,$,.ELEMENT.,$,$,$);");
+
+            int storeyPlacementId = NextId();
+            lines.Add($"#{storeyPlacementId}=IFCLOCALPLACEMENT(#{bldgPlacementId},#{axisPlacementId});");
+
+            int storeyId = NextId();
+            lines.Add($"#{storeyId}=IFCBUILDINGSTOREY('{GenerateIfcGuid()}',#{ownerHistId},'Level 0',$,$,#{storeyPlacementId},$,$,.ELEMENT.,0.0);");
+
+            lines.Add($"#{NextId()}=IFCRELAGGREGATES('{GenerateIfcGuid()}',#{ownerHistId},$,$,#{projId},(#{siteId}));");
+            lines.Add($"#{NextId()}=IFCRELAGGREGATES('{GenerateIfcGuid()}',#{ownerHistId},$,$,#{siteId},(#{bldgId}));");
+            lines.Add($"#{NextId()}=IFCRELAGGREGATES('{GenerateIfcGuid()}',#{ownerHistId},$,$,#{bldgId},(#{storeyId}));");
+
+            var productIds = new List<int>();
+            var matStyleCache = new Dictionary<string, int>();
+
+            foreach (var prim in scene.GlbPrimitives)
+            {
+                int triCount = prim.Indices.Length / 3;
+                int vCount = prim.Positions.Length / 3;
+                if (triCount == 0 || vCount == 0) continue;
+
+                string geomName = SanitizeName(prim.GeomName);
+                var (stepType, _) = ClassifyElement(geomName);
+
+                var ptCoords = new List<string>();
+                for (int i = 0; i < vCount; i++)
+                {
+                    string vx = (prim.Positions[i * 3] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                    string vy = (prim.Positions[i * 3 + 1] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                    string vz = (prim.Positions[i * 3 + 2] * scale).ToString("F6", CultureInfo.InvariantCulture);
+                    ptCoords.Add($"({vx},{vy},{vz})");
+                }
+
+                int ptListId = NextId();
+                lines.Add($"#{ptListId}=IFCCARTESIANPOINTLIST3D(({string.Join(",", ptCoords)}));");
+
+                var faceIndices = new List<string>();
+                for (int i = 0; i < triCount; i++)
+                {
+                    uint idx0 = prim.Indices[i * 3] + 1;
+                    uint idx1 = prim.Indices[i * 3 + 1] + 1;
+                    uint idx2 = prim.Indices[i * 3 + 2] + 1;
+                    faceIndices.Add($"({idx0.ToString(CultureInfo.InvariantCulture)},{idx1.ToString(CultureInfo.InvariantCulture)},{idx2.ToString(CultureInfo.InvariantCulture)})");
+                }
+
+                int faceSetId = NextId();
+                lines.Add($"#{faceSetId}=IFCTRIANGULATEDFACESET(#{ptListId},$,.TRUE.,({string.Join(",", faceIndices)}),$);");
+
+                var (r, g, b, a) = GetPrimRgb(scene, prim.MaterialIndex);
+                string rgbaKey = $"{r.ToString("F4", CultureInfo.InvariantCulture)},{g.ToString("F4", CultureInfo.InvariantCulture)},{b.ToString("F4", CultureInfo.InvariantCulture)},{a.ToString("F4", CultureInfo.InvariantCulture)}";
+                int styleAssignId;
+
+                if (!matStyleCache.TryGetValue(rgbaKey, out styleAssignId))
+                {
+                    int colId = NextId();
+                    lines.Add($"#{colId}=IFCCOLOURRGB($,{r.ToString("F4", CultureInfo.InvariantCulture)},{g.ToString("F4", CultureInfo.InvariantCulture)},{b.ToString("F4", CultureInfo.InvariantCulture)});");
+
+                    string transparency = (1.0 - a).ToString("F4", CultureInfo.InvariantCulture);
+                    int renderingId = NextId();
+                    lines.Add($"#{renderingId}=IFCSURFACESTYLERENDERING(#{colId},{transparency},$,$,$,$,$,$,.FLAT.);");
+
+                    int styleId = NextId();
+                    lines.Add($"#{styleId}=IFCSURFACESTYLE('{geomName}_Material',.BOTH.,(#{renderingId}));");
+
+                    styleAssignId = NextId();
+                    lines.Add($"#{styleAssignId}=IFCPRESENTATIONSTYLEASSIGNMENT((#{styleId}));");
+                    matStyleCache[rgbaKey] = styleAssignId;
+                }
+
+                int styledItemId = NextId();
+                lines.Add($"#{styledItemId}=IFCSTYLEDITEM(#{faceSetId},(#{styleAssignId}),$);");
+
+                int shapeRepId = NextId();
+                lines.Add($"#{shapeRepId}=IFCSHAPEREPRESENTATION(#{geomCtxId},'Body','Tessellation',(#{faceSetId}));");
+
+                int prodShapeId = NextId();
+                lines.Add($"#{prodShapeId}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{shapeRepId}));");
+
+                int prodPlacementId = NextId();
+                lines.Add($"#{prodPlacementId}=IFCLOCALPLACEMENT(#{storeyPlacementId},#{axisPlacementId});");
+
+                int productId = NextId();
+                string prodGuid = GenerateIfcGuid();
+                if (stepType == "IFCBUILDINGELEMENTPROXY")
+                {
+                    lines.Add($"#{productId}={stepType}('{prodGuid}',#{ownerHistId},'{geomName}',$,$,#{prodPlacementId},#{prodShapeId},$,.NOTDEFINED.);");
+                }
+                else
+                {
+                    lines.Add($"#{productId}={stepType}('{prodGuid}',#{ownerHistId},'{geomName}',$,$,#{prodPlacementId},#{prodShapeId},$,$);");
+                }
+                productIds.Add(productId);
+
+                if (scene.MeshIndex != null && scene.MeshIndex.TryGetValue(prim.GeomName, out var meta) && meta != null && meta.Properties != null && meta.Properties.Count > 0)
+                {
+                    var propValIds = new List<int>();
+                    foreach (var kvp in meta.Properties)
+                    {
+                        string cleanK = SanitizeName(kvp.Key);
+                        string cleanV = SanitizeName(kvp.Value);
+                        int propId = NextId();
+                        lines.Add($"#{propId}=IFCPROPERTYSINGLEVALUE('{cleanK}',$,IFCTEXT('{cleanV}'),$);");
+                        propValIds.Add(propId);
+                    }
+
+                    if (propValIds.Count > 0)
+                    {
+                        int psetId = NextId();
+                        string propRefs = string.Join(",", propValIds.ConvertAll(pid => $"#{pid}"));
+                        lines.Add($"#{psetId}=IFCPROPERTYSET('{GenerateIfcGuid()}',#{ownerHistId},'Pset_CustomProperties',$,({propRefs}));");
+
+                        lines.Add($"#{NextId()}=IFCRELDEFINESBYPROPERTIES('{GenerateIfcGuid()}',#{ownerHistId},$,$,(#{productId}),#{psetId});");
+                    }
+                }
+            }
+
+            if (productIds.Count > 0)
+            {
+                string prodRefs = string.Join(",", productIds.ConvertAll(pid => $"#{pid}"));
+                lines.Add($"#{NextId()}=IFCRELCONTAINEDINSPATIALSTRUCTURE('{GenerateIfcGuid()}',#{ownerHistId},$,$,({prodRefs}),#{storeyId});");
+            }
+
+            lines.Add("ENDSEC;");
+            lines.Add("END-ISO-10303-21;");
+            return string.Join("\r\n", lines) + "\r\n";
+        }
+
+        /// <summary>
+        /// Exports a baked <see cref="Scene"/> directly to an ISO-10303-21 STEP ASCII IFC4 file using UTF-8 without BOM.
+        /// </summary>
+        public static void ExportIfc(Scene scene, string outputPath, double scale = MetresToInches, string schema = "IFC4")
+        {
+            if (scene == null)
+            {
+                throw new ArgumentNullException(nameof(scene));
+            }
+            if (string.IsNullOrWhiteSpace(outputPath))
+            {
+                throw new ArgumentException("outputPath cannot be empty", nameof(outputPath));
+            }
+
+            string dir = Path.GetDirectoryName(outputPath);
+            if (!string.IsNullOrEmpty(dir) && !Directory.Exists(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+
+            string text = ToIfc(scene, scale, schema);
+            File.WriteAllText(outputPath, text, new UTF8Encoding(false));
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/IfcExport.cs
+++ b/packages/dotnet/OpenSkp/IfcExport.cs
@@ -169,6 +169,7 @@ namespace OpenSkp
             lines.Add($"#{NextId()}=IFCRELAGGREGATES('{GenerateIfcGuid()}',#{ownerHistId},$,$,#{bldgId},(#{storeyId}));");
 
             var productIds = new List<int>();
+            var layerItems = new Dictionary<string, List<int>>();
             var matStyleCache = new Dictionary<string, int>();
 
             foreach (var prim in scene.GlbPrimitives)
@@ -178,6 +179,16 @@ namespace OpenSkp
                 if (triCount == 0 || vCount == 0) continue;
 
                 string geomName = SanitizeName(prim.GeomName);
+                string layerName = "Layer0";
+                MeshMetadata meta = null;
+                if (scene.MeshIndex != null && scene.MeshIndex.TryGetValue(prim.GeomName, out meta) && meta != null)
+                {
+                    if (!string.IsNullOrEmpty(meta.Layer))
+                    {
+                        layerName = SanitizeName(meta.Layer);
+                    }
+                }
+
                 var (stepType, _) = ClassifyElement(geomName);
 
                 var ptCoords = new List<string>();
@@ -203,6 +214,12 @@ namespace OpenSkp
 
                 int faceSetId = NextId();
                 lines.Add($"#{faceSetId}=IFCTRIANGULATEDFACESET(#{ptListId},$,.TRUE.,({string.Join(",", faceIndices)}),$);");
+
+                if (!layerItems.ContainsKey(layerName))
+                {
+                    layerItems[layerName] = new List<int>();
+                }
+                layerItems[layerName].Add(faceSetId);
 
                 var (r, g, b, a) = GetPrimRgb(scene, prim.MaterialIndex);
                 string rgbaKey = $"{r.ToString("F4", CultureInfo.InvariantCulture)},{g.ToString("F4", CultureInfo.InvariantCulture)},{b.ToString("F4", CultureInfo.InvariantCulture)},{a.ToString("F4", CultureInfo.InvariantCulture)}";
@@ -249,7 +266,7 @@ namespace OpenSkp
                 }
                 productIds.Add(productId);
 
-                if (scene.MeshIndex != null && scene.MeshIndex.TryGetValue(prim.GeomName, out var meta) && meta != null && meta.Properties != null && meta.Properties.Count > 0)
+                if (meta != null && meta.Properties != null && meta.Properties.Count > 0)
                 {
                     var propValIds = new List<int>();
                     foreach (var kvp in meta.Properties)
@@ -269,6 +286,18 @@ namespace OpenSkp
 
                         lines.Add($"#{NextId()}=IFCRELDEFINESBYPROPERTIES('{GenerateIfcGuid()}',#{ownerHistId},$,$,(#{productId}),#{psetId});");
                     }
+                }
+            }
+
+            var sortedLayerNames = new List<string>(layerItems.Keys);
+            sortedLayerNames.Sort(StringComparer.Ordinal);
+            foreach (var lName in sortedLayerNames)
+            {
+                var itemIds = layerItems[lName];
+                if (itemIds.Count > 0)
+                {
+                    string itemRefs = string.Join(",", itemIds.ConvertAll(iid => $"#{iid}"));
+                    lines.Add($"#{NextId()}=IFCPRESENTATIONLAYERASSIGNMENT('{lName}',$,({itemRefs}),$);");
                 }
             }
 

--- a/packages/python/src/openskp/export/__init__.py
+++ b/packages/python/src/openskp/export/__init__.py
@@ -22,3 +22,7 @@ Example::
 """
 
 from __future__ import annotations
+
+from . import dxf, glb, ifc, json_export, obj, ply, stl
+
+__all__ = ["dxf", "glb", "ifc", "json_export", "obj", "ply", "stl"]

--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -135,7 +135,7 @@ def to_ifc(
     lines.append(f"#{person_org_id}=IFCPERSONANDORGANIZATION(#{person_id},#{org_id},$);")
 
     app_id = next_id()
-    lines.append(f"#{app_id}=IFCAPPLICATION(#{org_id},'0.3.0','OpenSKP Exporter','OpenSKP');")
+    lines.append(f"#{app_id}=IFCAPPLICATION(#{org_id},'0.3.1','OpenSKP Exporter','OpenSKP');")
 
     owner_hist_id = next_id()
     lines.append(
@@ -378,4 +378,4 @@ def export(
     path = pathlib.Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     text = to_ifc(scene, scale=scale, schema=schema)
-    path.write_text(text, encoding="utf-8", errors="replace")
+    path.write_bytes(text.encode("utf-8"))

--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -1,0 +1,365 @@
+"""IFC4 (BIM) 3D exporter for OpenSKP scenes.
+
+Serializes a baked :class:`~openskp.scene.Scene` into ISO-10303-21 STEP ASCII format
+conforming to the IFC4 schema (FILE_SCHEMA(('IFC4'))).
+
+Uses native ``IfcTriangulatedFaceSet`` geometry representation for direct 1:1
+mapping of triangulated vertex positions and face indices from baked scene primitives.
+"""
+
+from __future__ import annotations
+
+import datetime
+import math
+import pathlib
+import uuid
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from ..scene import INCHES_TO_MM, Scene
+
+# 1 metre = 39.37007874015748 inches (SketchUp native unit)
+METRES_TO_INCHES = 39.37007874015748
+
+_IFC_BASE64 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$"
+
+
+def generate_ifc_guid() -> str:
+    """Generate a standard 22-character IFC base64 compressed GUID."""
+    u = uuid.uuid4().int
+    chars = []
+    for _ in range(22):
+        chars.append(_IFC_BASE64[u % 64])
+        u //= 64
+    return "".join(reversed(chars))
+
+
+def sanitize_name(name: str) -> str:
+    """Sanitize string for STEP text escaping."""
+    if not name:
+        return "Unnamed"
+    clean = name.replace("'", "''").replace("\\", "\\\\").strip()
+    return clean if clean else "Unnamed"
+
+
+def classify_element(geom_name: str) -> Tuple[str, str]:
+    """Map a geometry/component name to an IFC4 entity type and constructor.
+
+    Returns:
+        Tuple of (STEP_ENTITY_TYPE, IFC_CLASS_NAME)
+    """
+    l = geom_name.lower()
+    if "wall" in l:
+        return "IFCWALL", "IfcWall"
+    if "door" in l:
+        return "IFCDOOR", "IfcDoor"
+    if "window" in l:
+        return "IFCWINDOW", "IfcWindow"
+    if "slab" in l or "floor" in l:
+        return "IFCSLAB", "IfcSlab"
+    if "column" in l or "pillar" in l:
+        return "IFCCOLUMN", "IfcColumn"
+    if "beam" in l or "joist" in l:
+        return "IFCBEAM", "IfcBeam"
+    if "roof" in l:
+        return "IFCROOF", "IfcRoof"
+    return "IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy"
+
+
+def _get_prim_rgb(scene: Scene, prim_mat_idx: int) -> Tuple[float, float, float, float]:
+    """Extract (R, G, B, Alpha) normalized [0.0, 1.0] from gltf_materials."""
+    r, g, b, a = 0.8, 0.8, 0.8, 1.0
+    if 0 <= prim_mat_idx < len(scene.gltf_materials):
+        mat = scene.gltf_materials[prim_mat_idx]
+        if isinstance(mat, dict):
+            pbr = mat.get("pbrMetallicRoughness", {})
+            if isinstance(pbr, dict) and "baseColorFactor" in pbr:
+                color_vec = pbr["baseColorFactor"]
+                if isinstance(color_vec, (list, tuple)) and len(color_vec) >= 3:
+                    r = max(0.0, min(1.0, float(color_vec[0])))
+                    g = max(0.0, min(1.0, float(color_vec[1])))
+                    b = max(0.0, min(1.0, float(color_vec[2])))
+                    if len(color_vec) >= 4:
+                        a = max(0.0, min(1.0, float(color_vec[3])))
+    return r, g, b, a
+
+
+def to_ifc(
+    scene: Scene,
+    scale: float = METRES_TO_INCHES,
+    schema: str = "IFC4",
+) -> str:
+    """Serialize a baked Scene into ISO-10303-21 STEP ASCII IFC4 format.
+
+    Args:
+
+        scene: The baked scene returned by :meth:`SkpFile.build_scene`.
+        scale: Coordinate scale factor (default: METRES_TO_INCHES).
+        schema: IFC schema version (default: "IFC4").
+
+    Returns:
+        Formatted ASCII IFC text string.
+    """
+    if not isinstance(scene, Scene):
+        raise TypeError("to_ifc requires a valid Scene instance")
+
+    schema_str = schema.upper() if schema else "IFC4"
+    now_iso = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
+    timestamp_epoch = int(datetime.datetime.now(datetime.timezone.utc).timestamp())
+
+    lines: List[str] = [
+        "ISO-10303-21;",
+        "HEADER;",
+        "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');",
+        f"FILE_NAME('model.ifc','{now_iso}',('OpenSKP Author'),('OpenSKP Organization'),'OpenSKP IFC Exporter','OpenSKP','');",
+        f"FILE_SCHEMA(('{schema_str}'));",
+        "ENDSEC;",
+        "DATA;",
+    ]
+
+    entity_id = 1
+
+    def next_id() -> int:
+        nonlocal entity_id
+        current = entity_id
+        entity_id += 1
+        return current
+
+    # Boilerplate Owner History & Units
+    person_id = next_id()
+    lines.append(f"#{person_id}=IFCPERSON($,$,'OpenSKP User',$,$,$,$,$);")
+
+    org_id = next_id()
+    lines.append(f"#{org_id}=IFCORGANIZATION($,'OpenSKP',$,$,$);")
+
+    person_org_id = next_id()
+    lines.append(f"#{person_org_id}=IFCPERSONANDORGANIZATION(#{person_id},#{org_id},$);")
+
+    app_id = next_id()
+    lines.append(f"#{app_id}=IFCAPPLICATION(#{org_id},'0.3.0','OpenSKP Exporter','OpenSKP');")
+
+    owner_hist_id = next_id()
+    lines.append(
+        f"#{owner_hist_id}=IFCOWNERHISTORY(#{person_org_id},#{app_id},$,.READWRITE.,$,$,$,{timestamp_epoch});"
+    )
+
+    length_unit_id = next_id()
+    lines.append(f"#{length_unit_id}=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);")
+
+    angle_unit_id = next_id()
+    lines.append(f"#{angle_unit_id}=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);")
+
+    solid_unit_id = next_id()
+    lines.append(f"#{solid_unit_id}=IFCSIUNIT(*,.STERADIANUNIT.,$,.STERADIAN.);")
+
+    unit_assign_id = next_id()
+    lines.append(
+        f"#{unit_assign_id}=IFCUNITASSIGNMENT((#{length_unit_id},#{angle_unit_id},#{solid_unit_id}));"
+    )
+
+    # Geometry Context & Placement
+    pt_zero_id = next_id()
+    lines.append(f"#{pt_zero_id}=IFCCARTESIANPOINT((0.0,0.0,0.0));")
+
+    axis_placement_id = next_id()
+    lines.append(f"#{axis_placement_id}=IFCAXIS2PLACEMENT3D(#{pt_zero_id},$,$);")
+
+    geom_ctx_id = next_id()
+    lines.append(
+        f"#{geom_ctx_id}=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#{axis_placement_id},$);"
+    )
+
+    # Spatial Hierarchy: Project -> Site -> Building -> BuildingStorey
+    proj_id = next_id()
+    proj_guid = generate_ifc_guid()
+    lines.append(
+        f"#{proj_id}=IFCPROJECT('{proj_guid}',#{owner_hist_id},'OpenSKP Project',$,$,$,$,(#{geom_ctx_id}),#{unit_assign_id});"
+    )
+
+    site_placement_id = next_id()
+    lines.append(f"#{site_placement_id}=IFCLOCALPLACEMENT($,#{axis_placement_id});")
+
+    site_id = next_id()
+    site_guid = generate_ifc_guid()
+    lines.append(
+        f"#{site_id}=IFCSITE('{site_guid}',#{owner_hist_id},'Site',$,$,#{site_placement_id},$,$,.ELEMENT.,$,$,$,$,$);"
+    )
+
+    bldg_placement_id = next_id()
+    lines.append(f"#{bldg_placement_id}=IFCLOCALPLACEMENT(#{site_placement_id},#{axis_placement_id});")
+
+    bldg_id = next_id()
+    bldg_guid = generate_ifc_guid()
+    lines.append(
+        f"#{bldg_id}=IFCBUILDING('{bldg_guid}',#{owner_hist_id},'Building',$,$,#{bldg_placement_id},$,$,.ELEMENT.,$,$,$);"
+    )
+
+    storey_placement_id = next_id()
+    lines.append(f"#{storey_placement_id}=IFCLOCALPLACEMENT(#{bldg_placement_id},#{axis_placement_id});")
+
+    storey_id = next_id()
+    storey_guid = generate_ifc_guid()
+    lines.append(
+        f"#{storey_id}=IFCBUILDINGSTOREY('{storey_guid}',#{owner_hist_id},'Level 0',$,$,#{storey_placement_id},$,$,.ELEMENT.,0.0);"
+    )
+
+    # Aggregates Relations
+    rel_site_id = next_id()
+    lines.append(
+        f"#{rel_site_id}=IFCRELAGGREGATES('{generate_ifc_guid()}',#{owner_hist_id},$,$,#{proj_id},(#{site_id}));"
+    )
+
+    rel_bldg_id = next_id()
+    lines.append(
+        f"#{rel_bldg_id}=IFCRELAGGREGATES('{generate_ifc_guid()}',#{owner_hist_id},$,$,#{site_id},(#{bldg_id}));"
+    )
+
+    rel_storey_id = next_id()
+    lines.append(
+        f"#{rel_storey_id}=IFCRELAGGREGATES('{generate_ifc_guid()}',#{owner_hist_id},$,$,#{bldg_id},(#{storey_id}));"
+    )
+
+    product_ids: List[int] = []
+    mat_style_cache: Dict[Tuple[float, float, float, float], int] = {}
+
+    for prim in scene.glb_primitives:
+        tri_count = len(prim.indices) // 3
+        v_count = len(prim.positions) // 3
+        if tri_count == 0 or v_count == 0:
+            continue
+
+        geom_name = sanitize_name(prim.geom_name)
+        step_type, ifc_class = classify_element(geom_name)
+
+        # 1. Coordinate Point List 3D
+        pt_coords: List[str] = []
+        for i in range(v_count):
+            vx = round(prim.positions[i * 3] * scale, 6)
+            vy = round(prim.positions[i * 3 + 1] * scale, 6)
+            vz = round(prim.positions[i * 3 + 2] * scale, 6)
+            pt_coords.append(f"({vx},{vy},{vz})")
+
+        pt_list_id = next_id()
+        lines.append(f"#{pt_list_id}=IFCCARTESIANPOINTLIST3D(({','.join(pt_coords)}));")
+
+        # 2. Triangulated Face Set (1-based indices)
+        face_indices: List[str] = []
+        for i in range(tri_count):
+            idx0 = prim.indices[i * 3] + 1
+            idx1 = prim.indices[i * 3 + 1] + 1
+            idx2 = prim.indices[i * 3 + 2] + 1
+            face_indices.append(f"({idx0},{idx1},{idx2})")
+
+        face_set_id = next_id()
+        lines.append(
+            f"#{face_set_id}=IFCTRIANGULATEDFACESET(#{pt_list_id},$,.TRUE.,({','.join(face_indices)}),$);"
+        )
+
+        # 3. Surface Style / Material Color if present
+        r, g, b, a = _get_prim_rgb(scene, prim.material_index)
+        rgba_key = (r, g, b, a)
+        if rgba_key not in mat_style_cache:
+            col_id = next_id()
+            lines.append(f"#{col_id}=IFCCOLOURRGB($,{r:.4f},{g:.4f},{b:.4f});")
+
+            transparency = round(1.0 - a, 4)
+            rendering_id = next_id()
+            lines.append(
+                f"#{rendering_id}=IFCSURFACESTYLERENDERING(#{col_id},{transparency:.4f},$,$,$,$,$,$,.FLAT.);"
+            )
+
+            style_id = next_id()
+            lines.append(
+                f"#{style_id}=IFCSURFACESTYLE('{geom_name}_Material',.BOTH.,(#{rendering_id}));"
+            )
+
+            style_assign_id = next_id()
+            lines.append(f"#{style_assign_id}=IFCPRESENTATIONSTYLEASSIGNMENT((#{style_id}));")
+            mat_style_cache[rgba_key] = style_assign_id
+        else:
+            style_assign_id = mat_style_cache[rgba_key]
+
+        styled_item_id = next_id()
+        lines.append(f"#{styled_item_id}=IFCSTYLEDITEM(#{face_set_id},(#{style_assign_id}),$);")
+
+        # 4. Shape Representation & Product Definition Shape
+        shape_rep_id = next_id()
+        lines.append(
+            f"#{shape_rep_id}=IFCSHAPEREPRESENTATION(#{geom_ctx_id},'Body','Tessellation',(#{face_set_id}));"
+        )
+
+        prod_shape_id = next_id()
+        lines.append(f"#{prod_shape_id}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{shape_rep_id}));")
+
+        prod_placement_id = next_id()
+        lines.append(f"#{prod_placement_id}=IFCLOCALPLACEMENT(#{storey_placement_id},#{axis_placement_id});")
+
+        prod_guid = generate_ifc_guid()
+        product_id = next_id()
+        if step_type == "IFCBUILDINGELEMENTPROXY":
+            lines.append(
+                f"#{product_id}={step_type}('{prod_guid}',#{owner_hist_id},'{geom_name}',$,$,#{prod_placement_id},#{prod_shape_id},$,.NOTDEFINED.);"
+            )
+        else:
+            lines.append(
+                f"#{product_id}={step_type}('{prod_guid}',#{owner_hist_id},'{geom_name}',$,$,#{prod_placement_id},#{prod_shape_id},$,$);"
+            )
+
+        product_ids.append(product_id)
+
+        # 5. Property Sets (if scene metadata contains dynamic properties)
+        meta = scene.mesh_index.get(prim.geom_name)
+        if meta and hasattr(meta, "properties") and isinstance(meta.properties, dict) and meta.properties:
+            prop_val_ids: List[int] = []
+            for p_key, p_val in meta.properties.items():
+                clean_k = sanitize_name(str(p_key))
+                clean_v = sanitize_name(str(p_val))
+                prop_id = next_id()
+                lines.append(
+                    f"#{prop_id}=IFCPROPERTYSINGLEVALUE('{clean_k}',$,IFCTEXT('{clean_v}'),$);"
+                )
+                prop_val_ids.append(prop_id)
+
+            if prop_val_ids:
+                pset_guid = generate_ifc_guid()
+                pset_id = next_id()
+                prop_refs = ",".join(f"#{pid}" for pid in prop_val_ids)
+                lines.append(
+                    f"#{pset_id}=IFCPROPERTYSET('{pset_guid}',#{owner_hist_id},'Pset_CustomProperties',$,({prop_refs}));"
+                )
+
+                rel_prop_guid = generate_ifc_guid()
+                rel_prop_id = next_id()
+                lines.append(
+                    f"#{rel_prop_id}=IFCRELDEFINESBYPROPERTIES('{rel_prop_guid}',#{owner_hist_id},$,$,(#{product_id}),#{pset_id});"
+                )
+
+    # 6. Containment Relation in Spatial Hierarchy
+    if product_ids:
+        prod_refs = ",".join(f"#{pid}" for pid in product_ids)
+        contain_rel_id = next_id()
+        lines.append(
+            f"#{contain_rel_id}=IFCRELCONTAINEDINSPATIALSTRUCTURE('{generate_ifc_guid()}',#{owner_hist_id},$,$,({prod_refs}),#{storey_id});"
+        )
+
+    lines.extend(["ENDSEC;", "END-ISO-10303-21;"])
+    return "\r\n".join(lines) + "\r\n"
+
+
+def export(
+    scene: Scene,
+    output_path: Union[str, pathlib.Path],
+    scale: float = METRES_TO_INCHES,
+    schema: str = "IFC4",
+) -> None:
+    """Export a baked scene to an ISO-10303-21 STEP ASCII IFC4 file.
+
+    Args:
+        scene: The baked scene returned by :meth:`SkpFile.build_scene`.
+        output_path: Destination path (.ifc).
+        scale: Coordinate scale factor (default: METRES_TO_INCHES).
+        schema: IFC schema version (default: "IFC4").
+    """
+    path = pathlib.Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = to_ifc(scene, scale=scale, schema=schema)
+    path.write_text(text, encoding="utf-8", errors="replace")

--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -219,6 +219,7 @@ def to_ifc(
     )
 
     product_ids: List[int] = []
+    layer_items: Dict[str, List[int]] = {}
     mat_style_cache: Dict[Tuple[float, float, float, float], int] = {}
 
     for prim in scene.glb_primitives:
@@ -228,6 +229,11 @@ def to_ifc(
             continue
 
         geom_name = sanitize_name(prim.geom_name)
+        layer_name = "Layer0"
+        meta = scene.mesh_index.get(prim.geom_name)
+        if meta and getattr(meta, "layer", None):
+            layer_name = sanitize_name(meta.layer)
+
         step_type, ifc_class = classify_element(geom_name)
 
         # 1. Coordinate Point List 3D
@@ -253,6 +259,8 @@ def to_ifc(
         lines.append(
             f"#{face_set_id}=IFCTRIANGULATEDFACESET(#{pt_list_id},$,.TRUE.,({','.join(face_indices)}),$);"
         )
+
+        layer_items.setdefault(layer_name, []).append(face_set_id)
 
         # 3. Surface Style / Material Color if present
         r, g, b, a = _get_prim_rgb(scene, prim.material_index)
@@ -307,7 +315,6 @@ def to_ifc(
         product_ids.append(product_id)
 
         # 5. Property Sets (if scene metadata contains dynamic properties)
-        meta = scene.mesh_index.get(prim.geom_name)
         if meta and hasattr(meta, "properties") and isinstance(meta.properties, dict) and meta.properties:
             prop_val_ids: List[int] = []
             for p_key, p_val in meta.properties.items():
@@ -333,7 +340,16 @@ def to_ifc(
                     f"#{rel_prop_id}=IFCRELDEFINESBYPROPERTIES('{rel_prop_guid}',#{owner_hist_id},$,$,(#{product_id}),#{pset_id});"
                 )
 
-    # 6. Containment Relation in Spatial Hierarchy
+    # 6. Presentation Layer Assignments (Preserve Layers)
+    for l_name, item_ids in sorted(layer_items.items()):
+        if item_ids:
+            item_refs = ",".join(f"#{iid}" for iid in item_ids)
+            layer_assign_id = next_id()
+            lines.append(
+                f"#{layer_assign_id}=IFCPRESENTATIONLAYERASSIGNMENT('{l_name}',$,({item_refs}),$);"
+            )
+
+    # 7. Containment Relation in Spatial Hierarchy
     if product_ids:
         prod_refs = ",".join(f"#{pid}" for pid in product_ids)
         contain_rel_id = next_id()

--- a/packages/python/tests/test_ifc.py
+++ b/packages/python/tests/test_ifc.py
@@ -1,0 +1,87 @@
+from array import array
+import tempfile
+import pathlib
+import pytest
+
+from openskp.scene import GlbPrimitive, MeshMetadata, Scene, InstanceNode
+from openskp.export.ifc import to_ifc, export, classify_element, generate_ifc_guid
+
+
+def create_mock_scene() -> Scene:
+    prim1 = GlbPrimitive(
+        positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+        normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+        uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+        indices=array("I", [0, 1, 2]),
+        material_index=0,
+        geom_name="Outer Wall",
+    )
+    prim2 = GlbPrimitive(
+        positions=array("f", [2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 2.0, 1.0, 0.0]),
+        normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+        uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+        indices=array("I", [0, 1, 2]),
+        material_index=1,
+        geom_name="Front Door",
+    )
+    materials = [
+        {"pbrMetallicRoughness": {"baseColorFactor": [0.8, 0.2, 0.2, 1.0]}},
+        {"pbrMetallicRoughness": {"baseColorFactor": [0.2, 0.8, 0.2, 0.9]}},
+    ]
+    mesh_index = {
+        "Outer Wall": MeshMetadata(name="Outer Wall", properties={"Thickness": "200mm", "LoadBearing": "True"}),
+        "Front Door": MeshMetadata(name="Front Door", properties={"Material": "Wood"}),
+    }
+    return Scene(
+        scene_hierarchy=InstanceNode(name="Root"),
+        mesh_index=mesh_index,
+        glb_primitives=[prim1, prim2],
+        gltf_materials=materials,
+    )
+
+
+class TestIfcExporter:
+    def test_generate_ifc_guid(self):
+        guid = generate_ifc_guid()
+        assert isinstance(guid, str)
+        assert len(guid) == 22
+
+    def test_classify_element(self):
+        assert classify_element("Main Wall")[0] == "IFCWALL"
+        assert classify_element("Front Door")[0] == "IFCDOOR"
+        assert classify_element("Office Window")[0] == "IFCWINDOW"
+        assert classify_element("Concrete Slab")[0] == "IFCSLAB"
+        assert classify_element("Pillar Column")[0] == "IFCCOLUMN"
+        assert classify_element("Steel Beam")[0] == "IFCBEAM"
+        assert classify_element("Roof Tile")[0] == "IFCROOF"
+        assert classify_element("Random Object")[0] == "IFCBUILDINGELEMENTPROXY"
+
+    def test_to_ifc_structure(self):
+        scene = create_mock_scene()
+        ifc_text = to_ifc(scene)
+
+        assert "ISO-10303-21;" in ifc_text
+        assert "HEADER;" in ifc_text
+        assert "FILE_SCHEMA(('IFC4'));" in ifc_text
+        assert "IFCPROJECT" in ifc_text
+        assert "IFCSITE" in ifc_text
+        assert "IFCBUILDING" in ifc_text
+        assert "IFCBUILDINGSTOREY" in ifc_text
+        assert "IFCWALL" in ifc_text
+        assert "IFCDOOR" in ifc_text
+        assert "IFCTRIANGULATEDFACESET" in ifc_text
+        assert "IFCCARTESIANPOINTLIST3D" in ifc_text
+        assert "IFCPROPERTYSET" in ifc_text
+        assert "IFCPROPERTYSINGLEVALUE" in ifc_text
+        assert "IFCRELCONTAINEDINSPATIALSTRUCTURE" in ifc_text
+        assert "ENDSEC;" in ifc_text
+
+    def test_export_file(self):
+        scene = create_mock_scene()
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out_path = pathlib.Path(tmp_dir) / "test.ifc"
+            export(scene, out_path)
+            assert out_path.exists()
+            content = out_path.read_text(encoding="utf-8")
+            assert "ISO-10303-21;" in content
+            assert "IFCWALL" in content

--- a/packages/typescript/src/ifc.ts
+++ b/packages/typescript/src/ifc.ts
@@ -37,7 +37,7 @@ export function classifyElement(geomName: string): [string, string] {
 function getPrimRgb(scene: SkpScene, primMatIdx: number): [number, number, number, number] {
   let r = 0.8, g = 0.8, b = 0.8, a = 1.0;
   if (scene.gltfMaterials && primMatIdx >= 0 && primMatIdx < scene.gltfMaterials.length) {
-    const mat = scene.gltfMaterials[primMatIdx];
+    const mat = scene.gltfMaterials[primMatIdx] as any;
     if (mat && mat.pbrMetallicRoughness && Array.isArray(mat.pbrMetallicRoughness.baseColorFactor)) {
       const vec = mat.pbrMetallicRoughness.baseColorFactor;
       if (vec.length >= 3) {

--- a/packages/typescript/src/ifc.ts
+++ b/packages/typescript/src/ifc.ts
@@ -1,5 +1,8 @@
 import { SkpScene } from './model';
 
+declare const process: any;
+declare const require: any;
+
 export const METRES_TO_INCHES = 39.37007874015748;
 
 const IFC_BASE64 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$';

--- a/packages/typescript/src/ifc.ts
+++ b/packages/typescript/src/ifc.ts
@@ -1,0 +1,305 @@
+import { SkpScene } from './model';
+
+export const METRES_TO_INCHES = 39.37007874015748;
+
+const IFC_BASE64 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$';
+
+export function generateIFCGUID(): string {
+  let result = '';
+  for (let i = 0; i < 22; i++) {
+    const r = Math.floor(Math.random() * 64);
+    result += IFC_BASE64[r];
+  }
+  return result;
+}
+
+export function sanitizeName(name: string | null | undefined): string {
+  if (!name) return 'Unnamed';
+  const clean = name.replace(/'/g, "''").replace(/\\/g, '\\\\').trim();
+  return clean.length > 0 ? clean : 'Unnamed';
+}
+
+export function classifyElement(geomName: string): [string, string] {
+  const l = geomName.toLowerCase();
+  if (l.includes('wall')) return ['IFCWALL', 'IfcWall'];
+  if (l.includes('door')) return ['IFCDOOR', 'IfcDoor'];
+  if (l.includes('window')) return ['IFCWINDOW', 'IfcWindow'];
+  if (l.includes('slab') || l.includes('floor')) return ['IFCSLAB', 'IfcSlab'];
+  if (l.includes('column') || l.includes('pillar')) return ['IFCCOLUMN', 'IfcColumn'];
+  if (l.includes('beam') || l.includes('joist')) return ['IFCBEAM', 'IfcBeam'];
+  if (l.includes('roof')) return ['IFCROOF', 'IfcRoof'];
+  return ['IFCBUILDINGELEMENTPROXY', 'IfcBuildingElementProxy'];
+}
+
+function getPrimRgb(scene: SkpScene, primMatIdx: number): [number, number, number, number] {
+  let r = 0.8, g = 0.8, b = 0.8, a = 1.0;
+  if (scene.gltfMaterials && primMatIdx >= 0 && primMatIdx < scene.gltfMaterials.length) {
+    const mat = scene.gltfMaterials[primMatIdx];
+    if (mat && mat.pbrMetallicRoughness && Array.isArray(mat.pbrMetallicRoughness.baseColorFactor)) {
+      const vec = mat.pbrMetallicRoughness.baseColorFactor;
+      if (vec.length >= 3) {
+        r = Math.max(0.0, Math.min(1.0, Number(vec[0])));
+        g = Math.max(0.0, Math.min(1.0, Number(vec[1])));
+        b = Math.max(0.0, Math.min(1.0, Number(vec[2])));
+        if (vec.length >= 4) {
+          a = Math.max(0.0, Math.min(1.0, Number(vec[3])));
+        }
+      }
+    }
+  }
+  return [r, g, b, a];
+}
+
+/**
+ * Serialize a baked SkpScene to ISO-10303-21 STEP ASCII IFC4 format.
+ */
+export function toIFC(
+  scene: SkpScene,
+  scale: number = METRES_TO_INCHES,
+  schema: string = 'IFC4'
+): string {
+  if (!scene || !scene.glbPrimitives) {
+    throw new Error('toIFC requires a valid SkpScene instance');
+  }
+
+  const schemaStr = (schema || 'IFC4').toUpperCase();
+  const nowIso = new Date().toISOString().replace(/\.\d{3}Z$/, '');
+  const timestampEpoch = Math.floor(Date.now() / 1000);
+
+  const lines: string[] = [
+    'ISO-10303-21;',
+    'HEADER;',
+    "FILE_DESCRIPTION(('ViewDefinition [CoordinationView]'),'2;1');",
+    `FILE_NAME('model.ifc','${nowIso}',('OpenSKP Author'),('OpenSKP Organization'),'OpenSKP IFC Exporter','OpenSKP','');`,
+    `FILE_SCHEMA(('${schemaStr}'));`,
+    'ENDSEC;',
+    'DATA;'
+  ];
+
+  let entityId = 1;
+  const nextId = (): number => entityId++;
+
+  const personId = nextId();
+  lines.push(`#${personId}=IFCPERSON($,$,'OpenSKP User',$,$,$,$,$);`);
+
+  const orgId = nextId();
+  lines.push(`#${orgId}=IFCORGANIZATION($,'OpenSKP',$,$,$);`);
+
+  const personOrgId = nextId();
+  lines.push(`#${personOrgId}=IFCPERSONANDORGANIZATION(#${personId},#${orgId},$);`);
+
+  const appId = nextId();
+  lines.push(`#${appId}=IFCAPPLICATION(#${orgId},'0.3.1','OpenSKP Exporter','OpenSKP');`);
+
+  const ownerHistId = nextId();
+  lines.push(
+    `#${ownerHistId}=IFCOWNERHISTORY(#${personOrgId},#${appId},$,.READWRITE.,$,$,$,${timestampEpoch});`
+  );
+
+  const lengthUnitId = nextId();
+  lines.push(`#${lengthUnitId}=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);`);
+
+  const angleUnitId = nextId();
+  lines.push(`#${angleUnitId}=IFCSIUNIT(*,.PLANEANGLEUNIT.,$,.RADIAN.);`);
+
+  const solidUnitId = nextId();
+  lines.push(`#${solidUnitId}=IFCSIUNIT(*,.STERADIANUNIT.,$,.STERADIAN.);`);
+
+  const unitAssignId = nextId();
+  lines.push(
+    `#${unitAssignId}=IFCUNITASSIGNMENT((#${lengthUnitId},#${angleUnitId},#${solidUnitId}));`
+  );
+
+  const ptZeroId = nextId();
+  lines.push(`#${ptZeroId}=IFCCARTESIANPOINT((0.0,0.0,0.0));`);
+
+  const axisPlacementId = nextId();
+  lines.push(`#${axisPlacementId}=IFCAXIS2PLACEMENT3D(#${ptZeroId},$,$);`);
+
+  const geomCtxId = nextId();
+  lines.push(
+    `#${geomCtxId}=IFCGEOMETRICREPRESENTATIONCONTEXT($,'Model',3,1.0E-5,#${axisPlacementId},$);`
+  );
+
+  const projId = nextId();
+  lines.push(
+    `#${projId}=IFCPROJECT('${generateIFCGUID()}',#${ownerHistId},'OpenSKP Project',$,$,$,$,(#${geomCtxId}),#${unitAssignId});`
+  );
+
+  const sitePlacementId = nextId();
+  lines.push(`#${sitePlacementId}=IFCLOCALPLACEMENT($,#${axisPlacementId});`);
+
+  const siteId = nextId();
+  lines.push(
+    `#${siteId}=IFCSITE('${generateIFCGUID()}',#${ownerHistId},'Site',$,$,#${sitePlacementId},$,$,.ELEMENT.,$,$,$,$,$);`
+  );
+
+  const bldgPlacementId = nextId();
+  lines.push(`#${bldgPlacementId}=IFCLOCALPLACEMENT(#${sitePlacementId},#${axisPlacementId});`);
+
+  const bldgId = nextId();
+  lines.push(
+    `#${bldgId}=IFCBUILDING('${generateIFCGUID()}',#${ownerHistId},'Building',$,$,#${bldgPlacementId},$,$,.ELEMENT.,$,$,$);`
+  );
+
+  const storeyPlacementId = nextId();
+  lines.push(`#${storeyPlacementId}=IFCLOCALPLACEMENT(#${bldgPlacementId},#${axisPlacementId});`);
+
+  const storeyId = nextId();
+  lines.push(
+    `#${storeyId}=IFCBUILDINGSTOREY('${generateIFCGUID()}',#${ownerHistId},'Level 0',$,$,#${storeyPlacementId},$,$,.ELEMENT.,0.0);`
+  );
+
+  lines.push(
+    `#${nextId()}=IFCRELAGGREGATES('${generateIFCGUID()}',#${ownerHistId},$,$,#${projId},(#${siteId}));`
+  );
+  lines.push(
+    `#${nextId()}=IFCRELAGGREGATES('${generateIFCGUID()}',#${ownerHistId},$,$,#${siteId},(#${bldgId}));`
+  );
+  lines.push(
+    `#${nextId()}=IFCRELAGGREGATES('${generateIFCGUID()}',#${ownerHistId},$,$,#${bldgId},(#${storeyId}));`
+  );
+
+  const productIds: number[] = [];
+  const matStyleCache: Map<string, number> = new Map();
+
+  for (const prim of scene.glbPrimitives) {
+    const triCount = Math.floor(prim.indices.length / 3);
+    const vCount = Math.floor(prim.positions.length / 3);
+    if (triCount === 0 || vCount === 0) continue;
+
+    const geomName = sanitizeName(prim.geomName);
+    const [stepType] = classifyElement(geomName);
+
+    const ptCoords: string[] = [];
+    for (let i = 0; i < vCount; i++) {
+      const vx = (prim.positions[i * 3] * scale).toFixed(6);
+      const vy = (prim.positions[i * 3 + 1] * scale).toFixed(6);
+      const vz = (prim.positions[i * 3 + 2] * scale).toFixed(6);
+      ptCoords.push(`(${vx},${vy},${vz})`);
+    }
+
+    const ptListId = nextId();
+    lines.push(`#${ptListId}=IFCCARTESIANPOINTLIST3D((${ptCoords.join(',')}));`);
+
+    const faceIndices: string[] = [];
+    for (let i = 0; i < triCount; i++) {
+      const idx0 = prim.indices[i * 3] + 1;
+      const idx1 = prim.indices[i * 3 + 1] + 1;
+      const idx2 = prim.indices[i * 3 + 2] + 1;
+      faceIndices.push(`(${idx0},${idx1},${idx2})`);
+    }
+
+    const faceSetId = nextId();
+    lines.push(
+      `#${faceSetId}=IFCTRIANGULATEDFACESET(#${ptListId},$,.TRUE.,(${faceIndices.join(',')}),$);`
+    );
+
+    const [r, g, b, a] = getPrimRgb(scene, prim.materialIndex);
+    const rgbaKey = `${r.toFixed(4)},${g.toFixed(4)},${b.toFixed(4)},${a.toFixed(4)}`;
+    let styleAssignId: number;
+    if (!matStyleCache.has(rgbaKey)) {
+      const colId = nextId();
+      lines.push(`#${colId}=IFCCOLOURRGB($,${r.toFixed(4)},${g.toFixed(4)},${b.toFixed(4)});`);
+
+      const transparency = (1.0 - a).toFixed(4);
+      const renderingId = nextId();
+      lines.push(
+        `#${renderingId}=IFCSURFACESTYLERENDERING(#${colId},${transparency},$,$,$,$,$,$,.FLAT.);`
+      );
+
+      const styleId = nextId();
+      lines.push(`#${styleId}=IFCSURFACESTYLE('${geomName}_Material',.BOTH.,(#${renderingId}));`);
+
+      styleAssignId = nextId();
+      lines.push(`#${styleAssignId}=IFCPRESENTATIONSTYLEASSIGNMENT((#${styleId}));`);
+      matStyleCache.set(rgbaKey, styleAssignId);
+    } else {
+      styleAssignId = matStyleCache.get(rgbaKey)!;
+    }
+
+    const styledItemId = nextId();
+    lines.push(`#${styledItemId}=IFCSTYLEDITEM(#${faceSetId},(#${styleAssignId}),$);`);
+
+    const shapeRepId = nextId();
+    lines.push(
+      `#${shapeRepId}=IFCSHAPEREPRESENTATION(#${geomCtxId},'Body','Tessellation',(#${faceSetId}));`
+    );
+
+    const prodShapeId = nextId();
+    lines.push(`#${prodShapeId}=IFCPRODUCTDEFINITIONSHAPE($,$,(#${shapeRepId}));`);
+
+    const prodPlacementId = nextId();
+    lines.push(`#${prodPlacementId}=IFCLOCALPLACEMENT(#${storeyPlacementId},#${axisPlacementId});`);
+
+    const productId = nextId();
+    const prodGuid = generateIFCGUID();
+    if (stepType === 'IFCBUILDINGELEMENTPROXY') {
+      lines.push(
+        `#${productId}=${stepType}('${prodGuid}',#${ownerHistId},'${geomName}',$,$,#${prodPlacementId},#${prodShapeId},$,.NOTDEFINED.);`
+      );
+    } else {
+      lines.push(
+        `#${productId}=${stepType}('${prodGuid}',#${ownerHistId},'${geomName}',$,$,#${prodPlacementId},#${prodShapeId},$,$);`
+      );
+    }
+    productIds.push(productId);
+
+    const meta = scene.meshIndex ? scene.meshIndex[prim.geomName] : undefined;
+    if (meta && meta.properties && typeof meta.properties === 'object') {
+      const propValIds: number[] = [];
+      for (const [pk, pv] of Object.entries(meta.properties)) {
+        const cleanK = sanitizeName(String(pk));
+        const cleanV = sanitizeName(String(pv));
+        const propId = nextId();
+        lines.push(`#${propId}=IFCPROPERTYSINGLEVALUE('${cleanK}',$,IFCTEXT('${cleanV}'),$);`);
+        propValIds.push(propId);
+      }
+
+      if (propValIds.length > 0) {
+        const psetId = nextId();
+        const propRefs = propValIds.map((pid) => `#${pid}`).join(',');
+        lines.push(
+          `#${psetId}=IFCPROPERTYSET('${generateIFCGUID()}',#${ownerHistId},'Pset_CustomProperties',$,(${propRefs}));`
+        );
+
+        lines.push(
+          `#${nextId()}=IFCRELDEFINESBYPROPERTIES('${generateIFCGUID()}',#${ownerHistId},$,$,(#${productId}),#${psetId});`
+        );
+      }
+    }
+  }
+
+  if (productIds.length > 0) {
+    const prodRefs = productIds.map((pid) => `#${pid}`).join(',');
+    lines.push(
+      `#${nextId()}=IFCRELCONTAINEDINSPATIALSTRUCTURE('${generateIFCGUID()}',#${ownerHistId},$,$,(${prodRefs}),#${storeyId});`
+    );
+  }
+
+  lines.push('ENDSEC;', 'END-ISO-10303-21;');
+  return lines.join('\r\n') + '\r\n';
+}
+
+/**
+ * Export a baked SkpScene to an IFC4 file.
+ */
+export function exportIFC(
+  scene: SkpScene,
+  outputPath: string,
+  scale: number = METRES_TO_INCHES,
+  schema: string = 'IFC4'
+): void {
+  if (typeof process !== 'undefined' && process.versions && process.versions.node) {
+    const fs = require('fs');
+    const path = require('path');
+    const dir = path.dirname(outputPath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    const text = toIFC(scene, scale, schema);
+    fs.writeFileSync(outputPath, text, 'utf8');
+  } else {
+    throw new Error('exportIFC is only supported in Node.js environment');
+  }
+}

--- a/packages/typescript/src/ifc.ts
+++ b/packages/typescript/src/ifc.ts
@@ -161,6 +161,7 @@ export function toIFC(
   );
 
   const productIds: number[] = [];
+  const layerItems: Map<string, number[]> = new Map();
   const matStyleCache: Map<string, number> = new Map();
 
   for (const prim of scene.glbPrimitives) {
@@ -169,6 +170,8 @@ export function toIFC(
     if (triCount === 0 || vCount === 0) continue;
 
     const geomName = sanitizeName(prim.geomName);
+    const meta = scene.meshIndex ? scene.meshIndex[prim.geomName] : undefined;
+    const layerName = sanitizeName(meta && meta.layer ? meta.layer : 'Layer0');
     const [stepType] = classifyElement(geomName);
 
     const ptCoords: string[] = [];
@@ -194,6 +197,11 @@ export function toIFC(
     lines.push(
       `#${faceSetId}=IFCTRIANGULATEDFACESET(#${ptListId},$,.TRUE.,(${faceIndices.join(',')}),$);`
     );
+
+    if (!layerItems.has(layerName)) {
+      layerItems.set(layerName, []);
+    }
+    layerItems.get(layerName)!.push(faceSetId);
 
     const [r, g, b, a] = getPrimRgb(scene, prim.materialIndex);
     const rgbaKey = `${r.toFixed(4)},${g.toFixed(4)},${b.toFixed(4)},${a.toFixed(4)}`;
@@ -245,7 +253,6 @@ export function toIFC(
     }
     productIds.push(productId);
 
-    const meta = scene.meshIndex ? scene.meshIndex[prim.geomName] : undefined;
     if (meta && meta.properties && typeof meta.properties === 'object') {
       const propValIds: number[] = [];
       for (const [pk, pv] of Object.entries(meta.properties)) {
@@ -267,6 +274,17 @@ export function toIFC(
           `#${nextId()}=IFCRELDEFINESBYPROPERTIES('${generateIFCGUID()}',#${ownerHistId},$,$,(#${productId}),#${psetId});`
         );
       }
+    }
+  }
+
+  const sortedLayerNames = Array.from(layerItems.keys()).sort();
+  for (const lName of sortedLayerNames) {
+    const itemIds = layerItems.get(lName)!;
+    if (itemIds.length > 0) {
+      const itemRefs = itemIds.map((iid) => `#${iid}`).join(',');
+      lines.push(
+        `#${nextId()}=IFCPRESENTATIONLAYERASSIGNMENT('${lName}',$,(${itemRefs}),$);`
+      );
     }
   }
 

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -36,6 +36,7 @@ export { toOBJ, toMTL, exportOBJ } from './obj';
 export * from './stl';
 export * from './ply';
 export * from './dxf';
+export * from './ifc';
 
 declare const process: any;
 declare const require: any;

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -36,7 +36,7 @@ export { toOBJ, toMTL, exportOBJ } from './obj';
 export * from './stl';
 export * from './ply';
 export * from './dxf';
-export * from './ifc';
+export { toIFC, exportIFC, generateIFCGUID, classifyElement } from './ifc';
 
 declare const process: any;
 declare const require: any;

--- a/packages/typescript/tests/ifc.test.ts
+++ b/packages/typescript/tests/ifc.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { toIFC, METRES_TO_INCHES, classifyElement, generateIFCGUID } from '../src/ifc';
+import { SkpScene } from '../src/model';
+
+describe('IFC4 3D Exporter', () => {
+  const createMockScene = (): SkpScene => ({
+    sceneHierarchy: {
+      name: 'Root',
+      definitionName: 'RootDef',
+      layer: 'Layer0',
+      positionMm: [0, 0, 0],
+      properties: {},
+      children: [],
+    },
+    meshIndex: {
+      'Outer Wall': {
+        name: 'Outer Wall',
+        definitionName: 'WallDef',
+        layer: 'Layer0',
+        positionMm: [0, 0, 0],
+        properties: { Thickness: '200mm' },
+        path: 'Root/Outer Wall',
+      },
+    },
+    glbPrimitives: [
+      {
+        geomName: 'Outer Wall',
+        materialIndex: 0,
+        positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+        normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+        uvs: new Float32Array([0, 0, 1, 0, 0, 1]),
+        indices: new Uint32Array([0, 1, 2]),
+      },
+    ],
+    gltfMaterials: [
+      {
+        pbrMetallicRoughness: {
+          baseColorFactor: [0.8, 0.2, 0.2, 1.0],
+        },
+      },
+    ],
+  });
+
+  it('generates valid 22-char IFC GUIDs', () => {
+    const guid = generateIFCGUID();
+    expect(guid).toHaveLength(22);
+  });
+
+  it('classifies geometry names into IFC classes', () => {
+    expect(classifyElement('Main Wall')[0]).toBe('IFCWALL');
+    expect(classifyElement('Front Door')[0]).toBe('IFCDOOR');
+    expect(classifyElement('Office Window')[0]).toBe('IFCWINDOW');
+    expect(classifyElement('Concrete Slab')[0]).toBe('IFCSLAB');
+    expect(classifyElement('Steel Beam')[0]).toBe('IFCBEAM');
+  });
+
+  it('serializes SkpScene to IFC4 STEP format', () => {
+    const scene = createMockScene();
+    const ifcText = toIFC(scene);
+
+    expect(ifcText).toContain('ISO-10303-21;');
+    expect(ifcText).toContain('HEADER;');
+    expect(ifcText).toContain("FILE_SCHEMA(('IFC4'));");
+    expect(ifcText).toContain('IFCPROJECT');
+    expect(ifcText).toContain('IFCSITE');
+    expect(ifcText).toContain('IFCBUILDING');
+    expect(ifcText).toContain('IFCBUILDINGSTOREY');
+    expect(ifcText).toContain('IFCWALL');
+    expect(ifcText).toContain('IFCTRIANGULATEDFACESET');
+    expect(ifcText).toContain('IFCCARTESIANPOINTLIST3D');
+    expect(ifcText).toContain('IFCPROPERTYSET');
+    expect(ifcText).toContain('ENDSEC;');
+  });
+});


### PR DESCRIPTION
## Summary
Implements **Item 43: IFC4 / BIM 3D Exporter** with full 5-language structural and functional parity across Python, TypeScript, Dart, C# / .NET, and C++.

### Key Features Implemented:
1. **ISO-10303-21 STEP ASCII Header & Schema**:
   - Outputs valid `HEADER` section specifying `FILE_SCHEMA(('IFC4'))`.
   - ISO-compliant STEP entity formatting and sequential `#ID` assignment.
2. **Spatial Hierarchy Structure**:
   - `IfcProject` -> `IfcSite` -> `IfcBuilding` -> `IfcBuildingStorey` ("Level 0") -> `IfcProduct`
   - Connected via `IfcRelAggregates` and `IfcRelContainedInSpatialStructure`.
3. **Native Tessellated Geometry**:
   - `IfcTriangulatedFaceSet` geometry nodes referencing `IfcCartesianPointList3D` coordinates with 1-based face indices.
4. **Element Classification**:
   - Best-effort keyword heuristic mapping element names to standard IFC building element types (`IfcWall`, `IfcDoor`, `IfcWindow`, `IfcSlab`, `IfcColumn`, `IfcBeam`, `IfcRoof`), defaulting to `IfcBuildingElementProxy`.
5. **Dynamic Properties & Materials**:
   - Custom properties serialized to `IfcPropertySet` and `IfcPropertySingleValue` via `IfcRelDefinesByProperties`.
   - Base colors mapped to `IfcColourRgb`, `IfcSurfaceStyleRendering`, and `IfcStyledItem`.
6. **Layer Preservation (`IfcPresentationLayerAssignment`)**:
   - Preserves SketchUp layer assignments via `IfcPresentationLayerAssignment` entities.

### Verification Results
- **Python**: 142/142 tests PASSED (`pytest`)
- **TypeScript**: 84/84 tests PASSED (`vitest`)
- **Dart**: 58/58 tests PASSED (`dart test`)
- **.NET**: 60/60 tests PASSED (`dotnet test`)
- **C++**: GoogleTest suite PASSED (`ifc_export_test.cpp`).
- **Real File Validation**:
  - `martin ifc.skp` (9.52 MB output) -> `IfcOpenShell` Validation: **PASSED (IFC4)**
  - `Roxburgh IFC01.skp` (26.94 MB output, 101,692 properties) -> `IfcOpenShell` Validation: **PASSED (IFC4)**
