### PR TITLE
Add freeform polyline curve support to the SKP writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,8 +61,13 @@ for the full scope notes.
   caller-given `start_angle`/`end_angle` (radians). Confirmed via the SDK
   that the written endpoint coordinates land exactly where the requested
   sweep says they should, not just that "some curve object" exists.
-  Freeform polyline curves (`CCurve`, distinct from a true arc) are not
-  yet exposed as public API.
+- Freeform polyline curves (`add_polyline`) — an arbitrary chain of
+  straight edges (open or `closed`) grouped into one genuine `CCurve`
+  entity, distinct from `CArcCurve`'s own geometric frame: just a type
+  tag and an edge count, ground-truth-derived from SDK-authored open and
+  closed polylines of several edge counts. Confirmed via the SDK that
+  every edge shares the same curve object, typed as `SUCurveType_Simple`
+  (not `ArcCurve`), with the correct edge count.
 - Every file now opens to the standard "Iso" view (parallel projection,
   looking at the origin) instead of the blank scaffold's own arbitrary
   default camera.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -569,16 +569,28 @@ builder.add_arc((50, 50, 0), normal=(0, 0, 1), radius=40, start_angle=0, end_ang
 
 Confirmed against the real SDK that the written endpoint coordinates
 land exactly where the requested sweep says they should - not just that
-some curve object exists with the right edge count. Freeform polyline
-curve grouping (`CCurve`, distinct from a true arc) isn't exposed as
-public API yet.
+some curve object exists with the right edge count.
+
+A freeform polyline (`add_polyline`) groups an arbitrary chain of
+straight edges into one genuine `CCurve` entity - distinct from
+`CArcCurve`: no geometric frame of its own, just a type tag and an edge
+count, the same grouping real SketchUp's own Freehand tool produces.
+`closed=True` also connects the last point back to the first:
+
+```python
+builder.add_polyline([(0, 0, 0), (10, 10, 0), (20, 0, 0), (30, 10, 0)])
+```
+
+Confirmed against the real SDK that every edge shares the same curve
+object, typed as `SUCurveType_Simple` (distinct from the arc/circle
+tests' `SUCurveType_ArcCurve`), with the correct edge count.
 
 Explicitly out of scope for this first pass: declaring a group's
 geometry inline nested inside another definition (as opposed to placing
 an already-built one via `add_group_instance`), attributes on groups,
-freeform polyline curves, and editing an existing arbitrary `.skp` file
-(a separately harder problem — real SketchUp re-serializes the whole
-document on save rather than appending to it — not attempted here). See
+and editing an existing arbitrary `.skp` file (a separately harder
+problem — real SketchUp re-serializes the whole document on save rather
+than appending to it — not attempted here). See
 [`openskp/create.py`](../packages/python/src/openskp/create.py) for the
 full, current scope notes, and the [Python package README](../packages/python/README.md#writing-early-stage)
 for a longer worked example.

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -131,9 +131,10 @@ positioning (on a face of any orientation), custom key/value
 attribute dictionaries on definitions/instances/faces (the same
 mechanism SketchUp's own "dynamic component" attributes use), and
 circular faces and partial arcs (genuine, editable-by-radius arc/circle
-entities, not disconnected straight edges that merely trace that shape)
-are all supported. See [`openskp/create.py`](src/openskp/create.py) for
-the full scope notes.
+entities, not disconnected straight edges that merely trace that shape),
+and freeform polyline curves (an arbitrary chain of edges grouped into
+one genuine `CCurve` entity) are all supported. See
+[`openskp/create.py`](src/openskp/create.py) for the full scope notes.
 
 ```python
 from openskp import create
@@ -177,6 +178,9 @@ builder.add_circle((100, 75, 0), normal=(0, 0, 1), radius=30, num_segments=24)
 # A partial (open) arc - same real curve entity, but edges only, no face
 import math
 builder.add_arc((100, 75, 0), normal=(0, 0, 1), radius=30, start_angle=0, end_angle=math.pi / 2)
+
+# A freeform polyline - an arbitrary edge chain grouped into one curve
+builder.add_polyline([(0, 0, 0), (10, 10, 0), (20, 0, 0), (30, 10, 0)])
 
 builder.save("output.skp")
 ```

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -39,10 +39,11 @@ are involved, and how.
   Circular faces and partial (open) arcs - real, editable-by-radius
   SketchUp arc/circle entities, not disconnected straight edges that
   merely trace that shape - are supported via :meth:`SkpBuilder.
-  add_circle` / :meth:`SkpBuilder.add_arc` and their
-  :class:`ComponentDefinitionBuilder` equivalents; freeform polyline
-  curve grouping (``CCurve``, distinct from a true arc) is not yet
-  supported.
+  add_circle` / :meth:`SkpBuilder.add_arc`, as are freeform polyline
+  curves (``CCurve`` - a labeled grouping of straight edges, distinct
+  from a true arc's own geometric frame) via :meth:`SkpBuilder.
+  add_polyline`; all three have :class:`ComponentDefinitionBuilder`
+  equivalents.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -247,6 +248,8 @@ _DEFINITION_BASE_BLOCK = bytes([0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
 _FTC_SCHEMA = 4
 
 _ARCCURVE_SCHEMA = 3
+
+_CCURVE_SCHEMA = 4
 
 # A face with no explicit texture positioning stores no CFaceTextureCoords
 # at all, so this identity is only ever used to fill the *other* side's slot
@@ -733,6 +736,26 @@ class _ArchiveWriter:
             self.buf += _f64(v)
         return slot
 
+    def write_curve(self, num_edges: int) -> int:
+        """Write one ``CCurve`` record and return its slot - a freeform
+        polyline curve grouping (as opposed to ``CArcCurve``'s arc
+        geometry): a labeled set of already-straight ``CEdge`` segments,
+        with no geometric data of its own beyond how many edges share it.
+
+        Ground truth (SDK-authored open and closed polylines, of several
+        different edge counts, read back and byte-decoded): the record
+        is just a 1-byte field - always ``1`` in every sample tested
+        (open or closed), written as a constant here since its meaning
+        (beyond a "this is a curve" type tag) hasn't been reverse-
+        engineered - followed by ``num_edges`` as a u32, matching
+        :mod:`openskp.legacy`'s own ``_read_curve`` shape exactly
+        (``r.u8()`` then ``r.u32()``).
+        """
+        slot = self._new_of_known_class("CCurve", schema=_CCURVE_SCHEMA)
+        self._preamble()
+        self.buf += bytes([1]) + _u32(num_edges)
+        return slot
+
     def _write_str(self, s: str) -> None:
         encoded = s.encode("utf-16-le")
         n = len(encoded) // 2
@@ -987,6 +1010,7 @@ class _ArchiveWriter:
         curve_params: Optional[
             Tuple[Point3, Tuple[float, float, float], Tuple[float, float, float], float, float, float, int]
         ] = None,
+        polyline_num_edges: Optional[int] = None,
     ) -> Tuple[List[int], List[int], int]:
         """Write a chain of straight ``CEdge`` records connecting ``points``
         in order, sharing vertices/edges via ``vertex_slots``/
@@ -994,18 +1018,22 @@ class _ArchiveWriter:
         its own, always-``closed`` polygon boundary) - ``closed=True``
         also connects the last point back to the first (an ``n``-edge
         loop); ``closed=False`` stops after the last pair (an ``n-1``-edge
-        open chain, for a partial arc with no face).
+        open chain, for a partial arc or polyline curve with no face).
 
         Returns ``(edge_slots, edge_senses, new_entities)`` - the last is
         how many new root-entity-list slots were consumed (edges newly
         declared; the caller adds any of its own, e.g. a face record).
 
-        ``curve_params``, if given, is a ``(center, normal, xaxis,
-        start_angle, end_angle, radius, num_segments)`` tuple for
-        :meth:`write_arc_curve` - ground truth shows the shared
-        ``CArcCurve`` is declared inline as the FIRST newly-declared
-        edge's own "curve" field, and every other edge newly declared by
-        this call backrefs that same slot instead of writing a null curve.
+        At most one of ``curve_params``/``polyline_num_edges`` should be
+        given - both describe the SAME first-use-inline-declaration
+        pattern (ground truth shows the shared curve object is declared
+        inline as the FIRST newly-declared edge's own "curve" field, and
+        every other edge newly declared by this call backrefs that same
+        slot instead of writing a null curve), just for two different
+        curve record types: ``curve_params`` is a ``(center, normal,
+        xaxis, start_angle, end_angle, radius, num_segments)`` tuple for
+        :meth:`write_arc_curve` (a circle/arc); ``polyline_num_edges`` is
+        the edge count :meth:`write_curve` needs (a freeform polyline).
         """
         n = len(points)
         pair_count = n if closed else n - 1
@@ -1038,11 +1066,12 @@ class _ArchiveWriter:
                     vertex_slots[points[idx]] = point_slots[idx]
                 else:
                     self._backref(point_slots[idx])
-            if curve_params is not None:
-                if curve_slot is None:
-                    curve_slot = self.write_arc_curve(*curve_params)
-                else:
-                    self._backref(curve_slot)
+            if curve_slot is not None:
+                self._backref(curve_slot)
+            elif curve_params is not None:
+                curve_slot = self.write_arc_curve(*curve_params)
+            elif polyline_num_edges is not None:
+                curve_slot = self.write_curve(polyline_num_edges)
             else:
                 self._null()  # curve = None
             edge_slots.append(edge_slot)
@@ -1076,6 +1105,38 @@ class _ArchiveWriter:
         _, _, new_entities = self._write_edge_chain(
             points, vertex_slots, edge_registry, False,
             hidden_edges, soft_edges, smooth_edges, curve_params,
+        )
+        return new_entities
+
+    def write_polyline(
+        self,
+        points: Sequence[Point3],
+        vertex_slots: Dict[Point3, int],
+        edge_registry: Dict[FrozenSet[int], Tuple[int, int]],
+        closed: bool = False,
+        hidden_edges: bool = False,
+        soft_edges: bool = False,
+        smooth_edges: bool = False,
+    ) -> int:
+        """Write a freeform polyline curve - a chain of straight ``CEdge``
+        records connecting ``points`` in order, all sharing one ``CCurve``
+        grouping (see :meth:`write_curve`), no face. ``closed=True``
+        additionally connects the last point back to the first. Distinct
+        from `write_arc`: there's no geometric arc frame here, just a
+        labeled set of already-straight edges - the same grouping real
+        SketchUp's own Freehand/multi-segment-line tools produce.
+        Returns how many new root-entity-list slots were consumed (edges
+        newly declared; the ``CCurve`` itself is declared inline as the
+        first one's own "curve" field, so it doesn't consume a separate
+        slot - the same pattern `write_arc`/`write_face` use for
+        ``CArcCurve``).
+        """
+        n = len(points)
+        pair_count = n if closed else n - 1
+        _, _, new_entities = self._write_edge_chain(
+            points, vertex_slots, edge_registry, closed,
+            hidden_edges, soft_edges, smooth_edges,
+            polyline_num_edges=pair_count,
         )
         return new_entities
 
@@ -1360,6 +1421,26 @@ class ComponentDefinitionBuilder:
         self._new_entity_count += writer.write_arc(
             points, self._vertex_slots, self._edge_registry, curve_params,
             hidden_edges, soft_edges, smooth_edges,
+        )
+
+    def add_polyline(
+        self,
+        points: Sequence[Point3],
+        closed: bool = False,
+        hidden_edges: bool = False,
+        soft_edges: bool = False,
+        smooth_edges: bool = False,
+    ) -> None:
+        """Add one freeform polyline curve to this definition - same
+        signature and behavior as :meth:`SkpBuilder.add_polyline`, except
+        vertices/edges are shared only within this definition."""
+        self._check_writable("polylines")
+        points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
+        if len(points) < 2:
+            raise SkpWriteError("a polyline needs at least 2 points")
+        self._new_entity_count += self._skp._definition_writer.write_polyline(
+            points, self._vertex_slots, self._edge_registry,
+            closed, hidden_edges, soft_edges, smooth_edges,
         )
 
     def add_instance(
@@ -2022,6 +2103,41 @@ class SkpBuilder:
         self._new_entity_count += self._geometry_writer.write_arc(
             points, self._vertex_slots, self._edge_registry, curve_params,
             hidden_edges, soft_edges, smooth_edges,
+        )
+        self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
+
+    def add_polyline(
+        self,
+        points: Sequence[Point3],
+        closed: bool = False,
+        hidden_edges: bool = False,
+        soft_edges: bool = False,
+        smooth_edges: bool = False,
+    ) -> None:
+        """Add one freeform polyline curve - a chain of straight edges
+        (``points`` in order, at least 2) grouped into one genuine
+        SketchUp "Curve" entity (selectable/editable as a whole, the same
+        grouping real SketchUp's own Freehand/multi-segment-line tools
+        produce), not disconnected individual edges that merely happen to
+        connect end-to-end. No face, unlike `add_face`. Distinct from
+        `add_arc`: there's no arc geometry here, just a labeled set of
+        already-straight edges - use this for an arbitrary polyline shape
+        that isn't a circular arc.
+
+        ``closed``, if true, also connects the last point back to the
+        first. ``hidden_edges``/``soft_edges``/``smooth_edges`` apply to
+        every edge (all newly declared, since a polyline's own points are
+        essentially never shared with prior geometry).
+
+        >>> builder.add_polyline([(0, 0, 0), (10, 10, 0), (20, 0, 0), (30, 10, 0)])
+        """
+        points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
+        if len(points) < 2:
+            raise SkpWriteError("a polyline needs at least 2 points")
+        self._ensure_geometry_writer()
+        self._new_entity_count += self._geometry_writer.write_polyline(
+            points, self._vertex_slots, self._edge_registry,
+            closed, hidden_edges, soft_edges, smooth_edges,
         )
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1621,6 +1621,55 @@ class TestCurvedEdges:
         # unnecessary because the two shapes never overlap.
         assert coords.count((10.0, 0.0, 0.0)) == 1
 
+    def test_write_curve_byte_layout(self):
+        # Ground truth (SDK-authored open and closed polylines of several
+        # edge counts, read back and byte-decoded): a 1-byte field always
+        # 1 (open or closed), followed by num_edges as a u32.
+        writer = create_module._ArchiveWriter(next_slot=1, class_slot={})
+        slot = writer.write_curve(3)
+        assert slot == 2  # first-ever declaration: class slot 1, object slot 2
+        record = bytes(writer.buf)[-5:]
+        assert record[0] == 1
+        assert struct.unpack("<I", record[1:])[0] == 3
+
+    def test_add_polyline_open_self_parses_no_face(self):
+        builder = create()
+        builder.add_polyline([(0.0, 0.0, 0.0), (10.0, 10.0, 0.0), (20.0, 0.0, 0.0), (30.0, 10.0, 0.0)])
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        edges = [v for (_, n, v) in root if n == "CEdge"]
+        faces = [v for (_, n, v) in root if n == "CFace"]
+        assert len(edges) == 3
+        assert len(faces) == 0
+        curve_slots = {e["curve"] for e in edges}
+        assert len(curve_slots) == 1
+        assert None not in curve_slots
+
+    def test_add_polyline_closed_wraps_around(self):
+        builder = create()
+        builder.add_polyline(
+            [(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)], closed=True,
+        )
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        edges = [v for (_, n, v) in root if n == "CEdge"]
+        assert len(edges) == 4
+        curve_slots = {e["curve"] for e in edges}
+        assert len(curve_slots) == 1
+
+    def test_add_polyline_rejects_too_few_points(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="at least 2 points"):
+            builder.add_polyline([(0, 0, 0)])
+
+    def test_add_polyline_in_component_definition(self):
+        builder = create()
+        with builder.add_component_definition("Wire") as wire:
+            wire.add_polyline([(0.0, 0.0, 0.0), (10.0, 0.0, 5.0), (20.0, 0.0, 0.0)])
+        builder.add_instance(wire)
+        data = builder.to_bytes()
+        legacy._walk(data)
+
 
 class TestLayers:
     def test_layer_assigned_to_face(self):
@@ -2813,6 +2862,75 @@ class TestRealSketchUpOracle:
             # angle 0 -> center + (radius, 0, 0); angle pi/2 -> center + (0, radius, 0)
             assert (90.0, 50.0, 0.0) in positions
             assert (50.0, 90.0, 0.0) in positions
+
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_polyline_recognized_as_simple_curve_by_real_sketchup(self, tmp_path):
+        # Same discipline as the circle/arc oracle tests above, but for a
+        # freeform polyline (add_polyline): no face, every edge shares the
+        # same curve object, and that curve's own type is the "simple"
+        # kind (SUCurveType_Simple = 0) - distinct from the arc/circle
+        # tests' SUCurveType_ArcCurve = 1, confirming real SketchUp
+        # recognizes this as the same grouping mechanism but a genuinely
+        # different curve kind, not an arc curve with an unused geometry.
+        import ctypes
+
+        builder = create()
+        builder.add_polyline([(0.0, 0.0, 0.0), (10.0, 10.0, 0.0), (20.0, 0.0, 0.0), (30.0, 10.0, 0.0)])
+        out = tmp_path / "polyline_oracle.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetNumFaces.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetNumEdges.argtypes = [ctypes.c_void_p, ctypes.c_bool, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUEntitiesGetEdges.argtypes = [
+            ctypes.c_void_p, ctypes.c_bool, ctypes.c_size_t,
+            ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUEdgeGetCurve.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUCurveGetType.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
+        dll.SUCurveGetNumEdges.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+
+            nf = ctypes.c_size_t()
+            dll.SUEntitiesGetNumFaces(entities, ctypes.byref(nf))
+            assert nf.value == 0
+
+            ne = ctypes.c_size_t()
+            dll.SUEntitiesGetNumEdges(entities, False, ctypes.byref(ne))
+            assert ne.value == 3
+            edges = (ctypes.c_void_p * 3)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetEdges(entities, False, 3, edges, ctypes.byref(got))
+            assert got.value == 3
+
+            curve_ptrs = set()
+            for i in range(3):
+                curve = ctypes.c_void_p()
+                err = dll.SUEdgeGetCurve(edges[i], ctypes.byref(curve))
+                assert err == 0
+                assert curve.value is not None
+                curve_ptrs.add(curve.value)
+            assert len(curve_ptrs) == 1, "every edge must share the exact same curve"
+
+            curve = ctypes.c_void_p(curve_ptrs.pop())
+            ctype = ctypes.c_int()
+            dll.SUCurveGetType(curve, ctypes.byref(ctype))
+            assert ctype.value == 0  # SUCurveType_Simple, not ArcCurve
+
+            cne = ctypes.c_size_t()
+            dll.SUCurveGetNumEdges(curve, ctypes.byref(cne))
+            assert cne.value == 3
 
             dll.SUModelRelease(ctypes.byref(model))
         finally:


### PR DESCRIPTION
## Summary

- `add_polyline()` on both `SkpBuilder` and `ComponentDefinitionBuilder` groups an arbitrary chain of straight edges (open or `closed`) into one genuine `CCurve` entity — the same grouping real SketchUp's own Freehand tool produces, distinct from `CArcCurve`'s own geometric frame.
- Record layout (1-byte type tag, always `1` across every ground-truth sample, plus a u32 edge count) derived from fresh SDK ground truth: open and closed polylines of several edge counts, built via `SUGeometryInputAddEdge` + `SUGeometryInputAddCurve` and read back byte-for-byte.
- Validated against the real SDK: every edge resolves to the same curve object, typed as `SUCurveType_Simple` (not `ArcCurve`), with the correct edge count.
- Generalized the shared `_write_edge_chain` helper (introduced for `add_arc`) to support both curve record types via the same first-use-inline-declaration pattern, so `write_face`/`write_arc`/`write_polyline` all share one implementation instead of duplicating it.

This closes out the last of the three deferred curved-edges follow-ups (circles, arcs, polylines).

## Test plan

- [x] New unit tests: byte-layout, open/closed self-parse, input validation, definition nesting — `pytest tests/test_create.py -k TestCurvedEdges`
- [x] Real SketchUp SDK oracle test confirming shared curve backref and correct simple-curve type/edge count
- [x] Full existing suite: 282 passed
- [x] `ruff check` clean