### PR TITLE
Add hidden= to instances/groups and color=/hidden= to layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,15 @@ for the full scope notes.
   satisfied by the time replay finishes writing root-level geometry);
   that limitation is now documented and tested rather than just
   discovered by trial and error.
+- `hidden=True` on `add_instance`/`add_group`/`add_group_instance` — hides
+  that specific placement (its contents still exist in the file), the
+  same drawbase bit `add_face`'s own `hidden` already used. `color=`/
+  `hidden=` on `add_layer` — the layer's own color and default
+  visibility, both already exposed on the read side as `Layer.color_r/g/
+  b`/`Layer.hidden` but previously fixed at a hardcoded default on write.
+  All three confirmed against the real SDK (`SUDrawingElementGetHidden`,
+  `SULayerGetVisibility`). `openskp.open_existing()` now replays both
+  faithfully instead of warning that they were dropped.
 
 ### Fixed
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -514,6 +514,17 @@ import math
 builder.add_instance(wheel, translation=(0, 0, 0), rotation=((0, 0, 1), math.radians(90)))
 ```
 
+`add_instance`/`add_group`/`add_group_instance` also all take
+`hidden=True` to hide that specific placement (its contents still exist
+in the file, just not shown by default), and `add_layer` takes
+`color=(r, g, b)`/`hidden=True` for the layer's own color and default
+visibility:
+
+```python
+roof = builder.add_layer("Roof", color=(180, 60, 40), hidden=True)
+builder.add_instance(chair, hidden=True)
+```
+
 A face's texture can also be explicitly positioned (scaled, rotated,
 sheared, offset - independently per side) instead of the default planar
 projection, given 3 world-point/UV correspondences - on a face of any
@@ -658,10 +669,9 @@ returned `warnings` list is the honest account of what couldn't be
 faithfully reproduced for that specific file - per-edge flags collapsed
 to a per-face approximation, a projected/distorted texture falling back
 to the default projection, a material's texture scale or colorized tint,
-an instance's hidden flag, a layer's color, section planes/text/
-dimensions (no writer support at all), and an original circle/arc's
-curve grouping (this project's reader doesn't preserve it, so it
-round-trips as a plain straight-edged face) - see
+section planes/text/dimensions (no writer support at all), and an
+original circle/arc's curve grouping (this project's reader doesn't
+preserve it, so it round-trips as a plain straight-edged face) - see
 [`openskp/edit.py`](../packages/python/src/openskp/edit.py)'s own
 module docstring for the complete, itemized list and the reasoning
 behind each one. Round-trip-validated against real, non-writer-authored

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -150,7 +150,7 @@ builder = create()
 # Materials and layers
 red = builder.add_material("Red", (255, 0, 0))
 brick = builder.add_texture_material("Brick", "brick.png")
-roof_layer = builder.add_layer("Roof")
+roof_layer = builder.add_layer("Roof", color=(180, 60, 40))
 
 # All add_component_definition/add_group calls must come before any
 # add_instance/add_face call - placing anything locks in the file's
@@ -173,6 +173,8 @@ builder.add_instance(chair, translation=(0, 0, 0))
 # rotation=(axis, angle_radians) is a shortcut for a hand-derived matrix3x3
 import math
 builder.add_instance(chair, translation=(50, 0, 0), rotation=((0, 0, 1), math.radians(180)))
+# hidden=True hides this specific placement (its contents still exist)
+builder.add_instance(chair, translation=(100, 0, 0), hidden=True)
 
 # Root-level geometry
 builder.add_face(

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -887,7 +887,13 @@ class _ArchiveWriter:
         self.buf.append(0)  # use_opacity = False
         return slot
 
-    def write_layer(self, name: str, with_pids: bool = True) -> int:
+    def write_layer(
+        self,
+        name: str,
+        with_pids: bool = True,
+        hidden: bool = False,
+        rgba: Optional[Tuple[int, int, int, int]] = None,
+    ) -> int:
         """Write one ``CLayer`` record and return its slot. CLayer is
         always already declared (the scaffold's Layer0 guarantees it), so
         this never emits a new-class declaration - only a short class-ref.
@@ -900,15 +906,21 @@ class _ArchiveWriter:
         layer a component definition embeds internally - see
         `write_definition_header`) omits both: ground truth shows that
         copy carries neither its own preamble pid nor this second one.
+
+        ``rgba``, if given, is this layer's own color (:mod:`openskp.
+        legacy`'s reader already exposes it as ``Layer.color_r/g/b``) -
+        ``None`` keeps the previous default of all-zero bytes here,
+        unchanged from before this parameter existed.
         """
         slot = self._new_of_known_class("CLayer", schema=_LAYER_SCHEMA)
         self._preamble(pid=None if with_pids else 0)
         self._write_str(name)
         pid2 = self._alloc_pid() if with_pids else 0
-        self.buf += bytes(3) + self._encode_pid(pid2)  # hidden=0, pad, pad, then mask+pidbytes
+        # byte 0 is the hidden flag, bytes 1-2 are always zero (ground truth)
+        self.buf += bytes([1 if hidden else 0, 0, 0]) + self._encode_pid(pid2)
         self._write_str(f"Layer_{name}")
         self.buf += struct.pack("<H", 256)  # ground truth is a constant 256 here
-        self.buf += bytes(4)  # rgba - layers don't carry a rendering color
+        self.buf += bytes(rgba) if rgba is not None else bytes(4)
         self._write_str("")  # second name field - empty in ground truth
         self.buf += bytes(8) + _f64(0.5) + bytes(5)  # 21-byte tail, opacity-like f64=0.5
         return slot
@@ -989,13 +1001,14 @@ class _ArchiveWriter:
         mat: int,
         layer: int,
         attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
+        hidden: bool = False,
     ) -> None:
         self._new_of_known_class(class_name, schema=schema)
         if real_attrs and attribute_dicts:
             self._preamble_with_real_attrs(attribute_dicts=attribute_dicts)
         else:
             self._preamble(real_attrs=real_attrs)
-        self._drawbase(mat=mat, layer=layer)
+        self._drawbase(mat=mat, layer=layer, hidden=hidden)
         self._backref(definition_slot)
         if matrix3x3 is None:
             matrix3x3 = (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
@@ -1013,6 +1026,7 @@ class _ArchiveWriter:
         instance_material: int = 0,
         instance_layer: int = 0,
         attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
+        hidden: bool = False,
     ) -> int:
         """Write one ``CComponentInstance`` placing a copy of
         ``definition_slot`` (from `write_definition_header`) and return how
@@ -1034,12 +1048,17 @@ class _ArchiveWriter:
         attributes use). Not available on `write_group` - ground truth
         shows a group's attribute pointer is always null, unlike a
         component instance's real (if often empty) container.
+
+        ``hidden`` hides the instance itself (SketchUp's "Hide" on this
+        specific placement) - the same drawbase bit `write_face` already
+        uses for a face, ground truth confirms it means the same thing
+        here.
         """
         # ground truth: instances also carry a real (empty) attr container, unlike CGroup
         self._write_instance_like(
             "CComponentInstance", _INSTANCE_SCHEMA, True,
             definition_slot, name, translation, matrix3x3, instance_material, instance_layer,
-            attribute_dicts,
+            attribute_dicts, hidden,
         )
         return 1
 
@@ -1051,6 +1070,7 @@ class _ArchiveWriter:
         matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
         group_material: int = 0,
         group_layer: int = 0,
+        hidden: bool = False,
     ) -> int:
         """Write one ``CGroup`` placing a copy of ``definition_slot`` and
         return how many new root-entity-list slots it consumed - always 1,
@@ -1066,6 +1086,7 @@ class _ArchiveWriter:
         self._write_instance_like(
             "CGroup", _GROUP_SCHEMA, False,
             definition_slot, name, translation, matrix3x3, group_material, group_layer,
+            hidden=hidden,
         )
         return 1
 
@@ -1516,7 +1537,7 @@ class ComponentDefinitionBuilder:
 
     def __init__(
         self, skp: "SkpBuilder", slot: int, name: str, count_patch_pos: int,
-        group_placement: Optional[Tuple[Tuple[float, float, float], Optional[Tuple[float, ...]], int, int]] = None,
+        group_placement: Optional[Tuple[Tuple[float, float, float], Optional[Tuple[float, ...]], int, int, bool]] = None,
     ):
         self._skp = skp
         self.slot = slot
@@ -1675,6 +1696,7 @@ class ComponentDefinitionBuilder:
         layer: Optional[int] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        hidden: bool = False,
     ) -> None:
         """Place one instance of another, already-closed component
         definition inside this one - the same nesting real SketchUp
@@ -1702,7 +1724,8 @@ class ComponentDefinitionBuilder:
 
         ``rotation``, if given, is a ``(axis, angle_radians)`` pair - an
         alternative to hand-deriving ``matrix3x3`` for the common case of
-        a pure rotation; pass at most one of the two.
+        a pure rotation; pass at most one of the two. ``hidden`` hides
+        this specific placement (SketchUp's "Hide" on the instance).
         """
         self._check_writable("instances")
         if definition._skp is not self._skp:
@@ -1716,7 +1739,7 @@ class ComponentDefinitionBuilder:
         attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += self._skp._definition_writer.write_instance(
             definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0,
-            attribute_dicts,
+            attribute_dicts, hidden,
         )
 
     def add_group_instance(
@@ -1728,6 +1751,7 @@ class ComponentDefinitionBuilder:
         rotation: Optional[Tuple[Tuple[float, float, float], float]] = None,
         material: Optional[int] = None,
         layer: Optional[int] = None,
+        hidden: bool = False,
     ) -> None:
         """Place another, already-closed component definition inside this
         one as a *group* (``CGroup``) rather than a component instance -
@@ -1751,7 +1775,8 @@ class ComponentDefinitionBuilder:
 
         ``rotation``, if given, is a ``(axis, angle_radians)`` pair - an
         alternative to hand-deriving ``matrix3x3`` for the common case of
-        a pure rotation; pass at most one of the two.
+        a pure rotation; pass at most one of the two. ``hidden`` hides
+        this specific placement.
         """
         self._check_writable("groups")
         if definition._skp is not self._skp:
@@ -1763,7 +1788,7 @@ class ComponentDefinitionBuilder:
             raise SkpWriteError(f"component definition {self.name!r} cannot nest a group instance of itself")
         matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
         self._new_entity_count += self._skp._definition_writer.write_group(
-            definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0
+            definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0, hidden,
         )
 
     def __enter__(self) -> "ComponentDefinitionBuilder":
@@ -1953,18 +1978,30 @@ class SkpBuilder:
         self._material_count += 1
         return slot
 
-    def add_layer(self, name: str) -> int:
+    def add_layer(
+        self,
+        name: str,
+        color: Optional[Sequence[int]] = None,
+        hidden: bool = False,
+    ) -> int:
         """Register a layer and return a handle to pass as `add_face`'s
         ``layer`` argument.
 
         Calling this again with a name already registered returns the same
-        handle rather than creating a duplicate layer.
+        handle rather than creating a duplicate layer (``color``/``hidden``
+        are ignored on a repeat call - only the first registration sets them).
 
         All layers must be added before the first `add_face` call, for the
         same reason as `add_material`. They must also come before any
         `add_component_definition` call - layers are spliced in earlier in
         the file, so a definition's own slot numbering depends on the
         final layer count too.
+
+        ``color``, if given, is ``(r, g, b)`` or ``(r, g, b, a)``, each
+        0-255 (alpha defaults to 255) - :mod:`openskp.legacy`'s reader
+        already exposes this back as ``Layer.color_r/g/b``. ``hidden``
+        sets the layer's own visibility (SketchUp's layer-panel checkbox),
+        exposed back as ``Layer.hidden``.
         """
         if self._geometry_writer is not None:
             raise SkpWriteError("add_layer must be called before any add_face calls")
@@ -1972,6 +2009,13 @@ class SkpBuilder:
             raise SkpWriteError("add_layer must be called before any add_component_definition calls")
         if name in self.layers_by_name:
             return self.layers_by_name[name]
+        rgba: Optional[Tuple[int, int, int, int]] = None
+        if color is not None:
+            if len(color) == 3:
+                color = (*color, 255)
+            if len(color) != 4 or not all(isinstance(c, int) and 0 <= c <= 255 for c in color):
+                raise SkpWriteError("color must be 3 or 4 integers in 0-255")
+            rgba = tuple(color)
         if self._layer_writer is None:
             material_shift = self._material_writer.next_slot - self._base
             self._layer_writer_start = self._layer_writer_base + material_shift
@@ -1985,7 +2029,7 @@ class SkpBuilder:
             self._layer_writer = _ArchiveWriter(
                 next_slot=self._layer_writer_start, class_slot=self._material_shifted_class_slot()
             )
-        slot = self._layer_writer.write_layer(name)
+        slot = self._layer_writer.write_layer(name, hidden=hidden, rgba=rgba)
         self.layers_by_name[name] = slot
         self._layer_count += 1
         return slot
@@ -2009,7 +2053,7 @@ class SkpBuilder:
 
     def _start_definition(
         self, name: str, caller: str,
-        group_placement: Optional[Tuple[Tuple[float, float, float], Optional[Tuple[float, ...]], int, int]] = None,
+        group_placement: Optional[Tuple[Tuple[float, float, float], Optional[Tuple[float, ...]], int, int, bool]] = None,
         attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> "ComponentDefinitionBuilder":
         if self._geometry_writer is not None:
@@ -2067,6 +2111,7 @@ class SkpBuilder:
         rotation: Optional[Tuple[Tuple[float, float, float], float]] = None,
         material: Optional[int] = None,
         layer: Optional[int] = None,
+        hidden: bool = False,
     ) -> "ComponentDefinitionBuilder":
         """Start a new group. Use the returned object as a context manager,
         adding its geometry via `.add_face` inside the ``with`` block - the
@@ -2084,11 +2129,13 @@ class SkpBuilder:
 
         ``rotation``, if given, is a ``(axis, angle_radians)`` pair - an
         alternative to hand-deriving ``matrix3x3`` for the common case of
-        a pure rotation; pass at most one of the two.
+        a pure rotation; pass at most one of the two. ``hidden`` hides
+        this group once placed.
         """
         matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
         return self._start_definition(
-            name or "Group", "add_group", group_placement=(translation, matrix3x3, material or 0, layer or 0)
+            name or "Group", "add_group",
+            group_placement=(translation, matrix3x3, material or 0, layer or 0, hidden),
         )
 
     def _definition_shift(self) -> int:
@@ -2112,6 +2159,7 @@ class SkpBuilder:
         layer: Optional[int] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        hidden: bool = False,
     ) -> None:
         """Place one instance of ``definition`` (from
         `add_component_definition`, already closed) in the model.
@@ -2135,6 +2183,10 @@ class SkpBuilder:
         specifically (as opposed to its definition), under a dictionary
         named ``attribute_dict_name`` - the same mechanism SketchUp's own
         "dynamic component" attributes use for per-instance overrides.
+
+        ``hidden`` hides this specific placement (SketchUp's "Hide" on
+        the instance) - its contents still exist in the file, just not
+        shown by default.
         """
         if definition._skp is not self:
             raise SkpWriteError(
@@ -2151,7 +2203,7 @@ class SkpBuilder:
         attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
         self._new_entity_count += self._geometry_writer.write_instance(
             definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0,
-            attribute_dicts,
+            attribute_dicts, hidden,
         )
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 
@@ -2183,9 +2235,9 @@ class SkpBuilder:
         # created - deferred until now so closing one group doesn't lock in
         # root-level slot numbering before a later add_group/
         # add_component_definition call has had a chance to run.
-        for comp, (translation, matrix3x3, mat, layer) in self._pending_groups:
+        for comp, (translation, matrix3x3, mat, layer, hidden) in self._pending_groups:
             self._new_entity_count += self._geometry_writer.write_group(
-                comp.slot, comp.name, translation, matrix3x3, mat, layer
+                comp.slot, comp.name, translation, matrix3x3, mat, layer, hidden,
             )
             self._face_count += 1
         self._pending_groups = []

--- a/packages/python/src/openskp/edit.py
+++ b/packages/python/src/openskp/edit.py
@@ -58,10 +58,6 @@ module's own docstring for why):
 * Per-face material/layer painting: only a face's front/back *material*
   is replayed - this project's reader doesn't expose a per-face layer
   assignment at all (only instances carry an explicit layer).
-* An instance's ``hidden`` flag isn't reproduced - `add_instance` has no
-  visibility parameter yet.
-* A layer's color and hidden state aren't reproduced - `add_layer` only
-  takes a name.
 * Every placed thing (originally a group or a component instance alike)
   is replayed as a plain component instance - structurally simpler, and
   visually identical, but no longer shows as a "Group" in SketchUp's
@@ -140,10 +136,12 @@ def open_existing(
     builder = create()
 
     material_slots = _replay_materials(builder, model, warnings)
-    layer_slots = {layer.name: builder.add_layer(layer.name) for layer in model.layers}
-    for layer in model.layers:
-        if layer.hidden or (layer.color_r, layer.color_g, layer.color_b) != (200, 200, 200):
-            warnings.append(f"layer {layer.name!r}: color/hidden state not reproduced")
+    layer_slots = {
+        layer.name: builder.add_layer(
+            layer.name, color=(layer.color_r, layer.color_g, layer.color_b), hidden=layer.hidden,
+        )
+        for layer in model.layers
+    }
 
     def_builders: Dict[int, ComponentDefinitionBuilder] = {}
     for def_id in _definition_order(model):
@@ -373,11 +371,8 @@ def _replay_instance(
     try:
         target.add_instance(
             def_builder, name=inst.name or None, translation=translation, matrix3x3=matrix3x3,
-            material=material, layer=layer,
+            material=material, layer=layer, hidden=inst.hidden,
             attributes=inst.properties or None, attribute_dict_name="dynamic_attributes",
         )
     except SkpWriteError as exc:
         warnings.append(f"{context}: instance {inst.name!r} skipped ({exc})")
-        return
-    if inst.hidden:
-        warnings.append(f"{context}: instance {inst.name!r} was hidden - hidden flag not reproduced")

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -601,6 +601,14 @@ class TestGroups:
         # attribute pointer, not the real (empty) CAttributeContainer.
         assert inst["attrs"] is None
 
+    def test_hidden_group(self):
+        builder = create()
+        with builder.add_group("Table", hidden=True) as table:
+            table.add_face(SQUARE)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        assert root[0][2]["db"]["hidden"] == 1
+
     def test_group_without_geometry_raises(self):
         builder = create()
         with pytest.raises(SkpWriteError, match="no geometry"):
@@ -688,6 +696,28 @@ class TestNestedDefinitions:
         assert {inst.name for inst in car_def.instances} == {"Wheel"}
         translations = sorted(inst.matrix[9] for inst in car_def.instances)
         assert translations == [0.0, 200.0]
+
+    def test_hidden_instance_at_root_and_nested(self):
+        builder = create()
+        with builder.add_component_definition("Wheel") as wheel:
+            wheel.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_instance(wheel, translation=(0.0, 0.0, 0.0), hidden=True)
+        builder.add_instance(car, hidden=True)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        assert root[0][2]["db"]["hidden"] == 1
+
+    def test_hidden_group_instance(self):
+        builder = create()
+        with builder.add_component_definition("Engine") as engine:
+            engine.add_face(SQUARE)
+        with builder.add_component_definition("Car") as car:
+            car.add_face(SQUARE)
+            car.add_group_instance(engine, hidden=True)
+        builder.add_instance(car)
+        data = builder.to_bytes()
+        legacy._walk(data)
 
     def test_real_sketchup_resolves_nested_instances(self, tmp_path):
         # Recursively resolving Car -> 2x Wheel -> 1 face each through 2
@@ -1936,6 +1966,41 @@ class TestLayers:
         builder = create()
         roof = builder.add_layer("Roof")
         assert builder.layers_by_name["Roof"] == roof
+
+    def test_layer_color_and_hidden_round_trip(self):
+        builder = create()
+        roof = builder.add_layer("Roof", color=(150, 75, 30), hidden=True)
+        builder.add_face(SQUARE, layer=roof)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        by_slot = {s: v for s, v in layers}
+        assert by_slot[roof]["rgba"] == (150, 75, 30, 255)
+        assert by_slot[roof]["hidden"] == 1
+
+    def test_layer_color_alpha_defaults_to_opaque(self):
+        builder = create()
+        roof = builder.add_layer("Roof", color=(10, 20, 30))
+        builder.add_face(SQUARE, layer=roof)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        by_slot = {s: v for s, v in layers}
+        assert by_slot[roof]["rgba"] == (10, 20, 30, 255)
+
+    def test_layer_without_color_or_hidden_matches_previous_bytes(self):
+        # No behavior change for callers not using the new parameters.
+        builder = create()
+        roof = builder.add_layer("Roof")
+        builder.add_face(SQUARE, layer=roof)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        by_slot = {s: v for s, v in layers}
+        assert by_slot[roof]["rgba"] == (0, 0, 0, 0)
+        assert by_slot[roof]["hidden"] == 0
+
+    def test_invalid_layer_color_raises(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="color"):
+            builder.add_layer("Bad", color=(300, 0, 0))
 
     def test_add_layer_after_add_face_raises(self):
         builder = create()
@@ -3294,6 +3359,75 @@ class TestRealSketchUpOracle:
             area = ctypes.c_double()
             dll.SUFaceGetArea(faces[0], ctypes.byref(area))
             assert area.value == pytest.approx(100 * 100 - 40 * 40)
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_hidden_instance_group_and_layer_visibility_match_real_sketchup(self, tmp_path):
+        import ctypes
+
+        builder = create()
+        roof = builder.add_layer("Roof", color=(150, 75, 30), hidden=True)
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with builder.add_group("Table", hidden=True) as table:
+            table.add_face(SQUARE)
+        builder.add_instance(chair, hidden=True, layer=roof)
+        out = tmp_path / "hidden_oracle.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetInstances.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUEntitiesGetGroups.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUDrawingElementGetHidden.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_bool)]
+        dll.SUModelGetNumLayers.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUModelGetLayers.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SULayerGetVisibility.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_bool)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+
+            inst = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetInstances(entities, 1, inst, ctypes.byref(got))
+            assert got.value == 1
+            hidden = ctypes.c_bool()
+            dll.SUDrawingElementGetHidden(inst[0], ctypes.byref(hidden))
+            assert hidden.value is True
+
+            grp = (ctypes.c_void_p * 1)()
+            got2 = ctypes.c_size_t()
+            dll.SUEntitiesGetGroups(entities, 1, grp, ctypes.byref(got2))
+            assert got2.value == 1
+            hidden2 = ctypes.c_bool()
+            dll.SUDrawingElementGetHidden(grp[0], ctypes.byref(hidden2))
+            assert hidden2.value is True
+
+            nl = ctypes.c_size_t()
+            dll.SUModelGetNumLayers(model, ctypes.byref(nl))
+            layers = (ctypes.c_void_p * nl.value)()
+            gotl = ctypes.c_size_t()
+            dll.SUModelGetLayers(model, nl.value, layers, ctypes.byref(gotl))
+            visibilities = []
+            for i in range(gotl.value):
+                vis = ctypes.c_bool()
+                dll.SULayerGetVisibility(layers[i], ctypes.byref(vis))
+                visibilities.append(vis.value)
+            assert False in visibilities  # the hidden "Roof" layer
+            assert True in visibilities  # the default, visible "Layer0"
+
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()

--- a/packages/python/tests/test_edit.py
+++ b/packages/python/tests/test_edit.py
@@ -82,6 +82,25 @@ class TestOpenExisting:
         inst = rebuilt.root.instances[0]
         assert (inst.matrix[9], inst.matrix[10], inst.matrix[11]) == pytest.approx((37.5, -12.25, 8.0))
 
+    def test_preserves_instance_hidden_and_layer_color(self, tmp_path):
+        builder = create()
+        roof = builder.add_layer("Roof", color=(150, 75, 30), hidden=True)
+        with builder.add_component_definition("Post") as post:
+            post.add_face([(0, 0, 0), (5, 0, 0), (5, 5, 0), (0, 5, 0)])
+        builder.add_instance(post, hidden=True, layer=roof)
+        src = tmp_path / "source.skp"
+        builder.save(str(src))
+
+        new_builder, warnings, definitions = edit.open_existing(str(src))
+        out = tmp_path / "rebuilt.skp"
+        out.write_bytes(new_builder.to_bytes())
+        rebuilt = SkpFile.open(str(out)).parse()
+
+        assert rebuilt.root.instances[0].hidden is True
+        roof_layer = next(layer for layer in rebuilt.layers if layer.name == "Roof")
+        assert (roof_layer.color_r, roof_layer.color_g, roof_layer.color_b) == (150, 75, 30)
+        assert roof_layer.hidden is True
+
     def test_nested_definition_dependency_order(self, tmp_path):
         # Car nests 2 instances of Wheel - Wheel must be fully built and
         # closed before Car opens (write order matters for this format).


### PR DESCRIPTION
## Summary
- `add_instance`/`add_group`/`add_group_instance` gain a `hidden=` parameter, reusing the already-validated `_drawbase` mechanism shared with faces/edges.
- `add_layer` gains `color=`/`hidden=` parameters — the read side (`legacy.py`) already decodes a layer's rgba/hidden bytes; the write side had them hardcoded to zero/false behind a stale comment claiming layers don't carry a rendering color.
- `open_existing()` now replays both through, closing 2 items from its documented fidelity-gap list (instance hidden flag, layer color/hidden state), down from 9 to 7.

## Test plan
- [x] New unit tests in `test_create.py` (layer color/hidden round trip, alpha default, byte-compat check, invalid color validation, hidden group/instance placement at root and nested)
- [x] New `test_edit.py` case round-tripping a hidden instance + colored/hidden layer through `open_existing()`
- [x] SDK oracle test verifying real SketchUp (`SUDrawingElementGetHidden`, `SULayerGetVisibility`) agrees with the written bytes
- [x] Full suite (333 tests) + ruff clean