### PR TITLE
fix(dart): remove invalid pub.dev topic

### DIFF
--- a/packages/dart/pubspec.yaml
+++ b/packages/dart/pubspec.yaml
@@ -6,7 +6,6 @@ repository: https://github.com/iamahsanmehmood/openskp/tree/main/packages/dart
 issue_tracker: https://github.com/iamahsanmehmood/openskp/issues
 topics:
   - sketchup
-  - 3d
   - parser
   - cad
   - gltf


### PR DESCRIPTION
## Summary
The 1.0.0 pub.dev publish attempt (tag v1.0.0) failed at validation with: `Invalid topics value (3d): must consist of lowercase alphanumerical characters or dash, starting with a-z`. The publish never completed - rejected before upload, so no version was consumed. This removes the offending "3d" topic from `pubspec.yaml`.

## Test plan
- [x] `dart pub publish --dry-run` — no more topics validation error
- [ ] CI green on this PR