### PR TITLE
Add holes= support to add_face, and replay them in open_existing()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,22 @@ for the full scope notes.
   instead of raising, the same silent fallback real SketchUp's own UI
   applies when you draw a not-quite-flat face. Off by default — existing
   strict-planarity behavior is unchanged unless opted into.
+  file had that couldn't be faithfully reproduced (a projected texture,
+  a colorized material's tint, and several others — see the module's
+  own docstring for the complete, itemized list) rather than silently
+  dropping it.
+- `add_face(..., holes=[...])` — cut one or more independent closed
+  polygons out of a face (a window opening in a wall, say) as real
+  additional loops in the same `CFace` record, not a separate,
+  unconnected geometry hack. Ground-truth-derived from an SDK-authored
+  window-in-a-wall face: a hole loop is structurally identical to the
+  boundary loop except one flag byte, and its winding direction doesn't
+  matter (confirmed via the SDK's own geometry-input API accepting
+  either, and independently by writing raw bytes both ways). Confirmed
+  against the real SDK that the hole's area is genuinely subtracted
+  (`SUFaceGetArea`), not just structurally present.
+  `openskp.open_existing()` now replays a multi-loop face faithfully
+  instead of skipping it.
 
 ### Fixed
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -549,6 +549,22 @@ warped_quad = [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 5)]
 builder.add_face(warped_quad, auto_triangulate=True)  # -> 2 triangular faces
 ```
 
+A face can also have one or more holes cut out of it - `holes=` takes
+a list of independent closed polygons, each on the same plane as the
+face itself; winding direction doesn't matter:
+
+```python
+wall = [(0, 0, 0), (200, 0, 0), (200, 100, 0), (0, 100, 0)]
+window = [(80, 30, 0), (120, 30, 0), (120, 70, 0), (80, 70, 0)]
+builder.add_face(wall, holes=[window])
+```
+
+Ground-truth-derived from an SDK-authored window-in-a-wall face: a hole
+is a real additional loop in the same `CFace` record - structurally
+identical to the boundary loop, differing only in one flag byte.
+Confirmed against the real SDK that the hole's area is genuinely
+subtracted (`SUFaceGetArea`), not just structurally present.
+
 Component definitions, instances, and faces can also carry custom
 key/value metadata - the same mechanism SketchUp's own "dynamic
 component" attributes use - via each of their `attributes` parameters
@@ -639,14 +655,14 @@ builder.save("building_edited.skp")
 Only a legacy-format (SketchUp 2013-2020) source file is accepted, for
 the same reason `openskp.create` only ever writes that format. The
 returned `warnings` list is the honest account of what couldn't be
-faithfully reproduced for that specific file - a face with more than one
-loop (a hole), per-edge flags collapsed to a per-face approximation, a
-projected/distorted texture falling back to the default projection, a
-material's texture scale or colorized tint, an instance's hidden flag, a
-layer's color, section planes/text/dimensions (no writer support at
-all), and an original circle/arc's curve grouping (this project's reader
-doesn't preserve it, so it round-trips as a plain straight-edged face) -
-see [`openskp/edit.py`](../packages/python/src/openskp/edit.py)'s own
+faithfully reproduced for that specific file - per-edge flags collapsed
+to a per-face approximation, a projected/distorted texture falling back
+to the default projection, a material's texture scale or colorized tint,
+an instance's hidden flag, a layer's color, section planes/text/
+dimensions (no writer support at all), and an original circle/arc's
+curve grouping (this project's reader doesn't preserve it, so it
+round-trips as a plain straight-edged face) - see
+[`openskp/edit.py`](../packages/python/src/openskp/edit.py)'s own
 module docstring for the complete, itemized list and the reasoning
 behind each one. Round-trip-validated against real, non-writer-authored
 architectural models, not just files this project's own writer produced.

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -133,7 +133,8 @@ mechanism SketchUp's own "dynamic component" attributes use), and
 circular faces and partial arcs (genuine, editable-by-radius arc/circle
 entities, not disconnected straight edges that merely trace that shape),
 and freeform polyline curves (an arbitrary chain of edges grouped into
-one genuine `CCurve` entity) are all supported, along with an
+one genuine `CCurve` entity) are all supported, along with faces with
+one or more holes cut out (a window opening in a wall, say) and an
 `add_face(..., auto_triangulate=True)` fallback for non-planar input.
 `openskp.open_existing()` can also load an *existing* legacy-format file
 and rebuild it as a new builder, so more geometry can be added to it
@@ -192,6 +193,11 @@ builder.add_polyline([(0, 0, 0), (10, 10, 0), (20, 0, 0), (30, 10, 0)])
 # faces instead of raising, the same thing SketchUp's own UI does
 warped_quad = [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 5)]
 builder.add_face(warped_quad, auto_triangulate=True)
+
+# A face with a hole cut out - a window opening in a wall
+wall = [(0, 0, 0), (200, 0, 0), (200, 100, 0), (0, 100, 0)]
+window = [(80, 30, 0), (120, 30, 0), (120, 70, 0), (80, 70, 0)]
+builder.add_face(wall, holes=[window])
 
 builder.save("output.skp")
 ```

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -1229,6 +1229,7 @@ class _ArchiveWriter:
         curve_params: Optional[
             Tuple[Point3, Tuple[float, float, float], Tuple[float, float, float], float, float, float, int]
         ] = None,
+        holes: Sequence[Sequence[Point3]] = (),
     ) -> int:
         """Write one planar face and return how many new root-entity-list
         slots it consumed (edges newly declared, plus the face itself) -
@@ -1276,6 +1277,20 @@ class _ArchiveWriter:
         OTHER edge newly declared by this call then backrefs that same
         slot instead of writing a null curve. An edge already shared
         with a previous face is left alone either way.
+
+        ``holes``, if given, is a sequence of point lists - each an
+        independent closed polygon (own winding direction doesn't
+        matter, confirmed via the SDK's own geometry-input API accepting
+        either), cut out of the face. Ground truth (an SDK-authored
+        window-in-a-wall face) shows a hole is just another ``CLoop`` in
+        the face's own ``nloops`` list, with its own independent edges -
+        the ONLY difference from the outer boundary loop is its first
+        flag byte (``0`` instead of ``1``; ground truth confirms this
+        exact byte marks a loop as a hole rather than the boundary,
+        tested with 2 holes in one face - both showed the same ``0``).
+        Every hole's points must lie on the same plane as ``points``
+        itself - a hole floating off the face's own plane doesn't mean
+        anything.
         """
         # Validate everything that CAN fail (a degenerate UV correspondence,
         # an unsupported attribute value) before writing a single byte or
@@ -1292,11 +1307,31 @@ class _ArchiveWriter:
         back_matrix = _uv_matrix_for_face(points, back_uv, (nx, ny, nz)) if back_uv is not None else None
         for _, entries in attribute_dicts:
             self._validate_attribute_entries(entries)
+        span = max(max(p[i] for p in points) - min(p[i] for p in points) for i in range(3))
+        tol = max(span, 1.0) * 1e-6
+        for hole in holes:
+            if len(hole) < 3:
+                raise SkpWriteError("a hole needs at least 3 points")
+            for p in hole:
+                dist = nx * p[0] + ny * p[1] + nz * p[2] - d
+                if abs(dist) > tol:
+                    raise SkpWriteError(
+                        f"hole point {p} is {abs(dist):.6g} units off the face's own "
+                        "plane - a hole must lie on the same plane as the outer boundary"
+                    )
 
         edge_slots, edge_senses, new_entities = self._write_edge_chain(
             points, vertex_slots, edge_registry, True,
             hidden_edges, soft_edges, smooth_edges, curve_params,
         )
+        hole_loops: List[Tuple[List[int], List[int]]] = []
+        for hole in holes:
+            h_edge_slots, h_edge_senses, h_new = self._write_edge_chain(
+                list(hole), vertex_slots, edge_registry, True,
+                hidden_edges, soft_edges, smooth_edges, None,
+            )
+            hole_loops.append((h_edge_slots, h_edge_senses))
+            new_entities += h_new
 
         self._new_of_known_class("CFace", schema=3)
         if front_uv is not None or back_uv is not None or attribute_dicts:
@@ -1305,7 +1340,7 @@ class _ArchiveWriter:
             self._preamble()
         self._drawbase(mat=face_material, layer=face_layer, hidden=hidden)
         self.buf += _f64(nx) + _f64(ny) + _f64(nz) + _f64(d)
-        self.buf += _u32(1)  # nloops = 1
+        self.buf += _u32(1 + len(holes))  # nloops
 
         loop_slot = self._new_of_known_class("CLoop", schema=1)
         self._preamble(pid=0)  # structural object: ground truth uses pid 0
@@ -1321,6 +1356,18 @@ class _ArchiveWriter:
             self.buf.append(edge_senses[i])
             self._backref(loop_slot)
         self._null()  # loop terminator
+
+        for h_edge_slots, h_edge_senses in hole_loops:
+            h_loop_slot = self._new_of_known_class("CLoop", schema=1)
+            self._preamble(pid=0)
+            self.buf += bytes([0, 1])  # ground truth: 0 marks a hole loop, not the boundary
+            for i in range(len(h_edge_slots)):
+                self._new_of_known_class("CEdgeUse", schema=1)
+                self._preamble(pid=0)
+                self._backref(h_edge_slots[i])
+                self.buf.append(h_edge_senses[i])
+                self._backref(h_loop_slot)
+            self._null()
 
         self.buf += struct.pack("<H", back_material)
         new_entities += 1  # the face itself
@@ -1410,6 +1457,7 @@ def _write_face_or_triangulate(
     back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]],
     attribute_dicts: Sequence[Tuple[str, Dict[str, object]]],
     auto_triangulate: bool,
+    holes: Sequence[Sequence[Point3]] = (),
 ) -> int:
     """Shared by :meth:`SkpBuilder.add_face` and
     :meth:`ComponentDefinitionBuilder.add_face` - writes ``points`` as one
@@ -1420,7 +1468,10 @@ def _write_face_or_triangulate(
     4-point face you draw that isn't quite flat is silently split into 2
     triangles rather than rejected. Not attempted for a genuinely
     degenerate (collinear) input - `_is_coplanar` still raises for that,
-    since no triangulation fixes it.
+    since no triangulation fixes it. Not attempted either when ``holes``
+    is given - a triangulated-with-holes face isn't supported, so a
+    non-planar boundary combined with holes just falls through to
+    `write_face`'s own (in that case, hole-plane) validation error.
 
     Not compatible with ``front_uv``/``back_uv``: positioning a texture
     from one 3-point correspondence doesn't generalize to a fan of
@@ -1429,12 +1480,13 @@ def _write_face_or_triangulate(
     Returns the total new-root-entity-list-slot count (same contract as
     `write_face`/`write_arc`/`write_polyline`).
     """
-    if not auto_triangulate or len(points) == 3 or _is_coplanar(points):
+    if holes or not auto_triangulate or len(points) == 3 or _is_coplanar(points):
         return writer.write_face(
             points, vertex_slots, edge_registry,
             material, layer, back_material,
             hidden, soft_edges, smooth_edges, hidden_edges,
             front_uv, back_uv, attribute_dicts,
+            holes=holes,
         )
     if front_uv is not None or back_uv is not None:
         raise SkpWriteError("auto_triangulate cannot be combined with front_uv/back_uv positioning")
@@ -1501,6 +1553,7 @@ class ComponentDefinitionBuilder:
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
         auto_triangulate: bool = False,
+        holes: Sequence[Sequence[Point3]] = (),
     ) -> None:
         """Add one planar face to this definition - same signature and
         behavior as :meth:`SkpBuilder.add_face`, except vertices/edges are
@@ -1510,12 +1563,14 @@ class ComponentDefinitionBuilder:
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
+        holes = [[(float(p[0]), float(p[1]), float(p[2])) for p in hole] for hole in holes]
         attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += _write_face_or_triangulate(
             self._skp._definition_writer, points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
             front_uv, back_uv, attribute_dicts, auto_triangulate,
+            holes=holes,
         )
 
     def add_circle(
@@ -2141,6 +2196,7 @@ class SkpBuilder:
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
         auto_triangulate: bool = False,
+        holes: Sequence[Sequence[Point3]] = (),
     ) -> None:
         """Add one planar face, defined by 3 or more coplanar points (in
         inches) forming a closed polygon in order - do not repeat the
@@ -2196,10 +2252,23 @@ class SkpBuilder:
         unpredictable number of independently-drawn triangles). Already-
         planar input is written as a single face either way - this only
         changes behavior for input that would otherwise be rejected.
+
+        ``holes``, if given, is a sequence of point lists - each an
+        independent closed polygon (winding direction doesn't matter)
+        cut out of the face, e.g. a window opening in a wall:
+
+        >>> wall = [(0, 0, 0), (200, 0, 0), (200, 100, 0), (0, 100, 0)]
+        >>> window = [(80, 30, 0), (120, 30, 0), (120, 70, 0), (80, 70, 0)]
+        >>> builder.add_face(wall, holes=[window])
+
+        Every hole's points must lie on the same plane as ``points``
+        itself. Not combined with ``auto_triangulate`` - see that
+        parameter's own note.
         """
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
+        holes = [[(float(p[0]), float(p[1]), float(p[2])) for p in hole] for hole in holes]
         self._ensure_geometry_writer()
         attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += _write_face_or_triangulate(
@@ -2207,6 +2276,7 @@ class SkpBuilder:
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
             front_uv, back_uv, attribute_dicts, auto_triangulate,
+            holes=holes,
         )
         self._face_count += 1
 

--- a/packages/python/src/openskp/edit.py
+++ b/packages/python/src/openskp/edit.py
@@ -24,9 +24,6 @@ module's own docstring for why):
 * Only a **legacy-format** (SketchUp 2013-2020) source file is accepted -
   :mod:`openskp.create` never writes any other format, so a modern VFF
   (2021+) source can't be faithfully round-tripped through it.
-* A face with more than one loop (a hole) is skipped - `write_face`
-  (like real SketchUp's own simplest case) only supports a single
-  boundary loop; a warning is returned identifying it.
 * Per-edge ``hidden``/``soft``/``smooth`` flags are applied per-FACE, not
   per-edge (an "any edge in this boundary has the flag" approximation) -
   `add_face` can only set these uniformly for every edge it newly
@@ -194,7 +191,7 @@ def _edge_map(defn: Definition) -> Dict[int, Tuple[int, int]]:
 def _definition_has_content(defn: Definition, def_builders: Dict[int, ComponentDefinitionBuilder]) -> bool:
     edges = _edge_map(defn)
     for face in defn.faces.values():
-        if len(face.loops) != 1:
+        if not face.loops:
             continue
         if len(_scene_mod._reconstruct_loop_vertices(face.loops[0], edges)) >= 3:
             return True
@@ -239,14 +236,22 @@ def _replay_face(
     warnings: List[str],
     context: str,
 ) -> None:
-    if len(face.loops) != 1:
-        warnings.append(f"{context}: face {face.id} has {len(face.loops)} loops (holes) - skipped")
+    if len(face.loops) < 1:
+        warnings.append(f"{context}: face {face.id} has no loops - skipped")
         return
     vert_ids = _scene_mod._reconstruct_loop_vertices(face.loops[0], edges)
     if len(vert_ids) < 3:
         warnings.append(f"{context}: face {face.id} has fewer than 3 usable points - skipped")
         return
     points = [(defn.vertices[v].x, defn.vertices[v].y, defn.vertices[v].z) for v in vert_ids]
+
+    holes: List[List[Point3]] = []
+    for hole_loop in face.loops[1:]:
+        hole_vert_ids = _scene_mod._reconstruct_loop_vertices(hole_loop, edges)
+        if len(hole_vert_ids) < 3:
+            warnings.append(f"{context}: face {face.id} has a hole with fewer than 3 usable points - skipped")
+            return
+        holes.append([(defn.vertices[v].x, defn.vertices[v].y, defn.vertices[v].z) for v in hole_vert_ids])
 
     loop_edges = [defn.edges[eid] for eid, _ in face.loops[0] if eid in defn.edges]
     hidden_edges = any(e.hidden for e in loop_edges)
@@ -265,6 +270,7 @@ def _replay_face(
             material=material, back_material=back_material,
             hidden=face.hidden, soft_edges=soft_edges, smooth_edges=smooth_edges, hidden_edges=hidden_edges,
             front_uv=front_uv, back_uv=back_uv,
+            holes=holes,
         )
     except SkpWriteError as exc:
         warnings.append(f"{context}: face {face.id} skipped ({exc})")

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -363,6 +363,101 @@ class TestAutoTriangulate:
         legacy._walk(data)
 
 
+class TestFaceHoles:
+    WALL = [(0.0, 0.0, 0.0), (200.0, 0.0, 0.0), (200.0, 100.0, 0.0), (0.0, 100.0, 0.0)]
+    WINDOW = [(80.0, 30.0, 0.0), (120.0, 30.0, 0.0), (120.0, 70.0, 0.0), (80.0, 70.0, 0.0)]
+    WINDOW_2 = [(20.0, 30.0, 0.0), (50.0, 30.0, 0.0), (50.0, 70.0, 0.0), (20.0, 70.0, 0.0)]
+
+    def test_single_hole_produces_two_loops(self):
+        builder = create()
+        builder.add_face(self.WALL, holes=[self.WINDOW])
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        faces = [v for (_, n, v) in root if n == "CFace"]
+        assert len(faces) == 1
+        assert len(faces[0]["loops"]) == 2
+        assert len(faces[0]["loops"][0]["uses"]) == 4  # outer boundary
+        assert len(faces[0]["loops"][1]["uses"]) == 4  # hole
+
+    def test_two_holes_produce_three_loops(self):
+        builder = create()
+        builder.add_face(self.WALL, holes=[self.WINDOW, self.WINDOW_2])
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        faces = [v for (_, n, v) in root if n == "CFace"]
+        assert len(faces[0]["loops"]) == 3
+
+    def test_hole_loop_flag_byte_is_zero_boundary_loop_stays_one(self):
+        # Ground truth (an SDK-authored window-in-a-wall face, byte-decoded):
+        # CLoop's first flag byte is 1 for the boundary loop, 0 for a hole
+        # loop - the second byte is 1 either way. legacy.py's reader treats
+        # both bytes as opaque (`_read_loop` just does `r.raw(2)`), so
+        # capture them directly by patching the reader for this one check.
+        flag_bytes = []
+        orig = legacy._READERS["CLoop"]
+
+        def patched(ar, r):
+            my_slot = ar.next_slot - 1
+            prev = ar.current_loop
+            ar.current_loop = my_slot
+            legacy._preamble(ar, r)
+            flag_bytes.append(r.raw(2))
+            uses = []
+            while True:
+                if r.peek_u16() == 0:
+                    r.pos += 2
+                    break
+                _, _, v = ar.read_object(r, expect="CEdgeUse")
+                uses.append(v)
+            ar.current_loop = prev
+            return {"k": "loop", "uses": uses}
+
+        legacy._READERS["CLoop"] = patched
+        try:
+            builder = create()
+            builder.add_face(self.WALL, holes=[self.WINDOW])
+            legacy._walk(builder.to_bytes())
+        finally:
+            legacy._READERS["CLoop"] = orig
+
+        assert flag_bytes == [bytes([1, 1]), bytes([0, 1])]
+
+    def test_hole_not_on_face_plane_raises(self):
+        builder = create()
+        off_plane_hole = [(80.0, 30.0, 5.0), (120.0, 30.0, 0.0), (120.0, 70.0, 0.0), (80.0, 70.0, 0.0)]
+        with pytest.raises(SkpWriteError, match="off the face's own plane"):
+            builder.add_face(self.WALL, holes=[off_plane_hole])
+
+    def test_hole_with_too_few_points_raises(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="at least 3 points"):
+            builder.add_face(self.WALL, holes=[[(1.0, 1.0, 0.0), (2.0, 2.0, 0.0)]])
+
+    def test_hole_winding_direction_does_not_matter(self):
+        # Ground truth (SDK oracle, both directions tested): a hole's own
+        # winding relative to the outer boundary doesn't affect whether
+        # it's recognized as a hole - confirm both orders self-parse
+        # identically (same loop/edge counts) rather than one silently
+        # producing a different structure.
+        forward = create()
+        forward.add_face(self.WALL, holes=[self.WINDOW])
+        reversed_builder = create()
+        reversed_builder.add_face(self.WALL, holes=[list(reversed(self.WINDOW))])
+        for b in (forward, reversed_builder):
+            ar, root, layers, materials = legacy._walk(b.to_bytes())
+            faces = [v for (_, n, v) in root if n == "CFace"]
+            assert len(faces[0]["loops"]) == 2
+            assert len(faces[0]["loops"][1]["uses"]) == 4
+
+    def test_hole_in_component_definition(self):
+        builder = create()
+        with builder.add_component_definition("Wall") as wall:
+            wall.add_face(self.WALL, holes=[self.WINDOW])
+        builder.add_instance(wall)
+        data = builder.to_bytes()
+        legacy._walk(data)
+
+
 class TestNonManifoldTopology:
     # Three triangular "fins" sharing one common edge (the z-axis segment
     # from (0,0,0) to (0,0,100)) - nothing in the CEdgeUse/loop encoding
@@ -3149,6 +3244,45 @@ class TestRealSketchUpOracle:
             nf = ctypes.c_size_t()
             dll.SUEntitiesGetNumFaces(entities, ctypes.byref(nf))
             assert nf.value == 2
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_face_hole_area_is_subtracted_by_real_sketchup(self, tmp_path):
+        # The real, load-bearing claim for holes: not just "the file opens
+        # and has 2 loops" but that real SketchUp actually treats the
+        # inner loop as a genuine subtracted opening - confirmed via the
+        # face's own reported area, not just structural presence.
+        import ctypes
+
+        outer = [(0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (100.0, 100.0, 0.0), (0.0, 100.0, 0.0)]
+        hole = [(30.0, 30.0, 0.0), (70.0, 30.0, 0.0), (70.0, 70.0, 0.0), (30.0, 70.0, 0.0)]
+        builder = create()
+        builder.add_face(outer, holes=[hole])
+        out = tmp_path / "hole_face.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetFaces.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUFaceGetArea.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_double)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            faces = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetFaces(entities, 1, faces, ctypes.byref(got))
+            assert got.value == 1
+            area = ctypes.c_double()
+            dll.SUFaceGetArea(faces[0], ctypes.byref(area))
+            assert area.value == pytest.approx(100 * 100 - 40 * 40)
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()

--- a/packages/python/tests/test_edit.py
+++ b/packages/python/tests/test_edit.py
@@ -127,13 +127,31 @@ class TestOpenExisting:
         assert rebuilt.materials[0].texture is not None
         assert rebuilt.materials[0].texture.data == _make_test_png()
 
-    def test_face_with_hole_is_skipped_not_corrupting(self, tmp_path):
-        # write_face itself only supports a single loop, so a 2-loop face
-        # can't come from this project's own writer - simulate the reader
-        # seeing one anyway by monkeypatching a definition's own faces
-        # after a normal parse, confirming the skip path doesn't corrupt
-        # anything written after it.
-        from openskp.model import Face
+    def test_face_with_hole_round_trips(self, tmp_path):
+        # add_face's holes= support (added alongside this module) means a
+        # multi-loop face is now faithfully replayed, not skipped.
+        wall = [(0.0, 0.0, 0.0), (200.0, 0.0, 0.0), (200.0, 100.0, 0.0), (0.0, 100.0, 0.0)]
+        window = [(80.0, 30.0, 0.0), (120.0, 30.0, 0.0), (120.0, 70.0, 0.0), (80.0, 70.0, 0.0)]
+        builder = create()
+        builder.add_face(wall, holes=[window])
+        src = tmp_path / "source.skp"
+        builder.save(str(src))
+
+        new_builder, warnings = edit.open_existing(str(src))
+        assert not any("hole" in w for w in warnings)
+        out = tmp_path / "rebuilt.skp"
+        out.write_bytes(new_builder.to_bytes())
+        rebuilt = SkpFile.open(str(out)).parse()
+        face = next(iter(rebuilt.root.faces.values()))
+        assert len(face.loops) == 2
+
+    def test_face_with_invalid_hole_is_skipped_not_corrupting(self, tmp_path):
+        # A hole loop that isn't on the face's own plane is something
+        # write_face itself rejects (upfront-validated, before writing
+        # any bytes) - simulate the reader seeing one anyway by
+        # monkeypatching a parsed definition's faces, confirming the
+        # skip-this-face path doesn't corrupt geometry written afterward.
+        from openskp.model import Edge, Face, Vertex
 
         builder = create()
         builder.add_face(SQUARE)
@@ -144,14 +162,30 @@ class TestOpenExisting:
         model = SkpFile.open(str(src)).parse()
         first_id = next(iter(model.root.faces))
         original = model.root.faces[first_id]
-        model.root.faces[first_id] = Face(id=original.id, loops=[original.loops[0], original.loops[0]])
+
+        # Fabricate an off-plane "hole" loop using fresh vertex/edge ids.
+        off_plane_pts = [(20.0, 20.0, 5.0), (40.0, 20.0, 5.0), (40.0, 40.0, 5.0), (20.0, 40.0, 5.0)]
+        base_vid = max(model.root.vertices) + 1
+        base_eid = max(model.root.edges) + 1
+        hole_loop = []
+        for i, p in enumerate(off_plane_pts):
+            vid = base_vid + i
+            model.root.vertices[vid] = Vertex(id=vid, x=p[0], y=p[1], z=p[2])
+        for i in range(4):
+            eid = base_eid + i
+            v1 = base_vid + i
+            v2 = base_vid + (i + 1) % 4
+            model.root.edges[eid] = Edge(id=eid, v1_id=v1, v2_id=v2)
+            hole_loop.append((eid, 1))
+
+        model.root.faces[first_id] = Face(id=original.id, loops=[original.loops[0], hole_loop])
 
         new_builder = create()
         warnings = []
         material_slots = edit._replay_materials(new_builder, model, warnings)
         layer_slots = {}
         edit._replay_body(new_builder, model.root, model, material_slots, layer_slots, warnings, "root", {})
-        assert any("holes" in w for w in warnings)
+        assert any("skipped" in w for w in warnings)
         data = new_builder.to_bytes()
         # self-parses cleanly and the second (valid) face survived
         out = tmp_path / "rebuilt.skp"


### PR DESCRIPTION
## Summary

- `add_face(..., holes=[...])` cuts one or more independent closed polygons out of a face (a window opening in a wall, say) as real additional loops in the same `CFace` record, not a separate, unconnected geometry hack.
- Ground-truth-derived from an SDK-authored window-in-a-wall face (`SUGeometryInputFaceAddInnerLoop`): a hole loop is structurally identical to the boundary loop except its first flag byte (`0` instead of `1`), and its winding direction doesn't matter — confirmed both via the SDK's own geometry-input API accepting either winding, and independently by writing raw bytes both ways and checking `SUFaceGetArea` correctly subtracts the hole either way.
- `openskp.edit`'s replay now reproduces a multi-loop face faithfully instead of skipping it, removing that gap from `open_existing()`'s known limitations.

Prompted by independent third-party feedback (an external AI-driven capability test of `openskp.create`) that identified "no boolean operations" as a limitation — a hole cut into a coplanar face is the common real-world case that feedback actually hit (cutting an opening in a flat wall/panel); a general arbitrary-volume 3D boolean subtract is a separate, much larger problem not attempted here.

## Test plan

- [x] New unit tests: single/multiple holes, ground-truth flag byte, off-plane rejection, too-few-points rejection, winding-direction independence, definition nesting — `pytest tests/test_create.py -k TestFaceHoles`
- [x] Real SketchUp SDK oracle test confirming the hole's area is genuinely subtracted (`SUFaceGetArea`)
- [x] `openskp.edit` tests updated: multi-loop face round-trips faithfully; a genuinely invalid (off-plane) hole is skipped without corrupting subsequent geometry
- [x] Full existing suite: 319 passed
- [x] `ruff check` clean