### PR TITLE
docs: update Export Capability Table and READMEs across all 5 ports to include IFC4 (BIM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ OpenSKP is the **first and only** open-source, cross-platform parser for SketchU
 | **Styles** | ✅ | Front/back face colors for unpainted faces |
 | **Dynamic Components** | ✅ | Extracts dynamic component attribute key-value pairs for both modern (2021+) and legacy (2013–2020) files, in all five languages |
 | **Observability** | ✅ | Opt-in progress reporting + structured, location-carrying parse errors — see [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
-| **Export to GLB / OBJ / STL / PLY / DXF 3D / JSON** | ✅ | GLB, Wavefront OBJ, STL, PLY, DXF 3D (AutoCAD R12 `3DFACE`), and JSON metadata export are available natively across all five languages — see [Export capabilities](docs/DEVELOPER_GUIDE.md#export-capabilities) |
+| **Export to GLB / OBJ / STL / PLY / DXF 3D / IFC4 / JSON** | ✅ | GLB, Wavefront OBJ, STL, PLY, DXF 3D (AutoCAD Polyface Mesh), IFC4 (BIM), and JSON metadata export are available natively across all five languages — see [Export capabilities](docs/DEVELOPER_GUIDE.md#export-capabilities) |
 | **Streaming / low-memory parsing** | ✅ | Peak memory bounded by the largest single definition, not the whole file — see [Memory architecture](docs/ARCHITECTURE.md#memory-architecture) |
 | **Pure Implementation** | ✅ | No SketchUp SDK, no native dependencies, no license required |
 | **Cross-Platform** | ✅ | Works on Linux, macOS, and Windows |
@@ -161,6 +161,7 @@ Console.WriteLine($"{scene.GlbPrimitives.Count} renderable mesh primitives");
 
 var glb = GlbExport.ToGlb(scene);       // ready to write to a .glb file
 GlbExport.ExportGlb(scene, "my_model.glb");
+IfcExport.ExportIfc(scene, "my_model.ifc");
 ```
 
 ### 🎯 Dart / Flutter
@@ -181,6 +182,7 @@ print('${scene.glbPrimitives.length} renderable mesh primitives');
 
 final glb = toGlb(scene);               // ready to write to a .glb file
 exportGlb(scene, 'my_model.glb');
+exportIfc(scene, 'my_model.ifc');
 ```
 
 ### ⚙️ C++17 / CMake
@@ -198,6 +200,7 @@ auto model = skp.parse();
 auto scene = skp.build_scene();
 auto glb = openskp::to_glb(scene);
 openskp::export_glb(scene, "my_model.glb");
+openskp::export_ifc(scene, "my_model.ifc");
 ```
 
 ---

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -140,7 +140,11 @@ All five languages produce equivalent structured output for the same file:
 
 | Format | Extension | Ships in |
 |---|---|---|
-| GLB (binary glTF 2.0) | `.glb` | Python (`openskp.export.glb`), TypeScript (`toGLB()`), C++ (`to_glb()` / `export_glb()`) |
-| Wavefront OBJ | `.obj` | Python (`openskp.export.obj`) only |
-| Full metadata JSON | `.json` | Python (`openskp.export.json_export`) only |
-| Raw scene data | — | All five, via scene building and `Scene`/`GlbPrimitive` — build your own serializer from this |
+| GLB (binary glTF 2.0) | `.glb` | All 5 languages (`glb.export` / `toGLB` / `GlbExport.ExportGlb` / `exportGlb` / `export_glb`) |
+| Wavefront OBJ | `.obj` | All 5 languages (`obj.export` / `toOBJ` / `ObjExport.ExportObj` / `exportObj` / `export_obj`) |
+| STL (3D Printing) | `.stl` | All 5 languages (`stl.export` / `toSTLAscii` / `StlExport.ExportStl` / `exportStl` / `export_stl`) |
+| PLY (Stanford Mesh) | `.ply` | All 5 languages (`ply.export` / `toPLYAscii` / `PlyExport.ExportPly` / `exportPly` / `export_ply`) |
+| DXF 3D (AutoCAD Polyface Mesh) | `.dxf` | All 5 languages (`dxf.export` / `toDXF` / `DxfExport.ExportDxf` / `exportDxf` / `export_dxf`) |
+| IFC4 (BIM ISO STEP) | `.ifc` | All 5 languages (`ifc.export` / `toIFC` / `IfcExport.ExportIfc` / `exportIfc` / `export_ifc`) |
+| Full metadata JSON | `.json` | All 5 languages (`json_export.export` / `toJSON` / `JsonExport.ExportJson` / `exportJson` / `export_json`) |
+| Raw scene data | — | All 5 languages via `buildScene()` — build custom serializers directly from `Scene` / `GlbPrimitive` |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,7 +41,7 @@ graph TD
     D --> E
     E --> F["parse() -> SkpModel\n(light, no scene resolution)"]
     E --> G["buildScene() -> Scene\n(opt-in: full instance tree,\ntriangulated, world-space)"]
-    G --> H["GLB export\n(Python, TypeScript, C++)"]
+    G --> H["Exporters (GLB, OBJ, STL, PLY, DXF, IFC, JSON)\n(all five languages)"]
 ```
 
 **VFF path** (`core.*` / `_core.py`): validate the `FF FE FF 0E` header,
@@ -133,7 +133,7 @@ platform:
 | Geometry extraction | `_core.py` | `geometry.ts` | `Geometry.cs` | `geometry.dart` | `geometry.cpp` |
 | Public model | `model.py` | `model.ts` | `Model.cs` | `model.dart` | `model.cpp` |
 | Scene baking | `scene.py` | `model.ts` | `Scene.cs` | `scene.dart` | `scene.cpp` |
-| GLB writing | `export/glb.py` | `index.ts` | — | — | `glb.cpp` |
+| Exporters (GLB, OBJ, STL, PLY, DXF, IFC, JSON) | `export/` | `obj.ts`, `stl.ts`, `ply.ts`, `dxf.ts`, `ifc.ts` | `GlbExport.cs`, `ObjExport.cs`, `StlExport.cs`, `PlyExport.cs`, `DxfExport.cs`, `IfcExport.cs`, `JsonExport.cs` | `glb_export.dart`, `obj_export.dart`, `stl_export.dart`, `ply_export.dart`, `dxf_export.dart`, `ifc_export.dart`, `json_export.dart` | `glb_export.cpp`, `obj_export.cpp`, `stl_export.cpp`, `ply_export.cpp`, `dxf_export.cpp`, `ifc_export.cpp`, `json_export.cpp` |
 | Triangulation | `triangulator.py` | `triangulator.ts` | `Triangulator.cs` + `Earcut.cs` | `triangulator.dart` + `earcut.dart` | `triangulator.cpp` + `earcut.cpp` |
 | Transform math | `transforms.py` | `transforms.ts` | `Transforms.cs` | `transforms.dart` | `transforms.cpp` |
 | Errors / observability | `errors.py` / logging | `errors.ts` / `observability.ts` | `Errors.cs` / `Observability.cs` | `errors.dart` / `observability.dart` | `errors.cpp` / `observability.cpp` |
@@ -171,7 +171,7 @@ equivalent, not the internal triangle split.
 | XML parsing | `ElementTree` | manual/DOM | `System.Xml` | `xml` | focused scanner |
 | Triangulation | `shapely` | `earcut` | ported earcut | ported earcut | native C++ |
 | Matrix math | `numpy` | native | native | native | native |
-| GLB/OBJ/JSON export | all | GLB | — | — | GLB via private TinyGLTF 2.9.7 |
+| GLB/OBJ/STL/PLY/DXF/IFC/JSON export | all (native / `trimesh`) | all (native) | all (native) | all (native) | all (native + private TinyGLTF 2.9.7) |
 
 ## Testing philosophy
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -312,15 +312,15 @@ already exactly the data a GLB/glTF exporter needs — triangulated,
 world-space, grouped by material. What differs is whether each language
 ships file-writing exporters on top of that data:
 
-| Language | Scene data (`buildScene()`) | GLB | OBJ | STL | PLY | DXF 3D (AutoCAD R12) | JSON metadata |
-|---|---|---|---|---|---|---|---|
-| Python | ✅ | ✅ `openskp.export.glb` | ✅ `openskp.export.obj` | ✅ `openskp.export.stl` | ✅ `openskp.export.ply` | ✅ `openskp.export.dxf` | ✅ `openskp.export.json_export` |
-| TypeScript | ✅ | ✅ `toGLB(scene)` | ✅ `toOBJ(scene)` / `exportOBJ` | ✅ `toSTLAscii` / `exportSTL` | ✅ `toPLYAscii` / `exportPLY` | ✅ `toDXF(scene)` / `exportDXF` | ✅ `toJSON(model, scene?)` |
-| .NET | ✅ | ✅ `GlbExport.ExportGlb` | ✅ `ObjExport.ExportObj` | ✅ `StlExport.ExportStl` | ✅ `PlyExport.ExportPly` | ✅ `DxfExport.ToDxf` / `ExportDxf` | ✅ `JsonExport.ExportJson` |
-| Dart | ✅ | ✅ `exportGlb` | ✅ `exportObj` | ✅ `exportStl` | ✅ `exportPly` | ✅ `toDxf` / `exportDxf` | ✅ `exportJson` |
-| C++ | ✅ | ✅ `export_glb` | ✅ `export_obj` | ✅ `export_stl` | ✅ `export_ply` | ✅ `to_dxf` / `export_dxf` | ✅ `export_json` |
+| Language | Scene data (`buildScene()`) | GLB | OBJ | STL | PLY | DXF 3D (AutoCAD R2000) | IFC4 (BIM) | JSON metadata |
+|---|---|---|---|---|---|---|---|---|
+| Python | ✅ | ✅ `openskp.export.glb` | ✅ `openskp.export.obj` | ✅ `openskp.export.stl` | ✅ `openskp.export.ply` | ✅ `openskp.export.dxf` | ✅ `openskp.export.ifc` | ✅ `openskp.export.json_export` |
+| TypeScript | ✅ | ✅ `toGLB(scene)` | ✅ `toOBJ(scene)` / `exportOBJ` | ✅ `toSTLAscii` / `exportSTL` | ✅ `toPLYAscii` / `exportPLY` | ✅ `toDXF(scene)` / `exportDXF` | ✅ `toIFC(scene)` / `exportIFC` | ✅ `toJSON(model, scene?)` |
+| .NET | ✅ | ✅ `GlbExport.ExportGlb` | ✅ `ObjExport.ExportObj` | ✅ `StlExport.ExportStl` | ✅ `PlyExport.ExportPly` | ✅ `DxfExport.ToDxf` / `ExportDxf` | ✅ `IfcExport.ToIfc` / `ExportIfc` | ✅ `JsonExport.ExportJson` |
+| Dart | ✅ | ✅ `exportGlb` | ✅ `exportObj` | ✅ `exportStl` | ✅ `exportPly` | ✅ `toDxf` / `exportDxf` | ✅ `toIfc` / `exportIfc` | ✅ `exportJson` |
+| C++ | ✅ | ✅ `export_glb` | ✅ `export_obj` | ✅ `export_stl` | ✅ `export_ply` | ✅ `to_dxf` / `export_dxf` | ✅ `to_ifc` / `export_ifc` | ✅ `export_json` |
 
-All five languages provide built-in file-writing and in-memory exporters for GLB, OBJ, STL, PLY, DXF 3D, and JSON metadata. Below is the Python export example:
+All five languages provide built-in file-writing and in-memory exporters for GLB, OBJ, STL, PLY, DXF 3D, IFC4 (BIM), and JSON metadata. Below is the Python export example:
 
 ```python
 from openskp import SkpFile
@@ -469,9 +469,9 @@ consumers to `isinstance(key, int)`-check every key — fixed to match the
 other four; TypeScript previously dropped root-level data from `parse()`
 entirely — also fixed, earlier in the same session.)
 
-### GLB/OBJ/STL/PLY/DXF/JSON export
+### GLB/OBJ/STL/PLY/DXF/IFC/JSON export
 
-Covered above under [Export capabilities](#export-capabilities) — GLB, Wavefront OBJ, STL (3D Printing), PLY (Stanford Mesh), DXF 3D (AutoCAD R2000 compliant), and JSON metadata export are natively supported in all five languages. All ports provide both in-memory string/buffer formatting (`to_dxf`/`toDXF`/`toDxf`/`ToDxf`) and direct file output functions (`export_dxf`/`exportDXF`/`exportDxf`/`ExportDxf`).
+Covered above under [Export capabilities](#export-capabilities) — GLB, Wavefront OBJ, STL (3D Printing), PLY (Stanford Mesh), DXF 3D (AutoCAD R2000 compliant), IFC4 (BIM ISO STEP), and JSON metadata export are natively supported in all five languages. All ports provide both in-memory string/buffer formatting (`to_ifc`/`toIFC`/`toIfc`/`ToIfc`) and direct file output functions (`export_ifc`/`exportIFC`/`exportIfc`/`ExportIfc`).
 
 ### Progress/logging mechanism
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -324,7 +324,7 @@ All five languages provide built-in file-writing and in-memory exporters for GLB
 
 ```python
 from openskp import SkpFile
-from openskp.export import glb, obj, json_export
+from openskp.export import glb, obj, stl, ply, dxf, ifc, json_export
 
 skp = SkpFile.open("model.skp")
 model = skp.parse()
@@ -332,6 +332,10 @@ scene = skp.build_scene()
 
 glb.export(skp, "output.glb")               # takes the SkpFile, writes .glb + .json via trimesh
 obj.export(scene, "output.obj")              # takes a built Scene, writes vertices/faces only
+stl.export(scene, "output.stl", binary=True) # writes 3D printing STL (ASCII/binary)
+ply.export(scene, "output.ply", binary=True) # writes Stanford PLY mesh
+dxf.export(scene, "output.dxf")              # writes AutoCAD R2000 3D Polyface Mesh DXF
+ifc.export(scene, "output.ifc")              # writes ISO 10303-21 STEP IFC4 BIM model
 json_export.export(model, "output.json", scene=scene)  # scene= populates scene_hierarchy
 ```
 

--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -67,6 +67,10 @@ openskp::export_glb(scene, "model.glb");
 auto dxf_str = openskp::to_dxf(scene);
 openskp::export_dxf(scene, "model.dxf");
 
+// IFC4 / BIM export (ISO 10303-21 STEP format)
+auto ifc_str = openskp::to_ifc(scene);
+openskp::export_ifc(scene, "model.ifc");
+
 // OBJ / STL / PLY export
 openskp::export_obj(scene, "model.obj");
 openskp::export_stl(scene, "model.stl");

--- a/packages/dart/README.md
+++ b/packages/dart/README.md
@@ -114,6 +114,10 @@ void main() async {
   // Export to 3D DXF (AutoCAD R2000 compliant)
   final dxfText = toDxf(scene);
   exportDxf(scene, 'my_model.dxf');
+
+  // Export to IFC4 / BIM (ISO 10303-21 STEP format)
+  final ifcText = toIfc(scene);
+  exportIfc(scene, 'my_model.ifc');
 }
 ```
 

--- a/packages/dotnet/OpenSkp/README.md
+++ b/packages/dotnet/OpenSkp/README.md
@@ -73,9 +73,10 @@ class Program
         // inside any component/group), including root-level instances.
         Console.WriteLine($"Root-level instances: {model.Root.Instances.Count}");
 
-        // Build scene graph into world-space meshes and export to DXF / GLB / OBJ / STL / PLY
+        // Build scene graph into world-space meshes and export to DXF / IFC / GLB / OBJ / STL / PLY
         Scene scene = SkpFile.BuildScene("house.skp");
         DxfExport.ExportDxf(scene, "house.dxf");
+        IfcExport.ExportIfc(scene, "house.ifc");
         GlbExport.ExportGlb("house.skp", "house.glb");
         ObjExport.ExportObj(scene, "house.obj");
         StlExport.ExportStl(scene, "house.stl");

--- a/packages/dotnet/OpenSkp/README.md
+++ b/packages/dotnet/OpenSkp/README.md
@@ -77,7 +77,7 @@ class Program
         Scene scene = SkpFile.BuildScene("house.skp");
         DxfExport.ExportDxf(scene, "house.dxf");
         IfcExport.ExportIfc(scene, "house.ifc");
-        GlbExport.ExportGlb("house.skp", "house.glb");
+        GlbExport.ExportGlb(scene, "house.glb");
         ObjExport.ExportObj(scene, "house.obj");
         StlExport.ExportStl(scene, "house.stl");
         PlyExport.ExportPly(scene, "house.ply");

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -43,7 +43,7 @@ for inst in scene.scene_hierarchy.children:
 ## Exporting
 
 ```python
-from openskp.export import glb, obj, stl, ply, dxf, json_export
+from openskp.export import glb, obj, stl, ply, dxf, ifc, json_export
 
 # Export to GLB (glTF 2.0 binary) - takes the SkpFile itself
 glb.export(skp, "output.glb")
@@ -59,6 +59,9 @@ ply.export(scene, "output.ply", binary=True)
 
 # Export to AutoCAD 3D DXF (AutoCAD R2000 compliant)
 dxf.export(scene, "output.dxf")
+
+# Export to IFC4 / BIM (ISO 10303-21 STEP ASCII format)
+ifc.export(scene, "output.ifc")
 
 # Export metadata as JSON - pass scene= to include the resolved hierarchy
 meta = json_export.to_dict(model, scene=scene)

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -45,7 +45,7 @@ console.log(scene.glbPrimitives.length, 'renderable mesh primitives');
 ## Exporting
 
 ```typescript
-import { toGLB, toOBJ, toSTL, toPLY, toDXF, exportDXF, toJSON } from 'openskp';
+import { toGLB, toOBJ, toSTL, toPLY, toDXF, exportDXF, toIFC, exportIFC, toJSON } from 'openskp';
 
 // Serialize a built scene straight to .glb bytes (in-memory, no disk I/O)
 const glbBytes = toGLB(scene);
@@ -64,6 +64,10 @@ const dxfText = toDXF(scene);
 
 // Node.js only: export directly to a .dxf file
 exportDXF(scene, 'output.dxf');
+
+// Export to IFC4 / BIM (ISO 10303-21 STEP format string / file)
+const ifcText = toIFC(scene);
+exportIFC(scene, 'output.ifc');
 
 // Full metadata as a JSON-compatible object
 const meta = toJSON(model, scene);

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -45,7 +45,7 @@ console.log(scene.glbPrimitives.length, 'renderable mesh primitives');
 ## Exporting
 
 ```typescript
-import { toGLB, toOBJ, toSTL, toPLY, toDXF, exportDXF, toIFC, exportIFC, toJSON } from 'openskp';
+import { toGLB, toOBJ, toSTLAscii, toSTLBinary, exportSTL, toPLYAscii, toPLYBinary, exportPLY, toDXF, exportDXF, toIFC, exportIFC, toJSON } from 'openskp';
 
 // Serialize a built scene straight to .glb bytes (in-memory, no disk I/O)
 const glbBytes = toGLB(scene);
@@ -54,10 +54,12 @@ const glbBytes = toGLB(scene);
 const objText = toOBJ(scene);
 
 // Export to STL ASCII or Binary string/buffer
-const stlText = toSTL(scene);
+const stlText = toSTLAscii(scene);
+const stlBytes = toSTLBinary(scene);
 
 // Export to PLY ASCII or Binary string/buffer
-const plyText = toPLY(scene);
+const plyText = toPLYAscii(scene);
+const plyBytes = toPLYBinary(scene);
 
 // Export to AutoCAD 3D DXF text format (R2000 / AC1015 compliant)
 const dxfText = toDXF(scene);


### PR DESCRIPTION
## Summary
- Added the **IFC4 (BIM ISO STEP)** exporter to the Export Capability Table in docs/DEVELOPER_GUIDE.md and docs/API_DESIGN.md.
- Updated feature tables and architecture documentation in README.md and docs/ARCHITECTURE.md.
- Updated code usage examples in package READMEs across all 5 language ports (packages/python/README.md, packages/typescript/README.md, packages/dart/README.md, packages/dotnet/OpenSkp/README.md, packages/cpp/README.md).
- Corrected TypeScript STL/PLY export function imports (toSTLAscii, toSTLBinary, toPLYAscii, toPLYBinary) and C# .NET GlbExport.ExportGlb(scene, ...) argument signature.