### PR TITLE
fix(dotnet): make BuildScene instance→mesh back-fill O(n) instead of O(n²)

### DIFF
--- a/packages/dotnet/OpenSkp.Tests/SceneInstancePropagationTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/SceneInstancePropagationTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// Regression tests for the deferred instance -> mesh (Properties, Name)
+    /// back-fill in SceneBuilder.Build.
+    ///
+    /// The old implementation re-scanned the entire meshIndex with a string
+    /// Contains per placed instance, i.e. O(instances x meshes). On real
+    /// production files with a few hundred thousand instances and meshes
+    /// that single loop took tens of minutes (measured: 323,856 instances x
+    /// 321,683 meshes -> ~73 minutes in BuildScene, ~98% of the total
+    /// conversion time). The replacement records one dictionary entry per
+    /// instance during instantiation and applies updates once afterwards by
+    /// walking each mesh's Path to its shallowest recorded ancestor.
+    ///
+    /// These tests build synthetic RawParsed models directly (internals are
+    /// visible to the test assembly) so the semantics and the linear-time
+    /// behaviour are pinned without needing a large .skp fixture.
+    /// </summary>
+    public class SceneInstancePropagationTests
+    {
+        private static GeometryBuilder TriangleBuilder(long vidBase)
+        {
+            var b = new GeometryBuilder();
+            b.Vertices[vidBase + 0] = (0.0, 0.0, 0.0);
+            b.Vertices[vidBase + 1] = (1.0, 0.0, 0.0);
+            b.Vertices[vidBase + 2] = (0.0, 1.0, 0.0);
+            b.Edges[vidBase + 0] = (vidBase + 0, vidBase + 1);
+            b.Edges[vidBase + 1] = (vidBase + 1, vidBase + 2);
+            b.Edges[vidBase + 2] = (vidBase + 2, vidBase + 0);
+            b.Faces[vidBase] = new GeometryBuilderFace
+            {
+                Loops = new List<List<(long EdgeId, long Orientation)>>
+                {
+                    new List<(long, long)> { (vidBase + 0, 1), (vidBase + 1, 1), (vidBase + 2, 1) },
+                },
+                Normal = (0.0, 0.0, 1.0),
+            };
+            return b;
+        }
+
+        private static Core.RawParsed Parsed(params (long Id, GeometryBuilder Builder, string? Name)[] defs)
+        {
+            var parsed = new Core.RawParsed();
+            foreach (var (id, builder, name) in defs)
+            {
+                parsed.DefsDict[id] = new Geometry.RawDefinition { Guid = "G" + id, Name = name, Builder = builder };
+            }
+            // Layer0 color is needed as the fallback face color.
+            parsed.LayerColors["Layer0"] = (136, 136, 136);
+            parsed.LayerIdToName[1] = "Layer0";
+            return parsed;
+        }
+
+        [Fact]
+        public void MeshBackfill_OutermostAncestorWins()
+        {
+            // ROOT (one direct face)
+            //  |- A (def1: one face + child instance C -> def3, dynamic props)
+            //  |    "- C (def3: one face, its own props)
+            //  "- B (def2: one face, no props)
+            var root = TriangleBuilder(100);
+            var def1 = TriangleBuilder(200);
+            var def2 = TriangleBuilder(300);
+            var def3 = TriangleBuilder(400);
+
+            def1.Instances.Add(new GeometryBuilderInstance
+            {
+                Name = "C",
+                RefIdx = 3,
+                Properties = new Dictionary<string, string> { ["height"] = "5" },
+            });
+
+            root.Instances.Add(new GeometryBuilderInstance
+            {
+                Name = "A",
+                RefIdx = 1,
+                Properties = new Dictionary<string, string> { ["width"] = "10" },
+            });
+            root.Instances.Add(new GeometryBuilderInstance { Name = "B", RefIdx = 2 });
+
+            var parsed = Parsed(
+                (1, def1, "def1"),
+                (2, def2, "def2"),
+                (3, def3, "def3"));
+            parsed.Root = new Geometry.RawDefinition { Guid = "ROOT", Name = "ROOT_MODEL", Builder = root };
+
+            var scene = SceneBuilder.Build(parsed);
+
+            // ROOT's own mesh: untouched by instance updates, fixed up to ROOT.
+            var rootMesh = Assert.Single(scene.MeshIndex.Values, m => m.Path == "ROOT");
+            Assert.Equal("ROOT", rootMesh.Name);
+            Assert.Empty(rootMesh.Properties);
+
+            // Mesh directly under instance A: gets A's properties/name.
+            var meshA = Assert.Single(scene.MeshIndex.Values, m => m.Path == "ROOT / A");
+            Assert.Equal("A", meshA.Name);
+            Assert.Equal("10", meshA.Properties["width"]);
+
+            // Mesh under A's child C: the OUTERMOST ancestor (A) wins, exactly
+            // like the old scan (A wrote last, after C).
+            var meshAC = Assert.Single(scene.MeshIndex.Values, m => m.Path == "ROOT / A / C");
+            Assert.Equal("A", meshAC.Name);
+            Assert.Equal("10", meshAC.Properties["width"]);
+            Assert.False(meshAC.Properties.ContainsKey("height"));
+
+            // Mesh under B: B has no dynamic props; still records (empty, "B").
+            var meshB = Assert.Single(scene.MeshIndex.Values, m => m.Path == "ROOT / B");
+            Assert.Equal("B", meshB.Name);
+            Assert.Empty(meshB.Properties);
+        }
+
+        [Fact]
+        public void MeshBackfill_LargeInstanceCount_IsLinear()
+        {
+            // 100k placed instances of a one-triangle definition. The old
+            // per-instance full-meshIndex scan is O(N^2): ~100k^2/2 string
+            // Contains calls (~55+ s measured locally). The deferred back-fill
+            // is O(N): this should finish in a couple of seconds, so a 30 s
+            // ceiling separates the two regimes with a wide margin and stays
+            // far from timing-flake territory for the fixed code.
+            const int count = 100_000;
+            var def = TriangleBuilder(1);
+            var root = new GeometryBuilder();
+            for (int i = 0; i < count; i++)
+            {
+                root.Instances.Add(new GeometryBuilderInstance { Name = "inst_" + i, RefIdx = 1 });
+            }
+            var parsed = Parsed((1, def, "def"));
+            parsed.Root = new Geometry.RawDefinition { Guid = "ROOT", Name = "ROOT_MODEL", Builder = root };
+
+            var sw = Stopwatch.StartNew();
+            var scene = SceneBuilder.Build(parsed);
+            sw.Stop();
+
+            Assert.Equal(count, scene.MeshIndex.Count);
+            Assert.Equal(count, scene.GlbPrimitives.Count);
+            Assert.True(
+                sw.Elapsed < TimeSpan.FromSeconds(30),
+                "BuildScene took " + sw.Elapsed.TotalSeconds.ToString("F1") + "s for " + count + " instances - expected linear (deferred back-fill), not O(n^2).");
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Scene.cs
+++ b/packages/dotnet/OpenSkp/Scene.cs
@@ -185,6 +185,13 @@ namespace OpenSkp
             var meshIndex = new Dictionary<string, MeshMetadata>();
             var glbPrimitives = new List<GlbPrimitive>();
 
+            // Instance path -> (Properties, Name) updates, collected in O(1) per
+            // instance and applied once after instantiation (see the prefix-walk
+            // loop below). Replaces the previous per-instance full meshIndex
+            // scan, which was O(instances x meshes) and dominated BuildScene on
+            // models with tens or hundreds of thousands of placed instances.
+            var pathUpdates = new Dictionary<string, (Dictionary<string, string> Props, string Name)>();
+
             var colorToMaterialIndex = new Dictionary<((int, int, int) Color, bool DoubleSided), int>();
             var gltfMaterials = new List<object>();
 
@@ -558,16 +565,15 @@ namespace OpenSkp
                     };
                     childInstancesInfo.Add(instInfo);
 
-                    string safeChildPath = fullPathName.Replace(" / ", "__").Replace(" ", "_");
-                    if (safeChildPath.Length > 80) safeChildPath = safeChildPath.Substring(0, 80);
-                    foreach (var meshKv in meshIndex)
-                    {
-                        if (meshKv.Key.Contains(safeChildPath))
-                        {
-                            meshKv.Value.Properties = properties;
-                            meshKv.Value.Name = inst.Name ?? "";
-                        }
-                    }
+                    // Record this instance's (Properties, Name) for the deferred
+                    // mesh back-fill below. The scan this replaces iterated the
+                    // entire meshIndex per placed instance (string Contains per
+                    // mesh), i.e. O(instances x meshes); with hundreds of
+                    // thousands of both this alone took tens of minutes on real
+                    // production files. The final state is identical: an
+                    // instance's update is applied to every mesh under its path,
+                    // and the outermost (most shallow) ancestor's update wins.
+                    pathUpdates[fullPathName] = (properties, inst.Name ?? "");
                 }
 
                 return childInstancesInfo;
@@ -576,9 +582,36 @@ namespace OpenSkp
             var identityMat = new List<double> { 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0 };
             var rootChildren = InstantiateRoot(parsed.Root.Builder, identityMat);
 
+            // Deferred mesh back-fill: for each mesh, walk its Path from the
+            // leaf up to the root and apply the shallowest recorded ancestor
+            // update. Equivalent to the old scan's final state (the outermost
+            // ancestor wrote last and won), O(meshes x path_depth) instead of
+            // O(instances x meshes). This also fixes a latent over-match in the
+            // old substring test: "ROOT / A_B" would previously match a mesh
+            // whose GeomName merely contained the substring "A_B" (e.g. inside
+            // "A_BC"), wrongly propagating the update to non-descendants.
             foreach (var meshKv2 in meshIndex)
             {
-                var existing = meshKv2.Value;
+                var mesh = meshKv2.Value;
+                var meshPath = mesh.Path ?? "";
+                (Dictionary<string, string> Props, string Name)? found = null;
+                string p = meshPath;
+                while (p.Length > 0)
+                {
+                    if (pathUpdates.TryGetValue(p, out var u)) found = u;
+                    int sep = p.LastIndexOf(" / ");
+                    p = sep >= 0 ? p.Substring(0, sep) : "";
+                }
+                if (found.HasValue)
+                {
+                    mesh.Properties = found.Value.Props;
+                    mesh.Name = found.Value.Name;
+                }
+            }
+
+            foreach (var meshKv3 in meshIndex)
+            {
+                var existing = meshKv3.Value;
                 if (existing.Path == "ROOT")
                 {
                     existing.Name = "ROOT";


### PR DESCRIPTION
## Summary

`SceneBuilder.Build` re-scans the **entire** `meshIndex` for **every** placed
instance with a `string.Contains` per mesh, making `BuildScene` O(instances ×
meshes). On a 183 MB production file (323,856 placed instances × 321,683
meshes) this single loop took **~73 minutes** of a ~75-minute conversion —
≈98% of the whole pipeline. The fix records each instance’s (Properties,
Name) in O(1) during instantiation and applies the updates once afterwards
by walking each mesh’s `Path` to its shallowest recorded ancestor
(O(meshes × path_depth)), preserving the existing final-state semantics.

## Type

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] New platform implementation

## Changes

**`packages/dotnet/OpenSkp/Scene.cs`** (`SceneBuilder.Build`):

- Replace the per-instance full `meshIndex` scan (string `Contains` per mesh)
  with an O(1) `pathUpdates[fullPathName] = (properties, name)` registration
  during instantiation.
- Add a post-instantiation pass that walks each mesh’s `MeshMetadata.Path`
  and applies the shallowest (outermost) recorded ancestor update — the same
  final state the old code produced (the outermost instance wrote last).
- Incidental fix: the old substring test could over-match — a path like
  `ROOT / A_B` matched any GeomName merely *containing* `A_B` (e.g. inside
  `A_BC`), propagating an update to non-descendant meshes. The
  Path-prefix walk cannot.
- Public API is unchanged (`SceneBuilder.Build` is internal); output is
  byte-identical for existing models.

**`packages/dotnet/OpenSkp.Tests/SceneInstancePropagationTests.cs`** (new):

- `MeshBackfill_OutermostAncestorWins` — pins semantics: nested instances,
  outermost ancestor wins, root mesh untouched (synthetic `RawParsed`, no
  fixture needed).
- `MeshBackfill_LargeInstanceCount_IsLinear` — 100k placed instances complete
  in ~1 s with the fix; **fails on the old code** (~2.5 min, over the 30 s
  bound), guarding against regression to quadratic behaviour.

## Testing

- Full .NET test suite: **69/69 pass** (67 pre-existing + 2 new).
- `dotnet format --verify-no-changes` passes for both `OpenSkp` and
  `OpenSkp.Tests` projects (matches the CI `format` job).
- `dotnet build -warnaserror` (analyzers as errors) passes with 0 warnings.
- Downstream consumer benchmark (183 MB SKP):

  | | before | after |
  | --- | --- | --- |
  | BuildScene (build_scene stage) | 4374.6 s | 32.5 s (**135×**) |
  | total conversion | 4481.5 s | 103 s (**43×**) |
  | output (.bin) | — | content-identical (all tables/geometry hashes match) |

- The 100k-instance linearity test was validated to fail on the pre-fix code
  (2m38s) and pass on the fixed code (~1s).

## Checklist

- [x] Code follows the project’s style guidelines (`dotnet format` clean;
  analyzers pass with `-warnaserror`)
- [x] Tests pass locally (69/69, saw the new tests fail on the old code)
- [x] Documentation updated (if applicable) — N/A: internal-only change, no
  public API or behavior change; the only behavior difference is the
  elimination of a latent non-descendant over-match
- [x] No breaking changes to the public API

---

## Note (follow-up, not in this PR)

The identical O(n²) scan exists in the TypeScript reference
(`packages/typescript/src/model.ts`, `buildSceneFromParsed`) and in Python
(`packages/python/src/openskp/scene.py`), but the current PR hasn't been processed yet.