### PR TITLE
ci: fix required-status-checks path-filter gotcha across all 5 workflows

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -2,12 +2,27 @@ name: C++ CI
 
 on:
   push:
-    paths: ['packages/cpp/**', '.clang-format', '.github/workflows/ci-cpp.yml']
   pull_request:
-    paths: ['packages/cpp/**', '.clang-format', '.github/workflows/ci-cpp.yml']
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      cpp: ${{ steps.filter.outputs.cpp }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            cpp:
+              - 'packages/cpp/**'
+              - '.clang-format'
+              - '.github/workflows/ci-cpp.yml'
+
   format:
+    needs: changes
+    if: needs.changes.outputs.cpp == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,6 +31,8 @@ jobs:
       - run: cmake --build format-build --target openskp-format-check
 
   build:
+    needs: changes
+    if: needs.changes.outputs.cpp == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -51,9 +68,32 @@ jobs:
           cmake --build consumer-build --config Release
 
   sanitizers:
+    needs: changes
+    if: needs.changes.outputs.cpp == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: cmake -S packages/cpp -B build -DOPENSKP_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer' -DCMAKE_C_FLAGS='-fsanitize=address,undefined -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS='-fsanitize=address,undefined'
       - run: cmake --build build --parallel
       - run: ctest --test-dir build --output-on-failure
+
+  # Single stable check name for branch protection to require, regardless of
+  # whether packages/cpp/** changed - see ci-python.yml's `required` job for
+  # why this exists.
+  required:
+    name: C++ CI required
+    needs: [changes, format, build, sanitizers]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check outcome
+        run: |
+          if [ "${{ needs.changes.outputs.cpp }}" != "true" ]; then
+            echo "packages/cpp/** unchanged - nothing to verify"
+            exit 0
+          fi
+          if [ "${{ needs.format.result }}" != "success" ] || [ "${{ needs.build.result }}" != "success" ] || [ "${{ needs.sanitizers.result }}" != "success" ]; then
+            echo "C++ CI failed"
+            exit 1
+          fi
+          echo "C++ CI passed"

--- a/.github/workflows/ci-dart.yml
+++ b/.github/workflows/ci-dart.yml
@@ -3,14 +3,27 @@ name: Dart CI
 on:
   push:
     branches: [main]
-    paths: ['packages/dart/**']
   pull_request:
     branches: [main]
-    paths: ['packages/dart/**']
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      dart: ${{ steps.filter.outputs.dart }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            dart:
+              - 'packages/dart/**'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.dart == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -36,3 +49,24 @@ jobs:
         run: |
           cd packages/dart
           dart test
+
+  # Single stable check name for branch protection to require, regardless of
+  # whether packages/dart/** changed - see ci-python.yml's `required` job
+  # for why this exists.
+  required:
+    name: Dart CI required
+    needs: [changes, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check outcome
+        run: |
+          if [ "${{ needs.changes.outputs.dart }}" != "true" ]; then
+            echo "packages/dart/** unchanged - nothing to verify"
+            exit 0
+          fi
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "Dart CI failed"
+            exit 1
+          fi
+          echo "Dart CI passed"

--- a/.github/workflows/ci-dotnet.yml
+++ b/.github/workflows/ci-dotnet.yml
@@ -3,14 +3,27 @@ name: .NET CI
 on:
   push:
     branches: [main]
-    paths: ['packages/dotnet/**']
   pull_request:
     branches: [main]
-    paths: ['packages/dotnet/**']
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      dotnet: ${{ steps.filter.outputs.dotnet }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            dotnet:
+              - 'packages/dotnet/**'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.dotnet == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -34,6 +47,8 @@ jobs:
         run: dotnet test packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj --no-build --configuration Release
 
   format:
+    needs: changes
+    if: needs.changes.outputs.dotnet == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -56,3 +71,24 @@ jobs:
       - name: Build with analyzers as errors
         run: |
           dotnet build packages/dotnet/OpenSkp.Tests/OpenSkp.Tests.csproj --no-restore --configuration Release -warnaserror
+
+  # Single stable check name for branch protection to require, regardless of
+  # whether packages/dotnet/** changed - see ci-python.yml's `required` job
+  # for why this exists.
+  required:
+    name: .NET CI required
+    needs: [changes, test, format]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check outcome
+        run: |
+          if [ "${{ needs.changes.outputs.dotnet }}" != "true" ]; then
+            echo "packages/dotnet/** unchanged - nothing to verify"
+            exit 0
+          fi
+          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.format.result }}" != "success" ]; then
+            echo ".NET CI failed"
+            exit 1
+          fi
+          echo ".NET CI passed"

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -3,13 +3,26 @@ name: Python CI
 on:
   push:
     branches: [main]
-    paths: ['packages/python/**']
   pull_request:
     branches: [main]
-    paths: ['packages/python/**']
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'packages/python/**'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -35,6 +48,8 @@ jobs:
           python -m pytest tests/ -v
 
   lint:
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,3 +68,28 @@ jobs:
 
       - name: Lint
         run: ruff check packages/python/src/ packages/python/tests/
+
+  # Single stable check name for branch protection to require, regardless of
+  # whether packages/python/** changed. A workflow with a `paths:` trigger
+  # filter simply never runs for PRs outside that path, which would leave a
+  # required check permanently "Expected" and block the merge forever - so
+  # the path filter moved from the trigger (which can suppress a run
+  # entirely) to this job-level check (which reports a real, if trivial,
+  # pass/fail every time).
+  required:
+    name: Python CI required
+    needs: [changes, test, lint]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check outcome
+        run: |
+          if [ "${{ needs.changes.outputs.python }}" != "true" ]; then
+            echo "packages/python/** unchanged - nothing to verify"
+            exit 0
+          fi
+          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "Python CI failed"
+            exit 1
+          fi
+          echo "Python CI passed"

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -3,13 +3,26 @@ name: TypeScript CI
 on:
   push:
     branches: [main]
-    paths: ['packages/typescript/**']
   pull_request:
     branches: [main]
-    paths: ['packages/typescript/**']
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      typescript: ${{ steps.filter.outputs.typescript }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            typescript:
+              - 'packages/typescript/**'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -44,6 +57,8 @@ jobs:
           npm test
 
   lint:
+    needs: changes
+    if: needs.changes.outputs.typescript == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -62,3 +77,24 @@ jobs:
         run: |
           cd packages/typescript
           npm run lint
+
+  # Single stable check name for branch protection to require, regardless of
+  # whether packages/typescript/** changed - see ci-python.yml's `required`
+  # job for why this exists.
+  required:
+    name: TypeScript CI required
+    needs: [changes, test, lint]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check outcome
+        run: |
+          if [ "${{ needs.changes.outputs.typescript }}" != "true" ]; then
+            echo "packages/typescript/** unchanged - nothing to verify"
+            exit 0
+          fi
+          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "TypeScript CI failed"
+            exit 1
+          fi
+          echo "TypeScript CI passed"


### PR DESCRIPTION
## Summary

All 5 per-language CI workflows use a `paths:` filter on their trigger, so a workflow simply never runs for a PR that doesn't touch that language's directory. That's fine as-is, but it's a real problem for enabling required status checks: a required check the workflow never reports for sits as "Expected" forever, blocking the merge button even though nothing's actually wrong - not a green/red state, just permanently pending.

This is prep work for enabling required status checks on `main` (currently only 1 approving review is required, not passing CI - which is most of why `main` has broken from merges twice before).

## Changes

Moves the path filter from the trigger to a job-level check in each workflow, using `dorny/paths-filter` to detect whether the relevant `packages/<language>/**` changed (plus `.clang-format` and its own workflow file for C++). Every existing job gets `needs: changes` + `if: needs.changes.outputs.<lang> == 'true'` - unrelated-language PRs get a fast, correctly-**skipped** run instead of no run at all, and a skipped job satisfies a required status check (unlike a job that never started).

Each workflow gets one new final `required` job with a stable name (`Python CI required`, `TypeScript CI required`, etc.) - passes trivially when that language's files didn't change, reflects the real outcome when they did. One required check per language, not one per matrix combination (Python alone has 12 OS × version combinations - enumerating those individually would be brittle to matrix changes).

No behavior change to the actual test/lint/build/format logic in any workflow - purely how they trigger and report.

## Testing

This PR itself only touches `.github/workflows/*.yml`, so it validates the "nothing relevant changed" fast path for all 5 workflows in one shot. Once merged, I'll do one small follow-up test touching an actual package file to confirm the "changed" path triggers the full matrix correctly before enabling required checks in branch protection.
