### PR TITLE
fix(ci): resolve nullable-warning and lint failures in IFC exporter

### DIFF
--- a/packages/dotnet/OpenSkp/IfcExport.cs
+++ b/packages/dotnet/OpenSkp/IfcExport.cs
@@ -180,7 +180,7 @@ namespace OpenSkp
 
                 string geomName = SanitizeName(prim.GeomName);
                 string layerName = "Layer0";
-                MeshMetadata meta = null;
+                MeshMetadata? meta = null;
                 if (scene.MeshIndex != null && scene.MeshIndex.TryGetValue(prim.GeomName, out meta) && meta != null)
                 {
                     if (!string.IsNullOrEmpty(meta.Layer))

--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -10,12 +10,11 @@ mapping of triangulated vertex positions and face indices from baked scene primi
 from __future__ import annotations
 
 import datetime
-import math
 import pathlib
 import uuid
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Tuple, Union
 
-from ..scene import INCHES_TO_MM, Scene
+from ..scene import Scene
 
 # 1 metre = 39.37007874015748 inches (SketchUp native unit)
 METRES_TO_INCHES = 39.37007874015748
@@ -47,20 +46,20 @@ def classify_element(geom_name: str) -> Tuple[str, str]:
     Returns:
         Tuple of (STEP_ENTITY_TYPE, IFC_CLASS_NAME)
     """
-    l = geom_name.lower()
-    if "wall" in l:
+    name_lower = geom_name.lower()
+    if "wall" in name_lower:
         return "IFCWALL", "IfcWall"
-    if "door" in l:
+    if "door" in name_lower:
         return "IFCDOOR", "IfcDoor"
-    if "window" in l:
+    if "window" in name_lower:
         return "IFCWINDOW", "IfcWindow"
-    if "slab" in l or "floor" in l:
+    if "slab" in name_lower or "floor" in name_lower:
         return "IFCSLAB", "IfcSlab"
-    if "column" in l or "pillar" in l:
+    if "column" in name_lower or "pillar" in name_lower:
         return "IFCCOLUMN", "IfcColumn"
-    if "beam" in l or "joist" in l:
+    if "beam" in name_lower or "joist" in name_lower:
         return "IFCBEAM", "IfcBeam"
-    if "roof" in l:
+    if "roof" in name_lower:
         return "IFCROOF", "IfcRoof"
     return "IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy"
 

--- a/packages/python/tests/test_ifc.py
+++ b/packages/python/tests/test_ifc.py
@@ -1,7 +1,6 @@
 from array import array
 import tempfile
 import pathlib
-import pytest
 
 from openskp.scene import GlbPrimitive, MeshMetadata, Scene, InstanceNode
 from openskp.export.ifc import to_ifc, export, classify_element, generate_ifc_guid


### PR DESCRIPTION
## Summary
- main's .NET CI has been failing since the IFC exporter merged (#141, #142): `IfcExport.cs` assigns `null` to a non-nullable `MeshMetadata` local, producing CS8600, which `dotnet format --verify-no-changes` treats as fatal.
- main's Python lint (ruff) has also been failing: unused imports (`math`, `Any`, `Optional`, `INCHES_TO_MM`, `pytest`) and an ambiguous single-character variable name (`l`) in `ifc.py`/`test_ifc.py`.
- Both are pre-existing, unrelated to any other in-flight work — this PR only touches the 3 affected files.

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 60/60 passed
- [x] `dotnet format --verify-no-changes` — `IfcExport.cs` now clean
- [x] `ruff check` — all checks pass
- [x] `pytest` — 142/142 passed (full Python suite)