### PR TITLE
fix(python): resolve __version__ from installed package metadata

### DIFF
--- a/packages/python/src/openskp/__init__.py
+++ b/packages/python/src/openskp/__init__.py
@@ -17,11 +17,16 @@ Example::
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version as _version
+
 from .errors import SkpParseError
 from .model import SkpFile, SkpModel
 from .scene import Scene, InstanceNode, MeshMetadata, GlbPrimitive
 
-__version__: str = "0.3.0"
+try:
+    __version__: str = _version("openskp")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 __all__: list[str] = [
     "SkpFile",
     "SkpModel",


### PR DESCRIPTION
## Summary
`openskp.__version__` was a hardcoded string in `__init__.py`, completely separate from `pyproject.toml`'s actual `version` field. It was never updated alongside the 1.0.0 version bump - the already-published 1.0.0 package on PyPI incorrectly reports `__version__ == "0.3.0"`. Checked all 4 other language ports for the same dual-source-of-truth pattern; none have it, this is Python-specific.

Fixed by resolving `__version__` dynamically via `importlib.metadata.version("openskp")` at import time, so it can never drift from what's actually installed again (same "stop hardcoding what a live source already knows" fix applied to the README/dev-guide version tables earlier).

Cannot fix the already-published 1.0.0 wheel/sdist - PyPI releases are immutable. This takes effect starting with the next Python release (tracked separately, alongside the pending Homepage URL fix).

## Test plan
- [x] `pip install -e .` + `python -c "import openskp; print(openskp.__version__)"` → correctly resolves to `1.0.0`
- [x] `pytest` — 142/142 passed
- [x] `ruff check` clean