### PR TITLE
Add rotation= convenience to add_instance/add_group/add_group_instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,12 @@ for the full scope notes.
   projected texture, a colorized material's tint, and several others —
   see the module's own docstring for the complete, itemized list) rather
   than silently dropping it.
+- `rotation=(axis, angle_radians)` on `add_instance`/`add_group`/
+  `add_group_instance` — a convenience alternative to hand-deriving a
+  `matrix3x3` rotation matrix for the common case of a pure rotation
+  (Rodrigues' rotation formula). Confirmed against the real SDK's own
+  `SUComponentInstanceGetTransform` to match SketchUp's transform
+  convention exactly, not just "some rotation was applied."
 
 ### Fixed
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -504,6 +504,16 @@ with builder.add_component_definition("Car") as car:
 builder.add_instance(car)
 ```
 
+`add_instance`/`add_group`/`add_group_instance` all also accept
+`rotation=(axis, angle_radians)` as a convenience alternative to
+hand-deriving a `matrix3x3` rotation matrix yourself - pass at most one
+of the two:
+
+```python
+import math
+builder.add_instance(wheel, translation=(0, 0, 0), rotation=((0, 0, 1), math.radians(90)))
+```
+
 A face's texture can also be explicitly positioned (scaled, rotated,
 sheared, offset - independently per side) instead of the default planar
 projection, given 3 world-point/UV correspondences - on a face of any

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -167,7 +167,9 @@ with builder.add_group("Table", translation=(100, 0, 0)) as table:
 
 # Now place instances of the reusable component
 builder.add_instance(chair, translation=(0, 0, 0))
-builder.add_instance(chair, translation=(50, 0, 0))
+# rotation=(axis, angle_radians) is a shortcut for a hand-derived matrix3x3
+import math
+builder.add_instance(chair, translation=(50, 0, 0), rotation=((0, 0, 1), math.radians(180)))
 
 # Root-level geometry
 builder.add_face(
@@ -179,7 +181,6 @@ builder.add_face(
 builder.add_circle((100, 75, 0), normal=(0, 0, 1), radius=30, num_segments=24)
 
 # A partial (open) arc - same real curve entity, but edges only, no face
-import math
 builder.add_arc((100, 75, 0), normal=(0, 0, 1), radius=30, start_angle=0, end_angle=math.pi / 2)
 
 # A freeform polyline - an arbitrary edge chain grouped into one curve

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -43,7 +43,9 @@ are involved, and how.
   curves (``CCurve`` - a labeled grouping of straight edges, distinct
   from a true arc's own geometric frame) via :meth:`SkpBuilder.
   add_polyline`; all three have :class:`ComponentDefinitionBuilder`
-  equivalents.
+  equivalents. An instance/group placement's rotation can be given
+  directly as ``rotation=(axis, angle_radians)`` instead of a hand-
+  derived ``matrix3x3`` - see :func:`_rotation_matrix3x3`.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -298,6 +300,45 @@ def _normalize3(v: Tuple[float, float, float]) -> Tuple[float, float, float]:
     if length < 1e-9:
         raise SkpWriteError("cannot determine a texture-positioning basis: the face's first edge is degenerate")
     return (v[0] / length, v[1] / length, v[2] / length)
+
+
+def _rotation_matrix3x3(
+    axis: Tuple[float, float, float], angle: float,
+) -> Tuple[float, float, float, float, float, float, float, float, float]:
+    """The row-major 3x3 rotation matrix for rotating by ``angle`` radians
+    (right-hand rule) around ``axis`` (need not be a unit vector) -
+    Rodrigues' rotation formula. Same row-major convention `add_instance`'s
+    own ``matrix3x3`` parameter already uses, so this is a drop-in way to
+    get a rotation without hand-deriving the matrix.
+    """
+    length = (axis[0] ** 2 + axis[1] ** 2 + axis[2] ** 2) ** 0.5
+    if length < 1e-9:
+        raise SkpWriteError("rotation axis must not be the zero vector")
+    x, y, z = (axis[0] / length, axis[1] / length, axis[2] / length)
+    c = math.cos(angle)
+    s = math.sin(angle)
+    t = 1.0 - c
+    return (
+        t * x * x + c, t * x * y - s * z, t * x * z + s * y,
+        t * x * y + s * z, t * y * y + c, t * y * z - s * x,
+        t * x * z - s * y, t * y * z + s * x, t * z * z + c,
+    )
+
+
+def _resolve_matrix3x3(
+    matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]],
+    rotation: Optional[Tuple[Tuple[float, float, float], float]],
+) -> Optional[Tuple[float, float, float, float, float, float, float, float, float]]:
+    """Shared by every ``add_instance``/``add_group``/``add_group_instance``
+    call - ``matrix3x3`` and ``rotation`` are alternate ways to specify the
+    same underlying transform field, not two separate ones, so exactly one
+    (or neither, for identity) may be given."""
+    if matrix3x3 is not None and rotation is not None:
+        raise SkpWriteError("pass at most one of matrix3x3/rotation - rotation is just a convenience for matrix3x3")
+    if rotation is not None:
+        axis, angle = rotation
+        return _rotation_matrix3x3(axis, angle)
+    return matrix3x3
 
 
 def _face_uv_basis(
@@ -1488,6 +1529,7 @@ class ComponentDefinitionBuilder:
         name: Optional[str] = None,
         translation: Tuple[float, float, float] = (0.0, 0.0, 0.0),
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
+        rotation: Optional[Tuple[Tuple[float, float, float], float]] = None,
         material: Optional[int] = None,
         layer: Optional[int] = None,
         attributes: Optional[Dict[str, object]] = None,
@@ -1516,6 +1558,10 @@ class ComponentDefinitionBuilder:
         ordering is also what rules out cycles: a definition can only
         ever nest others fully built strictly before it existed, never
         itself or anything still in progress.
+
+        ``rotation``, if given, is a ``(axis, angle_radians)`` pair - an
+        alternative to hand-deriving ``matrix3x3`` for the common case of
+        a pure rotation; pass at most one of the two.
         """
         self._check_writable("instances")
         if definition._skp is not self._skp:
@@ -1525,6 +1571,7 @@ class ComponentDefinitionBuilder:
             )
         if definition is self:
             raise SkpWriteError(f"component definition {self.name!r} cannot nest an instance of itself")
+        matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
         attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += self._skp._definition_writer.write_instance(
             definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0,
@@ -1537,6 +1584,7 @@ class ComponentDefinitionBuilder:
         name: Optional[str] = None,
         translation: Tuple[float, float, float] = (0.0, 0.0, 0.0),
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
+        rotation: Optional[Tuple[Tuple[float, float, float], float]] = None,
         material: Optional[int] = None,
         layer: Optional[int] = None,
     ) -> None:
@@ -1559,6 +1607,10 @@ class ComponentDefinitionBuilder:
         >>> with builder.add_component_definition("Car") as car:
         ...     car.add_face([(0, 0, 0), (150, 0, 0), (150, 60, 0), (0, 60, 0)])
         ...     car.add_group_instance(engine, translation=(50, 0, 10))
+
+        ``rotation``, if given, is a ``(axis, angle_radians)`` pair - an
+        alternative to hand-deriving ``matrix3x3`` for the common case of
+        a pure rotation; pass at most one of the two.
         """
         self._check_writable("groups")
         if definition._skp is not self._skp:
@@ -1568,6 +1620,7 @@ class ComponentDefinitionBuilder:
             )
         if definition is self:
             raise SkpWriteError(f"component definition {self.name!r} cannot nest a group instance of itself")
+        matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
         self._new_entity_count += self._skp._definition_writer.write_group(
             definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0
         )
@@ -1861,6 +1914,7 @@ class SkpBuilder:
         name: Optional[str] = None,
         translation: Tuple[float, float, float] = (0.0, 0.0, 0.0),
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
+        rotation: Optional[Tuple[Tuple[float, float, float], float]] = None,
         material: Optional[int] = None,
         layer: Optional[int] = None,
     ) -> "ComponentDefinitionBuilder":
@@ -1877,7 +1931,12 @@ class SkpBuilder:
         Same ordering rule as `add_component_definition` - must be called
         before any `add_face`/`add_instance`/`add_group` call already in
         progress on the builder itself.
+
+        ``rotation``, if given, is a ``(axis, angle_radians)`` pair - an
+        alternative to hand-deriving ``matrix3x3`` for the common case of
+        a pure rotation; pass at most one of the two.
         """
+        matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
         return self._start_definition(
             name or "Group", "add_group", group_placement=(translation, matrix3x3, material or 0, layer or 0)
         )
@@ -1898,6 +1957,7 @@ class SkpBuilder:
         name: Optional[str] = None,
         translation: Tuple[float, float, float] = (0.0, 0.0, 0.0),
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
+        rotation: Optional[Tuple[Tuple[float, float, float], float]] = None,
         material: Optional[int] = None,
         layer: Optional[int] = None,
         attributes: Optional[Dict[str, object]] = None,
@@ -1910,6 +1970,15 @@ class SkpBuilder:
         omitted); ``translation`` is applied after it, in inches.
         ``material``/``layer``, if given, are handles from `add_material`/
         `add_layer` applied to the instance itself (not its contents).
+
+        ``rotation``, if given, is a ``(axis, angle_radians)`` pair - an
+        alternative to ``matrix3x3`` for the common case of a pure
+        rotation, so the caller doesn't have to hand-derive a rotation
+        matrix (Rodrigues' formula) themselves; pass at most one of the
+        two.
+
+        >>> import math
+        >>> builder.add_instance(chair, rotation=((0, 0, 1), math.radians(90)))
 
         ``attributes``, if given, is custom key/value metadata (values
         may be ``str``, ``int``, or ``float``) attached to this instance
@@ -1927,6 +1996,7 @@ class SkpBuilder:
                 f"component definition {definition.name!r} is still open - "
                 "exit its `with` block before calling add_instance"
             )
+        matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
         self._ensure_geometry_writer()
         attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += self._geometry_writer.write_instance(

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1671,6 +1671,73 @@ class TestCurvedEdges:
         legacy._walk(data)
 
 
+class TestInstanceRotation:
+    def test_rotation_matrix_matches_matrix3x3_for_90deg_z(self):
+        # A +90-degree rotation around +Z (right-hand rule) sends the
+        # world X axis to the world Y axis - the same identity a rotation
+        # matrix must satisfy regardless of how it was derived.
+        m = create_module._rotation_matrix3x3((0.0, 0.0, 1.0), math.pi / 2)
+        # Apply m (row-major: m[0:3]=row0, m[3:6]=row1, m[6:9]=row2) to
+        # local point (1, 0, 0) - confirmed against the real SDK's own
+        # SUComponentInstanceGetTransform for this exact rotation.
+        x, y, z = 1.0, 0.0, 0.0
+        rx = m[0] * x + m[1] * y + m[2] * z
+        ry = m[3] * x + m[4] * y + m[5] * z
+        rz = m[6] * x + m[7] * y + m[8] * z
+        assert (rx, ry, rz) == pytest.approx((0.0, 1.0, 0.0), abs=1e-9)
+
+    def test_rotation_matrix_identity_at_zero_angle(self):
+        m = create_module._rotation_matrix3x3((0.0, 0.0, 1.0), 0.0)
+        assert m == pytest.approx((1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+
+    def test_rotation_matrix_rejects_zero_axis(self):
+        with pytest.raises(SkpWriteError, match="zero vector"):
+            create_module._rotation_matrix3x3((0.0, 0.0, 0.0), 1.0)
+
+    def test_add_instance_rotation_and_matrix3x3_are_mutually_exclusive(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="at most one"):
+            builder.add_instance(
+                chair, matrix3x3=(1, 0, 0, 0, 1, 0, 0, 0, 1), rotation=((0, 0, 1), math.pi / 2),
+            )
+
+    def test_add_instance_rotation_produces_same_matrix_as_equivalent_matrix3x3(self):
+        # Byte-for-byte comparison isn't meaningful here - each instance
+        # embeds a fresh random GUID - so compare the parsed-back
+        # transform field instead.
+        angle = math.pi / 3
+        expected = create_module._rotation_matrix3x3((0, 0, 1), angle)
+
+        b1 = create()
+        with b1.add_component_definition("Chair") as chair1:
+            chair1.add_face(SQUARE)
+        b1.add_instance(chair1, rotation=((0, 0, 1), angle))
+        ar, root, layers, materials = legacy._walk(b1.to_bytes())
+        inst = [v for (_, n, v) in root if n == "CComponentInstance"][0]
+        assert tuple(inst["xf"][0:9]) == pytest.approx(expected)
+
+    def test_add_group_rotation(self):
+        builder = create()
+        with builder.add_group("Table", rotation=((0, 0, 1), math.pi / 4)) as table:
+            table.add_face(SQUARE)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        assert any(n == "CGroup" for (_, n, v) in root)
+
+    def test_add_group_instance_rotation(self):
+        builder = create()
+        with builder.add_component_definition("Engine") as engine:
+            engine.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_face(SQUARE)
+            car.add_group_instance(engine, rotation=((1, 0, 0), math.pi / 6))
+        builder.add_instance(car)
+        data = builder.to_bytes()
+        legacy._walk(data)
+
+
 class TestLayers:
     def test_layer_assigned_to_face(self):
         builder = create()
@@ -2932,6 +2999,55 @@ class TestRealSketchUpOracle:
             dll.SUCurveGetNumEdges(curve, ctypes.byref(cne))
             assert cne.value == 3
 
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_instance_rotation_matches_real_sketchup_transform(self, tmp_path):
+        # A +90-degree rotation around +Z (right-hand rule) must send a
+        # local point on the +X axis to world +Y - confirms this writer's
+        # `rotation=` convenience matches real SketchUp's own transform
+        # convention, not just that SOME rotation was applied.
+        import ctypes
+
+        class SUPoint3D(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double), ("z", ctypes.c_double)]
+
+        class SUTransformation(ctypes.Structure):
+            _fields_ = [("values", ctypes.c_double * 16)]
+
+        builder = create()
+        with builder.add_component_definition("Marker") as marker:
+            marker.add_face([(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 1.0, 0.0), (0.0, 1.0, 0.0)])
+        builder.add_instance(marker, rotation=((0.0, 0.0, 1.0), math.pi / 2))
+        out = tmp_path / "rotation_oracle.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetInstances.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUComponentInstanceGetTransform.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            inst = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetInstances(entities, 1, inst, ctypes.byref(got))
+            assert got.value == 1
+            t = SUTransformation()
+            dll.SUComponentInstanceGetTransform(inst[0], ctypes.byref(t))
+            # SUTransformation.values is column-major: column 0 is where the
+            # local +X axis (10, 0, 0) ends up.
+            col0 = t.values[0:3]
+            world = (10.0 * col0[0], 10.0 * col0[1], 10.0 * col0[2])
+            assert world == pytest.approx((0.0, 10.0, 0.0), abs=1e-6)
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()


### PR DESCRIPTION
## Summary

- `rotation=(axis, angle_radians)` on `add_instance`/`add_group`/`add_group_instance` computes the row-major 3×3 rotation matrix (Rodrigues' formula) so callers don't have to hand-derive `matrix3x3` for the common case of a pure rotation. Mutually exclusive with an explicit `matrix3x3`.
- Confirmed against the real SDK's own `SUComponentInstanceGetTransform` that the convention matches SketchUp's transform exactly — a +90-degree rotation around +Z sends a local point on +X to world +Y.

Prompted by independent third-party feedback (an external AI-driven capability test of `openskp.create`) that instance rotation required hand-deriving a matrix.

## Test plan

- [x] New unit tests: matrix correctness at a known angle, identity at zero angle, zero-axis rejection, mutual exclusivity with `matrix3x3`, equivalence to a hand-derived matrix, group/group-instance rotation — `pytest tests/test_create.py -k TestInstanceRotation`
- [x] Real SketchUp SDK oracle test confirming the transform convention matches exactly
- [x] Full existing suite: 302 passed
- [x] `ruff check` clean