### PR TITLE
Add partial (open) arc support to the SKP writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,14 @@ for the full scope notes.
   not `num_segments` disconnected straight edges that merely trace that
   shape. Every edge in the tessellation shares one real curve backref,
   confirmed via the SDK's own `SUEdgeGetCurve`/`SUCurveGetType` to resolve
-  to a single, correctly-typed arc entity. A partial (open) arc and
-  freeform polyline curves (`CCurve`) are not yet exposed as public API.
+  to a single, correctly-typed arc entity.
+- Partial (open) arcs (`add_arc`) — the same genuine `CArcCurve` entity as
+  `add_circle`, but a chain of edges with no face, swept between
+  caller-given `start_angle`/`end_angle` (radians). Confirmed via the SDK
+  that the written endpoint coordinates land exactly where the requested
+  sweep says they should, not just that "some curve object" exists.
+  Freeform polyline curves (`CCurve`, distinct from a true arc) are not
+  yet exposed as public API.
 - Every file now opens to the standard "Iso" view (parallel projection,
   looking at the origin) instead of the blank scaffold's own arbitrary
   default camera.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -555,17 +555,30 @@ builder.add_circle((50, 50, 0), normal=(0, 0, 1), radius=40, num_segments=24)
 
 Confirmed against the real SDK: every edge's `SUEdgeGetCurve` resolves to
 the exact same curve object, typed as a genuine arc (`SUCurveGetType`)
-with the requested edge count. A partial (open) arc with no face, and
-freeform polyline curve grouping (`CCurve`, distinct from a true arc),
-aren't exposed as public API yet.
+with the requested edge count.
+
+A partial (open) arc (`add_arc`) is the same underlying `CArcCurve`
+entity, but a chain of edges with no face - given `start_angle`/
+`end_angle` (radians), swept from an arbitrary but fixed reference
+direction in the arc's own plane:
+
+```python
+import math
+builder.add_arc((50, 50, 0), normal=(0, 0, 1), radius=40, start_angle=0, end_angle=math.pi / 2)
+```
+
+Confirmed against the real SDK that the written endpoint coordinates
+land exactly where the requested sweep says they should - not just that
+some curve object exists with the right edge count. Freeform polyline
+curve grouping (`CCurve`, distinct from a true arc) isn't exposed as
+public API yet.
 
 Explicitly out of scope for this first pass: declaring a group's
 geometry inline nested inside another definition (as opposed to placing
 an already-built one via `add_group_instance`), attributes on groups,
-partial/open arcs, freeform polyline curves, and editing an existing
-arbitrary `.skp` file (a separately harder problem — real SketchUp
-re-serializes the whole document on save rather than appending to it —
-not attempted here). See
+freeform polyline curves, and editing an existing arbitrary `.skp` file
+(a separately harder problem — real SketchUp re-serializes the whole
+document on save rather than appending to it — not attempted here). See
 [`openskp/create.py`](../packages/python/src/openskp/create.py) for the
 full, current scope notes, and the [Python package README](../packages/python/README.md#writing-early-stage)
 for a longer worked example.

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -130,10 +130,10 @@ or groups of its own sub-parts, to any depth), explicit per-side texture
 positioning (on a face of any orientation), custom key/value
 attribute dictionaries on definitions/instances/faces (the same
 mechanism SketchUp's own "dynamic component" attributes use), and
-circular faces (genuine, editable-by-radius arc/circle entities, not
-disconnected straight edges that merely trace that shape) are all
-supported. See [`openskp/create.py`](src/openskp/create.py) for the full
-scope notes.
+circular faces and partial arcs (genuine, editable-by-radius arc/circle
+entities, not disconnected straight edges that merely trace that shape)
+are all supported. See [`openskp/create.py`](src/openskp/create.py) for
+the full scope notes.
 
 ```python
 from openskp import create
@@ -173,6 +173,10 @@ builder.add_face(
 
 # A true, editable circular face - not disconnected straight edges
 builder.add_circle((100, 75, 0), normal=(0, 0, 1), radius=30, num_segments=24)
+
+# A partial (open) arc - same real curve entity, but edges only, no face
+import math
+builder.add_arc((100, 75, 0), normal=(0, 0, 1), radius=30, start_angle=0, end_angle=math.pi / 2)
 
 builder.save("output.skp")
 ```

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -36,14 +36,13 @@ are involved, and how.
   component" attributes use - via each of their ``attributes`` parameters;
   not yet supported on groups (ground truth shows a group's own
   attribute pointer is always null, unlike a component instance's).
-  Circular faces - real, editable-by-radius SketchUp arc/circle
-  entities, not N disconnected straight edges that merely trace that
-  shape - are supported via :meth:`SkpBuilder.add_circle` /
-  :meth:`ComponentDefinitionBuilder.add_circle`; a partial (open) arc
-  with no face is a natural follow-up the underlying
-  :meth:`_ArchiveWriter.write_arc_curve` primitive already supports but
-  isn't yet exposed as public API, and freeform polyline curve grouping
-  (``CCurve``, distinct from a true arc) is also not yet supported.
+  Circular faces and partial (open) arcs - real, editable-by-radius
+  SketchUp arc/circle entities, not disconnected straight edges that
+  merely trace that shape - are supported via :meth:`SkpBuilder.
+  add_circle` / :meth:`SkpBuilder.add_arc` and their
+  :class:`ComponentDefinitionBuilder` equivalents; freeform polyline
+  curve grouping (``CCurve``, distinct from a true arc) is not yet
+  supported.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -353,6 +352,36 @@ def _circle_points(
     pts: List[Point3] = []
     for i in range(num_segments):
         angle = 2.0 * math.pi * i / num_segments
+        c, s = math.cos(angle), math.sin(angle)
+        pts.append((
+            center[0] + radius * (c * u[0] + s * w[0]),
+            center[1] + radius * (c * u[1] + s * w[1]),
+            center[2] + radius * (c * u[2] + s * w[2]),
+        ))
+    return pts
+
+
+def _arc_points(
+    center: Point3,
+    normal: Tuple[float, float, float],
+    radius: float,
+    num_segments: int,
+    u: Tuple[float, float, float],
+    w: Tuple[float, float, float],
+    start_angle: float,
+    end_angle: float,
+) -> List[Point3]:
+    """The ``num_segments + 1`` points (both endpoints included) tracing a
+    PARTIAL arc from ``start_angle`` to ``end_angle`` (radians, measured
+    from ``u`` toward ``w`` - the same convention :func:`_circle_points`
+    and :meth:`_ArchiveWriter.write_arc_curve` use, so this is a strict
+    generalization: ``_circle_points(...)`` is equivalent to
+    ``_arc_points(..., 0.0, 2*pi)[:-1]``, the closing point dropped since
+    a full circle's own last edge back to the start is implicit).
+    """
+    pts: List[Point3] = []
+    for i in range(num_segments + 1):
+        angle = start_angle + (end_angle - start_angle) * i / num_segments
         c, s = math.cos(angle), math.sin(angle)
         pts.append((
             center[0] + radius * (c * u[0] + s * w[0]),
@@ -946,6 +975,110 @@ class _ArchiveWriter:
         )
         return 1
 
+    def _write_edge_chain(
+        self,
+        points: Sequence[Point3],
+        vertex_slots: Dict[Point3, int],
+        edge_registry: Dict[FrozenSet[int], Tuple[int, int]],
+        closed: bool,
+        hidden_edges: bool = False,
+        soft_edges: bool = False,
+        smooth_edges: bool = False,
+        curve_params: Optional[
+            Tuple[Point3, Tuple[float, float, float], Tuple[float, float, float], float, float, float, int]
+        ] = None,
+    ) -> Tuple[List[int], List[int], int]:
+        """Write a chain of straight ``CEdge`` records connecting ``points``
+        in order, sharing vertices/edges via ``vertex_slots``/
+        ``edge_registry`` exactly like `write_face` (which uses this for
+        its own, always-``closed`` polygon boundary) - ``closed=True``
+        also connects the last point back to the first (an ``n``-edge
+        loop); ``closed=False`` stops after the last pair (an ``n-1``-edge
+        open chain, for a partial arc with no face).
+
+        Returns ``(edge_slots, edge_senses, new_entities)`` - the last is
+        how many new root-entity-list slots were consumed (edges newly
+        declared; the caller adds any of its own, e.g. a face record).
+
+        ``curve_params``, if given, is a ``(center, normal, xaxis,
+        start_angle, end_angle, radius, num_segments)`` tuple for
+        :meth:`write_arc_curve` - ground truth shows the shared
+        ``CArcCurve`` is declared inline as the FIRST newly-declared
+        edge's own "curve" field, and every other edge newly declared by
+        this call backrefs that same slot instead of writing a null curve.
+        """
+        n = len(points)
+        pair_count = n if closed else n - 1
+        point_slots = [vertex_slots.get(p) for p in points]
+        edge_slots: List[int] = []
+        edge_senses: List[int] = []
+        new_entities = 0
+        curve_slot: Optional[int] = None
+
+        for i in range(pair_count):
+            v1_idx, v2_idx = i, (i + 1) % n
+            v1_known, v2_known = point_slots[v1_idx], point_slots[v2_idx]
+            key = (
+                frozenset((v1_known, v2_known))
+                if v1_known is not None and v2_known is not None
+                else None
+            )
+            if key is not None and key in edge_registry:
+                edge_slot, fwd_v1 = edge_registry[key]
+                edge_slots.append(edge_slot)
+                edge_senses.append(0 if fwd_v1 == v1_known else 1)
+                continue
+
+            edge_slot = self._new_of_known_class("CEdge", schema=2)
+            self._preamble()
+            self._drawbase(hidden=hidden_edges, soft=soft_edges, smooth=smooth_edges)
+            for idx in (v1_idx, v2_idx):
+                if point_slots[idx] is None:
+                    point_slots[idx] = self._write_vertex(points[idx])
+                    vertex_slots[points[idx]] = point_slots[idx]
+                else:
+                    self._backref(point_slots[idx])
+            if curve_params is not None:
+                if curve_slot is None:
+                    curve_slot = self.write_arc_curve(*curve_params)
+                else:
+                    self._backref(curve_slot)
+            else:
+                self._null()  # curve = None
+            edge_slots.append(edge_slot)
+            edge_senses.append(0)
+            new_entities += 1
+            edge_registry[frozenset((point_slots[v1_idx], point_slots[v2_idx]))] = (
+                edge_slot,
+                point_slots[v1_idx],
+            )
+
+        return edge_slots, edge_senses, new_entities
+
+    def write_arc(
+        self,
+        points: Sequence[Point3],
+        vertex_slots: Dict[Point3, int],
+        edge_registry: Dict[FrozenSet[int], Tuple[int, int]],
+        curve_params: Tuple[Point3, Tuple[float, float, float], Tuple[float, float, float], float, float, float, int],
+        hidden_edges: bool = False,
+        soft_edges: bool = False,
+        smooth_edges: bool = False,
+    ) -> int:
+        """Write a partial (open) arc as a chain of straight ``CEdge``
+        records - no face, unlike `write_face`'s always-closed polygon
+        boundary. ``points`` are the ``num_segments + 1`` points along the
+        arc in order (see :func:`_arc_points`); ``curve_params`` are the
+        same args :meth:`write_arc_curve` needs, shared by every edge here
+        exactly like `write_face`'s ``curve_params``. Returns how many new
+        root-entity-list slots were consumed (edges newly declared).
+        """
+        _, _, new_entities = self._write_edge_chain(
+            points, vertex_slots, edge_registry, False,
+            hidden_edges, soft_edges, smooth_edges, curve_params,
+        )
+        return new_entities
+
     def write_face(
         self,
         points: Sequence[Point3],
@@ -1012,50 +1145,10 @@ class _ArchiveWriter:
         slot instead of writing a null curve. An edge already shared
         with a previous face is left alone either way.
         """
-        n = len(points)
-        point_slots = [vertex_slots.get(p) for p in points]
-        edge_slots: List[int] = []
-        edge_senses: List[int] = []
-        new_entities = 0
-        curve_slot: Optional[int] = None
-
-        for i in range(n):
-            v1_idx, v2_idx = i, (i + 1) % n
-            v1_known, v2_known = point_slots[v1_idx], point_slots[v2_idx]
-            key = (
-                frozenset((v1_known, v2_known))
-                if v1_known is not None and v2_known is not None
-                else None
-            )
-            if key is not None and key in edge_registry:
-                edge_slot, fwd_v1 = edge_registry[key]
-                edge_slots.append(edge_slot)
-                edge_senses.append(0 if fwd_v1 == v1_known else 1)
-                continue
-
-            edge_slot = self._new_of_known_class("CEdge", schema=2)
-            self._preamble()
-            self._drawbase(hidden=hidden_edges, soft=soft_edges, smooth=smooth_edges)
-            for idx in (v1_idx, v2_idx):
-                if point_slots[idx] is None:
-                    point_slots[idx] = self._write_vertex(points[idx])
-                    vertex_slots[points[idx]] = point_slots[idx]
-                else:
-                    self._backref(point_slots[idx])
-            if curve_params is not None:
-                if curve_slot is None:
-                    curve_slot = self.write_arc_curve(*curve_params)
-                else:
-                    self._backref(curve_slot)
-            else:
-                self._null()  # curve = None
-            edge_slots.append(edge_slot)
-            edge_senses.append(0)
-            new_entities += 1
-            edge_registry[frozenset((point_slots[v1_idx], point_slots[v2_idx]))] = (
-                edge_slot,
-                point_slots[v1_idx],
-            )
+        edge_slots, edge_senses, new_entities = self._write_edge_chain(
+            points, vertex_slots, edge_registry, True,
+            hidden_edges, soft_edges, smooth_edges, curve_params,
+        )
 
         nx, ny, nz, d = _plane_from_polygon(points)
 
@@ -1077,7 +1170,7 @@ class _ArchiveWriter:
         # silent-drop failure mode as the drawbase padding above.
         self.buf += bytes([1, 1])
 
-        for i in range(n):
+        for i in range(len(edge_slots)):
             self._new_of_known_class("CEdgeUse", schema=1)
             self._preamble(pid=0)
             self._backref(edge_slots[i])
@@ -1234,6 +1327,39 @@ class ComponentDefinitionBuilder:
             hidden, False, False, False,
             front_uv, back_uv, attribute_dicts,
             curve_params=curve_params,
+        )
+
+    def add_arc(
+        self,
+        center: Point3,
+        normal: Tuple[float, float, float],
+        radius: float,
+        start_angle: float,
+        end_angle: float,
+        num_segments: int = 24,
+        hidden_edges: bool = False,
+        soft_edges: bool = False,
+        smooth_edges: bool = False,
+    ) -> None:
+        """Add one partial (open) arc to this definition - same signature
+        and behavior as :meth:`SkpBuilder.add_arc`, except vertices/edges
+        are shared only within this definition."""
+        self._check_writable("arcs")
+        if not (3 <= num_segments <= 255):
+            raise SkpWriteError(f"num_segments must be between 3 and 255, got {num_segments}")
+        if end_angle == start_angle:
+            raise SkpWriteError("start_angle and end_angle must differ - use add_circle for a full circle")
+        center = (float(center[0]), float(center[1]), float(center[2]))
+        normal = _normalize3((float(normal[0]), float(normal[1]), float(normal[2])))
+        radius = float(radius)
+        writer = self._skp._definition_writer
+        u, w = _circle_basis(normal)
+        xaxis = (radius * u[0], radius * u[1], radius * u[2])
+        curve_params = (center, normal, xaxis, float(start_angle), float(end_angle), radius, num_segments)
+        points = _arc_points(center, normal, radius, num_segments, u, w, float(start_angle), float(end_angle))
+        self._new_entity_count += writer.write_arc(
+            points, self._vertex_slots, self._edge_registry, curve_params,
+            hidden_edges, soft_edges, smooth_edges,
         )
 
     def add_instance(
@@ -1845,6 +1971,59 @@ class SkpBuilder:
             curve_params=curve_params,
         )
         self._face_count += 1
+
+    def add_arc(
+        self,
+        center: Point3,
+        normal: Tuple[float, float, float],
+        radius: float,
+        start_angle: float,
+        end_angle: float,
+        num_segments: int = 24,
+        hidden_edges: bool = False,
+        soft_edges: bool = False,
+        smooth_edges: bool = False,
+    ) -> None:
+        """Add one partial (open) arc - a genuine SketchUp arc entity
+        (editable by radius/angle, re-tessellatable), not disconnected
+        straight edges that merely trace that shape. Unlike `add_circle`,
+        this creates edges only, no face.
+
+        ``center``/``radius`` are in inches; ``normal`` is the arc's
+        plane normal (need not be a unit vector). ``start_angle``/
+        ``end_angle`` (radians) measure the sweep from an arbitrary but
+        fixed 0-angle reference direction in that plane (perpendicular to
+        ``normal``, chosen automatically the same way for every arc/circle
+        built by this same normal) - there's no vertex/edge to derive a
+        caller-visible "angle 0" from the way a face has its own first
+        edge, so the reference direction itself isn't exposed. Sweeps in
+        either direction (``end_angle`` less than or greater than
+        ``start_angle``) and sweeps beyond a full turn are both valid.
+        ``num_segments`` (3-255) controls tessellation. ``hidden_edges``/
+        ``soft_edges``/``smooth_edges`` apply to every edge (all newly
+        declared, since an arc's own points are essentially never shared
+        with prior geometry).
+
+        >>> import math
+        >>> builder.add_arc((50, 50, 0), (0, 0, 1), radius=40, start_angle=0, end_angle=math.pi / 2)
+        """
+        if not (3 <= num_segments <= 255):
+            raise SkpWriteError(f"num_segments must be between 3 and 255, got {num_segments}")
+        if end_angle == start_angle:
+            raise SkpWriteError("start_angle and end_angle must differ - use add_circle for a full circle")
+        center = (float(center[0]), float(center[1]), float(center[2]))
+        normal = _normalize3((float(normal[0]), float(normal[1]), float(normal[2])))
+        radius = float(radius)
+        self._ensure_geometry_writer()
+        u, w = _circle_basis(normal)
+        xaxis = (radius * u[0], radius * u[1], radius * u[2])
+        curve_params = (center, normal, xaxis, float(start_angle), float(end_angle), radius, num_segments)
+        points = _arc_points(center, normal, radius, num_segments, u, w, float(start_angle), float(end_angle))
+        self._new_entity_count += self._geometry_writer.write_arc(
+            points, self._vertex_slots, self._edge_registry, curve_params,
+            hidden_edges, soft_edges, smooth_edges,
+        )
+        self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 
     def to_bytes(self) -> bytes:
         """Return the finished file's bytes."""

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -15,6 +15,7 @@ in the specific fields that mattered.
 from __future__ import annotations
 
 import importlib
+import math
 import os
 import struct
 
@@ -1539,6 +1540,87 @@ class TestCurvedEdges:
         # round-trips through our own reader without raising.
         legacy._walk(data)
 
+    def test_add_arc_self_parses_as_open_chain_no_face(self):
+        builder = create()
+        builder.add_arc(
+            (50.0, 50.0, 0.0), (0.0, 0.0, 1.0), radius=40.0,
+            start_angle=0.0, end_angle=math.pi / 2, num_segments=6,
+        )
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        edges = [v for (_, n, v) in root if n == "CEdge"]
+        faces = [v for (_, n, v) in root if n == "CFace"]
+        assert len(edges) == 6
+        assert len(faces) == 0
+        curve_slots = {e["curve"] for e in edges}
+        assert len(curve_slots) == 1
+        assert None not in curve_slots
+
+    def test_add_arc_endpoints_match_requested_sweep(self, tmp_path):
+        # angle 0 -> center + radius*u, angle pi/2 -> center + radius*w -
+        # confirm the actual written vertex coordinates land there exactly,
+        # not just that a curve object exists. CVertex isn't a root-level
+        # entity (it's nested inline inside CEdge, like CArcCurve) so
+        # legacy._walk's root-only view can't see it directly - go through
+        # the public parse API instead, which resolves nested vertices.
+        from openskp import SkpFile
+
+        builder = create()
+        builder.add_arc(
+            (50.0, 50.0, 0.0), (0.0, 0.0, 1.0), radius=40.0,
+            start_angle=0.0, end_angle=math.pi / 2, num_segments=6,
+        )
+        out = tmp_path / "arc_endpoints.skp"
+        builder.save(str(out))
+        model = SkpFile.open(str(out)).parse()
+        coords = {(round(v.x, 6), round(v.y, 6), round(v.z, 6)) for v in model.root.vertices.values()}
+        assert (90.0, 50.0, 0.0) in coords
+        assert (50.0, 90.0, 0.0) in coords
+
+    def test_add_arc_rejects_equal_angles(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="must differ"):
+            builder.add_arc((0, 0, 0), (0, 0, 1), radius=10.0, start_angle=1.0, end_angle=1.0)
+
+    def test_add_arc_rejects_bad_segment_count(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="num_segments"):
+            builder.add_arc((0, 0, 0), (0, 0, 1), radius=10.0, start_angle=0.0, end_angle=1.0, num_segments=2)
+
+    def test_add_arc_in_component_definition(self):
+        builder = create()
+        with builder.add_component_definition("Bracket") as bracket:
+            bracket.add_arc(
+                (0.0, 0.0, 0.0), (0.0, 0.0, 1.0), radius=15.0,
+                start_angle=0.0, end_angle=math.pi, num_segments=8,
+            )
+        builder.add_instance(bracket)
+        data = builder.to_bytes()
+        legacy._walk(data)
+
+    def test_add_arc_and_add_circle_share_vertex_registry(self, tmp_path):
+        # An arc and a circle built with the same center/radius/normal
+        # trace overlapping points (e.g. angle 0) - confirm the shared
+        # vertex_slots dict actually dedupes across the two calls rather
+        # than emitting a duplicate CVertex.
+        from openskp import SkpFile
+
+        builder = create()
+        builder.add_arc(
+            (0.0, 0.0, 0.0), (0.0, 0.0, 1.0), radius=10.0,
+            start_angle=0.0, end_angle=math.pi, num_segments=4,
+        )
+        builder.add_circle((0.0, 0.0, 0.0), (0.0, 0.0, 1.0), radius=10.0, num_segments=4)
+        out = tmp_path / "arc_circle_shared.skp"
+        builder.save(str(out))
+        model = SkpFile.open(str(out)).parse()
+        coords = [(round(v.x, 6), round(v.y, 6), round(v.z, 6)) for v in model.root.vertices.values()]
+        assert len(coords) == len(set(coords)), "no duplicate CVertex for a shared point"
+        # angle 0 for both is the same point (10, 0, 0) - confirm it's
+        # really shared (present once), not that dedup happened to be
+        # unnecessary because the two shapes never overlap.
+        assert coords.count((10.0, 0.0, 0.0)) == 1
+
 
 class TestLayers:
     def test_layer_assigned_to_face(self):
@@ -2644,6 +2726,93 @@ class TestRealSketchUpOracle:
             cne = ctypes.c_size_t()
             dll.SUCurveGetNumEdges(curve, ctypes.byref(cne))
             assert cne.value == 8
+
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_partial_arc_recognized_as_open_arc_by_real_sketchup(self, tmp_path):
+        # Same discipline as the circle oracle test above, but for a
+        # partial (open) arc built with add_arc: no face at all, and the
+        # actual endpoint positions must land exactly where the requested
+        # start_angle/end_angle sweep says they should - not just "some
+        # curve object exists with the right edge count".
+        import math as _math
+        import ctypes
+
+        class SUPoint3D(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double), ("z", ctypes.c_double)]
+
+        builder = create()
+        builder.add_arc(
+            (50.0, 50.0, 0.0), (0.0, 0.0, 1.0), radius=40.0,
+            start_angle=0.0, end_angle=_math.pi / 2, num_segments=6,
+        )
+        out = tmp_path / "arc_oracle.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetNumFaces.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetNumEdges.argtypes = [ctypes.c_void_p, ctypes.c_bool, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetEdges.argtypes = [
+            ctypes.c_void_p, ctypes.c_bool, ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUEdgeGetCurve.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEdgeGetStartVertex.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEdgeGetEndVertex.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUVertexGetPosition.argtypes = [ctypes.c_void_p, ctypes.POINTER(SUPoint3D)]
+        dll.SUCurveGetType.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
+        dll.SUCurveGetNumEdges.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+
+            nf = ctypes.c_size_t()
+            dll.SUEntitiesGetNumFaces(entities, ctypes.byref(nf))
+            assert nf.value == 0
+
+            ne = ctypes.c_size_t()
+            dll.SUEntitiesGetNumEdges(entities, False, ctypes.byref(ne))
+            assert ne.value == 6
+            edges = (ctypes.c_void_p * 6)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetEdges(entities, False, 6, edges, ctypes.byref(got))
+            assert got.value == 6
+
+            curve_ptrs = set()
+            positions = set()
+            for i in range(6):
+                curve = ctypes.c_void_p()
+                err = dll.SUEdgeGetCurve(edges[i], ctypes.byref(curve))
+                assert err == 0
+                assert curve.value is not None
+                curve_ptrs.add(curve.value)
+                for get_vertex in (dll.SUEdgeGetStartVertex, dll.SUEdgeGetEndVertex):
+                    vert = ctypes.c_void_p()
+                    get_vertex(edges[i], ctypes.byref(vert))
+                    pos = SUPoint3D()
+                    dll.SUVertexGetPosition(vert, ctypes.byref(pos))
+                    positions.add((round(pos.x, 6), round(pos.y, 6), round(pos.z, 6)))
+            assert len(curve_ptrs) == 1, "every edge must share the exact same curve"
+
+            curve = ctypes.c_void_p(curve_ptrs.pop())
+            ctype = ctypes.c_int()
+            dll.SUCurveGetType(curve, ctypes.byref(ctype))
+            assert ctype.value == 1  # SUCurveType_ArcCurve
+            cne = ctypes.c_size_t()
+            dll.SUCurveGetNumEdges(curve, ctypes.byref(cne))
+            assert cne.value == 6
+
+            # angle 0 -> center + (radius, 0, 0); angle pi/2 -> center + (0, radius, 0)
+            assert (90.0, 50.0, 0.0) in positions
+            assert (50.0, 90.0, 0.0) in positions
 
             dll.SUModelRelease(ctypes.byref(model))
         finally:


### PR DESCRIPTION
## Summary

- `add_arc()` on both `SkpBuilder` and `ComponentDefinitionBuilder` builds the same genuine `CArcCurve` entity `add_circle()` does, but as an open chain of edges swept between caller-given `start_angle`/`end_angle` (radians), with no face.
- Refactored `write_face`'s edge-writing loop into a shared `_write_edge_chain` helper (closed for polygon/circle boundaries, open for arcs) so both entry points share the same vertex/edge-sharing and curve-backref logic instead of duplicating it.
- Validated against the real SketchUp SDK: every edge resolves to the same correctly-typed arc curve object, and the actual written endpoint coordinates land exactly where the requested angle sweep says they should.

## Test plan

- [x] New unit tests: open-chain self-parse (no face), endpoint-position accuracy, angle/segment validation, definition nesting, shared vertex registry with `add_circle` — `pytest tests/test_create.py -k TestCurvedEdges`
- [x] Real SketchUp SDK oracle test confirming shared curve backref, correct arc type/edge count, and exact endpoint coordinates
- [x] Full existing suite: 276 passed
- [x] `ruff check` clean