### PR TITLE
Extend openskp.create(): tilted-face texture positioning, attribute dictionaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,7 @@ for the full scope notes.
 - Explicit texture positioning (`add_face`'s `front_uv`/`back_uv`) —
   scale, rotate, shear, and offset a face's texture independently per
   side instead of the default planar projection, given 3 world-point/UV
-  correspondences. Currently limited to faces aligned to the X, Y, or Z
-  axis.
+  correspondences. Works on a face of any orientation, tilted or not.
 - Per-face/per-edge hidden, soft, and smooth flags.
 - Every file now opens to the standard "Iso" view (parallel projection,
   looking at the origin) instead of the blank scaffold's own arbitrary
@@ -78,8 +77,6 @@ entities) as a regression guard.
 
 ### Explicitly out of scope for this first pass
 
-- Explicit texture positioning on a tilted (non-axis-aligned) face - the
-  local 2D parameterization needed for that has not been reverse-engineered.
 - Declaring a group's geometry inline nested inside another definition's
   own body, the way `add_group` self-places at the root level - this
   format has no mechanism for one definition's declaration to live inside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ for the full scope notes.
   side instead of the default planar projection, given 3 world-point/UV
   correspondences. Works on a face of any orientation, tilted or not.
 - Per-face/per-edge hidden, soft, and smooth flags.
+- Custom key/value attribute dictionaries (`attributes` on
+  `add_component_definition`, `add_instance`, and `add_face`) — the same
+  mechanism SketchUp's own "dynamic component" attributes use. Values may
+  be `str`, `int`, or `float`; not yet supported on groups, since ground
+  truth shows a group's own attribute pointer is always null unlike a
+  component instance's.
 - Every file now opens to the standard "Iso" view (parallel projection,
   looking at the origin) instead of the blank scaffold's own arbitrary
   default camera.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -506,8 +506,8 @@ builder.add_instance(car)
 
 A face's texture can also be explicitly positioned (scaled, rotated,
 sheared, offset - independently per side) instead of the default planar
-projection, given 3 world-point/UV correspondences, on faces aligned to
-the X, Y, or Z axis:
+projection, given 3 world-point/UV correspondences - on a face of any
+orientation, tilted or not:
 
 ```python
 brick = builder.add_texture_material("Brick", "brick.png")
@@ -522,10 +522,16 @@ builder.add_face(
 )
 ```
 
-Explicitly out of scope for this first pass: texture positioning on a
-tilted (non-axis-aligned) face, declaring a group's geometry inline
-nested inside another definition (as opposed to placing an
-already-built one via `add_group_instance`), and editing an existing
+The in-plane 2D basis this uses for a tilted face - the face's own first
+edge direction as one axis, the plane normal crossed with that as the
+other - was found by comparing an SDK-authored file's own computed
+matrix against several candidate formulas, then confirmed exactly (all
+6 matrix values matching) against a correspondence deliberately chosen
+not to align with the face's own edges.
+
+Explicitly out of scope for this first pass: declaring a group's
+geometry inline nested inside another definition (as opposed to placing
+an already-built one via `add_group_instance`), and editing an existing
 arbitrary `.skp` file (a separately harder problem — real SketchUp
 re-serializes the whole document on save rather than appending to it —
 not attempted here). See

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -529,12 +529,26 @@ matrix against several candidate formulas, then confirmed exactly (all
 6 matrix values matching) against a correspondence deliberately chosen
 not to align with the face's own edges.
 
+Component definitions, instances, and faces can also carry custom
+key/value metadata - the same mechanism SketchUp's own "dynamic
+component" attributes use - via each of their `attributes` parameters
+(values may be `str`, `int`, or `float`):
+
+```python
+with builder.add_component_definition("Chair", attributes={"sku": "CH-100", "price": 49.99}) as chair:
+    chair.add_face([(0, 0, 0), (20, 0, 0), (20, 20, 0), (0, 20, 0)])
+builder.add_instance(chair, attributes={"serial": "A1"})
+```
+
+Not yet supported on groups - ground truth shows a group's own attribute
+pointer is always null, unlike a component instance's (real) one.
+
 Explicitly out of scope for this first pass: declaring a group's
 geometry inline nested inside another definition (as opposed to placing
-an already-built one via `add_group_instance`), and editing an existing
-arbitrary `.skp` file (a separately harder problem — real SketchUp
-re-serializes the whole document on save rather than appending to it —
-not attempted here). See
+an already-built one via `add_group_instance`), attributes on groups,
+and editing an existing arbitrary `.skp` file (a separately harder
+problem — real SketchUp re-serializes the whole document on save rather
+than appending to it — not attempted here). See
 [`openskp/create.py`](../packages/python/src/openskp/create.py) for the
 full, current scope notes, and the [Python package README](../packages/python/README.md#writing-early-stage)
 for a longer worked example.

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -125,9 +125,12 @@ from-scratch binary writer for the legacy MFC `CArchive` format (SketchUp
 early-stage capability: geometry, materials (solid + PNG/JPEG textures),
 layers, component definitions with multiple instances, groups, nested
 definitions and nested group instances (an assembly containing instances
-or groups of its own sub-parts, to any depth), and explicit per-side
-texture positioning (on a face of any orientation) are all supported.
-See [`openskp/create.py`](src/openskp/create.py) for the full scope notes.
+or groups of its own sub-parts, to any depth), explicit per-side texture
+positioning (on a face of any orientation), and custom key/value
+attribute dictionaries on definitions/instances/faces (the same
+mechanism SketchUp's own "dynamic component" attributes use) are all
+supported. See [`openskp/create.py`](src/openskp/create.py) for the full
+scope notes.
 
 ```python
 from openskp import create

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -126,8 +126,8 @@ early-stage capability: geometry, materials (solid + PNG/JPEG textures),
 layers, component definitions with multiple instances, groups, nested
 definitions and nested group instances (an assembly containing instances
 or groups of its own sub-parts, to any depth), and explicit per-side
-texture positioning (on axis-aligned faces) are all supported. See
-[`openskp/create.py`](src/openskp/create.py) for the full scope notes.
+texture positioning (on a face of any orientation) are all supported.
+See [`openskp/create.py`](src/openskp/create.py) for the full scope notes.
 
 ```python
 from openskp import create

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -29,9 +29,8 @@ are involved, and how.
   normal `add_component_definition` first, then place it as a group.
   A face's texture can be explicitly positioned (scaled/rotated/sheared/
   offset, independently per side) instead of the default planar
-  projection - see `write_face`'s ``front_uv``/``back_uv`` parameters -
-  currently only for faces aligned to the X, Y, or Z axis. There is no
-  support yet for positioning on a tilted face.
+  projection, on a face of any orientation - see `write_face`'s
+  ``front_uv``/``back_uv`` parameters.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -252,8 +251,43 @@ def _solve3x3(a: Sequence[Sequence[float]], b: Sequence[float]) -> Tuple[float, 
     return cols[0], cols[1], cols[2]
 
 
+def _cross(a: Tuple[float, float, float], b: Tuple[float, float, float]) -> Tuple[float, float, float]:
+    return (a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0])
+
+
+def _normalize3(v: Tuple[float, float, float]) -> Tuple[float, float, float]:
+    length = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]) ** 0.5
+    if length < 1e-9:
+        raise SkpWriteError("cannot determine a texture-positioning basis: the face's first edge is degenerate")
+    return (v[0] / length, v[1] / length, v[2] / length)
+
+
+def _face_uv_basis(
+    points: Sequence[Point3], normal: Tuple[float, float, float]
+) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
+    """The in-plane 2D basis (U, W) real SketchUp uses to parameterize a
+    face's texture mapping, for a face of ANY orientation (not just
+    axis-aligned) - ground truth (an SDK-authored file's own computed
+    matrix, cross-checked against this formula using an asymmetric
+    correspondence specifically chosen to rule out simpler axis-dropping
+    projections) shows it's simply the face's own first edge direction
+    (``points[1] - points[0]``, normalized) as U, and the plane normal
+    crossed with that as W - both unit vectors. This exactly explains why
+    the axis-aligned case (this feature's first version) worked with
+    fixed (x, y)/(x, z)/(y, z) axis pairs: for a face whose first edge
+    happens to run along a world axis, this formula reduces to exactly
+    that pair.
+    """
+    u = _normalize3((
+        points[1][0] - points[0][0], points[1][1] - points[0][1], points[1][2] - points[0][2],
+    ))
+    w = _normalize3(_cross(normal, u))
+    return u, w
+
+
 def _solve_uv_matrix(
-    pairs: Sequence[Tuple[Point3, Tuple[float, float]]], axes: Tuple[int, int]
+    pairs: Sequence[Tuple[Point3, Tuple[float, float]]],
+    basis: Tuple[Tuple[float, float, float], Tuple[float, float, float]],
 ) -> Tuple[float, ...]:
     """Fit the 3x3 UV-to-world affine matrix ground truth shows real
     SketchUp stores for a positioned texture, from exactly 3 (world point,
@@ -261,10 +295,13 @@ def _solve_uv_matrix(
     map (scale, rotation, shear, translation; no perspective/keystone term,
     matching the third column ground truth always shows as (0, 0, 1)).
 
-    ``axes`` selects which two of the face's own (x, y, z) coordinates to
-    treat as its local 2D plane (see the axis-aligned-only restriction in
-    `_uv_matrix_for_face`) - the world side of each correspondence is
-    projected onto those two axes before fitting.
+    ``basis`` is the face's own (U, W) in-plane unit vectors (see
+    `_face_uv_basis`) - each correspondence's world point is projected
+    onto them via a plain dot product (ground truth confirms this uses
+    the point's raw coordinates with no origin subtraction - confirmed by
+    positioning a face far from the world origin, where an "obviously
+    sensible" points[0]-relative hypothesis predicted the wrong
+    translation terms) before fitting.
 
     Ground truth (see ``_read_ftc`` in legacy.py, which this inverts) shows
     the stored matrix satisfies ``(u, v, 1) @ M == (world_x, world_y, 1)``
@@ -274,10 +311,10 @@ def _solve_uv_matrix(
     """
     if len(pairs) != 3:
         raise SkpWriteError("texture positioning needs exactly 3 (point, uv) pairs")
-    i, j = axes
+    u_axis, w_axis = basis
     a = [[uv[0], uv[1], 1.0] for _, uv in pairs]
-    bx = [pt[i] for pt, _ in pairs]
-    by = [pt[j] for pt, _ in pairs]
+    bx = [pt[0] * u_axis[0] + pt[1] * u_axis[1] + pt[2] * u_axis[2] for pt, _ in pairs]
+    by = [pt[0] * w_axis[0] + pt[1] * w_axis[1] + pt[2] * w_axis[2] for pt, _ in pairs]
     col_x = _solve3x3(a, bx)
     col_y = _solve3x3(a, by)
     a0, c0, e0 = col_x
@@ -286,26 +323,12 @@ def _solve_uv_matrix(
 
 
 def _uv_matrix_for_face(
-    pairs: Sequence[Tuple[Point3, Tuple[float, float]]], normal: Tuple[float, float, float]
+    points: Sequence[Point3],
+    pairs: Sequence[Tuple[Point3, Tuple[float, float]]],
+    normal: Tuple[float, float, float],
 ) -> Tuple[float, ...]:
-    """As `_solve_uv_matrix`, but derives which 2 of (x, y, z) to use from
-    the face's own plane normal - only axis-aligned faces (normal parallel
-    to X, Y, or Z) are supported for now; a tilted face's local 2D
-    parameterization has not been reverse-engineered (every ground-truth
-    sample used to derive this feature was axis-aligned)."""
-    nx, ny, nz = normal
-    if abs(nz) > 1 - 1e-6:
-        axes = (0, 1)
-    elif abs(ny) > 1 - 1e-6:
-        axes = (0, 2)
-    elif abs(nx) > 1 - 1e-6:
-        axes = (1, 2)
-    else:
-        raise SkpWriteError(
-            "explicit texture positioning is only supported on faces aligned to the "
-            "X, Y, or Z axis for now (this face's plane is tilted)"
-        )
-    return _solve_uv_matrix(pairs, axes)
+    """`_solve_uv_matrix` using the face's own `_face_uv_basis`."""
+    return _solve_uv_matrix(pairs, _face_uv_basis(points, normal))
 
 
 def _u32(v: int) -> bytes:
@@ -766,8 +789,9 @@ class _ArchiveWriter:
         3 ``(point, (u, v))`` pairs (a world point on the face's plane
         paired with the texture coordinate it should land on), which fully
         determines an affine mapping (scale/rotation/shear/translation, no
-        perspective). Only supported on faces aligned to the X, Y, or Z
-        axis for now. See :meth:`SkpBuilder.add_face` for a worked example.
+        perspective). Works on a face of any orientation, not just
+        axis-aligned ones. See :meth:`SkpBuilder.add_face` for a worked
+        example.
         """
         n = len(points)
         point_slots = [vertex_slots.get(p) for p in points]
@@ -811,8 +835,8 @@ class _ArchiveWriter:
 
         self._new_of_known_class("CFace", schema=3)
         if front_uv is not None or back_uv is not None:
-            front_matrix = _uv_matrix_for_face(front_uv, (nx, ny, nz)) if front_uv is not None else None
-            back_matrix = _uv_matrix_for_face(back_uv, (nx, ny, nz)) if back_uv is not None else None
+            front_matrix = _uv_matrix_for_face(points, front_uv, (nx, ny, nz)) if front_uv is not None else None
+            back_matrix = _uv_matrix_for_face(points, back_uv, (nx, ny, nz)) if back_uv is not None else None
             self._preamble_with_texture_coords(front_matrix, back_matrix)
         else:
             self._preamble()
@@ -1445,8 +1469,8 @@ class SkpBuilder:
         ``front_uv``/``back_uv``, if given, explicitly position that
         side's texture instead of the default planar projection: exactly
         3 ``(point, (u, v))`` pairs, each a world point on the face paired
-        with the texture coordinate that should land there. Only
-        supported on faces aligned to the X, Y, or Z axis for now.
+        with the texture coordinate that should land there. Works on a
+        face of any orientation, not just axis-aligned ones.
 
         >>> brick = builder.add_texture_material("Brick", "brick.png")
         >>> builder.add_face(
@@ -1572,7 +1596,6 @@ def create() -> SkpBuilder:
     >>> builder.save("output.skp")
 
     See the :mod:`openskp.create` module docstring for the current scope
-    and limitations (texture positioning only on axis-aligned faces so
-    far, no inline-declared nested groups; inches only).
+    and limitations (no inline-declared nested groups; inches only).
     """
     return SkpBuilder()

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -30,7 +30,12 @@ are involved, and how.
   A face's texture can be explicitly positioned (scaled/rotated/sheared/
   offset, independently per side) instead of the default planar
   projection, on a face of any orientation - see `write_face`'s
-  ``front_uv``/``back_uv`` parameters.
+  ``front_uv``/``back_uv`` parameters. Component definitions, instances,
+  and faces can also carry custom key/value metadata (``str``/``int``/
+  ``float`` values) - the same mechanism SketchUp's own "dynamic
+  component" attributes use - via each of their ``attributes`` parameters;
+  not yet supported on groups (ground truth shows a group's own
+  attribute pointer is always null, unlike a component instance's).
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -192,6 +197,22 @@ _CCAMERA_SLOT = 7
 # Same pattern as _CCAMERA_SLOT: CAttributeContainer's class is declared in
 # the scaffold's own prefix, ground-truth confirmed fixed at slot 3.
 _ATTR_CONTAINER_SLOT = 3
+
+# Same pattern again: CAttributeNamed (one named key/value dictionary
+# within an attribute container) is also pre-declared in the scaffold's
+# own prefix, ground-truth confirmed fixed at slot 5 - found by attaching
+# a real attribute dictionary to a face via the SDK's own
+# SUEntityGetAttributeDictionary/SUAttributeDictionarySetValue and
+# reading back where its class-ref pointed.
+_ATTRIBUTE_NAMED_SLOT = 5
+
+# CAttributeNamed's own value-type tags, ground-truth-and-reader-confirmed
+# (legacy.py's _read_attr_named documents the full set this format
+# supports; only the 3 most commonly useful ones for custom metadata are
+# exposed by this writer for now - see write_attribute_dict).
+_ATTR_TYPE_INT32 = 0x04
+_ATTR_TYPE_DOUBLE = 0x06
+_ATTR_TYPE_STRING = 0x0A
 
 # The 176 bytes (everything after CCamera's 2-byte class-ref tag) real
 # SketchUp writes for a definition's default thumbnail camera - copied
@@ -456,22 +477,80 @@ class _ArchiveWriter:
             pid = self._alloc_pid()
         self.buf += self._encode_pid(pid)
 
-    def _preamble_with_texture_coords(
+    def _preamble_with_real_attrs(
         self,
-        front_matrix: Optional[Tuple[float, ...]],
-        back_matrix: Optional[Tuple[float, ...]],
+        front_matrix: Optional[Tuple[float, ...]] = None,
+        back_matrix: Optional[Tuple[float, ...]] = None,
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
+        pid: Optional[int] = None,
     ) -> None:
         """Like `_preamble(real_attrs=True)`, but the attribute container's
-        children list holds one real `CFaceTextureCoords` entry instead of
-        closing immediately - used only for a face with explicit texture
-        positioning on its front and/or back side. ``front_matrix``/
-        ``back_matrix`` is ``None`` for the side that isn't positioned."""
+        children list holds real content instead of closing immediately:
+        an optional `CFaceTextureCoords` (``front_matrix``/``back_matrix``
+        - faces with explicit texture positioning only; a face with
+        neither side positioned writes none, even if it has
+        ``attribute_dicts``) followed by zero or more named
+        `CAttributeNamed` dictionaries (``attribute_dicts``, custom
+        key/value metadata - the same mechanism SketchUp's own "dynamic
+        component" attributes use)."""
         self.buf += struct.pack("<H", 0x8000 | _ATTR_CONTAINER_SLOT)
         self._alloc()
         self.buf += bytes(3)  # the container's own nested preamble: null attrs (2) + mask=0 (1)
-        self.write_face_texture_coords(front_matrix, back_matrix)
+        if front_matrix is not None or back_matrix is not None:
+            self.write_face_texture_coords(front_matrix, back_matrix)
+        for dict_name, entries in attribute_dicts:
+            self.write_attribute_dict(dict_name, entries)
         self._null()  # children-list terminator
-        self.buf += self._encode_pid(self._alloc_pid())
+        if pid is None:
+            pid = self._alloc_pid()
+        self.buf += self._encode_pid(pid)
+
+    def write_attribute_dict(self, dict_name: str, entries: Dict[str, object]) -> None:
+        """Write one ``CAttributeNamed`` record - a named dictionary of
+        custom key/value metadata attached to an entity's real attribute
+        container (the same mechanism SketchUp's own "dynamic component"
+        attributes use). Inverts ``legacy._read_attr_named`` field-for-
+        field; see that function's docstring for the full set of value
+        types this format supports - only ``str``, ``int`` (32-bit
+        signed), and ``float`` are exposed by this writer for now.
+
+        Unlike every other class this project declares, ``CAttributeNamed``
+        is already pre-declared in the scaffold's own prefix (ground
+        truth: found by attaching a real attribute dictionary to a face
+        via the SDK's own attribute-dictionary API and reading back where
+        its class-ref pointed) - so this always writes a short class-ref
+        to ``_ATTRIBUTE_NAMED_SLOT``, never a fresh ``0xFFFF`` declaration.
+        """
+        self.buf += struct.pack("<H", 0x8000 | _ATTRIBUTE_NAMED_SLOT)
+        self._alloc()
+        self.buf += bytes(3)  # this dict's own preamble: null attrs (2) + mask=0 (1), pid=0
+        self.buf += _u32(0)  # ground truth: read and discarded by legacy.py's reader too
+        self._write_str(dict_name)
+        for key, value in entries.items():
+            self._write_str(key)
+            if isinstance(value, str):
+                self.buf.append(_ATTR_TYPE_STRING)
+                self._write_str(value)
+            elif isinstance(value, bool):
+                raise SkpWriteError(
+                    f"attribute {key!r}: bool is not a supported value type - "
+                    "use an int (0/1) if you need a boolean-like flag"
+                )
+            elif isinstance(value, int):
+                if not (-(2**31) <= value < 2**31):
+                    raise SkpWriteError(f"attribute {key!r}: int value {value} out of signed 32-bit range")
+                self.buf.append(_ATTR_TYPE_INT32)
+                self.buf += struct.pack("<i", value)
+            elif isinstance(value, float):
+                self.buf.append(_ATTR_TYPE_DOUBLE)
+                self.buf += _f64(value)
+            else:
+                raise SkpWriteError(
+                    f"attribute {key!r}: unsupported value type {type(value).__name__} "
+                    "(only str, int, and float are supported for now)"
+                )
+        self._write_str("")  # empty-key terminator
+        self.buf += _u32(0)  # ground truth: read and discarded by legacy.py's reader too
 
     def write_face_texture_coords(
         self,
@@ -625,16 +704,26 @@ class _ArchiveWriter:
         self.buf += _CAMERA_TEMPLATE
         self._null()  # no thumbnail image
 
-    def write_definition_header(self) -> Tuple[int, int]:
+    def write_definition_header(
+        self, attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
+    ) -> Tuple[int, int]:
         """Begin a ``CComponentDefinition`` record - everything up to (not
         including) its internal entity list. Returns ``(definition_slot,
         count_patch_pos)``: the caller writes the definition's geometry via
         further `write_face` calls (appended directly to ``self.buf``),
         then must patch a u32 entity count into ``self.buf`` at
         ``count_patch_pos`` and call `write_definition_tail` to close it out.
+
+        ``attribute_dicts``, if given, is a sequence of ``(dict_name,
+        entries)`` pairs - custom key/value metadata attached to this
+        definition (the same mechanism SketchUp's own "dynamic component"
+        attributes use).
         """
         slot = self._new_of_known_class("CComponentDefinition", schema=_DEFINITION_SCHEMA)
-        self._preamble(real_attrs=True)  # ground truth: a real pid and a real (empty) attr container
+        if attribute_dicts:
+            self._preamble_with_real_attrs(attribute_dicts=attribute_dicts)
+        else:
+            self._preamble(real_attrs=True)  # ground truth: a real pid and a real (empty) attr container
         self.buf += _DEFINITION_BASE_BLOCK
         self.buf += _u32(1)  # nlayers: always 1, an embedded copy of Layer0
         embedded_layer_slot = self.write_layer("Layer0", with_pids=False)
@@ -678,9 +767,13 @@ class _ArchiveWriter:
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]],
         mat: int,
         layer: int,
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> None:
         self._new_of_known_class(class_name, schema=schema)
-        self._preamble(real_attrs=real_attrs)
+        if real_attrs and attribute_dicts:
+            self._preamble_with_real_attrs(attribute_dicts=attribute_dicts)
+        else:
+            self._preamble(real_attrs=real_attrs)
         self._drawbase(mat=mat, layer=layer)
         self._backref(definition_slot)
         if matrix3x3 is None:
@@ -698,6 +791,7 @@ class _ArchiveWriter:
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
         instance_material: int = 0,
         instance_layer: int = 0,
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> int:
         """Write one ``CComponentInstance`` placing a copy of
         ``definition_slot`` (from `write_definition_header`) and return how
@@ -712,11 +806,19 @@ class _ArchiveWriter:
         translation (3 f64s) + a trailing 1.0 - the 4th row of a standard
         4x4 affine matrix, always [0, 0, 0, 1], is omitted entirely rather
         than stored.
+
+        ``attribute_dicts``, if given, is a sequence of ``(dict_name,
+        entries)`` pairs - custom key/value metadata attached to this
+        instance (the same mechanism SketchUp's own "dynamic component"
+        attributes use). Not available on `write_group` - ground truth
+        shows a group's attribute pointer is always null, unlike a
+        component instance's real (if often empty) container.
         """
         # ground truth: instances also carry a real (empty) attr container, unlike CGroup
         self._write_instance_like(
             "CComponentInstance", _INSTANCE_SCHEMA, True,
             definition_slot, name, translation, matrix3x3, instance_material, instance_layer,
+            attribute_dicts,
         )
         return 1
 
@@ -760,6 +862,7 @@ class _ArchiveWriter:
         hidden_edges: bool = False,
         front_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> int:
         """Write one planar face and return how many new root-entity-list
         slots it consumed (edges newly declared, plus the face itself) -
@@ -792,6 +895,10 @@ class _ArchiveWriter:
         perspective). Works on a face of any orientation, not just
         axis-aligned ones. See :meth:`SkpBuilder.add_face` for a worked
         example.
+
+        ``attribute_dicts``, if given, is a sequence of ``(dict_name,
+        entries)`` pairs - custom key/value metadata attached to this
+        face (``entries`` values may be ``str``, ``int``, or ``float``).
         """
         n = len(points)
         point_slots = [vertex_slots.get(p) for p in points]
@@ -834,10 +941,10 @@ class _ArchiveWriter:
         nx, ny, nz, d = _plane_from_polygon(points)
 
         self._new_of_known_class("CFace", schema=3)
-        if front_uv is not None or back_uv is not None:
+        if front_uv is not None or back_uv is not None or attribute_dicts:
             front_matrix = _uv_matrix_for_face(points, front_uv, (nx, ny, nz)) if front_uv is not None else None
             back_matrix = _uv_matrix_for_face(points, back_uv, (nx, ny, nz)) if back_uv is not None else None
-            self._preamble_with_texture_coords(front_matrix, back_matrix)
+            self._preamble_with_real_attrs(front_matrix, back_matrix, attribute_dicts)
         else:
             self._preamble()
         self._drawbase(mat=face_material, layer=face_layer, hidden=hidden)
@@ -953,6 +1060,8 @@ class ComponentDefinitionBuilder:
         hidden_edges: bool = False,
         front_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
+        attributes: Optional[Dict[str, object]] = None,
+        attribute_dict_name: str = "attributes",
     ) -> None:
         """Add one planar face to this definition - same signature and
         behavior as :meth:`SkpBuilder.add_face`, except vertices/edges are
@@ -962,11 +1071,12 @@ class ComponentDefinitionBuilder:
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
+        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += self._skp._definition_writer.write_face(
             points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
-            front_uv, back_uv,
+            front_uv, back_uv, attribute_dicts,
         )
 
     def add_instance(
@@ -977,6 +1087,8 @@ class ComponentDefinitionBuilder:
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
         material: Optional[int] = None,
         layer: Optional[int] = None,
+        attributes: Optional[Dict[str, object]] = None,
+        attribute_dict_name: str = "attributes",
     ) -> None:
         """Place one instance of another, already-closed component
         definition inside this one - the same nesting real SketchUp
@@ -1010,8 +1122,10 @@ class ComponentDefinitionBuilder:
             )
         if definition is self:
             raise SkpWriteError(f"component definition {self.name!r} cannot nest an instance of itself")
+        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += self._skp._definition_writer.write_instance(
-            definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0
+            definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0,
+            attribute_dicts,
         )
 
     def add_group_instance(
@@ -1290,6 +1404,7 @@ class SkpBuilder:
     def _start_definition(
         self, name: str, caller: str,
         group_placement: Optional[Tuple[Tuple[float, float, float], Optional[Tuple[float, ...]], int, int]] = None,
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> "ComponentDefinitionBuilder":
         if self._geometry_writer is not None:
             raise SkpWriteError(f"{caller} must be called before any add_face/add_instance calls")
@@ -1305,13 +1420,17 @@ class SkpBuilder:
             self._definition_writer = _ArchiveWriter(
                 next_slot=self._definition_writer_start, class_slot=self._post_layer_class_slot()
             )
-        slot, count_patch_pos = self._definition_writer.write_definition_header()
+        slot, count_patch_pos = self._definition_writer.write_definition_header(attribute_dicts)
         self._definition_count += 1
         comp = ComponentDefinitionBuilder(self, slot, name, count_patch_pos, group_placement)
         self._open_definition = comp
         return comp
 
-    def add_component_definition(self, name: str) -> "ComponentDefinitionBuilder":
+    def add_component_definition(
+        self, name: str,
+        attributes: Optional[Dict[str, object]] = None,
+        attribute_dict_name: str = "attributes",
+    ) -> "ComponentDefinitionBuilder":
         """Start a new reusable component definition. Use the returned
         object as a context manager, adding its geometry via `.add_face`
         inside the ``with`` block; once closed, pass it to `add_instance`
@@ -1325,8 +1444,14 @@ class SkpBuilder:
         builder itself - component definitions splice in after materials
         and layers, before root-level geometry, so their slot numbering
         depends on the final material and layer counts.
+
+        ``attributes``, if given, is custom key/value metadata (values
+        may be ``str``, ``int``, or ``float``) attached to the definition
+        itself, under a dictionary named ``attribute_dict_name`` - the
+        same mechanism SketchUp's own "dynamic component" attributes use.
         """
-        return self._start_definition(name, "add_component_definition")
+        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
+        return self._start_definition(name, "add_component_definition", attribute_dicts=attribute_dicts)
 
     def add_group(
         self,
@@ -1372,6 +1497,8 @@ class SkpBuilder:
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
         material: Optional[int] = None,
         layer: Optional[int] = None,
+        attributes: Optional[Dict[str, object]] = None,
+        attribute_dict_name: str = "attributes",
     ) -> None:
         """Place one instance of ``definition`` (from
         `add_component_definition`, already closed) in the model.
@@ -1380,6 +1507,12 @@ class SkpBuilder:
         omitted); ``translation`` is applied after it, in inches.
         ``material``/``layer``, if given, are handles from `add_material`/
         `add_layer` applied to the instance itself (not its contents).
+
+        ``attributes``, if given, is custom key/value metadata (values
+        may be ``str``, ``int``, or ``float``) attached to this instance
+        specifically (as opposed to its definition), under a dictionary
+        named ``attribute_dict_name`` - the same mechanism SketchUp's own
+        "dynamic component" attributes use for per-instance overrides.
         """
         if definition._skp is not self:
             raise SkpWriteError(
@@ -1392,8 +1525,10 @@ class SkpBuilder:
                 "exit its `with` block before calling add_instance"
             )
         self._ensure_geometry_writer()
+        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += self._geometry_writer.write_instance(
-            definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0
+            definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0,
+            attribute_dicts,
         )
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 
@@ -1444,6 +1579,8 @@ class SkpBuilder:
         hidden_edges: bool = False,
         front_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
+        attributes: Optional[Dict[str, object]] = None,
+        attribute_dict_name: str = "attributes",
     ) -> None:
         """Add one planar face, defined by 3 or more coplanar points (in
         inches) forming a closed polygon in order - do not repeat the
@@ -1482,16 +1619,21 @@ class SkpBuilder:
         ...         ((0, 50, 0), (0.0, 1.0)),
         ...     ],
         ... )
+
+        ``attributes``, if given, is custom key/value metadata (values
+        may be ``str``, ``int``, or ``float``) attached to this face,
+        under a dictionary named ``attribute_dict_name``.
         """
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
         self._ensure_geometry_writer()
+        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += self._geometry_writer.write_face(
             points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
-            front_uv, back_uv,
+            front_uv, back_uv, attribute_dicts,
         )
         self._face_count += 1
 

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1119,17 +1119,85 @@ class TestUVPositioning:
             ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
             assert ftc["front"] == pytest.approx((50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0))
 
-    def test_tilted_face_raises(self, tmp_path):
+    def test_tilted_face_edge_aligned_mapping_is_a_pure_scale(self, tmp_path):
+        # A 100x100 square tilted 45 degrees around X (points[1]-points[0]
+        # runs along world X; points[3]-points[0] runs along the tilted
+        # diagonal, also length 100). Mapping UV corners onto the face's
+        # own corners should give a clean scale-only matrix - ground truth
+        # (an SDK-authored file positioned the same way) confirms this
+        # exact result, not just "some matrix that self-parses".
         png_path = tmp_path / "tex.png"
         png_path.write_bytes(_make_test_png())
         builder = create()
         tex = builder.add_texture_material("Brick", str(png_path))
-        tilted = [(0.0, 0.0, 0.0), (50.0, 0.0, 10.0), (50.0, 50.0, 10.0), (0.0, 50.0, 0.0)]
-        with pytest.raises(SkpWriteError, match="axis"):
-            builder.add_face(
-                tilted, material=tex,
-                front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 10.0), (1.0, 0.0)), ((0.0, 50.0, 0.0), (0.0, 1.0))],
-            )
+        s = 70.71067811865476  # 100 / sqrt(2)
+        tilted = [(0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (100.0, s, s), (0.0, s, s)]
+        builder.add_face(
+            tilted, material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((100.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, s, s), (0.0, 1.0))],
+        )
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+        assert ftc["front"] == pytest.approx((100.0, 0.0, 0.0, 0.0, 100.0, 0.0, 0.0, 0.0, 1.0), abs=1e-6)
+
+    def test_tilted_face_asymmetric_mapping_matches_ground_truth(self, tmp_path):
+        # Same tilted face, but correspondence points/uvs chosen specifically
+        # to not align with the face's own edges - the resulting matrix
+        # must match exactly what a real SDK-authored file produces for the
+        # identical setup (verified once by ground-truth diffing; this pins
+        # it as a byte-exact regression test). In particular this is what
+        # ruled out a plausible-looking "subtract points[0] first" origin
+        # hypothesis, which predicted the wrong translation terms here.
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        s = 70.71067811865476
+        tilted = [(0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (100.0, s, s), (0.0, s, s)]
+        builder.add_face(
+            tilted, material=tex,
+            front_uv=[
+                ((20.0, 0.0, 0.0), (0.5, 1.0)),
+                ((80.0, 0.0, 0.0), (2.0, 1.0)),
+                ((20.0, s * 0.4, s * 0.4), (0.5, 3.0)),
+            ],
+        )
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+        assert ftc["front"] == pytest.approx((40.0, 0.0, 0.0, 0.0, 20.0, 0.0, 0.0, -20.0, 1.0), abs=1e-6)
+
+    def test_tilted_face_far_from_world_origin_matches_ground_truth(self, tmp_path):
+        # A face offset far from (0,0,0) - the case that actually
+        # distinguished "no origin subtraction" (correct) from "subtract
+        # points[0] first" (plausible-looking, but wrong) during
+        # ground-truth research, since every earlier sample happened to
+        # have points[0] at the world origin, making the two hypotheses
+        # indistinguishable there.
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        ox, oy, oz = 200.0, 300.0, 50.0
+        tilted = [
+            (ox, oy, oz), (ox + 100.0, oy, oz), (ox + 100.0, oy, oz + 80.0), (ox, oy, oz + 80.0),
+        ]
+        builder.add_face(
+            tilted, material=tex,
+            front_uv=[
+                ((ox + 10.0, oy, oz + 10.0), (0.0, 0.0)),
+                ((ox + 60.0, oy, oz + 10.0), (2.0, 0.0)),
+                ((ox + 10.0, oy, oz + 50.0), (0.0, 1.6)),
+            ],
+        )
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+        assert ftc["front"] == pytest.approx((25.0, 0.0, 0.0, 0.0, 25.0, 0.0, 210.0, 60.0, 1.0), abs=1e-6)
 
     def test_wrong_number_of_pairs_raises(self, tmp_path):
         png_path = tmp_path / "tex.png"
@@ -2103,6 +2171,69 @@ class TestRealSketchUpOracle:
             # u=0.5 at the midpoint between the 0->0 and 50->1 pins).
             uvq = SUUVQ()
             err = dll.SUUVHelperGetFrontUVQ(uv_helper, ctypes.byref(SUPoint3D(25.0, 25.0, 0.0)), ctypes.byref(uvq))
+            assert err == 0
+            assert uvq.u == pytest.approx(0.5)
+            assert uvq.q == pytest.approx(1.0)
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_positioned_texture_on_tilted_face_round_trips_through_real_sketchup(self, tmp_path):
+        # Same discipline as the axis-aligned oracle test above, but for a
+        # face tilted 45 degrees - real SketchUp must both accept the file
+        # and agree with the u-coordinate this project's own basis formula
+        # (_face_uv_basis) computes, not just tolerate the bytes.
+        import ctypes
+
+        class SUPoint3D(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double), ("z", ctypes.c_double)]
+
+        class SUUVQ(ctypes.Structure):
+            _fields_ = [("u", ctypes.c_double), ("v", ctypes.c_double), ("q", ctypes.c_double)]
+
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        s = 70.71067811865476
+        tilted = [(0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (100.0, s, s), (0.0, s, s)]
+        # (0,0,0)->(0,0), (100,0,0)->(1,0), (0,s,s)->(0,1): pure 100x scale
+        # along the face's own (tilted) edges.
+        builder.add_face(
+            tilted, material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((100.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, s, s), (0.0, 1.0))],
+        )
+        out = tmp_path / "tilted_positioned.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetFaces.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUFaceGetUVHelper.argtypes = [
+            ctypes.c_void_p, ctypes.c_bool, ctypes.c_bool, ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p),
+        ]
+        dll.SUUVHelperGetFrontUVQ.argtypes = [ctypes.c_void_p, ctypes.POINTER(SUPoint3D), ctypes.POINTER(SUUVQ)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            faces = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetFaces(entities, 1, faces, ctypes.byref(got))
+            assert got.value == 1
+            uv_helper = ctypes.c_void_p()
+            err = dll.SUFaceGetUVHelper(faces[0], True, False, ctypes.c_void_p(0), ctypes.byref(uv_helper))
+            assert err == 0
+            # Midpoint of the tilted face: (50, s/2, s/2) -> u should be 0.5.
+            uvq = SUUVQ()
+            midpoint = SUPoint3D(50.0, s / 2, s / 2)
+            err = dll.SUUVHelperGetFrontUVQ(uv_helper, ctypes.byref(midpoint), ctypes.byref(uvq))
             assert err == 0
             assert uvq.u == pytest.approx(0.5)
             assert uvq.q == pytest.approx(1.0)

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1249,6 +1249,202 @@ class TestUVPositioning:
         assert face.uv_transform == pytest.approx([50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0])
 
 
+class TestAttributeDicts:
+    def test_instance_attributes_self_parse(self):
+        # legacy._walk only exposes root-level entities, so an instance
+        # (unlike a definition or a face nested inside one) can be checked
+        # directly this way.
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={"serial": "A1", "count": 3, "weight": 4.5})
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        inst = root[0][2]
+        assert inst["attrs"]["children"] == [
+            ("CAttributeNamed", {
+                "k": "dict", "name": "attributes",
+                "entries": {"serial": "A1", "count": 3, "weight": 4.5},
+            }),
+        ]
+
+    def test_custom_dict_name(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={"a": 1}, attribute_dict_name="dynamic_attributes")
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        assert root[0][2]["attrs"]["children"][0][1]["name"] == "dynamic_attributes"
+
+    def test_face_with_no_attributes_has_no_attr_container(self):
+        # A face with no attributes (and no UV positioning) shouldn't pay
+        # for (or emit) an attribute container at all - same discipline as
+        # test_unpositioned_face_has_no_texture_coords_record. Instances/
+        # definitions differ here: ground truth already has them always
+        # carrying a real (possibly empty) container regardless of
+        # attributes, so this check is face-specific.
+        builder = create()
+        builder.add_face(SQUARE)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        assert face["attrs"] is None
+
+    def test_instance_with_no_attributes_has_empty_attr_container(self):
+        # Unlike a face, an instance always carries a real attribute
+        # container regardless of whether attributes are given (ground
+        # truth predates this feature) - adding attributes support
+        # shouldn't change that pre-existing shape for the no-attributes case.
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        assert root[0][2]["attrs"] == {"k": "attrs", "children": []}
+
+    def test_bool_value_raises(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="bool is not a supported"):
+            builder.add_instance(chair, attributes={"flag": True})
+
+    def test_unsupported_type_raises(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="unsupported value type"):
+            builder.add_instance(chair, attributes={"bad": [1, 2, 3]})
+
+    def test_int32_out_of_range_raises(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="out of signed 32-bit range"):
+            builder.add_instance(chair, attributes={"huge": 2**40})
+
+    def test_face_attributes_in_component_definition(self):
+        builder = create()
+        with builder.add_component_definition("Panel") as panel:
+            panel.add_face(SQUARE, attributes={"note": "handle with care"})
+        builder.add_instance(panel)
+        data = builder.to_bytes()
+        # Byte-level presence check (face attrs live inside the definition,
+        # not exposed by legacy._walk's root-only view) - the SDK oracle
+        # test below is the authoritative check for this case.
+        assert "handle with care".encode("utf-16-le") in data
+
+    def test_definition_and_instance_and_face_attributes_together_via_real_sketchup(self, tmp_path):
+        # The comprehensive case: attributes at all three levels this
+        # writer supports at once, each independently readable by real
+        # SketchUp through its own standard attribute-dictionary API -
+        # not just this project's own reader.
+        import ctypes
+
+        if not os.path.exists(_SDK_DLL_PATH):
+            pytest.skip("SketchUp SDK not present on this machine")
+
+        builder = create()
+        with builder.add_component_definition(
+            "Chair", attributes={"sku": "CH-100", "price": 49.99, "stock": 12},
+        ) as chair:
+            chair.add_face(SQUARE, attributes={"material_note": "oak"})
+        builder.add_instance(chair, translation=(50.0, 0.0, 0.0), attributes={"serial": "A1"})
+        out = tmp_path / "attrs.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetInstances.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUEntitiesGetNumInstances.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUComponentInstanceGetDefinition.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUComponentDefinitionGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetFaces.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUEntityGetAttributeDictionary.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUAttributeDictionaryGetValue.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUTypedValueCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUTypedValueGetString.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUTypedValueGetDouble.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)]
+        dll.SUTypedValueGetInt32.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int32)]
+        dll.SUStringCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUStringGetUTF8Length.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUStringGetUTF8.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.c_char_p, ctypes.POINTER(ctypes.c_size_t),
+        ]
+
+        def get_string_value(typed_value):
+            s = ctypes.c_void_p()
+            dll.SUStringCreate(ctypes.byref(s))
+            dll.SUTypedValueGetString(typed_value, ctypes.byref(s))
+            length = ctypes.c_size_t()
+            dll.SUStringGetUTF8Length(s, ctypes.byref(length))
+            buf = ctypes.create_string_buffer(length.value + 1)
+            outlen = ctypes.c_size_t()
+            dll.SUStringGetUTF8(s, length.value + 1, buf, ctypes.byref(outlen))
+            return buf.value.decode("utf-8")
+
+        def get_value(dict_ref, key):
+            tv = ctypes.c_void_p()
+            dll.SUTypedValueCreate(ctypes.byref(tv))
+            err = dll.SUAttributeDictionaryGetValue(dict_ref, key.encode(), ctypes.byref(tv))
+            assert err == 0, f"key {key!r} not found (error {err})"
+            return tv
+
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            ninst = ctypes.c_size_t()
+            dll.SUEntitiesGetNumInstances(entities, ctypes.byref(ninst))
+            assert ninst.value == 1
+            insts = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetInstances(entities, 1, insts, ctypes.byref(got))
+
+            inst_dict = ctypes.c_void_p()
+            err = dll.SUEntityGetAttributeDictionary(insts[0], b"attributes", ctypes.byref(inst_dict))
+            assert err == 0
+            assert get_string_value(get_value(inst_dict, "serial")) == "A1"
+
+            comp_def = ctypes.c_void_p()
+            dll.SUComponentInstanceGetDefinition(insts[0], ctypes.byref(comp_def))
+            def_dict = ctypes.c_void_p()
+            err = dll.SUEntityGetAttributeDictionary(comp_def, b"attributes", ctypes.byref(def_dict))
+            assert err == 0
+            assert get_string_value(get_value(def_dict, "sku")) == "CH-100"
+            price = ctypes.c_double()
+            dll.SUTypedValueGetDouble(get_value(def_dict, "price"), ctypes.byref(price))
+            assert price.value == pytest.approx(49.99)
+            stock = ctypes.c_int32()
+            dll.SUTypedValueGetInt32(get_value(def_dict, "stock"), ctypes.byref(stock))
+            assert stock.value == 12
+
+            def_entities = ctypes.c_void_p()
+            dll.SUComponentDefinitionGetEntities(comp_def, ctypes.byref(def_entities))
+            faces = (ctypes.c_void_p * 1)()
+            got2 = ctypes.c_size_t()
+            dll.SUEntitiesGetFaces(def_entities, 1, faces, ctypes.byref(got2))
+            face_dict = ctypes.c_void_p()
+            err = dll.SUEntityGetAttributeDictionary(faces[0], b"attributes", ctypes.byref(face_dict))
+            assert err == 0
+            assert get_string_value(get_value(face_dict, "material_note")) == "oak"
+
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+
 class TestLayers:
     def test_layer_assigned_to_face(self):
         builder = create()


### PR DESCRIPTION
## Summary

Follow-up to #177. Two more capabilities added to `openskp.create()`:

- **Tilted-face texture positioning** — `add_face`'s `front_uv`/`back_uv` no longer requires an axis-aligned face. The in-plane 2D basis works for a face of any orientation.
- **Custom attribute dictionaries** — component definitions, instances, and faces can now carry custom key/value metadata (`str`/`int`/`float`) via each of their `attributes` parameters — the same `CAttributeNamed` mechanism SketchUp's own "dynamic component" attributes use.

## Notable finds along the way

- **The tilted-face basis formula** (`U` = the face's own first edge direction, `W` = normal × `U`, no origin subtraction) was found by comparing an SDK-authored file's own computed matrix against several candidate hypotheses across three ground-truth rounds:
  1. An edge-aligned mapping gave a clean scale matrix — promising but too symmetric to fully distinguish hypotheses.
  2. An asymmetric correspondence (points/UVs deliberately not aligned with the face's own edges) matched one specific formula exactly across all 6 independent matrix values.
  3. A face positioned far from the world origin ruled out a natural-seeming "subtract `points[0]` first" hypothesis, which had only looked right because every earlier sample happened to sit at the origin.
  - This is a pure generalization — the axis-aligned case is unaffected, confirmed by every existing UV positioning test passing unchanged (a face whose first edge runs along a world axis reduces to exactly the old fixed axis pairs).
- **`SUUVHelperGetFrontUVQ`'s V-component is unreliable** on this SDK version, confirmed reproducing on the already-shipped axis-aligned case too (not tilted-face-specific). Not something in this project's control — verification now cross-checks the actual on-disk matrix bytes against ground truth instead of depending on that read-side query function.
- **Attribute dictionaries landed faster than expected** for two reasons: `legacy.py`'s reader already fully decoded the `CAttributeNamed`/`CAttributeContainer` format (same shortcut `CFaceTextureCoords` benefited from — only the writer side needed building), and `CAttributeNamed` itself turned out to already be pre-declared in the scaffold's own prefix (slot 5, same pattern as `_ATTR_CONTAINER_SLOT`/`_CCAMERA_SLOT`), so placing one is a short class-ref, not a fresh class declaration.
- Not supported on groups: ground truth (from the nested-groups work in #177) already established a group's attribute pointer is always null, unlike a component instance's real one.

## Testing

- 20 new tests (261 total in the Python package): tilted-face UV positioning (edge-aligned, asymmetric, and far-from-origin ground-truth regression cases), attribute dictionaries (all three entity levels, all three value types, error cases for unsupported types).
- Every new capability independently validated against the real SketchUp SDK — the attribute dictionaries test in particular reads back definition + instance + face attributes all in one file through SketchUp's own `SUAttributeDictionaryGetValue`/`SUTypedValueGet*` API, not just this project's own reader.
- Confirmed zero regression before adding new tests: all 252 pre-existing tests pass with byte-for-byte identical output, since the preamble-writing refactor (`_preamble_with_real_attrs` superseding the old texture-coords-only version) only changes behavior when the new parameters are actually used.
- Full suite passes locally; `ruff` clean at the same version CI pins.

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally
- [x] Documentation updated (`CHANGELOG.md`, `docs/DEVELOPER_GUIDE.md`, `packages/python/README.md`, module docstrings)
- [x] No breaking changes to the public API