### PR TITLE
chore(deps): pin postcss to 8.5.23, fixing 2 Dependabot alerts

### DIFF
--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -2382,9 +2382,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2621,9 +2621,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2641,7 +2641,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -65,5 +65,8 @@
     "typescript": "^5.3.0",
     "typescript-eslint": "8.67.0",
     "vitest": "^1.0.0"
+  },
+  "overrides": {
+    "postcss": "8.5.23"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the 2 open Dependabot alerts (#7 high, #8 moderate) for postcss's sourceMappingURL path-traversal advisories, by pinning postcss to 8.5.23 via an npm `overrides` entry.

postcss is a transitive dependency (pulled in via vite), not a direct devDependency here, so there's no direct version to bump — `overrides` is the standard way to force a transitive dependency version.

## Why only postcss

Checked all 8 open alerts against the actual dependency graph before touching anything:

| Package | Needs | Blocker |
|---|---|---|
| postcss | 8.5.23 | none — fixed in this PR |
| vitest (critical) | 3.2.6+ | Node 18/rolldown incompatibility — confirmed in #163 and #167, both closed for this exact reason. Not just a 4.x issue; 3.x hits the same wall. |
| vite (x3 alerts) | 6.4.2+ | same Node 18/rolldown issue, tied to vitest (#164, closed) |
| esbuild, vite's nested copy | 0.25.0+ | vite 5.4.21 itself pins `esbuild: ^0.21.3` — only movable by bumping vite (blocked above) |
| esbuild, tsup's copy | 0.28.1+ | tsup 8.5.1 (latest release) still pins `esbuild: ^0.27.0` — genuine upstream gap, unrelated to the Node 18 decision |

The other 6 stay open, correctly, until either Node 18 support is deliberately dropped from CI or vitest/rolldown ships something compatible with it — and separately, until tsup releases esbuild 0.28.x support.

## Testing

- Lock file diff confirmed minimal: only `postcss` (8.5.15 → 8.5.23) and its own `nanoid` dependency moved — nothing else in the tree.
- Full local run: `npm test` (98/98 passing), `npm run lint`, `npm run typecheck`, `npm run build` — all clean.
- `npm audit` no longer lists postcss.

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally
- [x] Documentation updated (if applicable) — n/a, dependency-only change
- [x] No breaking changes to the public API