### PR TITLE
chore(python): prepare 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,67 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.0] — 2026-08-13
+
+First stable release. All five language ports (Python, TypeScript, Dart,
+C# / .NET, C++) now carry full feature parity: parsing (geometry,
+materials, layers, dynamic properties, metadata) and native, dependency-light
+export to GLB, JSON, Wavefront OBJ/MTL, STL, PLY, DXF (3DFACE and AutoCAD
+Polyface Mesh), and IFC4 (BIM) — verified against real-world `.skp` fixtures
+and, for DXF specifically, against real desktop AutoCAD rather than lenient
+readers alone.
 
 ### Added
+
+- **All 5 languages**: native Wavefront OBJ exporter (`to_obj`/`toOBJ`/
+  `toObj`/`ToObj`, plus a file-writing counterpart in each language —
+  Python's is `openskp.export.obj.export()`, the other four are
+  `exportOBJ`/`exportObj`/`ExportObj`). InvariantCulture/classic-C-locale
+  formatting is enforced everywhere to guarantee dot decimal separators
+  regardless of the host OS locale.
+- **All 5 languages**: native STL exporter, both ASCII (`.stl`) and
+  little-endian binary (`_bin.stl`), with an optional `scale` multiplier
+  (default 1.0 for metres, 1000.0 for mm, matching what slicers like Cura/
+  PrusaSlicer/Bambu Studio expect). Verified byte-identical output (9,368,084
+  bytes, 187,360 triangles) across languages on the same real fixture.
+- **All 5 languages**: native PLY exporter (Polygon File Format), both ASCII
+  and little-endian binary, carrying vertex positions, normals, UV
+  coordinates, and RGBA vertex colors. C++'s binary writer uses
+  architecture-independent bitwise shifts rather than relying on host
+  endianness. Verified byte-identical output (9,316,015 bytes, 187,360
+  triangles) across languages on the same real fixture.
+- **All 5 languages**: rich Wavefront OBJ/MTL extension — a companion
+  `.mtl` material-library writer (`to_mtl`/`toMTL`/`toMtl`/`ToMtl`) emitting
+  `newmtl`/`Ka`/`Kd`/`Ks`/`Ns`/`d`/`illum` records plus `map_Kd` texture
+  references, with `to_obj` gaining an optional `mtl_filename` parameter to
+  link the two via `mtllib`. The `.obj` writer itself gained `vt` (UV) and
+  `vn` (normal) records, upgrading it from a positions-only debug dump to a
+  properly textured/shaded mesh format.
+- **All 5 languages**: native 3D DXF exporter, targeting AutoCAD R2000
+  (`AC1015`) compliance — full HEADER/CLASSES/TABLES/BLOCKS/OBJECTS
+  scaffold, `LAYER` table entries with ACI color codes, and entity output in
+  either `3DFACE` mode or AutoCAD Polyface Mesh mode (`POLYLINE` type 64 +
+  `VERTEX` + `SEQEND`). Polyface is now the default mode (previously
+  `3dface`), since it's the form AutoCAD itself generates for triangulated
+  meshes. See Fixed below — the exporter's real-world compatibility with
+  desktop AutoCAD required a second, much deeper pass beyond what made
+  lenient DXF readers (`ezdxf`) accept it.
+- **All 5 languages**: native IFC4 (BIM) exporter — ISO-10303-21 STEP ASCII
+  output with a full `IfcProject → IfcSite → IfcBuilding → IfcBuildingStorey
+  → IfcProduct` spatial hierarchy, `IfcTriangulatedFaceSet` tessellated
+  geometry, best-effort element classification (walls/doors/windows/slabs/
+  columns/beams/roofs, defaulting to `IfcBuildingElementProxy`), dynamic
+  properties via `IfcPropertySet`/`IfcRelDefinesByProperties`, material
+  colors via `IfcColourRgb`/`IfcSurfaceStyleRendering`, and layer
+  preservation via `IfcPresentationLayerAssignment`. Validated with
+  `IfcOpenShell` against two real-world files, including a 26.94 MB / 101,692-
+  property export.
+- **Web viewer**: the single "Export GLB" button is now an "Export Model"
+  dropdown covering every format the library supports — JSON, IFC4, DXF
+  (both Polyface Mesh and 3DFACE), PLY, STL, GLB, and OBJ. All formats share
+  one `downloadFile()` helper (Blob + object URL, revoked after use), and
+  exported filenames now derive from the uploaded `.skp`'s own name instead
+  of a fixed stem.
 
 - **Dart**: `toGlb(Scene)`/`exportGlb(Scene, path)` - binary glTF 2.0
   (GLB) export, matching Python's and C++'s `to_glb`/`export_glb` pair
@@ -123,6 +181,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **All 5 languages**: the DXF exporter produced files that `ezdxf.readfile()`
+  (and even `ezdxf`'s own `.audit()`) accepted without complaint, but real
+  desktop AutoCAD rejected outright — first with "Invalid or incomplete DXF
+  input", later with "Did not receive PlotStyleName" once the more obvious
+  problems were fixed. `ezdxf` is too lenient to catch what AutoCAD enforces
+  internally, and there's no public, comprehensive list of those rules, so
+  this was tracked down using real desktop AutoCAD as the only reliable
+  oracle, then cross-checked against what real `ezdxf` itself emits for
+  equivalent structures. Five distinct root causes, byte-verified against a
+  real `ezdxf`-generated file confirmed to open cleanly in AutoCAD:
+  1. An incomplete HEADER/CLASSES/TABLES/BLOCKS/OBJECTS scaffold — a
+     near-empty `CLASSES` table, a fabricated `VPORT` record, and a stripped
+     `OBJECTS` dictionary tree missing `MATERIAL`/`MLINESTYLE`/
+     `MLEADERSTYLE` records and a second `LAYOUT` record — all boilerplate
+     AutoCAD requires but lenient readers never check.
+  2. Every dynamically-generated `LAYER` record was missing group `370`
+     (lineweight) and `390` (PlotStyleName handle); AutoCAD rejects the
+     whole `TABLES` section without them once a drawing uses a Named plot
+     style table. Also dropped group `420` (24-bit true color), an R2004+
+     field real `ezdxf` never emits for R2000/AC1015 — ACI (`62`) is the
+     only color mechanism R2000 supports.
+  3. Polyface `POLYLINE`/`VERTEX`/`SEQEND` structure had three mismatches
+     against real `ezdxf`'s own polyface output: face-record `VERTEX`
+     entries were missing color (`62`) and dummy `0/0/0` coordinates while
+     carrying a subclass marker they shouldn't have, and `SEQEND`'s owner
+     (`330`) pointed at Model_Space instead of its parent `POLYLINE`'s own
+     handle. This is exactly why `3dface` mode opened fine while `polyface`
+     mode was rejected, despite sharing the same scaffold.
+  4. TypeScript, Dart, C#, and C++ never substituted the `$HANDSEED`
+     placeholder — every file these four exporters ever produced shipped
+     the literal text `__HANDSEED__` instead of a real hex value.
+  5. Unbounded layer names could exceed AutoCAD's documented limits; added a
+     defensive 255-character cap with a collision-safe hash suffix on
+     truncation.
+
+  Dynamic handles now start at `0x691`, matching the reference file's own
+  first entity handle, keeping every handle in an export globally unique.
+  Both `3dface` and `polyface` output confirmed opening cleanly in real
+  desktop AutoCAD after this fix (C++ mirrors the same verified structure
+  but could not be locally compiled/run in the environment this was fixed
+  in — CI is the correctness gate there).
+- **Python**: `export.dxf.export()` didn't set `newline=''` when opening the
+  output file on Windows, so `open()`'s universal-newline translation turned
+  every `\r\n` the writer emitted into `\r\r\n` (double carriage returns),
+  which CAD viewers rejected. Explicit 3DFACE output was affected before the
+  fix above even applied.
 - **TypeScript**: `toGLB()` never wrote a `TEXCOORD_0` accessor, despite
   `GlbPrimitive.uvs` existing on its data model since #65 - real UV data
   was computed but the actual exported `.glb` bytes never carried it.

--- a/packages/dart/CHANGELOG.md
+++ b/packages/dart/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.0.0
+
+- Added native Wavefront OBJ exporter (`toObj`/`exportObj`) plus a companion
+  MTL material-library writer (`toMtl`), linked via `mtllib` and an
+  `exportMtl` flag on `exportObj`.
+- Added native STL exporter (`toStlAscii`/`toStlBinary`/`exportStl`), ASCII
+  and little-endian binary, with an optional unit-scale multiplier.
+- Added native PLY exporter (`toPlyAscii`/`toPlyBinary`/`exportPly`), ASCII
+  and little-endian binary, carrying positions, normals, UVs, and RGBA
+  vertex colors.
+- Added native 3D DXF exporter (`toDxf`/`exportDxf`) targeting AutoCAD R2000
+  (`AC1015`) compliance, in both `3dface` and AutoCAD Polyface Mesh
+  (default) modes — verified opening cleanly in real desktop AutoCAD, not
+  just lenient DXF readers.
+- Added native IFC4 (BIM) exporter (`toIfc`/`exportIfc`) with full spatial
+  hierarchy, tessellated geometry, element classification, dynamic
+  properties, material colors, and layer preservation — validated with
+  IfcOpenShell.
+
 ## 0.3.0
 
 - Added `buildScene()` scene-baking API (`Scene`, `MeshIndex`, `GlbPrimitive`) for world-space, triangulated mesh outputs.

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -1,7 +1,48 @@
-# OpenSKP — Python Package
+# OpenSKP
 
-Open-source SketchUp (`.skp`) binary file parser. Extract geometry, metadata,
-layers, and materials from SketchUp files without requiring SketchUp itself.
+**The open-source SketchUp (`.skp`) file parser — Python edition.**
+
+Parse `.skp` files without SketchUp. No SDK. No license. Just code.
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![PyPI](https://img.shields.io/pypi/v/openskp.svg?logo=pypi&logoColor=white&label=pypi)](https://pypi.org/project/openskp/)
+[![Python Versions](https://img.shields.io/pypi/pyversions/openskp.svg?logo=python&logoColor=white)](https://pypi.org/project/openskp/)
+
+🏠 [openskp.com](https://openskp.com) · 🌐 [Try the Live Web Viewer](https://iamahsanmehmood.github.io/openskp/) · 📖 [Docs](https://iamahsanmehmood.github.io/openskp/docs/) · [Changelog](https://github.com/iamahsanmehmood/openskp/blob/main/CHANGELOG.md)
+
+> [!IMPORTANT]
+> This project was built by reverse engineering a proprietary binary format. It is not affiliated with or endorsed by Trimble Inc. or SketchUp.
+
+## What is OpenSKP?
+
+OpenSKP is the first and only open-source, cross-platform parser for SketchUp
+binary files — reverse-engineered from both the modern **VFF container**
+(SketchUp 2021+) and the classic **MFC `CArchive`** container (SketchUp
+2013–2020). It gives you full programmatic access to geometry, materials,
+components, layers, and metadata, with no SketchUp installation and no
+proprietary SDK required. The same parser and export API also ship as
+first-class packages for TypeScript, .NET, Dart, and C++ — see the
+[project README](https://github.com/iamahsanmehmood/openskp) for the full
+cross-language picture.
+
+## Features
+
+- **Full-fidelity parsing** — vertices, edges, faces, normals, UV
+  coordinates, nested component hierarchies, layers/tags, materials,
+  textures, styles, and dynamic-component attributes.
+- **Both SketchUp file generations** — modern VFF (2021+) and legacy MFC
+  (2013–2020) containers, transparently, behind one `parse()` call.
+- **Scene baking** — an opt-in `build_scene()` pass resolves the full placed
+  scene graph to world-space, triangulated, export-ready geometry.
+- **Native multi-format export** — glTF (GLB), Wavefront OBJ/MTL, STL,
+  PLY, AutoCAD DXF (3DFACE and Polyface Mesh), IFC4 (BIM/ISO 10303-21 STEP),
+  and JSON — all written from scratch, no third-party CAD/BIM SDK involved.
+  The DXF writer is verified against real desktop AutoCAD, not just lenient
+  DXF readers.
+- **Streaming / low-memory parsing** — peak memory is bounded by the
+  largest single definition, not the whole file.
+- **Structured observability** — opt-in progress reporting and
+  location-carrying parse errors for debugging malformed or unusual files.
 
 ## Installation
 
@@ -48,7 +89,7 @@ from openskp.export import glb, obj, stl, ply, dxf, ifc, json_export
 # Export to GLB (glTF 2.0 binary) - takes the SkpFile itself
 glb.export(skp, "output.glb")
 
-# Export to Wavefront OBJ - takes a built Scene
+# Export to Wavefront OBJ (+ companion .mtl) - takes a built Scene
 obj.export(scene, "output.obj")
 
 # Export to STL (3D Printing ASCII/Binary)
@@ -57,7 +98,7 @@ stl.export(scene, "output.stl", binary=True)
 # Export to PLY (Stanford 3D Triangle Mesh)
 ply.export(scene, "output.ply", binary=True)
 
-# Export to AutoCAD 3D DXF (AutoCAD R2000 compliant)
+# Export to AutoCAD 3D DXF (AutoCAD R2000 compliant, Polyface Mesh by default)
 dxf.export(scene, "output.dxf")
 
 # Export to IFC4 / BIM (ISO 10303-21 STEP ASCII format)
@@ -80,7 +121,7 @@ json_export.export(model, "output.json", scene=scene)
 | `openskp.materials` | Material and layer XML parsing |
 | `openskp.metadata` | Dynamic properties and scene hierarchy |
 | `openskp.transforms` | 3D matrix transforms and coordinate conversion |
-| `openskp.export` | GLB, OBJ, STL, PLY, DXF, and JSON exporters |
+| `openskp.export` | GLB, OBJ/MTL, STL, PLY, DXF, IFC4, and JSON exporters |
 
 ## Requirements
 
@@ -88,6 +129,15 @@ json_export.export(model, "output.json", scene=scene)
 - NumPy ≥ 1.20
 - Trimesh ≥ 3.0
 - Shapely ≥ 1.8
+
+## Used in Production
+
+OpenSKP powers the SketchUp import pipeline for
+[FrameSmart](https://frame-smart.com/) (a 3D collaboration platform with
+nearly 200 active users) and [IngeTrazo](https://ingetrazo.com/) (a
+SketchUp-alternative 3D modeler with a BIM → IFC bridge). Using OpenSKP in
+your own project? [Open an issue](https://github.com/iamahsanmehmood/openskp/issues)
+or a PR to get added here.
 
 ## License
 

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -4,15 +4,15 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openskp"
-version = "0.3.0"
-description = "Open-source SketchUp (.skp) binary file parser — extract geometry, metadata, layers, and materials"
+version = "1.0.0"
+description = "Open-source SketchUp (.skp) binary file parser — extract geometry, metadata, layers, and materials; export to GLB, OBJ, STL, PLY, DXF, and IFC4"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.9"
 authors = [{name = "Ahsan Mehmood"}]
-keywords = ["sketchup", "skp", "3d", "parser", "glb", "gltf", "bim", "cad"]
+keywords = ["sketchup", "skp", "3d", "parser", "glb", "gltf", "bim", "cad", "dxf", "autocad", "ifc", "obj", "stl", "ply"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
@@ -40,6 +40,7 @@ Homepage = "https://github.com/iamahsanmehmood/openskp"
 Documentation = "https://iamahsanmehmood.github.io/openskp/docs/"
 Repository = "https://github.com/iamahsanmehmood/openskp"
 Issues = "https://github.com/iamahsanmehmood/openskp/issues"
+Changelog = "https://github.com/iamahsanmehmood/openskp/blob/main/CHANGELOG.md"
 
 [project.scripts]
 openskp = "openskp.__init__:main"


### PR DESCRIPTION
## Summary
- Bumps the Python package to 1.0.0, corrects the PyPI classifier from Alpha to Production/Stable, and adds a Changelog project URL.
- Rewrites `packages/python/README.md` (the PyPI listing page) with a features section, production users, and verified quick-start/export examples.
- Adds the `[1.0.0]` entry to the root `CHANGELOG.md` and `packages/dart/CHANGELOG.md`, documenting everything shipped since the last update: native OBJ/STL/PLY/DXF/IFC4 exporters, the desktop-AutoCAD DXF compatibility fix, and the web viewer's export dropdown.

## Test plan
- [x] `pyproject.toml` parses as valid TOML
- [x] Every function/field name referenced in the rewritten README verified against current source
- [ ] CI green on this PR