### PR TITLE
feat(web-viewer): multi-format export dropdown (JSON, IFC, DXF, PLY, STL, GLB, OBJ)

### DIFF
--- a/examples/web-viewer/index.html
+++ b/examples/web-viewer/index.html
@@ -46,10 +46,73 @@
           <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" class="btn-icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="17 8 12 3 7 8"></polyline><line x1="12" y1="3" x2="12" y2="15"></line></svg>
           Upload SKP
         </button>
-        <button id="btn-export" class="btn btn-secondary" disabled>
-          <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" class="btn-icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-          Export GLB
-        </button>
+        
+        <!-- Export Multi-Format Dropdown -->
+        <div class="dropdown" id="export-dropdown">
+          <button id="btn-export" class="btn btn-secondary dropdown-toggle" disabled>
+            <svg viewBox="0 0 24 24" width="16" height="16" stroke="currentColor" stroke-width="2" fill="none" class="btn-icon"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
+            Export Model
+            <svg viewBox="0 0 24 24" width="12" height="12" stroke="currentColor" stroke-width="2" fill="none" class="btn-arrow"><polyline points="6 9 12 15 18 9"></polyline></svg>
+          </button>
+          <div class="dropdown-menu" id="export-menu">
+            <button class="dropdown-item" data-format="json">
+              <span class="fmt-icon">📄</span>
+              <div class="fmt-info">
+                <span class="fmt-title">JSON Metadata (.json)</span>
+                <span class="fmt-desc">Full 3D model metadata & attribute dictionaries</span>
+              </div>
+            </button>
+            <button class="dropdown-item" data-format="ifc">
+              <span class="fmt-icon">🏛️</span>
+              <div class="fmt-info">
+                <span class="fmt-title">IFC4 BIM (.ifc)</span>
+                <span class="fmt-desc">ISO STEP BIM model with spatial hierarchy</span>
+              </div>
+            </button>
+            <button class="dropdown-item" data-format="dxf-polyface">
+              <span class="fmt-icon">📐</span>
+              <div class="fmt-info">
+                <span class="fmt-title">AutoCAD DXF — Polyface Mesh (.dxf)</span>
+                <span class="fmt-desc">R2000 Polyface Mesh (POLYLINE type 64)</span>
+              </div>
+            </button>
+            <button class="dropdown-item" data-format="dxf-3dface">
+              <span class="fmt-icon">📐</span>
+              <div class="fmt-info">
+                <span class="fmt-title">AutoCAD DXF — 3DFACE Entities (.dxf)</span>
+                <span class="fmt-desc">Legacy 3DFACE individual triangle faces</span>
+              </div>
+            </button>
+            <button class="dropdown-item" data-format="ply">
+              <span class="fmt-icon">🔷</span>
+              <div class="fmt-info">
+                <span class="fmt-title">Stanford PLY (.ply)</span>
+                <span class="fmt-desc">3D triangle mesh with colors & normals</span>
+              </div>
+            </button>
+            <button class="dropdown-item" data-format="stl">
+              <span class="fmt-icon">🔺</span>
+              <div class="fmt-info">
+                <span class="fmt-title">3D Printing STL (.stl)</span>
+                <span class="fmt-desc">ASCII / Binary 3D printing geometry</span>
+              </div>
+            </button>
+            <button class="dropdown-item" data-format="glb">
+              <span class="fmt-icon">📦</span>
+              <div class="fmt-info">
+                <span class="fmt-title">glTF 2.0 GLB (.glb)</span>
+                <span class="fmt-desc">Binary 3D model with PBR materials</span>
+              </div>
+            </button>
+            <button class="dropdown-item" data-format="obj">
+              <span class="fmt-icon">🎨</span>
+              <div class="fmt-info">
+                <span class="fmt-title">Wavefront OBJ (.obj)</span>
+                <span class="fmt-desc">3D mesh with .mtl material library</span>
+              </div>
+            </button>
+          </div>
+        </div>
       </div>
 
       <input type="file" id="file-input" accept=".skp" style="display: none;">

--- a/examples/web-viewer/serve.py
+++ b/examples/web-viewer/serve.py
@@ -1,7 +1,10 @@
 import http.server
+import os
 import socketserver
 
 PORT = 8000
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 class MyHandler(http.server.SimpleHTTPRequestHandler):
     def end_headers(self):

--- a/examples/web-viewer/style.css
+++ b/examples/web-viewer/style.css
@@ -71,6 +71,33 @@ body,html{width:100%;height:100%;overflow:hidden;background-color:var(--bg-0);co
 .panel-close{display:none;background:none;border:none;color:var(--text-2);cursor:pointer;
   padding:4px;line-height:0}
 
+/* ── Export Dropdown ────────────────────────────────────────────────── */
+.dropdown{position:relative;display:inline-block}
+.dropdown-toggle{display:flex;align-items:center;gap:6px}
+.btn-arrow{transition:transform 0.2s ease}
+.dropdown.active .btn-arrow{transform:rotate(180deg)}
+
+.dropdown-menu{position:absolute;top:calc(100% + 8px);right:0;width:310px;
+  background:rgba(18,20,26,0.96);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
+  border:1px solid var(--border-h);border-radius:var(--r);padding:6px;
+  box-shadow:0 12px 32px rgba(0,0,0,0.5);display:none;flex-direction:column;gap:3px;z-index:100;
+  animation:dropdownFade 0.2s ease}
+.dropdown.active .dropdown-menu{display:flex}
+
+@keyframes dropdownFade {
+  from { opacity: 0; transform: translateY(-6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.dropdown-item{display:flex;align-items:center;gap:10px;padding:9px 12px;
+  background:transparent;border:none;border-radius:var(--r-sm);color:var(--text-0);
+  cursor:pointer;text-align:left;transition:all 0.15s ease;width:100%}
+.dropdown-item:hover{background:var(--bg-3);border-color:var(--accent-line)}
+.fmt-icon{font-size:1.1rem;flex-shrink:0}
+.fmt-info{display:flex;flex-direction:column;gap:2px}
+.fmt-title{font-size:0.83rem;font-weight:600;color:var(--text-0)}
+.fmt-desc{font-size:0.7rem;color:var(--text-2)}
+
 .badge{background:var(--accent-dim);color:var(--accent);font-size:0.72rem;font-weight:700;
   padding:2px 9px;border-radius:20px;border:1px solid var(--accent-line)}
 

--- a/examples/web-viewer/viewer.js
+++ b/examples/web-viewer/viewer.js
@@ -1,7 +1,19 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { GLTFExporter } from 'three/addons/exporters/GLTFExporter.js';
-import { parseSkp, buildScene } from './dist/index.mjs';
+import {
+  parseSkp,
+  buildScene,
+  toGLB,
+  toOBJ,
+  toSTLAscii,
+  toSTLBinary,
+  toPLYAscii,
+  toPLYBinary,
+  toDXF,
+  toIFC,
+  toJSON,
+} from './dist/index.mjs';
 
 // Application state variables
 let scene, camera, renderer, controls;
@@ -11,6 +23,7 @@ let selectedMesh = null;
 let selectedBoxHelper = null;
 let currentModel = null;
 let currentScene = null;
+let currentLoadedFilename = '';
 let layerVisibility = {};
 
 // DOM Elements
@@ -412,6 +425,7 @@ function loadSkpBuffer(arrayBuffer, filename) {
   setTimeout(() => {
     try {
       clearScene();
+      currentLoadedFilename = filename || 'model.skp';
       
       const startTime = performance.now();
       // parseSkp() is the light, per-definition raw parse (version, layers,
@@ -509,44 +523,68 @@ function loadSkpBuffer(arrayBuffer, filename) {
   }, 100);
 }
 
-// Download scene as GLB using Three.js GLTFExporter
-function exportToGLB() {
-  if (modelGroup.children.length === 0) return;
+// Helper function to trigger browser file download
+function downloadFile(filename, content, mimeType) {
+  const blob = content instanceof Blob ? content : new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  link.click();
+  URL.revokeObjectURL(url);
+}
 
-  setLoader(true, 'Packaging & exporting GLB...');
+// Multi-format exporter router
+function handleExportFormat(format) {
+  if (!currentScene || !currentModel) {
+    alert('No active model loaded to export.');
+    return;
+  }
+
+  const stem = currentLoadedFilename ? currentLoadedFilename.replace(/\.skp$/i, '') : 'model';
+
+  setLoader(true, `Exporting model as ${format.toUpperCase()}...`);
 
   setTimeout(() => {
     try {
-      const exporter = new GLTFExporter();
-      
-      // We export the entire model group
-      exporter.parse(
-        modelGroup,
-        (gltfBuffer) => {
-          setLoader(false);
-          
-          const blob = new Blob([gltfBuffer], { type: 'application/octet-stream' });
-          const url = URL.createObjectURL(blob);
-          
-          const link = document.createElement('a');
-          link.href = url;
-          link.download = `exported_model.glb`;
-          link.click();
-          
-          URL.revokeObjectURL(url);
-          statusText.textContent = 'GLB exported and downloaded successfully!';
-        },
-        (error) => {
-          setLoader(false);
-          console.error('GLTF Export error:', error);
-          alert(`Failed to export GLB: ${error.message}`);
-        },
-        { binary: true }
-      );
+      if (format === 'json') {
+        const data = toJSON(currentModel, currentScene);
+        downloadFile(`${stem}_metadata.json`, JSON.stringify(data, null, 2), 'application/json');
+        statusText.textContent = 'JSON metadata exported and downloaded!';
+      } else if (format === 'ifc') {
+        const ifcText = toIFC(currentScene);
+        downloadFile(`${stem}.ifc`, ifcText, 'application/x-step');
+        statusText.textContent = 'IFC4 BIM model exported and downloaded!';
+      } else if (format === 'dxf-polyface' || format === 'dxf') {
+        const dxfText = toDXF(currentScene, 39.37007874015748, 'polyface');
+        downloadFile(`${stem}_polyface.dxf`, dxfText, 'image/vnd.dxf');
+        statusText.textContent = 'AutoCAD 3D Polyface Mesh DXF exported and downloaded!';
+      } else if (format === 'dxf-3dface') {
+        const dxfText = toDXF(currentScene, 39.37007874015748, '3dface');
+        downloadFile(`${stem}_3dface.dxf`, dxfText, 'image/vnd.dxf');
+        statusText.textContent = 'AutoCAD 3DFACE Entities DXF exported and downloaded!';
+      } else if (format === 'ply') {
+        const plyBytes = toPLYBinary(currentScene);
+        downloadFile(`${stem}.ply`, plyBytes, 'application/octet-stream');
+        statusText.textContent = 'Stanford PLY mesh exported and downloaded!';
+      } else if (format === 'stl') {
+        const stlBytes = toSTLBinary(currentScene);
+        downloadFile(`${stem}.stl`, stlBytes, 'application/octet-stream');
+        statusText.textContent = '3D Printing STL exported and downloaded!';
+      } else if (format === 'glb') {
+        const glbBytes = toGLB(currentScene);
+        downloadFile(`${stem}.glb`, glbBytes, 'model/gltf-binary');
+        statusText.textContent = 'glTF 2.0 GLB binary exported and downloaded!';
+      } else if (format === 'obj') {
+        const objText = toOBJ(currentScene);
+        downloadFile(`${stem}.obj`, objText, 'text/plain');
+        statusText.textContent = 'Wavefront OBJ exported and downloaded!';
+      }
     } catch (err) {
+      console.error(`Export ${format} error:`, err);
+      alert(`Failed to export ${format.toUpperCase()}: ${err.message}`);
+    } finally {
       setLoader(false);
-      console.error(err);
-      alert(`Error during export setup: ${err.message}`);
     }
   }, 50);
 }
@@ -640,7 +678,34 @@ btnSizeProceed.addEventListener('click', () => {
   }
 });
 
-btnExport.addEventListener('click', exportToGLB);
+const exportDropdown = document.getElementById('export-dropdown');
+const exportMenu = document.getElementById('export-menu');
+
+btnExport.addEventListener('click', (e) => {
+  e.stopPropagation();
+  if (!btnExport.disabled && exportDropdown) {
+    exportDropdown.classList.toggle('active');
+  }
+});
+
+document.addEventListener('click', (e) => {
+  if (exportDropdown && !exportDropdown.contains(e.target)) {
+    exportDropdown.classList.remove('active');
+  }
+});
+
+if (exportMenu) {
+  exportMenu.querySelectorAll('.dropdown-item').forEach((item) => {
+    item.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const fmt = item.getAttribute('data-format');
+      if (exportDropdown) exportDropdown.classList.remove('active');
+      if (fmt) {
+        handleExportFormat(fmt);
+      }
+    });
+  });
+}
 
 // Mobile drawers: on phone-width screens the Layers/Inspector panels are
 // hidden by default (see the max-width:768px block in style.css) so the


### PR DESCRIPTION
## Summary

Replaces the single "Export GLB" button with an "Export Model" dropdown covering every export format the library supports: JSON metadata, IFC4 BIM, AutoCAD DXF (both Polyface Mesh and 3DFACE modes), Stanford PLY, 3D-printing STL, glTF GLB, and Wavefront OBJ.

- Downloads go through a shared `downloadFile()` helper (Blob + object URL, revoked after the click) instead of the GLTFExporter-specific flow the GLB-only button used, so every format shares the same download path.
- Exported filenames are derived from the uploaded `.skp`'s own name rather than a fixed `exported_model` stem.
- `serve.py` now `chdir`s to its own script directory on startup, so the dev server serves the right files regardless of which directory it's launched from.

## Note on DXF export

This PR depends on #143 for the DXF export options to actually be useful - the DXF exporter itself had a real bug (fixed there) where it produced files desktop AutoCAD rejected. This PR just adds the UI to reach it; #143 is what makes the output correct. Tested manually end-to-end: DXF exports from this viewer (against a large real-world model) now confirmed opening cleanly in desktop AutoCAD after #143's fix + rebuilding this viewer's vendored `dist/` bundle (that bundle isn't committed - it's gitignored and rebuilt fresh by CI's `deploy-pages.yml` on every push to `main`, so no local rebuild needs to be checked in here).

## Testing

Ran the dev server locally, tested all 7 export formats via drag-and-drop against real `.skp` fixtures. Reviewed for XSS risk (no unescaped `innerHTML` interpolation) and resource cleanup (object URLs are revoked after download).