### PR TITLE
Expose materials_by_name/layers_by_name and open_existing()'s definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,10 +90,10 @@ for the full scope notes.
   models (not just files this project's own writer produced), confirming
   face/instance/definition counts and the real SDK's own acceptance of
   the rebuilt file. Returns a list of warnings for anything the source
-  file had that couldn't be faithfully reproduced (a face with a hole, a
-  projected texture, a colorized material's tint, and several others —
-  see the module's own docstring for the complete, itemized list) rather
-  than silently dropping it.
+  file had that couldn't be faithfully reproduced (a projected texture,
+  a colorized material's tint, and several others — see the module's
+  own docstring for the complete, itemized list) rather than silently
+  dropping it.
 - `rotation=(axis, angle_radians)` on `add_instance`/`add_group`/
   `add_group_instance` — a convenience alternative to hand-deriving a
   `matrix3x3` rotation matrix for the common case of a pure rotation
@@ -107,10 +107,6 @@ for the full scope notes.
   instead of raising, the same silent fallback real SketchUp's own UI
   applies when you draw a not-quite-flat face. Off by default — existing
   strict-planarity behavior is unchanged unless opted into.
-  file had that couldn't be faithfully reproduced (a projected texture,
-  a colorized material's tint, and several others — see the module's
-  own docstring for the complete, itemized list) rather than silently
-  dropping it.
 - `add_face(..., holes=[...])` — cut one or more independent closed
   polygons out of a face (a window opening in a wall, say) as real
   additional loops in the same `CFace` record, not a separate,
@@ -123,6 +119,21 @@ for the full scope notes.
   (`SUFaceGetArea`), not just structurally present.
   `openskp.open_existing()` now replays a multi-loop face faithfully
   instead of skipping it.
+- `SkpBuilder.materials_by_name`/`layers_by_name` — every material/layer
+  registered so far, by name, always kept up to date as a side effect of
+  `add_material`/`add_texture_material`/`add_layer` (previously a private,
+  undocumented implementation detail). `openskp.open_existing()` now
+  also returns a third value, `definitions` (component definition name →
+  its builder), so a caller can reuse the source file's own materials,
+  layers, and component definitions on new geometry — e.g.
+  `builder.add_face(pts, material=builder.materials_by_name["Walnut"])`
+  or `builder.add_instance(definitions["Wheel"], translation=...)` —
+  without reaching into a private attribute. Registering a genuinely NEW
+  material/layer/definition/group on the returned builder still isn't
+  possible (the file format's own ordering requirement is already
+  satisfied by the time replay finishes writing root-level geometry);
+  that limitation is now documented and tested rather than just
+  discovered by trial and error.
 
 ### Fixed
 
@@ -165,9 +176,6 @@ entities) as a regression guard.
   format has no mechanism for one definition's declaration to live inside
   another's, so a nested group's geometry has to be built separately
   first (see `add_group_instance` above).
-- Editing an existing arbitrary `.skp` file — a separately harder
-  problem (real SketchUp re-serializes the whole document on save rather
-  than appending), not attempted here.
 - The other four language ports (TypeScript, .NET, Dart, C++) do not
   have write support yet.
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -644,7 +644,7 @@ content that more geometry can still be added to before saving:
 ```python
 from openskp import open_existing
 
-builder, warnings = open_existing("building.skp")
+builder, warnings, definitions = open_existing("building.skp")
 for w in warnings:
     print("not fully reproduced:", w)
 
@@ -666,6 +666,26 @@ round-trips as a plain straight-edged face) - see
 module docstring for the complete, itemized list and the reasoning
 behind each one. Round-trip-validated against real, non-writer-authored
 architectural models, not just files this project's own writer produced.
+
+Every material/layer the source had is already reachable on the
+returned `builder` without a separate lookup - `builder.materials_by_name
+["Walnut"]`/`builder.layers_by_name["Roof"]` - and `definitions` maps
+each replayed component definition's own name to its builder, for
+placing more instances of something the source already defined:
+
+```python
+builder.add_face(points, material=builder.materials_by_name["Walnut"])
+builder.add_instance(definitions["Wheel"], translation=(50, 0, 0))
+```
+
+What the returned `builder` can no longer do is register a genuinely
+NEW material, layer, or component definition/group - by the time
+replay finishes writing the source's own root-level geometry, this
+writer's usual file-format ordering requirement (materials/layers/
+definitions must be finalized before any geometry) is already
+satisfied, so `add_material`/`add_layer`/`add_component_definition`/
+`add_group` all raise on this particular builder. Build anything new
+into a separate `create()` call instead.
 
 ## The web viewer
 

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -214,17 +214,20 @@ producing a brand-new file with equivalent content:
 ```python
 from openskp import open_existing
 
-builder, warnings = open_existing("building.skp")
+builder, warnings, definitions = open_existing("building.skp")
 for w in warnings:
     print("not fully reproduced:", w)
 
-builder.add_circle((0, 0, 100), (0, 0, 1), radius=50)
+# Every material/layer the source had is already reusable, no separate lookup:
+builder.add_circle((0, 0, 100), (0, 0, 1), radius=50, material=builder.materials_by_name.get("Roofing"))
+# definitions maps each replayed component's own name to its builder:
+builder.add_instance(definitions["Window"], translation=(0, 300, 0))
 builder.save("building_edited.skp")
 ```
 
 `warnings` lists anything the source file had that couldn't be
-faithfully reproduced (a face with a hole, a projected texture, a
-material's texture scale, and several others) — see
+faithfully reproduced (a projected texture, a material's texture scale,
+and several others) — see
 [`openskp/edit.py`](src/openskp/edit.py) for the complete, itemized
 scope.
 

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -1852,7 +1852,14 @@ class SkpBuilder:
         # Materials always start allocating at `base`, the same slot the
         # (possibly absent) material section would have occupied.
         self._material_writer = _ArchiveWriter(next_slot=base, class_slot={})
-        self._materials_by_name: Dict[str, int] = {}
+        #: Every material registered so far, by name - populated by
+        #: `add_material`/`add_texture_material` as a side effect (they
+        #: already de-dupe by name through this same dict), not something
+        #: a caller needs to maintain separately. Useful for reusing a
+        #: handle without having kept the one `add_material` originally
+        #: returned - e.g. after `openskp.open_existing()`, every material
+        #: the source file had is already here.
+        self.materials_by_name: Dict[str, int] = {}
         self._material_count = 0
         # Deferred: layers splice in AFTER materials, so the layer writer's
         # starting slot depends on the final material count. Constructed
@@ -1861,7 +1868,9 @@ class SkpBuilder:
         self._layer_writer_base = layer_writer_base
         self._layer_writer: Optional[_ArchiveWriter] = None
         self._layer_writer_start: Optional[int] = None
-        self._layers_by_name: Dict[str, int] = {}
+        #: Every layer registered so far, by name - same pattern as
+        #: `materials_by_name`, populated automatically by `add_layer`.
+        self.layers_by_name: Dict[str, int] = {}
         self._layer_count = 0
         # Deferred the same way as the layer writer: component definitions
         # splice in after layers, before root-level geometry, so their
@@ -1898,14 +1907,14 @@ class SkpBuilder:
             raise SkpWriteError("add_material must be called before any add_layer calls")
         if self._definition_writer is not None:
             raise SkpWriteError("add_material must be called before any add_component_definition calls")
-        if name in self._materials_by_name:
-            return self._materials_by_name[name]
+        if name in self.materials_by_name:
+            return self.materials_by_name[name]
         if len(rgba) == 3:
             rgba = (*rgba, 255)
         if len(rgba) != 4 or not all(isinstance(c, int) and 0 <= c <= 255 for c in rgba):
             raise SkpWriteError("rgba must be 3 or 4 integers in 0-255")
         slot = self._material_writer.write_material(name, tuple(rgba))
-        self._materials_by_name[name] = slot
+        self.materials_by_name[name] = slot
         self._material_count += 1
         return slot
 
@@ -1934,13 +1943,13 @@ class SkpBuilder:
             raise SkpWriteError("add_texture_material must be called before any add_layer calls")
         if self._definition_writer is not None:
             raise SkpWriteError("add_texture_material must be called before any add_component_definition calls")
-        if name in self._materials_by_name:
-            return self._materials_by_name[name]
+        if name in self.materials_by_name:
+            return self.materials_by_name[name]
         with open(image_path, "rb") as f:
             image_bytes = f.read()
         subtype = _detect_image_subtype(image_bytes)
         slot = self._material_writer.write_textured_material(name, image_bytes, image_path, subtype=subtype)
-        self._materials_by_name[name] = slot
+        self.materials_by_name[name] = slot
         self._material_count += 1
         return slot
 
@@ -1961,8 +1970,8 @@ class SkpBuilder:
             raise SkpWriteError("add_layer must be called before any add_face calls")
         if self._definition_writer is not None:
             raise SkpWriteError("add_layer must be called before any add_component_definition calls")
-        if name in self._layers_by_name:
-            return self._layers_by_name[name]
+        if name in self.layers_by_name:
+            return self.layers_by_name[name]
         if self._layer_writer is None:
             material_shift = self._material_writer.next_slot - self._base
             self._layer_writer_start = self._layer_writer_base + material_shift
@@ -1977,7 +1986,7 @@ class SkpBuilder:
                 next_slot=self._layer_writer_start, class_slot=self._material_shifted_class_slot()
             )
         slot = self._layer_writer.write_layer(name)
-        self._layers_by_name[name] = slot
+        self.layers_by_name[name] = slot
         self._layer_count += 1
         return slot
 

--- a/packages/python/src/openskp/edit.py
+++ b/packages/python/src/openskp/edit.py
@@ -17,6 +17,23 @@ definition, every face/instance) to produce a brand-new file - not a
 byte-patched copy of the original, but a freshly-built one with equivalent
 content, to which the caller can add more geometry before saving.
 
+**Adding more geometry after the fact.** The returned builder can take
+more ``add_face``/``add_circle``/``add_instance``/etc. calls, and every
+material/layer the source had is already reachable via
+``builder.materials_by_name``/``builder.layers_by_name`` (no separate
+lookup needed - `open_existing` also returns a ``definitions`` dict
+mapping each component definition's name to its builder, for placing
+more instances of something the source already defined). What the
+returned builder can no longer do is register a genuinely NEW material,
+layer, or component definition/group - :mod:`openskp.create`'s own
+file-format ordering requirement (materials/layers/definitions must all
+be finalized before any geometry is written) is already satisfied by the
+time replay finishes writing the source's own root-level geometry
+(which happens for any source file with root-level content - in
+practice, almost always), so all four of `add_material`/`add_layer`/
+`add_component_definition`/`add_group` raise on the returned builder.
+Build anything new into a separate `create()` call instead.
+
 **Scope and known fidelity gaps** (this reads long because every gap here
 is a genuine, deliberately-scoped limitation, not an oversight - see each
 module's own docstring for why):
@@ -72,16 +89,38 @@ from .create import ComponentDefinitionBuilder, Point3, SkpBuilder, SkpWriteErro
 from .model import Definition, Face, Instance, SkpFile, SkpModel
 
 
-def open_existing(path: "str | pathlib.Path") -> Tuple[SkpBuilder, List[str]]:
+def open_existing(
+    path: "str | pathlib.Path",
+) -> Tuple[SkpBuilder, List[str], Dict[str, ComponentDefinitionBuilder]]:
     """Parse ``path`` (a legacy-format ``.skp`` file) and rebuild it as a
     new :class:`SkpBuilder`, replaying materials, layers, every component
     definition, and all root-level geometry/instances.
 
-    Returns ``(builder, warnings)`` - ``builder`` is ready for more
-    ``add_face``/``add_circle``/`add_instance``/etc. calls before
-    :meth:`SkpBuilder.save`; ``warnings`` lists anything from the source
-    file that couldn't be faithfully reproduced (see this module's own
-    docstring for the exact, deliberately-scoped gaps this draws from).
+    Returns ``(builder, warnings, definitions)``:
+
+    * ``builder`` is ready for more ``add_face``/``add_circle``/
+      ``add_instance``/etc. calls before :meth:`SkpBuilder.save`. Every
+      material and layer the source file had is already reachable via
+      ``builder.materials_by_name``/``builder.layers_by_name`` - reuse
+      one as e.g. ``add_face(points, material=builder.materials_by_name
+      ["Walnut"])``. A file format ordering requirement this writer has
+      always had (materials/layers/definitions must be finalized before
+      any geometry is written) means a genuinely NEW material/layer/
+      definition/group can no longer be added to ``builder`` at this
+      point, since replaying the source's own root-level geometry
+      already finalized all of those sections - build anything new into
+      a SEPARATE `create()` builder instead.
+    * ``warnings`` lists anything from the source file that couldn't be
+      faithfully reproduced (see this module's own docstring for the
+      exact, deliberately-scoped gaps this draws from).
+    * ``definitions`` maps each replayed component definition's own name
+      to its (already-closed) :class:`~openskp.create.
+      ComponentDefinitionBuilder`, so the caller can place additional
+      instances of something the source file already defined via
+      ``builder.add_instance(definitions["Wheel"], translation=...)``.
+      If two source definitions share a name, the later one wins - real
+      SketchUp allows duplicate component names, this project's writer
+      doesn't need them to be unique, only this convenience lookup does.
 
     Raises:
         SkpWriteError: if ``path`` isn't a legacy-format file.
@@ -119,7 +158,12 @@ def open_existing(path: "str | pathlib.Path") -> Tuple[SkpBuilder, List[str]]:
 
     _replay_body(builder, model.root, model, material_slots, layer_slots, warnings, "root", def_builders)
 
-    return builder, warnings
+    definitions_by_name = {
+        model.definitions[def_id].name: db
+        for def_id, db in def_builders.items()
+        if model.definitions[def_id].name
+    }
+    return builder, warnings, definitions_by_name
 
 
 def _replay_materials(builder: SkpBuilder, model: SkpModel, warnings: List[str]) -> Dict[int, int]:

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1018,6 +1018,12 @@ class TestMaterials:
         ar, root, layers, materials = legacy._walk(data)
         assert len(materials) == 1
 
+    def test_materials_by_name_reflects_registered_handle(self):
+        builder = create()
+        red = builder.add_material("Red", (255, 0, 0))
+        assert builder.materials_by_name["Red"] == red
+        assert builder.materials_by_name == {"Red": red}
+
     def test_add_material_after_add_face_raises(self):
         builder = create()
         builder.add_face(SQUARE)
@@ -1925,6 +1931,11 @@ class TestLayers:
         data = builder.to_bytes()
         ar, root, layers, materials = legacy._walk(data)
         assert len(layers) == 2  # Layer0 + Shared
+
+    def test_layers_by_name_reflects_registered_handle(self):
+        builder = create()
+        roof = builder.add_layer("Roof")
+        assert builder.layers_by_name["Roof"] == roof
 
     def test_add_layer_after_add_face_raises(self):
         builder = create()

--- a/packages/python/tests/test_edit.py
+++ b/packages/python/tests/test_edit.py
@@ -51,7 +51,7 @@ class TestOpenExisting:
         src = tmp_path / "source.skp"
         builder.save(str(src))
 
-        new_builder, warnings = edit.open_existing(str(src))
+        new_builder, warnings, definitions = edit.open_existing(str(src))
         data = new_builder.to_bytes()
         out = tmp_path / "rebuilt.skp"
         out.write_bytes(data)
@@ -74,7 +74,7 @@ class TestOpenExisting:
         src = tmp_path / "source.skp"
         builder.save(str(src))
 
-        new_builder, warnings = edit.open_existing(str(src))
+        new_builder, warnings, definitions = edit.open_existing(str(src))
         out = tmp_path / "rebuilt.skp"
         out.write_bytes(new_builder.to_bytes())
         rebuilt = SkpFile.open(str(out)).parse()
@@ -96,7 +96,7 @@ class TestOpenExisting:
         src = tmp_path / "source.skp"
         builder.save(str(src))
 
-        new_builder, warnings = edit.open_existing(str(src))
+        new_builder, warnings, definitions = edit.open_existing(str(src))
         out = tmp_path / "rebuilt.skp"
         out.write_bytes(new_builder.to_bytes())
         rebuilt = SkpFile.open(str(out)).parse()
@@ -104,6 +104,71 @@ class TestOpenExisting:
         by_name = {d.name: d for d in rebuilt.definitions.values()}
         assert set(by_name) == {"Wheel", "Car"}
         assert len(by_name["Car"].instances) == 2
+
+    def test_materials_and_layers_reusable_after_replay(self, tmp_path):
+        # The practical gap independent testing surfaced: after
+        # open_existing(), a caller needs a way to reuse the source
+        # file's own materials/layers on new geometry without reaching
+        # into a private attribute.
+        builder = create()
+        red = builder.add_material("Red", (255, 0, 0))
+        roof = builder.add_layer("Roof")
+        builder.add_face(SQUARE, material=red, layer=roof)
+        src = tmp_path / "source.skp"
+        builder.save(str(src))
+
+        new_builder, warnings, definitions = edit.open_existing(str(src))
+        assert "Red" in new_builder.materials_by_name
+        assert "Roof" in new_builder.layers_by_name
+        # The reused handle actually works on new geometry, not just present.
+        new_builder.add_face(
+            [(300, 0, 0), (310, 0, 0), (310, 10, 0), (300, 10, 0)],
+            material=new_builder.materials_by_name["Red"],
+            layer=new_builder.layers_by_name["Roof"],
+        )
+        out = tmp_path / "rebuilt.skp"
+        out.write_bytes(new_builder.to_bytes())
+        rebuilt = SkpFile.open(str(out)).parse()
+        assert len(rebuilt.materials) == 1  # still just "Red" - reused, not duplicated
+        assert len(rebuilt.root.faces) == 2
+
+    def test_definitions_returned_by_name(self, tmp_path):
+        builder = create()
+        with builder.add_component_definition("Wheel") as wheel:
+            wheel.add_face([(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)])
+        builder.add_instance(wheel, translation=(0, 0, 0))
+        src = tmp_path / "source.skp"
+        builder.save(str(src))
+
+        new_builder, warnings, definitions = edit.open_existing(str(src))
+        assert "Wheel" in definitions
+        # The returned definition is directly usable for a NEW placement.
+        new_builder.add_instance(definitions["Wheel"], translation=(100, 0, 0))
+        out = tmp_path / "rebuilt.skp"
+        out.write_bytes(new_builder.to_bytes())
+        rebuilt = SkpFile.open(str(out)).parse()
+        assert len(rebuilt.definitions) == 1  # still just one Wheel definition
+        assert len(rebuilt.root.instances) == 2  # but now placed twice
+
+    def test_new_material_layer_definition_group_all_rejected_after_replay(self, tmp_path):
+        # Documented, tested constraint (not a bug): replaying a source
+        # file's own root-level geometry already finalizes the writer's
+        # materials/layers/definitions sections, per the same file-format
+        # ordering requirement every create() builder has always had.
+        builder = create()
+        builder.add_face(SQUARE)
+        src = tmp_path / "source.skp"
+        builder.save(str(src))
+
+        new_builder, warnings, definitions = edit.open_existing(str(src))
+        with pytest.raises(SkpWriteError, match="before any add_face"):
+            new_builder.add_material("Chrome", (180, 180, 185))
+        with pytest.raises(SkpWriteError, match="before any add_face"):
+            new_builder.add_layer("Extra")
+        with pytest.raises(SkpWriteError, match="before any add_face/add_instance"):
+            new_builder.add_component_definition("New")
+        with pytest.raises(SkpWriteError, match="before any add_face/add_instance"):
+            new_builder.add_group("NewGroup")
 
     def test_positioned_texture_round_trips(self, tmp_path):
         png_path = tmp_path / "tex.png"
@@ -117,7 +182,7 @@ class TestOpenExisting:
         src = tmp_path / "source.skp"
         builder.save(str(src))
 
-        new_builder, warnings = edit.open_existing(str(src))
+        new_builder, warnings, definitions = edit.open_existing(str(src))
         out = tmp_path / "rebuilt.skp"
         out.write_bytes(new_builder.to_bytes())
         rebuilt = SkpFile.open(str(out)).parse()
@@ -137,7 +202,7 @@ class TestOpenExisting:
         src = tmp_path / "source.skp"
         builder.save(str(src))
 
-        new_builder, warnings = edit.open_existing(str(src))
+        new_builder, warnings, definitions = edit.open_existing(str(src))
         assert not any("hole" in w for w in warnings)
         out = tmp_path / "rebuilt.skp"
         out.write_bytes(new_builder.to_bytes())
@@ -194,7 +259,7 @@ class TestOpenExisting:
         assert len(rebuilt.root.faces) == 1
 
     def test_empty_source_can_still_be_saved_after_adding_geometry(self, tmp_path):
-        new_builder, warnings = edit.open_existing(FIXTURES / "blank_v17.skp")
+        new_builder, warnings, definitions = edit.open_existing(FIXTURES / "blank_v17.skp")
         with pytest.raises(SkpWriteError, match="no geometry"):
             new_builder.to_bytes()
         new_builder.add_face(SQUARE)
@@ -213,7 +278,7 @@ class TestRealWorldFixtures:
         path = FIXTURES / fixture_name
         if not path.exists():
             pytest.skip(f"fixture {fixture_name} not present")
-        new_builder, warnings = edit.open_existing(str(path))
+        new_builder, warnings, definitions = edit.open_existing(str(path))
         data = new_builder.to_bytes()
         out = tmp_path / "rebuilt.skp"
         out.write_bytes(data)
@@ -226,7 +291,7 @@ class TestRealWorldFixtures:
         if not path.exists():
             pytest.skip("fixture not present")
         orig = SkpFile.open(str(path)).parse()
-        new_builder, warnings = edit.open_existing(str(path))
+        new_builder, warnings, definitions = edit.open_existing(str(path))
         out = tmp_path / "rebuilt.skp"
         out.write_bytes(new_builder.to_bytes())
         rebuilt = SkpFile.open(str(out)).parse()
@@ -259,7 +324,7 @@ class TestRealSketchUpOracle:
             pytest.skip("fixture not present")
 
         orig = SkpFile.open(str(path)).parse()
-        new_builder, warnings = edit.open_existing(str(path))
+        new_builder, warnings, definitions = edit.open_existing(str(path))
         out = tmp_path / "rebuilt.skp"
         out.write_bytes(new_builder.to_bytes())
 


### PR DESCRIPTION
## Summary

- `SkpBuilder.materials_by_name`/`layers_by_name` (renamed from the private `_materials_by_name`/`_layers_by_name`, already populated as a side effect of `add_material`/`add_texture_material`/`add_layer`) are now public API.
- `open_existing()` returns a third value, `definitions` (component definition name → its builder).
- Together these let a caller reuse a source file's own materials, layers, and component definitions on new geometry after editing, without reaching into a private attribute — independent testing had already discovered and relied on the private dict, so this makes that a supported, documented, tested path instead.
- Also documents and tests the real constraint this doesn't remove: `add_material`/`add_layer`/`add_component_definition`/`add_group` all still raise on a builder returned by `open_existing()`, since replaying the source's own root-level geometry already satisfies the file format's ordering requirement. Registering something genuinely new still needs a separate `create()` call.
- Fixes a few doc staleness issues found while updating these: an `open_existing()` example still using the old 2-tuple return, a leftover duplicated fragment in `CHANGELOG.md` from an earlier merge, and outdated "face with a hole" mentions in gap lists that predated `holes=` support.

Prompted by independent third-party feedback (a follow-up AI-driven test of `openskp.edit`) that had to reach into `builder._materials_by_name` to reuse existing materials, since there was no public way to do it.

## Test plan

- [x] New unit tests: `materials_by_name`/`layers_by_name` reflect registered handles — `pytest tests/test_create.py -k "materials_by_name or layers_by_name"`
- [x] New `openskp.edit` tests: materials/layers reusable and actually usable on new geometry after replay; definitions returned by name and usable for a new instance placement; all four of `add_material`/`add_layer`/`add_component_definition`/`add_group` confirmed to still raise after replay
- [x] Full existing suite: 324 passed
- [x] `ruff check` clean