### PR TITLE
fix(typescript): resolve lint violations surfaced by eslint 9 -> 10

### DIFF
--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -729,7 +729,7 @@ function readText(ar: Archive, r: R): any {
   // variable-length variant middle, delimited by an 11-byte block
   // `01 00 00 00 ?? 00 03 00 00 00 01` right before the text string
   let p = r.pos;
-  let idx = -1;
+  let idx: number;
   while (true) {
     idx = findBytes(r.data, STR_MARKER, p, r.pos + 512);
     if (idx < 0) {
@@ -757,11 +757,10 @@ function readEntityList(ar: Archive, r: R, count: number, owner: string): [numbe
     const p = r.pos;
     const prevFlag = ar.inEntityList;
     ar.inEntityList = true;
-    let s: number | null = null;
-    let n: string | null = null;
-    let v: any = null;
     try {
-      [s, n, v] = ar.readObject(r);
+      const [s, n, v] = ar.readObject(r);
+      ar.inEntityList = prevFlag;
+      ents.push([s as number, n, v]);
     } catch (e) {
       ar.inEntityList = prevFlag;
       if (!(e instanceof LegacyParseError) || owner !== 'root') {
@@ -770,8 +769,6 @@ function readEntityList(ar: Archive, r: R, count: number, owner: string): [numbe
       r.pos = p;
       break;
     }
-    ar.inEntityList = prevFlag;
-    ents.push([s as number, n, v]);
   }
   return ents;
 }
@@ -786,9 +783,9 @@ function readDefinition(ar: Archive, r: R): any {
   for (let i = 0; i < nlayers; i++) {
     ar.readObject(r, 'CLayer');
   }
-  let decl = r.u16();
+  const decl = r.u16();
   if (decl === 0x7fff) {
-    decl = r.u32();
+    r.u32();
   }
   r.u32();
   let count = r.u32();

--- a/packages/typescript/src/vff.ts
+++ b/packages/typescript/src/vff.ts
@@ -175,7 +175,12 @@ export function extractSkpContents(data: Uint8Array, options?: ParseOptions): Sk
   try {
     unzipped = unzipSync(zipBytes, { filter: wanted });
   } catch (e) {
-    throw new Error('Failed to decompress ZIP archive: ' + (e as Error).message);
+    // The Error constructor's `cause` option is an ES2022 addition not covered
+    // by this package's ES2020 lib target; set it manually instead - it's a
+    // real runtime feature regardless (Node 16.9+ and all current browsers).
+    const wrapped = new Error('Failed to decompress ZIP archive: ' + (e as Error).message);
+    (wrapped as Error & { cause?: unknown }).cause = e;
+    throw wrapped;
   }
 
   let modelData: Uint8Array | null = null;


### PR DESCRIPTION
Hotfix - main's TypeScript CI has been red since merging #166/#168 (eslint 9->10 major bump). The new default rules (`no-useless-assignment`, `preserve-caught-error`) flagged genuine pre-existing dead-code/error-handling issues in `legacy.ts`/`vff.ts` that neither dependency PR's own diff touched, so their own CI runs never exercised these files.

Fixes 4 `no-useless-assignment` sites in `legacy.ts` (dead initializers/dead writes - kept the byte-cursor-advancing reads, just stopped storing values that were never subsequently read) and 1 `preserve-caught-error` site in `vff.ts` (attaches the original error as `.cause` when re-throwing, set manually post-construction since this package's ES2020 target predates the `Error(message, {cause})` constructor typings - `cause` itself is a real Node 16.9+ runtime feature regardless).

Verified locally: `tsc --noEmit` clean, `eslint` clean, 93/93 tests pass.

## Checklist
- [x] No breaking changes to the public API
- [x] No unrelated changes included