### PR TITLE
ci: add Dependabot config, enable vulnerability alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # GitHub Actions used across all workflows (repo-wide, not per-package).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "pip"
+    directory: "/packages/python"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/typescript"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "nuget"
+    directory: "/packages/dotnet"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/dart"
+    schedule:
+      interval: "weekly"
+
+  # C++ dependencies (miniz, tinygltf, googletest) are pulled via CMake
+  # FetchContent in packages/cpp/CMakeLists.txt, not a manifest format
+  # Dependabot supports - no entry here to keep up to date automatically.


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` for weekly automated dependency-update PRs, and enables vulnerability alerts + automated security fixes at the repo level (both were off).

## Changes

- `pip` (packages/python), `npm` (packages/typescript), `nuget` (packages/dotnet), `pub` (packages/dart) - one entry each, weekly schedule.
- `github-actions` (repo-wide) - grouped into a single PR per update batch, keeps workflow action versions current. More relevant now that `ci/require-status-checks` added a new third-party action (`dorny/paths-filter`).
- No entry for C++: its dependencies (miniz, tinygltf, googletest) are pulled via CMake `FetchContent` in `packages/cpp/CMakeLists.txt`, not a manifest format Dependabot supports.

Turning on vulnerability alerts immediately surfaced 8 pre-existing alerts (1 critical, 2 high, 4 moderate, 1 low) - all in TypeScript's npm **devDependencies** (vite/vitest/esbuild/postcss: build and test tooling, not code shipped in the published package). Dependabot will now open fix PRs for these automatically.

## Checklist
- [x] No breaking changes to the public API
- [x] No unrelated changes included
