### PR TITLE
fix: geometry loses its material in two cases (ZIP entry names, instance-painted faces)

### DIFF
--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -512,7 +512,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
     currentMatrix: number[],
     parentLayer: string = 'Layer0',
     pathName: string = 'ROOT',
-    inheritedMaterialColor?: { r: number; g: number; b: number }
+    inheritedMaterial?: Material
   ): InstanceNode[] {
     const d = defsDict.get(defId);
     if (!d) return [];
@@ -618,10 +618,16 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
       };
 
       for (const [_fId, fData] of builder.faces.entries()) {
-        const fallbackColor = inheritedMaterialColor ?? getLayerColor(parentLayer);
+        const fallbackColor = inheritedMaterial?.color ?? getLayerColor(parentLayer);
 
-        const frontMat = resolveMaterial((fData as any).materialId);
-        const backMat = resolveMaterial((fData as any).backMaterialId);
+        // A face with no material of its own is painted by the instance
+        // (SketchUp's "paint the component"). Inheriting the whole material -
+        // not just its colour - is what gives computeFaceUv the texture's tile
+        // size: without it tileW/tileH fall back to 1 and the UVs come out in
+        // raw inches, so a 1.9 m decor sheet tiles ~150 times across a 600 mm
+        // panel instead of covering a third of it.
+        const frontMat = resolveMaterial((fData as any).materialId) ?? inheritedMaterial;
+        const backMat = resolveMaterial((fData as any).backMaterialId) ?? inheritedMaterial;
         const frontColor = frontMat?.color ?? fallbackColor;
         const backColor = backMat?.color ?? fallbackColor;
 
@@ -751,7 +757,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
       const newMatrix = multiplyMatrices(currentMatrix, instMatrix);
 
       let lName = parentLayer;
-      let instColor = inheritedMaterialColor;
+      let instMaterial = inheritedMaterial;
       // Legacy (pre-2021 MFC) instances carry a precomputed `properties`
       // record (see legacy.ts's extractLegacyDynamicProperties) - VFF
       // instances don't set this, so this stays {} for them and gets
@@ -771,7 +777,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         if (matName) {
           const mat = materialsMap.get(matName) || materialsByFolder.get(matName);
           if (mat) {
-            instColor = mat.color;
+            instMaterial = mat;
           }
         }
       }
@@ -805,7 +811,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         });
       }
       activeDefinitions.add(refIdx);
-      const childNodes = instantiate(refIdx, newMatrix, lName, fullPathName, instColor);
+      const childNodes = instantiate(refIdx, newMatrix, lName, fullPathName, instMaterial);
       activeDefinitions.delete(refIdx);
 
       const tx = (newMatrix[9] ?? 0) * 25.4;

--- a/packages/typescript/src/vff.ts
+++ b/packages/typescript/src/vff.ts
@@ -29,6 +29,35 @@ function findSequence(data: Uint8Array, sequence: number[], startOffset: number 
   return -1;
 }
 
+/**
+ * Recover a ZIP entry name that was decoded as Latin-1.
+ *
+ * SketchUp writes entry names as UTF-8 but does not set the language encoding
+ * flag (general purpose bit 11), so a spec-compliant reader falls back to
+ * CP437/Latin-1: a material folder named "ДСП Egger" arrives as "ÐÐ¡Ð Egger".
+ * That mangled name is later compared against the material's real name and
+ * never matches, so the material silently loses its id and every face using it
+ * falls back to the layer colour.
+ *
+ * The Latin-1 mapping is lossless, so the original bytes can be recovered and
+ * decoded again as UTF-8. Names that are not valid UTF-8 are kept as they are,
+ * and a pure ASCII name survives the round trip unchanged.
+ */
+function decodeEntryName(entry: string): string {
+  if (!/[\u0080-\u00ff]/.test(entry)) return entry;
+  const bytes = new Uint8Array(entry.length);
+  for (let i = 0; i < entry.length; i++) {
+    const code = entry.charCodeAt(i);
+    if (code > 0xff) return entry;
+    bytes[i] = code;
+  }
+  try {
+    return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+  } catch {
+    return entry;
+  }
+}
+
 export function validateHeader(data: Uint8Array): boolean {
   if (data.length < 4) return false;
   return (
@@ -187,12 +216,13 @@ export function extractSkpContents(data: Uint8Array, options?: ParseOptions): Sk
   let metaData: Uint8Array | null = null;
   const materialFiles: Record<string, Uint8Array> = {};
 
-  for (const entry of Object.keys(unzipped)) {
+  for (const rawEntry of Object.keys(unzipped)) {
+    const entry = decodeEntryName(rawEntry);
     const lower = entry.toLowerCase();
     if (lower === 'model.dat' || lower.endsWith('/model.dat')) {
-      modelData = unzipped[entry];
+      modelData = unzipped[rawEntry];
     } else if (lower === 'meta/meta.dat') {
-      metaData = unzipped[entry];
+      metaData = unzipped[rawEntry];
     } else if (
       lower.endsWith('.xml') ||
       lower.endsWith('.png') ||
@@ -200,7 +230,7 @@ export function extractSkpContents(data: Uint8Array, options?: ParseOptions): Sk
       lower.endsWith('.jpeg') ||
       lower.includes('material')
     ) {
-      materialFiles[entry] = unzipped[entry];
+      materialFiles[entry] = unzipped[rawEntry];
     }
   }
 

--- a/packages/typescript/tests/instance-material-uv.test.ts
+++ b/packages/typescript/tests/instance-material-uv.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { GeometryBuilder, type ParsedDefinition } from '../src/geometry';
+import { buildSceneFromParsed, type Material, type ParsedRawData } from '../src/model';
+
+/**
+ * A face with no material of its own is painted by the instance around it
+ * (SketchUp's "paint the component"). The scene builder resolved the inherited
+ * COLOUR but not the material itself, so the UV maths never saw the inherited
+ * texture's tile size and fell back to a tile of 1 inch: a 24" decor sheet
+ * tiled 24 times across a 24" panel instead of covering it exactly once.
+ */
+
+const TILE_W = 24;
+const TILE_H = 12;
+const PANEL_INCHES = 24;
+
+function texturedMaterial(): Material {
+  return {
+    name: 'Decor',
+    color: { r: 10, g: 20, b: 30, a: 255 },
+    transparency: 1,
+    id: 7,
+    texture: {
+      filename: 'decor.jpg',
+      width: TILE_W,
+      height: TILE_H,
+      data: new Uint8Array([0xff, 0xd8, 0xff]),
+    },
+    colorized: false,
+    colorizeType: 0,
+  };
+}
+
+/** One flat square panel in the XY plane, with no material on the face. */
+function panelDefinition(): ParsedDefinition {
+  const builder = new GeometryBuilder();
+  builder.vertices.set(1, [0, 0, 0]);
+  builder.vertices.set(2, [PANEL_INCHES, 0, 0]);
+  builder.vertices.set(3, [PANEL_INCHES, PANEL_INCHES, 0]);
+  builder.vertices.set(4, [0, PANEL_INCHES, 0]);
+  builder.edges.set(11, [1, 2]);
+  builder.edges.set(12, [2, 3]);
+  builder.edges.set(13, [3, 4]);
+  builder.edges.set(14, [4, 1]);
+  builder.faces.set(21, {
+    loops: [
+      [
+        { edgeId: 11, orientation: 0 },
+        { edgeId: 12, orientation: 0 },
+        { edgeId: 13, orientation: 0 },
+        { edgeId: 14, orientation: 0 },
+      ],
+    ],
+    normal: [0, 0, 1],
+    materialId: null,
+    backMaterialId: null,
+  });
+  return { guid: 'PANEL', name: 'Panel', isImage: false, alwaysFacesCamera: false, builder };
+}
+
+function parsedWith(instanceMaterialId: number | null): ParsedRawData {
+  const root = new GeometryBuilder();
+  root.instances.push({
+    offset: 0,
+    refGuid: 'PANEL',
+    refIdx: 1,
+    name: 'Panel instance',
+    // Identity 3x3 + zero translation, in the 12-number layout the builder uses.
+    matrix: [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0],
+    materialId: instanceMaterialId,
+    children: [],
+  });
+
+  const material = texturedMaterial();
+  return {
+    version: '1.0',
+    units: 'Inches',
+    layerColors: new Map([['Layer0', [255, 255, 255]]]),
+    layerHidden: new Map(),
+    layerIdToName: new Map(),
+    materialIdToName: new Map([[7, 'Decor']]),
+    materialsMap: new Map([['Decor', material]]),
+    materialsByFolder: new Map(),
+    styles: [],
+    defsDict: new Map<number | string, ParsedDefinition>([
+      ['ROOT', { guid: 'ROOT', name: 'ROOT_MODEL', isImage: false, alwaysFacesCamera: false, builder: root }],
+      [1, panelDefinition()],
+    ]),
+  };
+}
+
+function uvSpan(scene: ReturnType<typeof buildSceneFromParsed>) {
+  const prim = scene.glbPrimitives[0];
+  let minU = Infinity, maxU = -Infinity, minV = Infinity, maxV = -Infinity;
+  for (let i = 0; i < prim.uvs.length; i += 2) {
+    minU = Math.min(minU, prim.uvs[i]);
+    maxU = Math.max(maxU, prim.uvs[i]);
+    minV = Math.min(minV, prim.uvs[i + 1]);
+    maxV = Math.max(maxV, prim.uvs[i + 1]);
+  }
+  return [maxU - minU, maxV - minV];
+}
+
+describe('a face inherits the instance material', () => {
+  it('scales UVs by the inherited texture tile', () => {
+    const scene = buildSceneFromParsed(parsedWith(7));
+    const [spanU, spanV] = uvSpan(scene);
+
+    // 24" panel with a 24x12" tile: exactly one repeat across, two down.
+    expect(spanU).toBeCloseTo(PANEL_INCHES / TILE_W, 5);
+    expect(spanV).toBeCloseTo(PANEL_INCHES / TILE_H, 5);
+  });
+
+  it('leaves an unpainted instance on the raw face frame', () => {
+    const scene = buildSceneFromParsed(parsedWith(null));
+    const [spanU] = uvSpan(scene);
+
+    // No material anywhere, so there is no tile size to scale by.
+    expect(spanU).toBeCloseTo(PANEL_INCHES, 5);
+  });
+});

--- a/packages/typescript/tests/zip-entry-name-encoding.test.ts
+++ b/packages/typescript/tests/zip-entry-name-encoding.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { zipSync } from 'fflate';
+import { randomBytes } from 'node:crypto';
+import { extractSkpContents } from '../src/vff';
+
+/**
+ * SketchUp stores ZIP entry names as UTF-8 but leaves the language encoding
+ * flag (general purpose bit 11) clear, so a spec-compliant reader decodes them
+ * as CP437/Latin-1: a material folder named "ДСП Egger" arrives as
+ * "ÐÐ¡Ð Egger". The mangled folder name is later matched against the
+ * material's real name, and when it does not match the material keeps
+ * `id: null` - every face using it then falls back to its layer colour and
+ * loses its texture.
+ */
+
+function buildSkpBytes(zipBytes: Uint8Array): Uint8Array {
+  const header = new Uint8Array(16); // VFF magic + padding
+  header.set([0xff, 0xfe, 0xff, 0x0e], 0);
+  const combined = new Uint8Array(header.length + zipBytes.length);
+  combined.set(header, 0);
+  combined.set(zipBytes, header.length);
+  return combined;
+}
+
+/** What a Latin-1 reader makes of a UTF-8 name - the state we receive. */
+function asLatin1(text: string): string {
+  const utf8 = new TextEncoder().encode(text);
+  let out = '';
+  for (const byte of utf8) out += String.fromCharCode(byte);
+  return out;
+}
+
+describe('ZIP entry names decoded as Latin-1', () => {
+  it('restores a non-ASCII material folder name', () => {
+    const folder = 'ДСП Egger F 204';
+    const zipBytes = zipSync({
+      'model.dat': new Uint8Array(randomBytes(1024)),
+      [`materials/${asLatin1(folder)}/material.xml`]: new TextEncoder().encode('<material/>'),
+    });
+
+    const contents = extractSkpContents(buildSkpBytes(zipBytes));
+
+    expect(Object.keys(contents.materialFiles)).toContain(`materials/${folder}/material.xml`);
+  });
+
+  it('leaves an ASCII name untouched', () => {
+    const zipBytes = zipSync({
+      'model.dat': new Uint8Array(randomBytes(1024)),
+      'materials/Metal_Seamed/material.xml': new TextEncoder().encode('<material/>'),
+    });
+
+    const contents = extractSkpContents(buildSkpBytes(zipBytes));
+
+    expect(Object.keys(contents.materialFiles)).toContain('materials/Metal_Seamed/material.xml');
+  });
+
+  it('keeps a name that is not valid UTF-8 as it is', () => {
+    // 0xFF never starts a valid UTF-8 sequence, so the name stays as read
+    // rather than being mangled further by a hopeful re-decode.
+    const name = `materials/${String.fromCharCode(0xff)}odd/material.xml`;
+    const zipBytes = zipSync({
+      'model.dat': new Uint8Array(randomBytes(1024)),
+      [name]: new TextEncoder().encode('<material/>'),
+    });
+
+    const contents = extractSkpContents(buildSkpBytes(zipBytes));
+
+    expect(Object.keys(contents.materialFiles)).toContain(name);
+  });
+});


### PR DESCRIPTION
Two independent bugs, both of which end with geometry losing its material — and both found while building a browser viewer for `.skp` on top of openskp, against real customer furniture models.

---

# 1. Materials parsed with `id === null` (ZIP entry names)

SketchUp stores entry names inside the `.skp` archive as UTF-8 but leaves the ZIP language encoding flag (general purpose bit 11) clear. A spec-compliant reader therefore decodes them as CP437/Latin-1, so a material folder named `ДСП Egger` arrives as `ÐÐ¡Ð Egger`.

That folder name is the key of `materialsByFolder`, and `model.ts` joins TLV material ids onto materials by name:

```ts
for (const [mId, mName] of materialIdToName.entries()) {
  const mat = materialsMap.get(mName) || materialsByFolder.get(mName);
  if (!mat) continue;          // <- mangled key never matches
  if (mat.id === null) mat.id = mId;
  materialsById.set(mId, mat);
}
```

The mangled key never matches, so the material keeps `id: null` and its TLV id is missing from `materialsById`. Every face referencing that id is then treated as material-less and falls back to the layer colour.

Worth noting the name in the TLV record is *also* truncated (`$69498 ДСП Egger F 204 ST9 Мармур Каррара`, cut at 57 bytes, against the full `… білий 2800х2070х18 мм` in `material.xml`), so `materialsMap` cannot match it either — the folder key is the only join that can work here, which is exactly the one the encoding breaks.

**Fix:** recover the original bytes and decode them again as UTF-8. The Latin-1 mapping is lossless, so the round trip is exact; names that are not valid UTF-8 are kept as they are, and pure ASCII names pass through untouched.

| | before | after |
|---|---|---|
| entries in `materialsById` | 12 | 13 |
| face `materialId 770085` resolves | no | yes |
| countertop | tag colour, no texture | its own material + texture |
| countertop UV span | 59.06 (raw inches) | 2.46 repeats over a 23.4″ part with a 24″ tile |

---

# 2. A face inherits only the colour of the instance material, not the material

A face with no material of its own is painted by the instance around it (SketchUp's "paint the component"). `instantiate()` resolves that inheritance for the **colour** only — it passes `inheritedMaterialColor` down the recursion — so `addSide` still receives `undefined` for the material and `computeFaceUv` falls back to `tileW = tileH = 1`:

```ts
const tex = mat?.texture;
const tileW = tex && tex.width > 1e-9 ? tex.width : 1;
const tileH = tex && tex.height > 1e-9 ? tex.height : 1;
```

The UVs of every such face therefore come out in raw inches. This is not an exotic case: in one of the affected files **not a single face** references a textured material — every panel is painted at the group level, which is how furniture models normally come out of a cabinet plugin.

Measured on that file:

| material | tile | part | UV span before | UV span after |
|---|---|---|---|---|
| `$154335 ДСП Swiss Krono 4413` | 46.89″ | 21.7″ | 40.45 (1.87 repeats per inch — a pattern every 13 mm) | 0.86 |
| `$171665 МДФ Arpa 4625` | 75.59″ | 23.5″ | 10.00 | 0.13 |

**Fix:** thread the whole material through the recursion instead of only its colour, and let a face with no material of its own inherit it. The colour keeps working exactly as before, since it is read from the same material.

---

## Tests

* `tests/zip-entry-name-encoding.test.ts` — builds synthetic archives the way `zip-entry-size-cap.test.ts` does: a non-ASCII folder name is restored, an ASCII name is untouched, a name that is not valid UTF-8 is left alone.
* `tests/instance-material-uv.test.ts` — builds a synthetic parsed model (one unpainted square panel inside a painted instance) and asserts the UV span equals panel/tile in both axes. On the previous behaviour it reports 24 repeats instead of 1.

Full suite passes (98 tests), plus `npm run lint` and `npm run typecheck`.

## Notes

The affected models are customer files, so I cannot attach one publicly — happy to share privately if you want to reproduce against the originals. Any `.skp` with non-ASCII material names hits the first bug; any file where groups are painted rather than faces hits the second.

Thanks for openskp. It does a remarkable job on files nothing else opens without SketchUp, and the code was a pleasure to read while tracking these down.
