### PR TITLE
Add auto_triangulate to add_face for non-planar polygon input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ for the full scope notes.
   (Rodrigues' rotation formula). Confirmed against the real SDK's own
   `SUComponentInstanceGetTransform` to match SketchUp's transform
   convention exactly, not just "some rotation was applied."
+- `add_face(..., auto_triangulate=True)` — a non-coplanar polygon (a
+  tessellated curved surface's warped "quad," the case that previously
+  had to be hand-split into triangles before calling `add_face` at all)
+  is now fan-triangulated into real, always-planar faces automatically
+  instead of raising, the same silent fallback real SketchUp's own UI
+  applies when you draw a not-quite-flat face. Off by default — existing
+  strict-planarity behavior is unchanged unless opted into.
 
 ### Fixed
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -539,6 +539,16 @@ matrix against several candidate formulas, then confirmed exactly (all
 6 matrix values matching) against a correspondence deliberately chosen
 not to align with the face's own edges.
 
+`add_face` only stores true planar faces (all it can represent), so
+non-coplanar points raise by default - pass `auto_triangulate=True` to
+fan-triangulate instead, the same silent fallback real SketchUp's own UI
+applies to a not-quite-flat quad you draw by hand:
+
+```python
+warped_quad = [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 5)]
+builder.add_face(warped_quad, auto_triangulate=True)  # -> 2 triangular faces
+```
+
 Component definitions, instances, and faces can also carry custom
 key/value metadata - the same mechanism SketchUp's own "dynamic
 component" attributes use - via each of their `attributes` parameters

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -133,11 +133,13 @@ mechanism SketchUp's own "dynamic component" attributes use), and
 circular faces and partial arcs (genuine, editable-by-radius arc/circle
 entities, not disconnected straight edges that merely trace that shape),
 and freeform polyline curves (an arbitrary chain of edges grouped into
-one genuine `CCurve` entity) are all supported. `openskp.open_existing()`
-can also load an *existing* legacy-format file and rebuild it as a new
-builder, so more geometry can be added to it before saving (see
-[Editing an existing file](#editing-an-existing-file) below). See
-[`openskp/create.py`](src/openskp/create.py) for the full scope notes.
+one genuine `CCurve` entity) are all supported, along with an
+`add_face(..., auto_triangulate=True)` fallback for non-planar input.
+`openskp.open_existing()` can also load an *existing* legacy-format file
+and rebuild it as a new builder, so more geometry can be added to it
+before saving (see [Editing an existing file](#editing-an-existing-file)
+below). See [`openskp/create.py`](src/openskp/create.py) for the full
+scope notes.
 
 ```python
 from openskp import create
@@ -185,6 +187,11 @@ builder.add_arc((100, 75, 0), normal=(0, 0, 1), radius=30, start_angle=0, end_an
 
 # A freeform polyline - an arbitrary edge chain grouped into one curve
 builder.add_polyline([(0, 0, 0), (10, 10, 0), (20, 0, 0), (30, 10, 0)])
+
+# A non-planar "quad" - auto_triangulate fans it into 2 real triangular
+# faces instead of raising, the same thing SketchUp's own UI does
+warped_quad = [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 5)]
+builder.add_face(warped_quad, auto_triangulate=True)
 
 builder.save("output.skp")
 ```

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -45,7 +45,10 @@ are involved, and how.
   add_polyline`; all three have :class:`ComponentDefinitionBuilder`
   equivalents. An instance/group placement's rotation can be given
   directly as ``rotation=(axis, angle_radians)`` instead of a hand-
-  derived ``matrix3x3`` - see :func:`_rotation_matrix3x3`.
+  derived ``matrix3x3`` - see :func:`_rotation_matrix3x3`. ``add_face``'s
+  ``auto_triangulate`` fan-splits a non-coplanar polygon into real,
+  always-planar triangular faces instead of raising - the same thing
+  real SketchUp's own UI does silently for a not-quite-flat quad.
 * Coordinates are in **inches** - SketchUp's own native internal unit for
   this era of the format. Converting from another unit is the caller's
   responsibility for now.
@@ -1364,6 +1367,88 @@ def _plane_from_polygon(points: Sequence[Point3]) -> Tuple[float, float, float, 
     return nx, ny, nz, d
 
 
+def _is_coplanar(points: Sequence[Point3]) -> bool:
+    """Same fit/tolerance `_plane_from_polygon` uses, but returns a bool
+    for "not coplanar" instead of raising - used by `add_face`'s
+    ``auto_triangulate`` to decide whether a fan-triangulation fallback
+    is even needed. Still raises for a collinear/degenerate input (no
+    triangulation fixes that - it's not a "not flat enough" problem)."""
+    n = len(points)
+    nx = ny = nz = 0.0
+    for i in range(n):
+        x0, y0, z0 = points[i]
+        x1, y1, z1 = points[(i + 1) % n]
+        nx += (y0 - y1) * (z0 + z1)
+        ny += (z0 - z1) * (x0 + x1)
+        nz += (x0 - x1) * (y0 + y1)
+    length = (nx * nx + ny * ny + nz * nz) ** 0.5
+    if length < 1e-9:
+        raise SkpWriteError("face points are collinear or degenerate; cannot compute a plane")
+    nx, ny, nz = nx / length, ny / length, nz / length
+    cx = sum(p[0] for p in points) / n
+    cy = sum(p[1] for p in points) / n
+    cz = sum(p[2] for p in points) / n
+    d = nx * cx + ny * cy + nz * cz
+    span = max(max(p[i] for p in points) - min(p[i] for p in points) for i in range(3))
+    tol = max(span, 1.0) * 1e-6
+    return all(abs(nx * p[0] + ny * p[1] + nz * p[2] - d) <= tol for p in points)
+
+
+def _write_face_or_triangulate(
+    writer: "_ArchiveWriter",
+    points: List[Point3],
+    vertex_slots: Dict[Point3, int],
+    edge_registry: Dict[FrozenSet[int], Tuple[int, int]],
+    material: int,
+    layer: int,
+    back_material: int,
+    hidden: bool,
+    soft_edges: bool,
+    smooth_edges: bool,
+    hidden_edges: bool,
+    front_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]],
+    back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]],
+    attribute_dicts: Sequence[Tuple[str, Dict[str, object]]],
+    auto_triangulate: bool,
+) -> int:
+    """Shared by :meth:`SkpBuilder.add_face` and
+    :meth:`ComponentDefinitionBuilder.add_face` - writes ``points`` as one
+    face normally, unless ``auto_triangulate`` is set AND the points
+    aren't coplanar, in which case it fan-triangulates from ``points[0]``
+    and writes one real, always-planar triangular face per fan wedge
+    instead of raising. This mirrors real SketchUp's own UI behavior: a
+    4-point face you draw that isn't quite flat is silently split into 2
+    triangles rather than rejected. Not attempted for a genuinely
+    degenerate (collinear) input - `_is_coplanar` still raises for that,
+    since no triangulation fixes it.
+
+    Not compatible with ``front_uv``/``back_uv``: positioning a texture
+    from one 3-point correspondence doesn't generalize to a fan of
+    independently-drawn triangles.
+
+    Returns the total new-root-entity-list-slot count (same contract as
+    `write_face`/`write_arc`/`write_polyline`).
+    """
+    if not auto_triangulate or len(points) == 3 or _is_coplanar(points):
+        return writer.write_face(
+            points, vertex_slots, edge_registry,
+            material, layer, back_material,
+            hidden, soft_edges, smooth_edges, hidden_edges,
+            front_uv, back_uv, attribute_dicts,
+        )
+    if front_uv is not None or back_uv is not None:
+        raise SkpWriteError("auto_triangulate cannot be combined with front_uv/back_uv positioning")
+    total = 0
+    for i in range(1, len(points) - 1):
+        total += writer.write_face(
+            [points[0], points[i], points[i + 1]], vertex_slots, edge_registry,
+            material, layer, back_material,
+            hidden, soft_edges, smooth_edges, hidden_edges,
+            None, None, attribute_dicts,
+        )
+    return total
+
+
 class ComponentDefinitionBuilder:
     """Accumulates one component/group definition's geometry. Construct via
     :meth:`SkpBuilder.add_component_definition` or :meth:`SkpBuilder.
@@ -1415,6 +1500,7 @@ class ComponentDefinitionBuilder:
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        auto_triangulate: bool = False,
     ) -> None:
         """Add one planar face to this definition - same signature and
         behavior as :meth:`SkpBuilder.add_face`, except vertices/edges are
@@ -1425,11 +1511,11 @@ class ComponentDefinitionBuilder:
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
         attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
-        self._new_entity_count += self._skp._definition_writer.write_face(
-            points, self._vertex_slots, self._edge_registry,
+        self._new_entity_count += _write_face_or_triangulate(
+            self._skp._definition_writer, points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
-            front_uv, back_uv, attribute_dicts,
+            front_uv, back_uv, attribute_dicts, auto_triangulate,
         )
 
     def add_circle(
@@ -2054,6 +2140,7 @@ class SkpBuilder:
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        auto_triangulate: bool = False,
     ) -> None:
         """Add one planar face, defined by 3 or more coplanar points (in
         inches) forming a closed polygon in order - do not repeat the
@@ -2096,17 +2183,30 @@ class SkpBuilder:
         ``attributes``, if given, is custom key/value metadata (values
         may be ``str``, ``int``, or ``float``) attached to this face,
         under a dictionary named ``attribute_dict_name``.
+
+        By default, non-coplanar ``points`` raise `SkpWriteError` - this
+        writer only stores true planar faces, since that's all a single
+        ``CFace`` record can represent. ``auto_triangulate=True`` instead
+        mirrors real SketchUp's own behavior when you draw a not-quite-flat
+        polygon: it's silently fan-triangulated from ``points[0]`` into
+        several always-planar triangular faces (2 for a quad) rather than
+        rejected. Each triangle gets its own copy of ``attributes``, if
+        given; not compatible with ``front_uv``/``back_uv`` (positioning a
+        texture from one 3-point correspondence doesn't generalize to an
+        unpredictable number of independently-drawn triangles). Already-
+        planar input is written as a single face either way - this only
+        changes behavior for input that would otherwise be rejected.
         """
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
         self._ensure_geometry_writer()
         attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
-        self._new_entity_count += self._geometry_writer.write_face(
-            points, self._vertex_slots, self._edge_registry,
+        self._new_entity_count += _write_face_or_triangulate(
+            self._geometry_writer, points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
-            front_uv, back_uv, attribute_dicts,
+            front_uv, back_uv, attribute_dicts, auto_triangulate,
         )
         self._face_count += 1
 

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -296,6 +296,73 @@ class TestConcavePolygons:
         assert face["plane"][:3] == pytest.approx((0.0, 0.0, 1.0), abs=1e-9)
 
 
+class TestAutoTriangulate:
+    # A "quad" whose 4th point is deliberately raised out of the other
+    # 3's plane - a corner "pop" no shared-plane tilt could produce, the
+    # same non-planarity a tessellated curved surface hits in practice.
+    WARPED_QUAD = [(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 5.0)]
+    FLAT_SQUARE = [(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)]
+
+    def test_non_planar_without_auto_triangulate_still_raises(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="not coplanar"):
+            builder.add_face(self.WARPED_QUAD)
+
+    def test_non_planar_with_auto_triangulate_splits_into_two_faces(self):
+        builder = create()
+        builder.add_face(self.WARPED_QUAD, auto_triangulate=True)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        faces = [v for (_, n, v) in root if n == "CFace"]
+        assert len(faces) == 2
+
+    def test_already_planar_input_stays_a_single_face(self):
+        # auto_triangulate should be a no-op for input that's already flat
+        # - not force-split every face into triangles.
+        builder = create()
+        builder.add_face(self.FLAT_SQUARE, auto_triangulate=True)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        faces = [v for (_, n, v) in root if n == "CFace"]
+        assert len(faces) == 1
+
+    def test_triangulated_faces_share_the_fan_origin_vertex(self):
+        builder = create()
+        builder.add_face(self.WARPED_QUAD, auto_triangulate=True)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        edges = [v for (_, n, v) in root if n == "CEdge"]
+        vertex_ids = set()
+        for e in edges:
+            vertex_ids.add(e["v1"])
+            vertex_ids.add(e["v2"])
+        # 4 corners, no duplicate CVertex for the shared fan-origin point
+        assert len(vertex_ids) == 4
+
+    def test_auto_triangulate_rejects_front_uv(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="auto_triangulate cannot be combined"):
+            builder.add_face(
+                self.WARPED_QUAD, auto_triangulate=True,
+                front_uv=[((0, 0, 0), (0.0, 0.0)), ((10, 0, 0), (1.0, 0.0)), ((10, 10, 0), (1.0, 1.0))],
+            )
+
+    def test_auto_triangulate_still_raises_for_degenerate_input(self):
+        # A genuinely collinear/degenerate input isn't "fixed" by
+        # triangulation - _is_coplanar itself still raises for it.
+        builder = create()
+        with pytest.raises(SkpWriteError, match="collinear or degenerate"):
+            builder.add_face([(0.0, 0.0, 0.0), (5.0, 0.0, 0.0), (10.0, 0.0, 0.0)], auto_triangulate=True)
+
+    def test_auto_triangulate_in_component_definition(self):
+        builder = create()
+        with builder.add_component_definition("Fin") as fin:
+            fin.add_face(self.WARPED_QUAD, auto_triangulate=True)
+        builder.add_instance(fin)
+        data = builder.to_bytes()
+        legacy._walk(data)
+
+
 class TestNonManifoldTopology:
     # Three triangular "fins" sharing one common edge (the z-axis segment
     # from (0,0,0) to (0,0,100)) - nothing in the CEdgeUse/loop encoding
@@ -3048,6 +3115,40 @@ class TestRealSketchUpOracle:
             col0 = t.values[0:3]
             world = (10.0 * col0[0], 10.0 * col0[1], 10.0 * col0[2])
             assert world == pytest.approx((0.0, 10.0, 0.0), abs=1e-6)
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_auto_triangulated_warped_quad_opens_as_two_faces_in_real_sketchup(self, tmp_path):
+        # A non-planar "quad" real SketchUp itself would silently split
+        # into 2 triangles when drawn by hand - confirms this writer's
+        # auto_triangulate fallback produces the same structurally valid
+        # result the real application accepts, not just something our
+        # own lenient reader tolerates.
+        import ctypes
+
+        builder = create()
+        builder.add_face(
+            [(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 5.0)],
+            auto_triangulate=True,
+        )
+        out = tmp_path / "warped_quad.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetNumFaces.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            nf = ctypes.c_size_t()
+            dll.SUEntitiesGetNumFaces(entities, ctypes.byref(nf))
+            assert nf.value == 2
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()


### PR DESCRIPTION
## Summary

- `add_face(..., auto_triangulate=True)` fan-triangulates a non-coplanar polygon (`points[0]` as the fan origin) into real, always-planar triangular faces instead of raising `SkpWriteError` — the same silent fallback real SketchUp's own UI applies when you draw a not-quite-flat quad.
- Off by default, so existing strict-planarity behavior is unchanged unless opted into.
- Not compatible with `front_uv`/`back_uv` (positioning from one 3-point correspondence doesn't generalize to an unpredictable number of independently-drawn triangles); still raises for genuinely degenerate (collinear) input, which no triangulation fixes.
- Confirmed against the real SDK: a warped quad split this way opens as 2 separate faces in real SketchUp, matching what the application's own UI produces for the same input.

Prompted by independent third-party feedback (an external AI-driven capability test of `openskp.create`) that hit this exact case building a curved chair backrest — it had to manually pre-split every non-planar quad into triangles before calling `add_face`.

## Test plan

- [x] New unit tests: raises without the flag, splits correctly with it, no-op for already-planar input, shared fan-origin vertex, incompatibility with `front_uv`, still raises for degenerate input, definition nesting — `pytest tests/test_create.py -k TestAutoTriangulate`
- [x] Real SketchUp SDK oracle test confirming a warped quad opens as 2 faces
- [x] Full existing suite: 310 passed
- [x] `ruff check` clean