### PR TITLE
Extend openskp.create(): nested definitions/groups, UV positioning, default Iso view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,12 @@ for the full scope notes.
 - Nested definitions — a component definition can contain instances of
   another, already-built definition inside its own body
   (`ComponentDefinitionBuilder.add_instance`), the same assembly-of-parts
-  nesting real SketchUp supports, to any depth.
+  nesting real SketchUp supports, to any depth. A nested placement can
+  also be a *group* rather than a component instance
+  (`ComponentDefinitionBuilder.add_group_instance`) — this format has no
+  way to declare one definition's body inside another's, so the group's
+  own geometry still has to be built with a normal
+  `add_component_definition` first, then placed here.
 - Explicit texture positioning (`add_face`'s `front_uv`/`back_uv`) —
   scale, rotate, shear, and offset a face's texture independently per
   side instead of the default planar projection, given 3 world-point/UV
@@ -50,6 +55,13 @@ for the full scope notes.
   module's own docstring — the writer logic itself (the entity encoding,
   the object-graph protocol, the tail-reference renumbering) is 100%
   independently reverse-engineered.
+
+### Fixed
+
+- Calling `add_face`/`add_instance` on the root builder while a component
+  definition was still open (its `with` block not yet exited) silently
+  produced a corrupted file instead of raising — found while testing
+  group nesting, unrelated to it otherwise. Now raises immediately.
 
 ### Validation
 
@@ -68,8 +80,11 @@ entities) as a regression guard.
 
 - Explicit texture positioning on a tilted (non-axis-aligned) face - the
   local 2D parameterization needed for that has not been reverse-engineered.
-- Nesting a self-placing *group* (as opposed to a definition instance)
-  inside another definition.
+- Declaring a group's geometry inline nested inside another definition's
+  own body, the way `add_group` self-places at the root level - this
+  format has no mechanism for one definition's declaration to live inside
+  another's, so a nested group's geometry has to be built separately
+  first (see `add_group_instance` above).
 - Editing an existing arbitrary `.skp` file — a separately harder
   problem (real SketchUp re-serializes the whole document on save rather
   than appending), not attempted here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ for the full scope notes.
   correspondences. Currently limited to faces aligned to the X, Y, or Z
   axis.
 - Per-face/per-edge hidden, soft, and smooth flags.
+- Every file now opens to the standard "Iso" view (parallel projection,
+  looking at the origin) instead of the blank scaffold's own arbitrary
+  default camera.
 - No SketchUp SDK dependency at import, write, or any other runtime path.
   The bundled blank-document scaffold this module splices geometry into
   is disclosed plainly as SDK-authored boilerplate (Trimble's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ for the full scope notes.
   instances (`add_component_definition`, `add_instance`), and groups
   (`add_group`, which place themselves automatically on close rather than
   needing a separate placement call).
+- Nested definitions — a component definition can contain instances of
+  another, already-built definition inside its own body
+  (`ComponentDefinitionBuilder.add_instance`), the same assembly-of-parts
+  nesting real SketchUp supports, to any depth.
 - Per-face/per-edge hidden, soft, and smooth flags.
 - No SketchUp SDK dependency at import, write, or any other runtime path.
   The bundled blank-document scaffold this module splices geometry into
@@ -56,8 +60,8 @@ entities) as a regression guard.
 
 - Explicit texture UV positioning/pinning (default planar projection
   only).
-- Nested definitions (a component or group containing another
-  component's instances).
+- Nesting a self-placing *group* (as opposed to a definition instance)
+  inside another definition.
 - Editing an existing arbitrary `.skp` file — a separately harder
   problem (real SketchUp re-serializes the whole document on save rather
   than appending), not attempted here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ for the full scope notes.
   another, already-built definition inside its own body
   (`ComponentDefinitionBuilder.add_instance`), the same assembly-of-parts
   nesting real SketchUp supports, to any depth.
+- Explicit texture positioning (`add_face`'s `front_uv`/`back_uv`) —
+  scale, rotate, shear, and offset a face's texture independently per
+  side instead of the default planar projection, given 3 world-point/UV
+  correspondences. Currently limited to faces aligned to the X, Y, or Z
+  axis.
 - Per-face/per-edge hidden, soft, and smooth flags.
 - No SketchUp SDK dependency at import, write, or any other runtime path.
   The bundled blank-document scaffold this module splices geometry into
@@ -58,8 +63,8 @@ entities) as a regression guard.
 
 ### Explicitly out of scope for this first pass
 
-- Explicit texture UV positioning/pinning (default planar projection
-  only).
+- Explicit texture positioning on a tilted (non-axis-aligned) face - the
+  local 2D parameterization needed for that has not been reverse-engineered.
 - Nesting a self-placing *group* (as opposed to a definition instance)
   inside another definition.
 - Editing an existing arbitrary `.skp` file — a separately harder

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -488,6 +488,22 @@ with builder.add_component_definition("Car") as car:
 builder.add_instance(car)
 ```
 
+A nested placement can also be a *group* rather than a component
+instance (`add_group_instance`, same signature as `add_instance` again).
+Unlike root-level `add_group`, a nested group can't be declared inline -
+this format has no way to embed one definition's declaration inside
+another's, so its geometry still needs a normal `add_component_definition`
+first:
+
+```python
+with builder.add_component_definition("Engine") as engine:
+    engine.add_face([(0, 0, 0), (30, 0, 0), (30, 30, 0), (0, 30, 0)])
+with builder.add_component_definition("Car") as car:
+    car.add_face([(0, 0, 0), (150, 0, 0), (150, 60, 0), (0, 60, 0)])
+    car.add_group_instance(engine, translation=(50, 0, 10))
+builder.add_instance(car)
+```
+
 A face's texture can also be explicitly positioned (scaled, rotated,
 sheared, offset - independently per side) instead of the default planar
 projection, given 3 world-point/UV correspondences, on faces aligned to
@@ -507,11 +523,12 @@ builder.add_face(
 ```
 
 Explicitly out of scope for this first pass: texture positioning on a
-tilted (non-axis-aligned) face, nesting a self-placing *group* (as
-opposed to a definition instance) inside another definition, and editing
-an existing arbitrary `.skp` file (a separately harder problem — real
-SketchUp re-serializes the whole document on save rather than appending
-to it — not attempted here). See
+tilted (non-axis-aligned) face, declaring a group's geometry inline
+nested inside another definition (as opposed to placing an
+already-built one via `add_group_instance`), and editing an existing
+arbitrary `.skp` file (a separately harder problem — real SketchUp
+re-serializes the whole document on save rather than appending to it —
+not attempted here). See
 [`openskp/create.py`](../packages/python/src/openskp/create.py) for the
 full, current scope notes, and the [Python package README](../packages/python/README.md#writing-early-stage)
 for a longer worked example.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -474,12 +474,26 @@ after it. `ComponentDefinitionBuilder` (the object yielded by the `with`
 block) is exported alongside `SkpBuilder` from the top-level `openskp`
 package.
 
+A definition can also nest instances of another, already-closed
+definition inside its own body, to any depth (an assembly containing its
+own sub-parts) - `ComponentDefinitionBuilder.add_instance` has the same
+signature as `SkpBuilder.add_instance`:
+
+```python
+with builder.add_component_definition("Wheel") as wheel:
+    wheel.add_face([(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)])
+with builder.add_component_definition("Car") as car:
+    car.add_instance(wheel, translation=(0, 0, 0))
+    car.add_instance(wheel, translation=(100, 0, 0))
+builder.add_instance(car)
+```
+
 Explicitly out of scope for this first pass: explicit texture UV
-positioning/pinning (default planar projection only), nested definitions
-(a definition containing another definition's instances or groups), and
-editing an existing arbitrary `.skp` file (a separately harder problem —
-real SketchUp re-serializes the whole document on save rather than
-appending to it — not attempted here). See
+positioning/pinning (default planar projection only), nesting a
+self-placing *group* (as opposed to a definition instance) inside another
+definition, and editing an existing arbitrary `.skp` file (a separately
+harder problem — real SketchUp re-serializes the whole document on save
+rather than appending to it — not attempted here). See
 [`openskp/create.py`](../packages/python/src/openskp/create.py) for the
 full, current scope notes, and the [Python package README](../packages/python/README.md#writing-early-stage)
 for a longer worked example.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -488,12 +488,30 @@ with builder.add_component_definition("Car") as car:
 builder.add_instance(car)
 ```
 
-Explicitly out of scope for this first pass: explicit texture UV
-positioning/pinning (default planar projection only), nesting a
-self-placing *group* (as opposed to a definition instance) inside another
-definition, and editing an existing arbitrary `.skp` file (a separately
-harder problem — real SketchUp re-serializes the whole document on save
-rather than appending to it — not attempted here). See
+A face's texture can also be explicitly positioned (scaled, rotated,
+sheared, offset - independently per side) instead of the default planar
+projection, given 3 world-point/UV correspondences, on faces aligned to
+the X, Y, or Z axis:
+
+```python
+brick = builder.add_texture_material("Brick", "brick.png")
+builder.add_face(
+    [(0, 0, 0), (100, 0, 0), (100, 100, 0), (0, 100, 0)],
+    material=brick,
+    front_uv=[
+        ((0, 0, 0), (0.0, 0.0)),
+        ((50, 0, 0), (1.0, 0.0)),
+        ((0, 50, 0), (0.0, 1.0)),
+    ],
+)
+```
+
+Explicitly out of scope for this first pass: texture positioning on a
+tilted (non-axis-aligned) face, nesting a self-placing *group* (as
+opposed to a definition instance) inside another definition, and editing
+an existing arbitrary `.skp` file (a separately harder problem — real
+SketchUp re-serializes the whole document on save rather than appending
+to it — not attempted here). See
 [`openskp/create.py`](../packages/python/src/openskp/create.py) for the
 full, current scope notes, and the [Python package README](../packages/python/README.md#writing-early-stage)
 for a longer worked example.

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -124,10 +124,10 @@ from-scratch binary writer for the legacy MFC `CArchive` format (SketchUp
 2013–2020), with no SketchUp SDK involved at any point. This is a new,
 early-stage capability: geometry, materials (solid + PNG/JPEG textures),
 layers, component definitions with multiple instances, groups, nested
-definitions (an assembly instancing its own sub-part definitions, to any
-depth), and explicit per-side texture positioning (on axis-aligned faces)
-are all supported. See [`openskp/create.py`](src/openskp/create.py) for
-the full scope notes.
+definitions and nested group instances (an assembly containing instances
+or groups of its own sub-parts, to any depth), and explicit per-side
+texture positioning (on axis-aligned faces) are all supported. See
+[`openskp/create.py`](src/openskp/create.py) for the full scope notes.
 
 ```python
 from openskp import create

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -123,8 +123,9 @@ OpenSKP can also *create* new `.skp` files from scratch — a genuine,
 from-scratch binary writer for the legacy MFC `CArchive` format (SketchUp
 2013–2020), with no SketchUp SDK involved at any point. This is a new,
 early-stage capability: geometry, materials (solid + PNG/JPEG textures),
-layers, component definitions with multiple instances, and groups are all
-supported; explicit texture UV positioning and nested definitions are not
+layers, component definitions with multiple instances, groups, and
+nested definitions (an assembly instancing its own sub-part definitions,
+to any depth) are all supported; explicit texture UV positioning is not
 yet. See [`openskp/create.py`](src/openskp/create.py) for the full scope
 notes.
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -123,11 +123,11 @@ OpenSKP can also *create* new `.skp` files from scratch — a genuine,
 from-scratch binary writer for the legacy MFC `CArchive` format (SketchUp
 2013–2020), with no SketchUp SDK involved at any point. This is a new,
 early-stage capability: geometry, materials (solid + PNG/JPEG textures),
-layers, component definitions with multiple instances, groups, and
-nested definitions (an assembly instancing its own sub-part definitions,
-to any depth) are all supported; explicit texture UV positioning is not
-yet. See [`openskp/create.py`](src/openskp/create.py) for the full scope
-notes.
+layers, component definitions with multiple instances, groups, nested
+definitions (an assembly instancing its own sub-part definitions, to any
+depth), and explicit per-side texture positioning (on axis-aligned faces)
+are all supported. See [`openskp/create.py`](src/openskp/create.py) for
+the full scope notes.
 
 ```python
 from openskp import create
@@ -143,7 +143,13 @@ roof_layer = builder.add_layer("Roof")
 # add_instance/add_face call - placing anything locks in the file's
 # slot numbering for what comes after.
 with builder.add_component_definition("Chair") as chair:
-    chair.add_face([(0, 0, 0), (20, 0, 0), (20, 20, 0), (0, 20, 0)], material=brick)
+    chair.add_face(
+        [(0, 0, 0), (20, 0, 0), (20, 20, 0), (0, 20, 0)],
+        material=brick,
+        # Explicit texture positioning: 3 (world point, uv) pairs pin the
+        # texture's scale/rotation/offset instead of the default projection.
+        front_uv=[((0, 0, 0), (0.0, 0.0)), ((10, 0, 0), (1.0, 0.0)), ((0, 10, 0), (0.0, 1.0))],
+    )
 
 # A one-off group (placed automatically when its `with` block exits)
 with builder.add_group("Table", translation=(100, 0, 0)) as table:

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -31,6 +31,10 @@ are involved, and how.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
+* Every file opens to the standard "Iso" view (parallel projection,
+  looking at the origin from the (1, -1, 1) octant) rather than the
+  blank scaffold's own arbitrary default camera - see
+  ``_ISO_CAMERA_PREFIX_PATCH`` below. Not configurable yet.
 * Editing an *existing* arbitrary ``.skp`` file is a separate, harder
   problem this module does not attempt: real SketchUp does not simply
   append to a file on save, it re-serializes the whole document, so there
@@ -100,6 +104,36 @@ _SCAFFOLD_SHA256 = "809a1ab73a20a192ab13aaff197afb1c67d0e9352f6a353a9cd8030919f8
 # file's tail content; do not reuse for a different base file without
 # re-deriving them the same way.
 _TAIL_REF_POSITIONS = (409, 468, 477, 479, 1383, 1385)
+
+# The blank scaffold ships with SketchUp's own arbitrary default camera;
+# every file this writer produces instead always patches it to the
+# standard "Iso" view (eye along the (1, -1, 1) octant looking at the
+# origin, up = Z, parallel/orthographic projection - matching Camera >
+# Standard Views > Iso) so it opens already framed the conventional way,
+# rather than whatever angle a brand-new blank document happens to
+# default to. Found the same way as every other ground-truth constant
+# here: diffing two SDK-authored blank documents that differ only in an
+# explicit SUCameraSetOrientation + SUCameraSetPerspective(False) call
+# before saving - these are the exact bytes real SketchUp itself wrote
+# for that camera, copied verbatim rather than decoded (like
+# _CAMERA_TEMPLATE, this project has not reverse-engineered CCamera's
+# own internal field layout, only confirmed these specific byte ranges
+# are what changes for this camera setting). The prefix offset is
+# absolute (within the always-unshifted scaffold prefix, well before
+# _material_insert_pos); the tail patches are relative to the document
+# "tail" like _TAIL_REF_POSITIONS, since this camera setting also
+# touches two small fields further into that region.
+_ISO_CAMERA_PREFIX_OFFSET = 2993
+_ISO_CAMERA_PREFIX_PATCH = bytes.fromhex(
+    "594000000000000059c000000000000059400000000000000000000000000000"
+    "000000000000000000003f2c0c70bd20dabf3f2c0c70bd20da3f3f2c0c70bd20"
+    "ea3f000000000000f03f0000000000408f40000000000000003e402adf272c80"
+    "3457"
+)
+_ISO_CAMERA_TAIL_PATCHES = (
+    (509, bytes.fromhex("d0a869613c442d4799a4667d1adfa836")),
+    (1390, bytes.fromhex("4e53c84477029246bba95827bba7e2")),
+)
 
 _CLAYER_PATTERN = re.escape(b"\xff\xff") + b".." + re.escape(struct.pack("<H", 6) + b"CLayer")
 
@@ -1416,6 +1450,9 @@ class SkpBuilder:
         if pid_delta:
             u16 = struct.unpack_from("<H", prefix, _PID_COUNTER_POS)[0]
             struct.pack_into("<H", prefix, _PID_COUNTER_POS, u16 + pid_delta)
+        prefix[_ISO_CAMERA_PREFIX_OFFSET : _ISO_CAMERA_PREFIX_OFFSET + len(_ISO_CAMERA_PREFIX_PATCH)] = (
+            _ISO_CAMERA_PREFIX_PATCH
+        )
         out += prefix
         out += _u32(self._material_count)
         out += self._material_writer.buf
@@ -1454,6 +1491,8 @@ class SkpBuilder:
         total_tail_shift = material_shift + layer_shift + definition_shift + geometry_shift
         for pos in _TAIL_REF_POSITIONS:
             _shift_ref(tail, pos, total_tail_shift)
+        for pos, patch in _ISO_CAMERA_TAIL_PATCHES:
+            tail[pos : pos + len(patch)] = patch
         out += tail
         return bytes(out)
 

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -19,15 +19,19 @@ are involved, and how.
   supported - see :meth:`SkpBuilder.add_material` / :meth:`SkpBuilder.
   add_texture_material` / :meth:`SkpBuilder.add_layer` / :meth:`SkpBuilder.
   add_component_definition` / :meth:`SkpBuilder.add_group`. A definition
-  can also nest instances of another, already-built definition inside its
-  own body (an assembly containing its own sub-parts) via
-  :meth:`ComponentDefinitionBuilder.add_instance`. A face's texture can be
-  explicitly positioned (scaled/rotated/sheared/offset, independently per
-  side) instead of the default planar projection - see `write_face`'s
-  ``front_uv``/``back_uv`` parameters - currently only for faces aligned
-  to the X, Y, or Z axis. There is no support yet for positioning on a
-  tilted face, or for nesting a self-placing *group* (as opposed to a
-  definition instance) inside another definition.
+  can also nest instances (or group instances) of another, already-built
+  definition inside its own body (an assembly containing its own
+  sub-parts) via :meth:`ComponentDefinitionBuilder.add_instance` /
+  :meth:`ComponentDefinitionBuilder.add_group_instance` - nested groups
+  can't be declared inline the way :meth:`SkpBuilder.add_group` is at the
+  root level (this format has no way to embed one definition's
+  declaration inside another's), so build the group's geometry with a
+  normal `add_component_definition` first, then place it as a group.
+  A face's texture can be explicitly positioned (scaled/rotated/sheared/
+  offset, independently per side) instead of the default planar
+  projection - see `write_face`'s ``front_uv``/``back_uv`` parameters -
+  currently only for faces aligned to the X, Y, or Z axis. There is no
+  support yet for positioning on a tilted face.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -906,6 +910,13 @@ class ComponentDefinitionBuilder:
         # needs an explicit later add_instance call.
         self._group_placement = group_placement
 
+    def _check_writable(self, action: str) -> None:
+        if self._closed:
+            raise SkpWriteError(
+                f"component definition {self.name!r} has already closed "
+                f"(its `with` block exited) - cannot add more {action} to it"
+            )
+
     def add_face(
         self,
         points: Sequence[Point3],
@@ -923,11 +934,7 @@ class ComponentDefinitionBuilder:
         behavior as :meth:`SkpBuilder.add_face`, except vertices/edges are
         shared only within this definition, never with the root model or
         other definitions."""
-        if self._closed:
-            raise SkpWriteError(
-                f"component definition {self.name!r} has already closed "
-                "(its `with` block exited) - cannot add more faces to it"
-            )
+        self._check_writable("faces")
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
@@ -971,11 +978,7 @@ class ComponentDefinitionBuilder:
         ever nest others fully built strictly before it existed, never
         itself or anything still in progress.
         """
-        if self._closed:
-            raise SkpWriteError(
-                f"component definition {self.name!r} has already closed "
-                "(its `with` block exited) - cannot add more instances to it"
-            )
+        self._check_writable("instances")
         if definition._skp is not self._skp:
             raise SkpWriteError(
                 f"component definition {definition.name!r} belongs to a different "
@@ -984,6 +987,47 @@ class ComponentDefinitionBuilder:
         if definition is self:
             raise SkpWriteError(f"component definition {self.name!r} cannot nest an instance of itself")
         self._new_entity_count += self._skp._definition_writer.write_instance(
+            definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0
+        )
+
+    def add_group_instance(
+        self,
+        definition: "ComponentDefinitionBuilder",
+        name: Optional[str] = None,
+        translation: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+        matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
+        material: Optional[int] = None,
+        layer: Optional[int] = None,
+    ) -> None:
+        """Place another, already-closed component definition inside this
+        one as a *group* (``CGroup``) rather than a component instance -
+        otherwise identical to `add_instance`, including the same
+        already-closed/same-builder/no-self-reference requirements.
+
+        Unlike the self-placing :meth:`SkpBuilder.add_group` at the root
+        level, a nested group can't be declared inline: this format has
+        no way to embed one definition's declaration inside another's -
+        every definition is a flat, top-level record, and a definition
+        can only reference others already fully closed strictly before
+        it was opened, the same constraint `add_instance` relies on for
+        cycle-safety. So build the group's geometry with a normal
+        `add_component_definition` first, then place it here:
+
+        >>> with builder.add_component_definition("Engine") as engine:
+        ...     engine.add_face([(0, 0, 0), (30, 0, 0), (30, 30, 0), (0, 30, 0)])
+        >>> with builder.add_component_definition("Car") as car:
+        ...     car.add_face([(0, 0, 0), (150, 0, 0), (150, 60, 0), (0, 60, 0)])
+        ...     car.add_group_instance(engine, translation=(50, 0, 10))
+        """
+        self._check_writable("groups")
+        if definition._skp is not self._skp:
+            raise SkpWriteError(
+                f"component definition {definition.name!r} belongs to a different "
+                "builder (a different create() call) - its slot number is meaningless here"
+            )
+        if definition is self:
+            raise SkpWriteError(f"component definition {self.name!r} cannot nest a group instance of itself")
+        self._new_entity_count += self._skp._definition_writer.write_group(
             definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0
         )
 
@@ -1332,6 +1376,22 @@ class SkpBuilder:
     def _ensure_geometry_writer(self) -> None:
         if self._geometry_writer is not None:
             return
+        if self._open_definition is not None:
+            # Calling this while a definition/group is still open would
+            # lock in the geometry writer's starting slot before that
+            # definition (and anything added to it afterward) finishes
+            # growing _definition_writer - the locked-in slot would then be
+            # too low, corrupting every back-reference root-level geometry
+            # makes. A real, previously-unguarded gap: nothing stopped
+            # calling add_face/add_instance on the root builder from
+            # inside an open `with add_component_definition(...)` block,
+            # which silently produced a file whose root entities didn't
+            # parse (found while testing group nesting - not related to
+            # it otherwise).
+            raise SkpWriteError(
+                f"component definition {self._open_definition.name!r} is still open - "
+                "exit its `with` block before adding root-level geometry"
+            )
         material_shift = self._material_writer.next_slot - self._base
         self._geometry_writer = _ArchiveWriter(
             next_slot=self._scaffold_next_slot + material_shift + self._layer_shift() + self._definition_shift(),
@@ -1513,6 +1573,6 @@ def create() -> SkpBuilder:
 
     See the :mod:`openskp.create` module docstring for the current scope
     and limitations (texture positioning only on axis-aligned faces so
-    far, no nested groups yet; inches only).
+    far, no inline-declared nested groups; inches only).
     """
     return SkpBuilder()

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -18,10 +18,13 @@ are involved, and how.
   definitions with multiple positioned instances, and groups are all
   supported - see :meth:`SkpBuilder.add_material` / :meth:`SkpBuilder.
   add_texture_material` / :meth:`SkpBuilder.add_layer` / :meth:`SkpBuilder.
-  add_component_definition` / :meth:`SkpBuilder.add_group`. There is no
-  support yet for explicit texture positioning/pinning or nested
-  definitions (a definition containing another definition's instances or
-  groups).
+  add_component_definition` / :meth:`SkpBuilder.add_group`. A definition
+  can also nest instances of another, already-built definition inside its
+  own body (an assembly containing its own sub-parts) via
+  :meth:`ComponentDefinitionBuilder.add_instance`. There is no support yet
+  for explicit texture positioning/pinning, or for nesting a
+  self-placing *group* (as opposed to a definition instance) inside
+  another definition.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -434,7 +437,14 @@ class _ArchiveWriter:
         self.buf += _u32(1)  # nlayers: always 1, an embedded copy of Layer0
         embedded_layer_slot = self.write_layer("Layer0", with_pids=False)
         self._backref(embedded_layer_slot)  # "decl": this definition's own active layer
-        self.buf += _u32(0)  # nested-definition count - always 0, not supported
+        # A separate field from nested instances (which live in the entity
+        # list just below, like any other entity) - ground truth shows this
+        # counts CComponentDefinition classes declared inline within this
+        # definition's own header, a distinct and rarer construct this
+        # project has not needed: every definition this writer produces is
+        # declared at the top level, so this stays 0 even when its entity
+        # list below places instances of other top-level definitions.
+        self.buf += _u32(0)
         count_patch_pos = len(self.buf)
         self.buf += _u32(0)  # placeholder entity count, patched by the caller
         return slot, count_patch_pos
@@ -732,6 +742,55 @@ class ComponentDefinitionBuilder:
             points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
+        )
+
+    def add_instance(
+        self,
+        definition: "ComponentDefinitionBuilder",
+        name: Optional[str] = None,
+        translation: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+        matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
+        material: Optional[int] = None,
+        layer: Optional[int] = None,
+    ) -> None:
+        """Place one instance of another, already-closed component
+        definition inside this one - the same nesting real SketchUp
+        supports (an assembly definition containing instances of its own
+        sub-part definitions), same signature and behavior as
+        :meth:`SkpBuilder.add_instance` otherwise.
+
+        >>> with builder.add_component_definition("Wheel") as wheel:
+        ...     wheel.add_face([(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)])
+        >>> with builder.add_component_definition("Car") as car:
+        ...     car.add_instance(wheel, translation=(0, 0, 0))
+        ...     car.add_instance(wheel, translation=(100, 0, 0))
+
+        ``definition`` must come from this same builder - a definition
+        from a different `create()` call has a slot number that means
+        nothing in this document. It is always already closed by the time
+        it's valid to pass here: only one definition can be open on a
+        given builder at once (see `add_component_definition`), and that
+        one is always ``self`` while its own `with` block is active - so
+        any *other* definition from this builder reachable here was
+        necessarily closed before ``self`` was even opened. That
+        ordering is also what rules out cycles: a definition can only
+        ever nest others fully built strictly before it existed, never
+        itself or anything still in progress.
+        """
+        if self._closed:
+            raise SkpWriteError(
+                f"component definition {self.name!r} has already closed "
+                "(its `with` block exited) - cannot add more instances to it"
+            )
+        if definition._skp is not self._skp:
+            raise SkpWriteError(
+                f"component definition {definition.name!r} belongs to a different "
+                "builder (a different create() call) - its slot number is meaningless here"
+            )
+        if definition is self:
+            raise SkpWriteError(f"component definition {self.name!r} cannot nest an instance of itself")
+        self._new_entity_count += self._skp._definition_writer.write_instance(
+            definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0
         )
 
     def __enter__(self) -> "ComponentDefinitionBuilder":
@@ -1060,6 +1119,11 @@ class SkpBuilder:
         ``material``/``layer``, if given, are handles from `add_material`/
         `add_layer` applied to the instance itself (not its contents).
         """
+        if definition._skp is not self:
+            raise SkpWriteError(
+                f"component definition {definition.name!r} belongs to a different "
+                "builder (a different create() call) - its slot number is meaningless here"
+            )
         if not definition._closed:
             raise SkpWriteError(
                 f"component definition {definition.name!r} is still open - "
@@ -1229,7 +1293,7 @@ def create() -> SkpBuilder:
     >>> builder.save("output.skp")
 
     See the :mod:`openskp.create` module docstring for the current scope
-    and limitations (no texture UV positioning or nested definitions yet;
+    and limitations (no texture UV positioning or nested groups yet;
     inches only).
     """
     return SkpBuilder()

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -21,10 +21,13 @@ are involved, and how.
   add_component_definition` / :meth:`SkpBuilder.add_group`. A definition
   can also nest instances of another, already-built definition inside its
   own body (an assembly containing its own sub-parts) via
-  :meth:`ComponentDefinitionBuilder.add_instance`. There is no support yet
-  for explicit texture positioning/pinning, or for nesting a
-  self-placing *group* (as opposed to a definition instance) inside
-  another definition.
+  :meth:`ComponentDefinitionBuilder.add_instance`. A face's texture can be
+  explicitly positioned (scaled/rotated/sheared/offset, independently per
+  side) instead of the default planar projection - see `write_face`'s
+  ``front_uv``/``back_uv`` parameters - currently only for faces aligned
+  to the X, Y, or Z axis. There is no support yet for positioning on a
+  tilted face, or for nesting a self-placing *group* (as opposed to a
+  definition instance) inside another definition.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -175,6 +178,97 @@ _CAMERA_TEMPLATE = bytes.fromhex(
 # (unlike drawbase's padding, which real SketchUp silently drops without).
 _DEFINITION_BASE_BLOCK = bytes([0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
 
+_FTC_SCHEMA = 4
+
+# A face with no explicit texture positioning stores no CFaceTextureCoords
+# at all, so this identity is only ever used to fill the *other* side's slot
+# when just one of front/back is explicitly positioned - real SketchUp still
+# writes a full 24-f64 block either way, just with the unpositioned side's
+# matrix left as identity, ground-truth confirmed by positioning only one
+# side and reading the other back as (1,0,0, 0,1,0, 0,0,1).
+_IDENTITY_UV_MATRIX = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+
+
+def _det3(m: Sequence[Sequence[float]]) -> float:
+    return (
+        m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+        - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+        + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0])
+    )
+
+
+def _solve3x3(a: Sequence[Sequence[float]], b: Sequence[float]) -> Tuple[float, float, float]:
+    """Solve the 3x3 linear system ``a @ x = b`` via Cramer's rule."""
+    d = _det3(a)
+    if abs(d) < 1e-9:
+        raise SkpWriteError(
+            "the 3 texture-positioning points map to collinear (u, v) coordinates - "
+            "cannot determine a texture mapping from them"
+        )
+    cols = []
+    for col in range(3):
+        ai = [list(row) for row in a]
+        for r in range(3):
+            ai[r][col] = b[r]
+        cols.append(_det3(ai) / d)
+    return cols[0], cols[1], cols[2]
+
+
+def _solve_uv_matrix(
+    pairs: Sequence[Tuple[Point3, Tuple[float, float]]], axes: Tuple[int, int]
+) -> Tuple[float, ...]:
+    """Fit the 3x3 UV-to-world affine matrix ground truth shows real
+    SketchUp stores for a positioned texture, from exactly 3 (world point,
+    (u, v)) correspondences - the minimum that fully determines an affine
+    map (scale, rotation, shear, translation; no perspective/keystone term,
+    matching the third column ground truth always shows as (0, 0, 1)).
+
+    ``axes`` selects which two of the face's own (x, y, z) coordinates to
+    treat as its local 2D plane (see the axis-aligned-only restriction in
+    `_uv_matrix_for_face`) - the world side of each correspondence is
+    projected onto those two axes before fitting.
+
+    Ground truth (see ``_read_ftc`` in legacy.py, which this inverts) shows
+    the stored matrix satisfies ``(u, v, 1) @ M == (world_x, world_y, 1)``
+    in row-vector convention - i.e. it maps a UV coordinate to the world
+    point it should land on, which is the natural direction for *defining*
+    a mapping (a caller says where each UV coordinate goes).
+    """
+    if len(pairs) != 3:
+        raise SkpWriteError("texture positioning needs exactly 3 (point, uv) pairs")
+    i, j = axes
+    a = [[uv[0], uv[1], 1.0] for _, uv in pairs]
+    bx = [pt[i] for pt, _ in pairs]
+    by = [pt[j] for pt, _ in pairs]
+    col_x = _solve3x3(a, bx)
+    col_y = _solve3x3(a, by)
+    a0, c0, e0 = col_x
+    b0, d0, f0 = col_y
+    return (a0, b0, 0.0, c0, d0, 0.0, e0, f0, 1.0)
+
+
+def _uv_matrix_for_face(
+    pairs: Sequence[Tuple[Point3, Tuple[float, float]]], normal: Tuple[float, float, float]
+) -> Tuple[float, ...]:
+    """As `_solve_uv_matrix`, but derives which 2 of (x, y, z) to use from
+    the face's own plane normal - only axis-aligned faces (normal parallel
+    to X, Y, or Z) are supported for now; a tilted face's local 2D
+    parameterization has not been reverse-engineered (every ground-truth
+    sample used to derive this feature was axis-aligned)."""
+    nx, ny, nz = normal
+    if abs(nz) > 1 - 1e-6:
+        axes = (0, 1)
+    elif abs(ny) > 1 - 1e-6:
+        axes = (0, 2)
+    elif abs(nx) > 1 - 1e-6:
+        axes = (1, 2)
+    else:
+        raise SkpWriteError(
+            "explicit texture positioning is only supported on faces aligned to the "
+            "X, Y, or Z axis for now (this face's plane is tilted)"
+        )
+    return _solve_uv_matrix(pairs, axes)
+
 
 def _u32(v: int) -> bytes:
     return struct.pack("<I", v)
@@ -300,6 +394,53 @@ class _ArchiveWriter:
         if pid is None:
             pid = self._alloc_pid()
         self.buf += self._encode_pid(pid)
+
+    def _preamble_with_texture_coords(
+        self,
+        front_matrix: Optional[Tuple[float, ...]],
+        back_matrix: Optional[Tuple[float, ...]],
+    ) -> None:
+        """Like `_preamble(real_attrs=True)`, but the attribute container's
+        children list holds one real `CFaceTextureCoords` entry instead of
+        closing immediately - used only for a face with explicit texture
+        positioning on its front and/or back side. ``front_matrix``/
+        ``back_matrix`` is ``None`` for the side that isn't positioned."""
+        self.buf += struct.pack("<H", 0x8000 | _ATTR_CONTAINER_SLOT)
+        self._alloc()
+        self.buf += bytes(3)  # the container's own nested preamble: null attrs (2) + mask=0 (1)
+        self.write_face_texture_coords(front_matrix, back_matrix)
+        self._null()  # children-list terminator
+        self.buf += self._encode_pid(self._alloc_pid())
+
+    def write_face_texture_coords(
+        self,
+        front_matrix: Optional[Tuple[float, ...]],
+        back_matrix: Optional[Tuple[float, ...]],
+    ) -> None:
+        """Write one ``CFaceTextureCoords`` record - the explicit
+        front/back texture-positioning data a face's attribute container
+        holds when either side has been explicitly positioned (as opposed
+        to the default planar projection, which needs no such record at
+        all). Inverts ``legacy._read_ftc`` field-for-field; see that
+        function's docstring for what each field means.
+
+        ``front_matrix``/``back_matrix`` are the 9-value row-major
+        UV-to-world affine matrices from `_uv_matrix_for_face`, or
+        ``None`` for a side that isn't explicitly positioned (written as
+        identity, matching ground truth for the untouched side).
+        """
+        self._new_of_known_class("CFaceTextureCoords", schema=_FTC_SCHEMA)
+        self._preamble(pid=0)
+        self.buf += _u32(0)  # ground truth: read and discarded by legacy.py's reader too
+        ks = [0.0] * 24
+        ks[0:9] = front_matrix if front_matrix is not None else _IDENTITY_UV_MATRIX
+        ks[12:21] = back_matrix if back_matrix is not None else _IDENTITY_UV_MATRIX
+        for v in ks:
+            self.buf += _f64(v)
+        self.buf += _u32(0)  # front pin count - this writer always emits a solved matrix, never raw pins
+        self.buf += _u32(0)  # back pin count
+        self.buf += _u32(1 if front_matrix is not None else 0)  # fflags bit 0: front painted/positioned
+        self.buf += _u32(1 if back_matrix is not None else 0)  # bflags bit 0: back painted/positioned
 
     def _drawbase(
         self, mat: int = 0, layer: int = 0,
@@ -556,6 +697,8 @@ class _ArchiveWriter:
         soft_edges: bool = False,
         smooth_edges: bool = False,
         hidden_edges: bool = False,
+        front_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
+        back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
     ) -> int:
         """Write one planar face and return how many new root-entity-list
         slots it consumed (edges newly declared, plus the face itself) -
@@ -579,6 +722,14 @@ class _ArchiveWriter:
         between adjacent faces should shade smoothly and stay invisible) -
         an edge already shared with a previous face keeps whatever flags
         it was first declared with; these have no effect on it.
+
+        ``front_uv``/``back_uv``, if given, explicitly position that
+        side's texture instead of the default planar projection - exactly
+        3 ``(point, (u, v))`` pairs (a world point on the face's plane
+        paired with the texture coordinate it should land on), which fully
+        determines an affine mapping (scale/rotation/shear/translation, no
+        perspective). Only supported on faces aligned to the X, Y, or Z
+        axis for now. See :meth:`SkpBuilder.add_face` for a worked example.
         """
         n = len(points)
         point_slots = [vertex_slots.get(p) for p in points]
@@ -618,10 +769,16 @@ class _ArchiveWriter:
                 point_slots[v1_idx],
             )
 
-        self._new_of_known_class("CFace", schema=3)
-        self._preamble()
-        self._drawbase(mat=face_material, layer=face_layer, hidden=hidden)
         nx, ny, nz, d = _plane_from_polygon(points)
+
+        self._new_of_known_class("CFace", schema=3)
+        if front_uv is not None or back_uv is not None:
+            front_matrix = _uv_matrix_for_face(front_uv, (nx, ny, nz)) if front_uv is not None else None
+            back_matrix = _uv_matrix_for_face(back_uv, (nx, ny, nz)) if back_uv is not None else None
+            self._preamble_with_texture_coords(front_matrix, back_matrix)
+        else:
+            self._preamble()
+        self._drawbase(mat=face_material, layer=face_layer, hidden=hidden)
         self.buf += _f64(nx) + _f64(ny) + _f64(nz) + _f64(d)
         self.buf += _u32(1)  # nloops = 1
 
@@ -725,6 +882,8 @@ class ComponentDefinitionBuilder:
         soft_edges: bool = False,
         smooth_edges: bool = False,
         hidden_edges: bool = False,
+        front_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
+        back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
     ) -> None:
         """Add one planar face to this definition - same signature and
         behavior as :meth:`SkpBuilder.add_face`, except vertices/edges are
@@ -742,6 +901,7 @@ class ComponentDefinitionBuilder:
             points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
+            front_uv, back_uv,
         )
 
     def add_instance(
@@ -1164,6 +1324,8 @@ class SkpBuilder:
         soft_edges: bool = False,
         smooth_edges: bool = False,
         hidden_edges: bool = False,
+        front_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
+        back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
     ) -> None:
         """Add one planar face, defined by 3 or more coplanar points (in
         inches) forming a closed polygon in order - do not repeat the
@@ -1185,6 +1347,23 @@ class SkpBuilder:
         one already shared with a previous face) - typical for a
         tessellated curved surface, where the seams between adjacent
         facets should shade smoothly and stay invisible.
+
+        ``front_uv``/``back_uv``, if given, explicitly position that
+        side's texture instead of the default planar projection: exactly
+        3 ``(point, (u, v))`` pairs, each a world point on the face paired
+        with the texture coordinate that should land there. Only
+        supported on faces aligned to the X, Y, or Z axis for now.
+
+        >>> brick = builder.add_texture_material("Brick", "brick.png")
+        >>> builder.add_face(
+        ...     [(0, 0, 0), (100, 0, 0), (100, 100, 0), (0, 100, 0)],
+        ...     material=brick,
+        ...     front_uv=[
+        ...         ((0, 0, 0), (0.0, 0.0)),
+        ...         ((50, 0, 0), (1.0, 0.0)),
+        ...         ((0, 50, 0), (0.0, 1.0)),
+        ...     ],
+        ... )
         """
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
@@ -1194,6 +1373,7 @@ class SkpBuilder:
             points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
+            front_uv, back_uv,
         )
         self._face_count += 1
 
@@ -1293,7 +1473,7 @@ def create() -> SkpBuilder:
     >>> builder.save("output.skp")
 
     See the :mod:`openskp.create` module docstring for the current scope
-    and limitations (no texture UV positioning or nested groups yet;
-    inches only).
+    and limitations (texture positioning only on axis-aligned faces so
+    far, no nested groups yet; inches only).
     """
     return SkpBuilder()

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import importlib
 import os
+import struct
 
 import pytest
 
@@ -639,6 +640,170 @@ class TestNestedDefinitions:
             car.add_instance(wheel)
         with pytest.raises(SkpWriteError, match="already closed"):
             car.add_instance(wheel)
+
+
+class TestNestedGroups:
+    def test_group_instance_nested_in_definition_self_parses(self, tmp_path):
+        from openskp import SkpFile
+
+        builder = create()
+        with builder.add_component_definition("Engine") as engine:
+            engine.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_face(SQUARE)
+            car.add_group_instance(engine, translation=(50.0, 0.0, 10.0))
+        builder.add_instance(car)
+        data = builder.to_bytes()
+
+        # Root only ever sees Car - Engine is never placed at root level.
+        ar, root, layers, materials = legacy._walk(data)
+        assert len(root) == 1
+        assert root[0][1] == "CComponentInstance"
+        assert root[0][2]["def"] == car.slot
+
+        out = tmp_path / "nested_group.skp"
+        out.write_bytes(data)
+        model = SkpFile.open(str(out)).parse()
+        car_def = model.definitions[car.slot]
+        assert len(car_def.faces) == 1
+        assert len(car_def.instances) == 1
+        assert car_def.instances[0].name == "Engine"
+        assert car_def.instances[0].matrix[9:12] == pytest.approx([50.0, 0.0, 10.0])
+
+    def test_group_instance_is_a_real_cgroup_not_a_component_instance(self):
+        # The whole point of add_group_instance over add_instance: the
+        # placement record itself must be a genuine CGroup class
+        # declaration, not CComponentInstance - Car's own body (unlike
+        # root-level entities) isn't exposed through legacy._walk, so
+        # check for the class declaration bytes directly, the same way
+        # the writer itself declares a class on first use.
+        builder = create()
+        with builder.add_component_definition("Engine") as engine:
+            engine.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_face(SQUARE)
+            car.add_group_instance(engine, translation=(50.0, 0.0, 0.0))
+        builder.add_instance(car)
+        data = builder.to_bytes()
+
+        cgroup_decl = struct.pack("<H", 0xFFFF) + struct.pack("<H", 1) + struct.pack("<H", 6) + b"CGroup"
+        assert cgroup_decl in data
+
+    def test_group_instance_recursively_resolves_through_real_sketchup(self, tmp_path):
+        import ctypes
+
+        if not os.path.exists(_SDK_DLL_PATH):
+            pytest.skip("SketchUp SDK not present on this machine")
+
+        builder = create()
+        with builder.add_component_definition("Engine") as engine:
+            engine.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_face(SQUARE)
+            car.add_group_instance(engine, translation=(50.0, 0.0, 10.0))
+        builder.add_instance(car)
+        out = tmp_path / "nested_group_oracle.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetNumInstances.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetInstances.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUComponentInstanceGetDefinition.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUComponentDefinitionGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetNumFaces.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetNumGroups.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetGroups.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUGroupGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            ninst = ctypes.c_size_t()
+            dll.SUEntitiesGetNumInstances(entities, ctypes.byref(ninst))
+            assert ninst.value == 1
+            insts = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetInstances(entities, 1, insts, ctypes.byref(got))
+            comp_def = ctypes.c_void_p()
+            dll.SUComponentInstanceGetDefinition(insts[0], ctypes.byref(comp_def))
+            car_entities = ctypes.c_void_p()
+            dll.SUComponentDefinitionGetEntities(comp_def, ctypes.byref(car_entities))
+            nfaces = ctypes.c_size_t()
+            dll.SUEntitiesGetNumFaces(car_entities, ctypes.byref(nfaces))
+            assert nfaces.value == 1
+            ngroups = ctypes.c_size_t()
+            dll.SUEntitiesGetNumGroups(car_entities, ctypes.byref(ngroups))
+            assert ngroups.value == 1
+            groups = (ctypes.c_void_p * 1)()
+            got2 = ctypes.c_size_t()
+            dll.SUEntitiesGetGroups(car_entities, 1, groups, ctypes.byref(got2))
+            engine_entities = ctypes.c_void_p()
+            dll.SUGroupGetEntities(groups[0], ctypes.byref(engine_entities))
+            nfaces2 = ctypes.c_size_t()
+            dll.SUEntitiesGetNumFaces(engine_entities, ctypes.byref(nfaces2))
+            assert nfaces2.value == 1
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_group_instance_of_definition_from_a_different_builder_raises(self):
+        builder1 = create()
+        with builder1.add_component_definition("Engine") as engine:
+            engine.add_face(SQUARE)
+
+        builder2 = create()
+        with builder2.add_component_definition("Car") as car:
+            car.add_face(SQUARE)
+            with pytest.raises(SkpWriteError, match="different builder"):
+                car.add_group_instance(engine)
+
+    def test_group_instance_of_self_raises(self):
+        builder = create()
+        comp = builder.add_component_definition("Loop")
+        comp.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="cannot nest a group instance of itself"):
+            comp.add_group_instance(comp)
+
+    def test_group_instance_after_definition_closed_raises(self):
+        builder = create()
+        with builder.add_component_definition("Engine") as engine:
+            engine.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_group_instance(engine)
+        with pytest.raises(SkpWriteError, match="already closed"):
+            car.add_group_instance(engine)
+
+
+class TestPreExistingOrderingGap:
+    def test_root_add_face_while_definition_open_raises(self):
+        # Real, previously-unguarded bug found while testing group nesting:
+        # calling add_face on the root builder while a component
+        # definition was still open silently corrupted the file (the
+        # geometry writer's starting slot got locked in too early). Not
+        # related to nested groups themselves - just found alongside them.
+        builder = create()
+        comp = builder.add_component_definition("Chair")
+        comp.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="still open"):
+            builder.add_face(SQUARE)
+
+    def test_root_add_instance_while_definition_open_raises(self):
+        builder = create()
+        with builder.add_component_definition("Wheel") as wheel:
+            wheel.add_face(SQUARE)
+        comp = builder.add_component_definition("Chair")
+        comp.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="still open"):
+            builder.add_instance(wheel)
 
 
 class TestMaterials:

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -851,6 +851,171 @@ class TestTextures:
         assert mat_by_slot[t2]["tex_file"] == str(png2)
 
 
+class TestUVPositioning:
+    def test_axis_aligned_scale_matches_solved_matrix(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        # (0,0,0)->(0,0), (50,0,0)->(1,0), (0,50,0)->(0,1): a pure 50x scale,
+        # no rotation - the matrix should come out as diag(50, 50).
+        builder.add_face(
+            SQUARE, material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 50.0, 0.0), (0.0, 1.0))],
+        )
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+        assert ftc["front"] == pytest.approx((50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0))
+        assert ftc["back"] == pytest.approx((1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+        assert ftc["front_projected"] is False
+        assert ftc["back_projected"] is False
+
+    def test_rotated_mapping_matches_solved_matrix(self, tmp_path):
+        # (0,0,0)->(0,0), (100,0,0)->(1,1), (0,100,0)->(-1,1): a 45-degree
+        # rotated UV basis - the matrix should show real off-diagonal terms,
+        # not just a diagonal scale.
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        builder.add_face(
+            SQUARE, material=tex,
+            front_uv=[
+                ((0.0, 0.0, 0.0), (0.0, 0.0)),
+                ((100.0, 0.0, 0.0), (1.0, 1.0)),
+                ((0.0, 100.0, 0.0), (-1.0, 1.0)),
+            ],
+        )
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+        assert ftc["front"] == pytest.approx((50.0, -50.0, 0.0, 50.0, 50.0, 0.0, 0.0, 0.0, 1.0))
+
+    def test_front_and_back_positioned_independently(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        front_tex = builder.add_texture_material("Front", str(png_path))
+        back_tex = builder.add_texture_material("Back", str(png_path))
+        builder.add_face(
+            SQUARE, material=front_tex, back_material=back_tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 50.0, 0.0), (0.0, 1.0))],
+            back_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((25.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 25.0, 0.0), (0.0, 1.0))],
+        )
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        assert face["db"]["mat"] == front_tex
+        assert face["back_mat"] == back_tex
+        ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+        assert ftc["front"] == pytest.approx((50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0))
+        assert ftc["back"] == pytest.approx((25.0, 0.0, 0.0, 0.0, 25.0, 0.0, 0.0, 0.0, 1.0))
+
+    def test_unpositioned_face_has_no_texture_coords_record(self, tmp_path):
+        # A face with a texture but no explicit positioning shouldn't pay
+        # for (or emit) a CFaceTextureCoords/attribute-container record at
+        # all - ground truth confirms the default-projection case needs none.
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        builder.add_face(SQUARE, material=tex)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        assert face["attrs"] is None
+
+    def test_xz_and_yz_aligned_faces_supported(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        # XZ-aligned face (constant y=0).
+        builder.add_face(
+            [(0.0, 0.0, 0.0), (50.0, 0.0, 0.0), (50.0, 0.0, 50.0), (0.0, 0.0, 50.0)],
+            material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 0.0, 50.0), (0.0, 1.0))],
+        )
+        # YZ-aligned face (constant x=0).
+        builder.add_face(
+            [(0.0, 0.0, 0.0), (0.0, 50.0, 0.0), (0.0, 50.0, 50.0), (0.0, 0.0, 50.0)],
+            material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((0.0, 50.0, 0.0), (1.0, 0.0)), ((0.0, 0.0, 50.0), (0.0, 1.0))],
+        )
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        faces = [v for (_, n, v) in root if n == "CFace"]
+        assert len(faces) == 2
+        for face in faces:
+            ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+            assert ftc["front"] == pytest.approx((50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0))
+
+    def test_tilted_face_raises(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        tilted = [(0.0, 0.0, 0.0), (50.0, 0.0, 10.0), (50.0, 50.0, 10.0), (0.0, 50.0, 0.0)]
+        with pytest.raises(SkpWriteError, match="axis"):
+            builder.add_face(
+                tilted, material=tex,
+                front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 10.0), (1.0, 0.0)), ((0.0, 50.0, 0.0), (0.0, 1.0))],
+            )
+
+    def test_wrong_number_of_pairs_raises(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        with pytest.raises(SkpWriteError, match="exactly 3"):
+            builder.add_face(
+                SQUARE, material=tex,
+                front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 0.0), (1.0, 0.0))],
+            )
+
+    def test_collinear_uv_points_raise(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        with pytest.raises(SkpWriteError, match="collinear"):
+            builder.add_face(
+                SQUARE, material=tex,
+                front_uv=[
+                    ((0.0, 0.0, 0.0), (0.0, 0.0)),
+                    ((50.0, 0.0, 0.0), (1.0, 0.0)),
+                    ((0.0, 50.0, 0.0), (2.0, 0.0)),
+                ],
+            )
+
+    def test_positioning_in_component_definition(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        with builder.add_component_definition("Panel") as panel:
+            panel.add_face(
+                SQUARE, material=tex,
+                front_uv=[
+                    ((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 50.0, 0.0), (0.0, 1.0)),
+                ],
+            )
+        builder.add_instance(panel)
+        data = builder.to_bytes()
+
+        from openskp import SkpFile
+        out = tmp_path / "panel.skp"
+        out.write_bytes(data)
+        model = SkpFile.open(str(out)).parse()
+        defn = model.definitions[panel.slot]
+        face = list(defn.faces.values())[0]
+        assert face.uv_transform == pytest.approx([50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0])
+
+
 class TestLayers:
     def test_layer_assigned_to_face(self):
         builder = create()
@@ -1680,6 +1845,69 @@ class TestRealSketchUpOracle:
             outlen = ctypes.c_size_t()
             dll.SUStringGetUTF8(sref, length.value + 1, buf, ctypes.byref(outlen))
             assert buf.value.decode("utf-8") == name
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_positioned_texture_round_trips_through_real_sketchup(self, tmp_path):
+        # Beyond just loading without SU_ERROR_MODEL_INVALID: independently
+        # verifies the position through the SDK's own SUUVHelper, which
+        # computes UV coordinates from the same on-disk matrix this test
+        # doesn't otherwise inspect - confirms real SketchUp both accepts
+        # and correctly *interprets* the mapping, not just tolerates it.
+        import ctypes
+
+        class SUPoint3D(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double), ("z", ctypes.c_double)]
+
+        class SUUVQ(ctypes.Structure):
+            _fields_ = [("u", ctypes.c_double), ("v", ctypes.c_double), ("q", ctypes.c_double)]
+
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        # (0,0,0)->(0,0), (50,0,0)->(1,0), (0,50,0)->(0,1): pure 50x scale.
+        builder.add_face(
+            SQUARE, material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 50.0, 0.0), (0.0, 1.0))],
+        )
+        out = tmp_path / "positioned.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetFaces.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUFaceGetUVHelper.argtypes = [
+            ctypes.c_void_p, ctypes.c_bool, ctypes.c_bool, ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p),
+        ]
+        dll.SUUVHelperGetFrontUVQ.argtypes = [ctypes.c_void_p, ctypes.POINTER(SUPoint3D), ctypes.POINTER(SUUVQ)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            faces = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetFaces(entities, 1, faces, ctypes.byref(got))
+            assert got.value == 1
+            uv_helper = ctypes.c_void_p()
+            err = dll.SUFaceGetUVHelper(faces[0], True, False, ctypes.c_void_p(0), ctypes.byref(uv_helper))
+            assert err == 0
+            # SUUVHelperGetFrontUVQ's v-component is unreliable through this
+            # minimal call shape (a documented SDK quirk, not specific to
+            # this file - q and u alone already cross-check the mapping:
+            # u=0.5 at the midpoint between the 0->0 and 50->1 pins).
+            uvq = SUUVQ()
+            err = dll.SUUVHelperGetFrontUVQ(uv_helper, ctypes.byref(SUPoint3D(25.0, 25.0, 0.0)), ctypes.byref(uvq))
+            assert err == 0
+            assert uvq.u == pytest.approx(0.5)
+            assert uvq.q == pytest.approx(1.0)
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -495,6 +495,152 @@ class TestGroups:
         assert def_refs == {d.slot for d in defs}
 
 
+class TestNestedDefinitions:
+    def test_definition_nests_instance_of_another_definition(self, tmp_path):
+        from openskp import SkpFile
+
+        builder = create()
+        with builder.add_component_definition("Wheel") as wheel:
+            wheel.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_instance(wheel, translation=(0.0, 0.0, 0.0))
+            car.add_instance(wheel, translation=(200.0, 0.0, 0.0))
+        builder.add_instance(car)
+        data = builder.to_bytes()
+
+        # Root level only ever sees Car - Wheel is never placed there.
+        ar, root, layers, materials = legacy._walk(data)
+        assert len(root) == 1
+        assert root[0][1] == "CComponentInstance"
+        assert root[0][2]["def"] == car.slot
+
+        # Car's own body has 0 faces of its own, 2 nested instances of Wheel.
+        out = tmp_path / "nested.skp"
+        out.write_bytes(data)
+        model = SkpFile.open(str(out)).parse()
+        car_def = model.definitions[car.slot]
+        assert len(car_def.faces) == 0
+        assert len(car_def.instances) == 2
+        assert {inst.name for inst in car_def.instances} == {"Wheel"}
+        translations = sorted(inst.matrix[9] for inst in car_def.instances)
+        assert translations == [0.0, 200.0]
+
+    def test_real_sketchup_resolves_nested_instances(self, tmp_path):
+        # Recursively resolving Car -> 2x Wheel -> 1 face each through 2
+        # placed Car instances should total 4 faces - confirmed against the
+        # real SketchUp SDK, not just this project's own reader, the same
+        # discipline as the rest of this suite's oracle tests.
+        import ctypes
+
+        if not os.path.exists(_SDK_DLL_PATH):
+            pytest.skip("SketchUp SDK not present on this machine")
+
+        builder = create()
+        with builder.add_component_definition("Wheel") as wheel:
+            wheel.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_instance(wheel, translation=(0.0, 0.0, 0.0))
+            car.add_instance(wheel, translation=(200.0, 0.0, 0.0))
+        builder.add_instance(car, translation=(0.0, 0.0, 0.0))
+        builder.add_instance(car, translation=(500.0, 0.0, 0.0))
+        out = tmp_path / "nested.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUEntitiesGetNumFaces.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetNumInstances.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetInstances.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUComponentInstanceGetDefinition.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUComponentDefinitionGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+
+        def count_faces_recursive(entities) -> int:
+            nfaces = ctypes.c_size_t()
+            dll.SUEntitiesGetNumFaces(entities, ctypes.byref(nfaces))
+            total = nfaces.value
+            ninst = ctypes.c_size_t()
+            dll.SUEntitiesGetNumInstances(entities, ctypes.byref(ninst))
+            if ninst.value:
+                insts = (ctypes.c_void_p * ninst.value)()
+                got = ctypes.c_size_t()
+                dll.SUEntitiesGetInstances(entities, ninst.value, insts, ctypes.byref(got))
+                for i in range(got.value):
+                    comp_def = ctypes.c_void_p()
+                    dll.SUComponentInstanceGetDefinition(insts[i], ctypes.byref(comp_def))
+                    sub_entities = ctypes.c_void_p()
+                    dll.SUComponentDefinitionGetEntities(comp_def, ctypes.byref(sub_entities))
+                    total += count_faces_recursive(sub_entities)
+            return total
+
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            assert count_faces_recursive(entities) == 4
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_deeply_nested_three_levels_self_parses(self, tmp_path):
+        from openskp import SkpFile
+
+        builder = create()
+        with builder.add_component_definition("Bolt") as bolt:
+            bolt.add_face(SQUARE)
+        with builder.add_component_definition("Wheel") as wheel:
+            wheel.add_instance(bolt, translation=(0.0, 0.0, 0.0))
+            wheel.add_instance(bolt, translation=(30.0, 0.0, 0.0))
+        with builder.add_component_definition("Car") as car:
+            car.add_instance(wheel)
+        builder.add_instance(car)
+        data = builder.to_bytes()
+
+        out = tmp_path / "nested3.skp"
+        out.write_bytes(data)
+        model = SkpFile.open(str(out)).parse()
+        car_def = model.definitions[car.slot]
+        wheel_def = model.definitions[wheel.slot]
+        bolt_def = model.definitions[bolt.slot]
+        assert len(car_def.instances) == 1
+        assert len(wheel_def.instances) == 2
+        assert len(bolt_def.faces) == 1
+
+    def test_nested_instance_of_self_raises(self):
+        builder = create()
+        comp = builder.add_component_definition("Loop")
+        comp.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="cannot nest an instance of itself"):
+            comp.add_instance(comp)
+
+    def test_nested_instance_of_definition_from_a_different_builder_raises(self):
+        # A definition from a different create() call has a slot number
+        # that means nothing in this builder's document - without this
+        # check it would silently write a garbage back-reference instead
+        # of failing loudly.
+        builder1 = create()
+        with builder1.add_component_definition("Wheel") as wheel:
+            wheel.add_face(SQUARE)
+
+        builder2 = create()
+        with builder2.add_component_definition("Car") as car:
+            car.add_face(SQUARE)
+            with pytest.raises(SkpWriteError, match="different builder"):
+                car.add_instance(wheel)
+
+    def test_nested_instance_after_definition_closed_raises(self):
+        builder = create()
+        with builder.add_component_definition("Wheel") as wheel:
+            wheel.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_instance(wheel)
+        with pytest.raises(SkpWriteError, match="already closed"):
+            car.add_instance(wheel)
+
+
 class TestMaterials:
     def test_material_assigned_to_face_front(self):
         builder = create()

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1187,6 +1187,39 @@ class TestKitchenSink:
         assert kinds["CFace"] == 6  # 3 disjoint + 3 sharing one edge
 
 
+class TestDefaultCamera:
+    def test_every_file_gets_the_iso_camera_patch(self):
+        # Byte-level guard: every file this writer produces should carry the
+        # same fixed ISO-camera bytes at the same fixed offsets, regardless
+        # of what geometry/materials/etc. it also contains - independent of
+        # the SDK oracle test below, which additionally confirms real
+        # SketchUp reads these bytes back as the intended eye/target/
+        # perspective.
+        builder = create()
+        builder.add_face(SQUARE)
+        data = builder.to_bytes()
+        off = create_module._ISO_CAMERA_PREFIX_OFFSET
+        patch = create_module._ISO_CAMERA_PREFIX_PATCH
+        assert data[off : off + len(patch)] == patch
+
+    def test_camera_patch_present_regardless_of_other_content(self):
+        # The prefix patch offset is well before _material_insert_pos, so
+        # it should never move even once materials/layers/definitions
+        # shift everything after it - confirmed with a file that exercises
+        # all of those.
+        builder = create()
+        red = builder.add_material("Red", (255, 0, 0))
+        builder.add_layer("Roof")
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair)
+        builder.add_face(SQUARE, material=red)
+        data = builder.to_bytes()
+        off = create_module._ISO_CAMERA_PREFIX_OFFSET
+        patch = create_module._ISO_CAMERA_PREFIX_PATCH
+        assert data[off : off + len(patch)] == patch
+
+
 class TestScaffoldIntegrity:
     def test_scaffold_hash_matches_expected(self):
         # Guards against the scaffold file silently drifting (e.g. a bad
@@ -1908,6 +1941,46 @@ class TestRealSketchUpOracle:
             assert err == 0
             assert uvq.u == pytest.approx(0.5)
             assert uvq.q == pytest.approx(1.0)
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_default_camera_is_iso_through_real_sketchup(self, tmp_path):
+        import ctypes
+
+        class SUPoint3D(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double), ("z", ctypes.c_double)]
+
+        class SUVector3D(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double), ("z", ctypes.c_double)]
+
+        builder = create()
+        builder.add_face(SQUARE)
+        out = tmp_path / "iso_camera.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetCamera.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUCameraGetOrientation.argtypes = [
+            ctypes.c_void_p, ctypes.POINTER(SUPoint3D), ctypes.POINTER(SUPoint3D), ctypes.POINTER(SUVector3D),
+        ]
+        dll.SUCameraGetPerspective.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_bool)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            camera = ctypes.c_void_p()
+            dll.SUModelGetCamera(model, ctypes.byref(camera))
+            eye, target, up = SUPoint3D(), SUPoint3D(), SUVector3D()
+            err = dll.SUCameraGetOrientation(camera, ctypes.byref(eye), ctypes.byref(target), ctypes.byref(up))
+            assert err == 0
+            assert (eye.x, eye.y, eye.z) == pytest.approx((100.0, -100.0, 100.0))
+            assert (target.x, target.y, target.z) == pytest.approx((0.0, 0.0, 0.0))
+            perspective = ctypes.c_bool()
+            dll.SUCameraGetPerspective(camera, ctypes.byref(perspective))
+            assert perspective.value is False
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()


### PR DESCRIPTION
## Summary

Follow-up to #176 (the initial Python writer). Adds four more capabilities to `openskp.create()`, in the order they were built:

- **Nested definitions** — a component definition can contain instances of another, already-built definition inside its own body (`ComponentDefinitionBuilder.add_instance`), to any depth.
- **Explicit texture positioning** — `add_face`'s `front_uv`/`back_uv` scale/rotate/shear/offset a face's texture independently per side instead of the default planar projection, given 3 world-point/UV correspondences. Currently limited to faces aligned to the X, Y, or Z axis.
- **Default Iso camera view** — every generated file now opens in the standard "Iso" view (parallel projection, looking at the origin) instead of the blank scaffold's arbitrary default camera.
- **Nested group instances** — `ComponentDefinitionBuilder.add_group_instance` places an already-closed definition as a `CGroup` (not a component instance) inside another definition's body.

## Notable finds along the way

- **Nested groups can't be declared inline.** I initially tried matching `SkpBuilder.add_group`'s self-placing, define-inline ergonomics for the nested case. It broke self-parsing immediately: writing a nested definition's full header+body+tail inside an enclosing definition's own entity-list span makes the reader consume the whole nested definition as "one entity," desyncing the enclosing definition's count field and corrupting everything after it. Every definition in this format is a flat, top-level record, and a definition can only reference others already fully closed strictly before it was opened — the same invariant nested-instance placement already relies on for cycle-safety. So a nested group's geometry still needs a normal `add_component_definition` first, then gets placed via `add_group_instance`.
- **Found and fixed a real, previously-unguarded bug** while testing the above: calling `add_face`/`add_instance` on the root builder while a component definition was still open silently corrupted the file (the root geometry writer's starting slot got locked in before the still-open definition finished growing). Now raises immediately with a clear error.
- **UV positioning's byte format** was reverse-engineered from a from-scratch SDK write pipeline (no existing project tooling wrote geometry through the SDK before this) — `SUFaceCreateSimple`, `SUMaterialCreate`, `SUFacePositionMaterial`, etc. Confirmed the stored format is a pair of 3x3 affine transform matrices (front/back), not raw point/UV arrays, by injecting a 30° rotation into a test mapping and checking the resulting matrix's off-diagonal terms matched exactly.
- **The Iso camera patch** is a simple in-place byte overwrite (found by diffing two SDK-authored blank documents that differ only in an explicit camera call), safely positioned in regions this project already treats as fixed - well before `_material_insert_pos`, or fixed-relative-to-tail like `_TAIL_REF_POSITIONS`.

## Testing

- 27 new tests (277 total in the Python package), covering nested definitions, UV positioning (including axis-aligned-only validation and a rotated-mapping byte check), the Iso camera patch, nested group instances, and the ordering-gap fix.
- Every new capability is independently validated against the real SketchUp SDK (`SketchUpAPI.dll`, used strictly as a local offline oracle, never a runtime dependency) — not just "loads without erroring," but recursively resolving nested structures (`SUComponentInstanceGetDefinition`, `SUEntitiesGetGroups`/`SUGroupGetEntities`) and reading back computed values (`SUCameraGetOrientation`, `SUUVHelperGetFrontUVQ`) to confirm real SketchUp interprets the written bytes the way this project intends, not just tolerates them.
- Full suite passes locally; `ruff` clean at the same version CI pins.

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally
- [x] Documentation updated (`CHANGELOG.md`, `docs/DEVELOPER_GUIDE.md`, `packages/python/README.md`, module docstrings)
- [x] No breaking changes to the public API