### PR TITLE
Elevate the writer/editor as a co-equal capability across all docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img src="assets/logo.png" width="500" Height="400" alt="OpenSKP logo"/>
 
-### The Open-Source SketchUp File Parser
+### The Open-Source SketchUp File Toolkit
 
-**Parse `.skp` files without SketchUp. No SDK. No license. Just code.**
+**Parse `.skp` files in five languages — and write them natively in Python. No SDK. No license. Just code.**
 
 ### 🏠 [openskp.com](https://openskp.com) · 🌐 [Try the Live Web Viewer (Drag-and-Drop)](https://iamahsanmehmood.github.io/openskp/) · 📖 [Browse the Docs Site](https://iamahsanmehmood.github.io/openskp/docs/)
 
@@ -18,7 +18,7 @@
 
 ---
 
-*Open-source SketchUp binary file parser for Python, TypeScript, .NET, Dart, and C++*
+*Open-source SketchUp binary file parser for Python, TypeScript, .NET, Dart, and C++ — plus a native `.skp` writer and editor in Python*
 
 [Quick Start](#-quick-start) · [Features](#-features) · [Used in Production](#-used-in-production) · [Documentation](#-documentation) · [Contributing](#-contributing)
 
@@ -28,9 +28,11 @@
 
 ## 🌟 What is OpenSKP?
 
-OpenSKP is the **first and only** open-source, cross-platform parser for SketchUp (`.skp`) binary files. Built entirely through reverse engineering of SketchUp's binary formats — both the modern **VFF container** (2021+) and the classic **MFC `CArchive`** container (2013–2020) — it gives you full programmatic access to 3D models — geometry, materials, components, layers, and more — without requiring the SketchUp application or its proprietary SDK, in **Python, TypeScript, .NET, Dart, and C++**.
+OpenSKP is the **first and only** open-source, cross-platform toolkit for SketchUp (`.skp`) binary files — built entirely through reverse engineering, with no SketchUp application or proprietary SDK required at any point.
 
-🧪 **New:** OpenSKP can now *write* native `.skp` files too — not just parse them. This is early-stage and Python-only for now (see the [Features](#-features) table below and [`openskp.create`](packages/python/src/openskp/create.py)); the other four ports don't have it yet, and contributions to bring them up to parity are very welcome.
+**Reading** is available in **five languages** — Python, TypeScript, .NET, Dart, and C++ — parsing both the modern **VFF container** (2021+) and the classic **MFC `CArchive`** container (2013–2020) into full programmatic access: geometry, materials, components, layers, and more.
+
+**Writing** is available in **Python**: a from-scratch legacy-format writer ([`openskp.create`](packages/python/src/openskp/create.py)) that produces real, editable geometry — materials and textures, layers, nested component definitions and groups, circular/arc curves, freeform polylines, faces with holes cut out — plus an editor ([`openskp.open_existing`](packages/python/src/openskp/edit.py)) that loads a file that already exists and extends it. Every writer feature is validated against the real SketchUp SDK, not just against this project's own reader, and it holds up rebuilding complex, real architectural models — not only synthetic test fixtures. Writing is Python-only today; porting it to the other four languages is a planned future direction, not yet under way — contributions toward that are very welcome.
 
 > [!IMPORTANT]
 > This project was built by reverse engineering a proprietary binary format. It is not affiliated with or endorsed by Trimble Inc. or SketchUp.
@@ -52,7 +54,8 @@ OpenSKP is the **first and only** open-source, cross-platform parser for SketchU
 | **Dynamic Components** | ✅ | Extracts dynamic component attribute key-value pairs for both modern (2021+) and legacy (2013–2020) files, in all five languages |
 | **Observability** | ✅ | Opt-in progress reporting + structured, location-carrying parse errors — see [docs/OBSERVABILITY.md](docs/OBSERVABILITY.md) |
 | **Export to GLB / OBJ / STL / PLY / DXF 3D / IFC4 / JSON** | ✅ | GLB, Wavefront OBJ, STL, PLY, DXF 3D (AutoCAD Polyface Mesh), IFC4 (BIM), and JSON metadata export are available natively across all five languages — see [Export capabilities](docs/DEVELOPER_GUIDE.md#export-capabilities) |
-| **Write native `.skp` files** | 🧪 Early (Python) | Build new `.skp` files from scratch — geometry, solid/textured materials, layers, component definitions with multiple instances, and groups. No SDK involved. Early-stage and Python-only for now — see [`openskp.create`](packages/python/src/openskp/create.py) |
+| **Write native `.skp` files** | 🧪 Python only | Build new `.skp` files from scratch — geometry (including genuine circular/arc curves, freeform polylines, faces with holes cut out, and non-planar auto-triangulation), solid/textured materials, layers, nested component definitions and groups, instance rotation/visibility, and custom attribute dictionaries. No SDK involved — every feature validated against the real SketchUp SDK. See [`openskp.create`](packages/python/src/openskp/create.py) |
+| **Edit existing `.skp` files** | 🧪 Python only | Load an existing legacy-format file and extend it — reuses its materials, layers, and component definitions, adds new geometry or instances, and saves a new file. See [`openskp.open_existing`](packages/python/src/openskp/edit.py) |
 | **Streaming / low-memory parsing** | ✅ | Peak memory bounded by the largest single definition, not the whole file — see [Memory architecture](docs/ARCHITECTURE.md#memory-architecture) |
 | **Pure Implementation** | ✅ | No SketchUp SDK, no native dependencies, no license required |
 | **Cross-Platform** | ✅ | Works on Linux, macOS, and Windows |
@@ -95,7 +98,8 @@ where the five ports currently differ.
 Pick your language — every sample below runs against the current public
 API (verified while writing this README). For the full picture (the
 opt-in `buildScene()` step for triangulated meshes, memory/performance
-guidance, progress + error observability, legacy-format support), see the
+guidance, progress + error observability, legacy-format support, and the
+full writer/editor API), see the
 **[Developer Guide](docs/DEVELOPER_GUIDE.md)**.
 
 ### 🐍 Python
@@ -123,7 +127,7 @@ scene = SkpFile.open("my_model.skp").build_scene()
 print(f"{len(scene.glb_primitives)} renderable mesh primitives")
 ```
 
-🧪 **Writing** (early-stage, Python-only):
+🧪 **Writing** (Python-only):
 
 ```python
 from openskp import create
@@ -133,9 +137,15 @@ red = builder.add_material("Red", (255, 0, 0))
 with builder.add_component_definition("Chair") as chair:
     chair.add_face([(0, 0, 0), (20, 0, 0), (20, 20, 0), (0, 20, 0)])
 builder.add_instance(chair, translation=(50, 0, 0))
+builder.add_instance(chair, translation=(100, 0, 0), hidden=True)
 builder.add_face([(0, 0, 0), (100, 0, 0), (100, 100, 0), (0, 100, 0)], material=red)
 builder.save("output.skp")
 ```
+
+And to extend a file that already exists rather than starting from
+scratch, use `open_existing()` — see
+[Editing an existing file](docs/DEVELOPER_GUIDE.md#editing-an-existing-file)
+in the Developer Guide.
 
 ### 📘 TypeScript / JavaScript
 
@@ -266,8 +276,8 @@ openskp/
 ├── CHANGELOG.md               # Release history
 │
 ├── packages/
-│   ├── python/                # 🐍 Python implementation
-│   │   ├── src/openskp/       # _core.py, legacy.py, model.py, scene.py, errors.py, ...
+│   ├── python/                # 🐍 Python implementation — parse + write
+│   │   ├── src/openskp/       # _core.py, legacy.py, model.py, scene.py, create.py, edit.py, ...
 │   │   └── tests/
 │   ├── typescript/            # 📘 TypeScript / JavaScript implementation
 │   │   ├── src/                # index.ts, model.ts, legacy.ts, observability.ts, ...

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -36,8 +36,8 @@ scene = skp.build_scene()
 print(len(scene.glb_primitives), "GLB-ready mesh primitives")
 ```
 
-🧪 **Writing (early-stage, Python-only — no equivalent in the other four
-languages yet):**
+🧪 **Writing (Python-only — no equivalent in the other four languages yet;
+porting it is a planned future direction):**
 
 ```python
 from openskp import create

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -434,11 +434,18 @@ for (const auto& prim : scene.glb_primitives) {
 
 Everything above this section is about reading `.skp` files. As of this
 writing, one language — Python — can also go the other direction: create a
-new `.skp` file from nothing.
+new `.skp` file from nothing, or load and extend a file that already
+exists. Python-only today, but the write path itself has matured well
+past a proof of concept — every feature below has been validated
+feature-by-feature against the real SketchUp SDK, and it holds up
+rebuilding complex, real architectural models, not just synthetic test
+fixtures. Porting it to the other four languages is a planned future
+direction, not yet under way — contributions toward that are very
+welcome.
 
 | Language | Write new `.skp` files |
 |---|---|
-| Python | 🧪 `openskp.create()` — early-stage, legacy-format (2013–2020) only |
+| Python | 🧪 `openskp.create()` / `openskp.open_existing()` — legacy-format (2013–2020) only |
 | TypeScript | ❌ not yet |
 | .NET | ❌ not yet |
 | Dart | ❌ not yet |
@@ -636,7 +643,7 @@ Explicitly out of scope for this first pass: declaring a group's
 geometry inline nested inside another definition (as opposed to placing
 an already-built one via `add_group_instance`), and attributes on
 groups. See [`openskp/create.py`](../packages/python/src/openskp/create.py)
-for the full, current scope notes, and the [Python package README](../packages/python/README.md#writing-early-stage)
+for the full, current scope notes, and the [Python package README](../packages/python/README.md#writing)
 for a longer worked example.
 
 ### Editing an existing file

--- a/examples/web-viewer/docs/index.html
+++ b/examples/web-viewer/docs/index.html
@@ -218,6 +218,8 @@ code[class*="language-"]{font-family:var(--font-code)!important;font-size:12.5px
 <nav id="mobile-nav-docs">
   <a class="mnav-item" href="#install"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4a2 2 0 0 0 1-1.73z"></path><polyline points="3.27 6.96 12 12.01 20.73 6.96"></polyline><line x1="12" y1="22.08" x2="12" y2="12"></line></svg>Install</a>
   <a class="mnav-item" href="#concepts"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"></polygon><polyline points="2 17 12 22 22 17"></polyline><polyline points="2 12 12 17 22 12"></polyline></svg>Concepts</a>
+  <a class="mnav-item" href="#writing-create"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="12" y1="18" x2="12" y2="12"></line><line x1="9" y1="15" x2="15" y2="15"></line></svg>Create</a>
+  <a class="mnav-item" href="#writing-edit"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>Edit</a>
   <a class="mnav-item" href="#data-model"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>Data Model</a>
   <a class="mnav-item" href="#legacy"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"></polyline><rect x="1" y="3" width="22" height="5"></rect><line x1="10" y1="12" x2="14" y2="12"></line></svg>Legacy</a>
   <a class="mnav-item" href="#performance"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"></polygon></svg>Performance</a>
@@ -239,6 +241,16 @@ code[class*="language-"]{font-family:var(--font-code)!important;font-size:12.5px
     </a>
     <a class="nav-item" href="#concepts" onclick="setActive(this)">
       <svg class="nav-icon" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"></polygon><polyline points="2 17 12 22 22 17"></polyline><polyline points="2 12 12 17 22 12"></polyline></svg>Core Concepts
+    </a>
+  </div>
+  <div class="nav-divider"></div>
+  <div class="nav-section">
+    <span class="nav-lbl">Writing (Python)</span>
+    <a class="nav-item" href="#writing-create" onclick="setActive(this)">
+      <svg class="nav-icon" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="12" y1="18" x2="12" y2="12"></line><line x1="9" y1="15" x2="15" y2="15"></line></svg>Create Files
+    </a>
+    <a class="nav-item" href="#writing-edit" onclick="setActive(this)">
+      <svg class="nav-icon" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>Edit Files
     </a>
   </div>
   <div class="nav-divider"></div>
@@ -283,7 +295,7 @@ code[class*="language-"]{font-family:var(--font-code)!important;font-size:12.5px
 <!-- Hero -->
 <div id="hero">
   <div class="hero-title">OpenSKP Documentation</div>
-  <div class="hero-sub">The open-source SketchUp (.skp) file parser — Python, TypeScript, .NET, Dart, and C++. No SketchUp SDK, no license, both the modern VFF (2021+) and classic MFC (2013–2020) formats. This page is the detailed, verified developer reference; the full write-ups live in <a href="https://github.com/iamahsanmehmood/openskp/tree/main/docs" target="_blank" rel="noopener">docs/</a> on GitHub.</div>
+  <div class="hero-sub">The open-source SketchUp (.skp) file toolkit — parsing in Python, TypeScript, .NET, Dart, and C++, plus a native <code>.skp</code> writer and editor in Python. No SketchUp SDK, no license, both the modern VFF (2021+) and classic MFC (2013–2020) formats. This page is the detailed, verified developer reference; the full write-ups live in <a href="https://github.com/iamahsanmehmood/openskp/tree/main/docs" target="_blank" rel="noopener">docs/</a> on GitHub.</div>
   <div class="hero-stats">
     <div><div class="hero-stat-n">5</div><div class="hero-stat-l">Languages</div></div>
     <div><div class="hero-stat-n">179</div><div class="hero-stat-l">Tests passing</div></div>
@@ -431,6 +443,217 @@ std::cout &lt;&lt; scene.glb_primitives.size() &lt;&lt; " mesh primitives\n";</c
     <div class="fn-body">
       <div class="fn-desc">Walks the <strong>entire placed scene graph</strong>: every instance of every component, nested arbitrarily deep, each with its transform resolved to world space, each face triangulated (a ported <a href="https://github.com/mapbox/earcut" target="_blank" rel="noopener">earcut</a> — the same algorithm in all five languages) and grouped by resolved color into GLB-ready mesh primitives. For a file that reuses a handful of definitions across many thousands of placements, this can produce <strong>far more data</strong> than the file's raw geometry — that's why it's a separate, opt-in call.</div>
       <div class="callout callout-info">Calling both <code>parse()</code> and <code>buildScene()</code> re-parses the raw TLV data <strong>twice</strong> — a deliberate trade of extra CPU time for guaranteeing <code>parse()</code> alone never pays for scene-baking's cost. They're independent, not layered.</div>
+    </div>
+  </div>
+</section>
+
+<!-- Writing: Create Files -->
+<section id="writing-create">
+  <div class="sec-head">
+    <div class="sec-icon"><svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="12" y1="18" x2="12" y2="12"></line><line x1="9" y1="15" x2="15" y2="15"></line></svg></div>
+    <div>
+      <div class="sec-title">Creating Files</div>
+      <div class="sec-sub"><code>openskp.create()</code> — build a new .skp file from nothing, Python only</div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-body">
+      <div class="fn-desc">OpenSKP can also go the other direction: <code>openskp.create()</code> returns an <code>SkpBuilder</code> that assembles a genuine legacy MFC <code>CArchive</code>-format <code>.skp</code> file (SketchUp 2013–2020) from nothing — geometry, materials, layers, component definitions, and groups — with <strong>no SketchUp SDK</strong> involved at import, build, or save time. It works by inverting this project's own reader logic against a small bundled blank-document scaffold.</div>
+      <div class="fn-desc">Every feature on this page has been validated feature-by-feature against the <strong>real SketchUp SDK</strong> (<code>SketchUpAPI.dll</code>), not just against this project's own reader — and it holds up rebuilding complex, real architectural models, not only synthetic test fixtures.</div>
+      <div class="callout callout-warn"><strong>Python-only today.</strong> Porting the writer to TypeScript, .NET, Dart, and C++ is a planned future direction, not yet under way — contributions toward that are very welcome.</div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Materials, layers &amp; geometry</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc">Solid-color and PNG/JPEG-textured materials, and named layers with their own color and default visibility — reused by name across every face, instance, and group you place.</div>
+      <div class="code-wrap">
+        <div class="code-hdr"><span class="code-lang">python</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">from openskp import create
+
+builder = create()
+red = builder.add_material("Red", (255, 0, 0))
+brick = builder.add_texture_material("Brick", "brick.png")
+roof = builder.add_layer("Roof", color=(180, 60, 40))
+
+builder.add_face(
+    [(0, 0, 0), (200, 0, 0), (200, 150, 0), (0, 150, 0)],
+    material=red, layer=roof,
+)
+builder.save("output.skp")</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Definitions, instances &amp; groups</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc">Reusable component definitions with multiple positioned instances, one-off groups, and nesting to any depth — a definition can place instances or groups of its own already-built sub-parts, the same way a real SketchUp assembly does.</div>
+      <div class="code-wrap">
+        <div class="code-hdr"><span class="code-lang">python</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">with builder.add_component_definition("Wheel") as wheel:
+    wheel.add_face([(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0)])
+
+with builder.add_component_definition("Car") as car:
+    car.add_instance(wheel, translation=(0, 0, 0))
+    car.add_instance(wheel, translation=(100, 0, 0))
+
+builder.add_instance(car, translation=(0, 0, 0))
+with builder.add_group("Table", translation=(200, 0, 0)) as table:
+    table.add_face([(0, 0, 0), (60, 0, 0), (60, 40, 0), (0, 40, 0)])</code></pre>
+      </div>
+      <div class="callout callout-info">One ordering rule falls out of the format's own slot numbering: every <code>add_component_definition</code>/<code>add_group</code> call must happen before any <code>add_face</code>/<code>add_instance</code> call on the builder itself.</div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Rotation &amp; visibility</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc"><code>rotation=(axis, angle_radians)</code> is a shortcut for a hand-derived <code>matrix3x3</code>, and every placement — instance or group — can be created <code>hidden=True</code> (its contents still exist in the file, just not shown by default).</div>
+      <div class="code-wrap">
+        <div class="code-hdr"><span class="code-lang">python</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">import math
+
+builder.add_instance(wheel, translation=(0, 0, 0), rotation=((0, 0, 1), math.radians(90)))
+builder.add_instance(wheel, translation=(100, 0, 0), hidden=True)</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Curved geometry</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc"><code>add_circle</code>/<code>add_arc</code> write a genuine, editable-by-radius <code>CArcCurve</code> entity — not disconnected straight edges that merely trace the shape. <code>add_polyline</code> groups an arbitrary edge chain into one real <code>CCurve</code> entity, the same grouping SketchUp's own Freehand tool produces.</div>
+      <div class="code-wrap">
+        <div class="code-hdr"><span class="code-lang">python</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">builder.add_circle((100, 75, 0), normal=(0, 0, 1), radius=30, num_segments=24)
+builder.add_arc((100, 75, 0), normal=(0, 0, 1), radius=30, start_angle=0, end_angle=math.pi / 2)
+builder.add_polyline([(0, 0, 0), (10, 10, 0), (20, 0, 0), (30, 10, 0)])</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Faces: holes &amp; non-planar input</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc">A face can have one or more holes cut out of it (a window opening in a wall) via <code>holes=</code>, and <code>auto_triangulate=True</code> fan-triangulates non-planar input instead of raising — the same silent fallback real SketchUp's own UI applies to a not-quite-flat quad.</div>
+      <div class="code-wrap">
+        <div class="code-hdr"><span class="code-lang">python</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">wall = [(0, 0, 0), (200, 0, 0), (200, 100, 0), (0, 100, 0)]
+window = [(80, 30, 0), (120, 30, 0), (120, 70, 0), (80, 70, 0)]
+builder.add_face(wall, holes=[window])
+
+warped_quad = [(0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 5)]
+builder.add_face(warped_quad, auto_triangulate=True)  # -&gt; 2 triangular faces</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Texture positioning &amp; custom attributes</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc">A face's texture can be explicitly positioned (scaled, rotated, sheared, offset — independently per side) via 3 world-point/UV correspondences, on a face of any orientation. Component definitions, instances, and faces can also carry custom key/value metadata — the same mechanism SketchUp's own "dynamic component" attributes use.</div>
+      <div class="code-wrap">
+        <div class="code-hdr"><span class="code-lang">python</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">builder.add_face(
+    [(0, 0, 0), (100, 0, 0), (100, 100, 0), (0, 100, 0)],
+    material=brick,
+    front_uv=[((0, 0, 0), (0.0, 0.0)), ((50, 0, 0), (1.0, 0.0)), ((0, 50, 0), (0.0, 1.0))],
+)
+
+with builder.add_component_definition("Chair", attributes={"sku": "CH-100", "price": 49.99}) as chair:
+    chair.add_face([(0, 0, 0), (20, 0, 0), (20, 20, 0), (0, 20, 0)])</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Scope at a glance</div></div></div>
+    <div class="fn-body">
+      <div class="tblwrap">
+      <table class="doc-table">
+        <thead><tr><th>Feature</th><th>Status</th></tr></thead>
+        <tbody>
+          <tr><td>Solid + PNG/JPEG-textured materials</td><td><span class="yes">✓</span></td></tr>
+          <tr><td>Layers with color &amp; default visibility</td><td><span class="yes">✓</span></td></tr>
+          <tr><td>Component definitions, multi-instance, groups, nesting</td><td><span class="yes">✓</span></td></tr>
+          <tr><td>Instance/group rotation &amp; hidden state</td><td><span class="yes">✓</span></td></tr>
+          <tr><td>Circular/arc curves &amp; freeform polylines</td><td><span class="yes">✓</span></td></tr>
+          <tr><td>Faces with holes &amp; auto-triangulation</td><td><span class="yes">✓</span></td></tr>
+          <tr><td>Explicit per-side texture positioning</td><td><span class="yes">✓</span></td></tr>
+          <tr><td>Custom attributes on definitions/instances/faces</td><td><span class="yes">✓</span></td></tr>
+          <tr><td>Attributes on groups</td><td><span class="no">✗ not yet</span></td></tr>
+          <tr><td>Modern VFF (2021+) output</td><td><span class="no">✗ legacy format only</span></td></tr>
+        </tbody>
+      </table>
+      </div>
+      <div class="fn-desc" style="margin-top:14px">See <a href="https://github.com/iamahsanmehmood/openskp/blob/main/packages/python/src/openskp/create.py" target="_blank" rel="noopener"><code>openskp/create.py</code></a> for the full, current scope notes.</div>
+    </div>
+  </div>
+</section>
+
+<!-- Writing: Edit Files -->
+<section id="writing-edit">
+  <div class="sec-head">
+    <div class="sec-icon"><svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg></div>
+    <div>
+      <div class="sec-title">Editing Existing Files</div>
+      <div class="sec-sub"><code>openskp.open_existing()</code> — load a file that already exists, and extend it</div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-body">
+      <div class="fn-desc"><code>openskp.create()</code> only ever starts from its own blank scaffold. Real SketchUp never patches a file in place either — it fully re-serializes the whole document on every save — so there's no stable byte region to append to for an arbitrary existing file. <code>open_existing()</code> takes the same approach real SketchUp effectively does: <strong>parse → replay → extend → save</strong>. It fully parses the source file with this project's own reader, then replays everything it understood — materials, layers, every component definition, all root-level geometry and instances — back through the writer's own public API, producing a brand-new file with equivalent content that more geometry can still be added to.</div>
+      <div class="code-wrap">
+        <div class="code-hdr"><span class="code-lang">python</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">from openskp import open_existing
+
+builder, warnings, definitions = open_existing("building.skp")
+for w in warnings:
+    print("not fully reproduced:", w)
+
+# Every material/layer the source had is already reusable, no separate lookup:
+roof = builder.materials_by_name.get("Roofing")
+builder.add_circle((0, 0, 100), (0, 0, 1), radius=50, material=roof)
+
+# definitions maps each replayed component's own name to its builder:
+builder.add_instance(definitions["Window"], translation=(0, 300, 0))
+builder.save("building_edited.skp")</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">What can and can't be added afterward</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc">The returned builder is ready for more <code>add_face</code>/<code>add_circle</code>/<code>add_instance</code>/etc. calls, reusing every material and layer the source already had. What it can no longer do is register a genuinely <strong>new</strong> material, layer, or component definition/group — by the time replay finishes writing the source's own root-level geometry, this writer's usual file-format ordering requirement (materials/layers/definitions must be finalized before any geometry) is already satisfied.</div>
+      <div class="callout callout-warn"><code>add_material</code>, <code>add_layer</code>, <code>add_component_definition</code>, and <code>add_group</code> all raise on a builder returned by <code>open_existing()</code> — build anything genuinely new into a separate <code>create()</code> call instead.</div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Known fidelity gaps</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc">The returned <code>warnings</code> list is the honest, per-file account of what couldn't be faithfully reproduced. Only a legacy-format (2013–2020) source is accepted, for the same reason the writer only ever produces that format. Round-trip-validated against real, non-writer-authored architectural models, not just files this project's own writer produced.</div>
+      <div class="tblwrap">
+      <table class="doc-table">
+        <thead><tr><th>Gap</th><th>Detail</th></tr></thead>
+        <tbody>
+          <tr><td>Per-edge flags</td><td>hidden/soft/smooth are applied per-face, not per-edge — an "any edge in this boundary has the flag" approximation</td></tr>
+          <tr><td>Projective textures</td><td>positioned textures replay via a 3-point affine fit — exact at those points, but a genuinely projective/distorted source mapping won't interpolate identically. A draped/projected texture falls back to the default projection</td></tr>
+          <tr><td>Texture tile size &amp; tint</td><td>a material's original texture scale isn't preserved yet, and a colorized (tinted) material replays as its plain source texture</td></tr>
+          <tr><td>Per-face layer painting</td><td>only a face's front/back material is replayed — the reader doesn't expose a per-face layer assignment</td></tr>
+          <tr><td>Group vs. instance</td><td>every placed thing replays as a plain component instance — visually identical, but no longer shows as a "Group" in SketchUp's Outliner</td></tr>
+          <tr><td>Section planes, text, dimensions</td><td>not carried over at all — the writer has no support for these entity types</td></tr>
+          <tr><td>Curve grouping</td><td>a circle/arc/polyline's original curve grouping is lost — the reader doesn't preserve it, so it round-trips as a plain straight-edged face</td></tr>
+          <tr><td>Definition/face attributes</td><td>not reproduced — the reader's public model doesn't expose either (only an instance's own properties are)</td></tr>
+        </tbody>
+      </table>
+      </div>
+      <div class="fn-desc" style="margin-top:14px">See <a href="https://github.com/iamahsanmehmood/openskp/blob/main/packages/python/src/openskp/edit.py" target="_blank" rel="noopener"><code>openskp/edit.py</code></a>'s own module docstring for the complete, itemized list and the reasoning behind each one.</div>
     </div>
   </div>
 </section>

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -25,9 +25,9 @@ first-class packages for TypeScript, .NET, Dart, and C++ — see the
 [project README](https://github.com/iamahsanmehmood/openskp) for the full
 cross-language picture.
 
-🧪 This Python package can also *write* new `.skp` files from scratch now
-— early-stage and Python-only for the moment (see
-[Writing](#writing-early-stage) below).
+🧪 This Python package can also *write* new `.skp` files from scratch, and
+edit existing ones — Python-only for the moment, validated feature-by-feature
+against the real SketchUp SDK (see [Writing](#writing) below).
 
 ## Features
 
@@ -47,11 +47,14 @@ cross-language picture.
   largest single definition, not the whole file.
 - **Structured observability** — opt-in progress reporting and
   location-carrying parse errors for debugging malformed or unusual files.
-- **Write support (early-stage, Python-only)** — build new legacy-format
-  `.skp` files from scratch: geometry (including true, editable circular
-  faces), materials (solid + PNG/JPEG textures), layers, component
-  definitions with multiple instances, and groups. No SDK involved. See
-  [Writing](#writing-early-stage) below.
+- **Write support (Python-only)** — build new legacy-format `.skp` files
+  from scratch: geometry (including true, editable circular/arc curves,
+  freeform polylines, faces with holes cut out, and non-planar
+  auto-triangulation), materials (solid + PNG/JPEG textures), layers,
+  nested component definitions and groups, instance rotation/visibility,
+  and custom attribute dictionaries — or load and extend an existing file
+  with `open_existing()`. No SDK involved; every feature validated
+  against the real SketchUp SDK. See [Writing](#writing) below.
 
 ## Installation
 
@@ -118,29 +121,35 @@ meta = json_export.to_dict(model, scene=scene)
 json_export.export(model, "output.json", scene=scene)
 ```
 
-## Writing (early-stage)
+## Writing
 
 OpenSKP can also *create* new `.skp` files from scratch — a genuine,
 from-scratch binary writer for the legacy MFC `CArchive` format (SketchUp
-2013–2020), with no SketchUp SDK involved at any point. This is a new,
-early-stage capability: geometry, materials (solid + PNG/JPEG textures),
-layers, component definitions with multiple instances, groups, nested
+2013–2020), with no SketchUp SDK involved at any point. Python-only for
+now, but feature-complete for common modeling needs and validated
+feature-by-feature against the real SketchUp SDK: geometry, materials
+(solid + PNG/JPEG textures), layers (with color and default visibility),
+component definitions with multiple instances, groups, nested
 definitions and nested group instances (an assembly containing instances
-or groups of its own sub-parts, to any depth), explicit per-side texture
-positioning (on a face of any orientation), custom key/value
-attribute dictionaries on definitions/instances/faces (the same
-mechanism SketchUp's own "dynamic component" attributes use), and
-circular faces and partial arcs (genuine, editable-by-radius arc/circle
-entities, not disconnected straight edges that merely trace that shape),
-and freeform polyline curves (an arbitrary chain of edges grouped into
-one genuine `CCurve` entity) are all supported, along with faces with
-one or more holes cut out (a window opening in a wall, say) and an
-`add_face(..., auto_triangulate=True)` fallback for non-planar input.
-`openskp.open_existing()` can also load an *existing* legacy-format file
-and rebuild it as a new builder, so more geometry can be added to it
-before saving (see [Editing an existing file](#editing-an-existing-file)
-below). See [`openskp/create.py`](src/openskp/create.py) for the full
-scope notes.
+or groups of its own sub-parts, to any depth), per-instance rotation and
+visibility, explicit per-side texture positioning (on a face of any
+orientation), custom key/value attribute dictionaries on
+definitions/instances/faces (the same mechanism SketchUp's own "dynamic
+component" attributes use), and circular faces and partial arcs (genuine,
+editable-by-radius arc/circle entities, not disconnected straight edges
+that merely trace that shape), and freeform polyline curves (an arbitrary
+chain of edges grouped into one genuine `CCurve` entity) are all
+supported, along with faces with one or more holes cut out (a window
+opening in a wall, say) and an `add_face(..., auto_triangulate=True)`
+fallback for non-planar input. `openskp.open_existing()` can also load an
+*existing* legacy-format file and rebuild it as a new builder, so more
+geometry can be added to it before saving (see
+[Editing an existing file](#editing-an-existing-file) below). See
+[`openskp/create.py`](src/openskp/create.py) for the full scope notes.
+
+This is Python-only today — porting the writer to the other four
+languages (TypeScript, .NET, Dart, C++) is a planned future direction,
+not yet under way. Contributions toward that are very welcome.
 
 ```python
 from openskp import create
@@ -246,8 +255,8 @@ scope.
 | `openskp.metadata` | Dynamic properties and scene hierarchy |
 | `openskp.transforms` | 3D matrix transforms and coordinate conversion |
 | `openskp.export` | GLB, OBJ/MTL, STL, PLY, DXF, IFC4, and JSON exporters |
-| `openskp.create` | Writer — build new `.skp` files from scratch (early-stage) |
-| `openskp.edit` | Load an existing legacy `.skp` file and rebuild it as a new writer (early-stage) |
+| `openskp.create` | Writer — build new `.skp` files from scratch |
+| `openskp.edit` | Load an existing legacy `.skp` file and rebuild it as a new writer |
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Root README, package README, Developer Guide, and API Design doc now present reading and writing as two co-equal pillars instead of writing being a bolted-on "New" aside — honestly scoped as Python-only today, with porting to the other four languages named as a planned future direction, not started.
- Drops stale "early-stage" language now that the writer's feature set (rotation, hidden/color, curves, holes, auto-triangulate, `open_existing()`) is validated feature-by-feature against the real SketchUp SDK.
- Adds a full "Writing (Python)" section (Create Files / Edit Files) to the GitHub Pages docs site, which previously had zero mention of the writer at all — matches the existing dark/amber design system.
- Fixes a broken `#writing-early-stage` anchor link left over from a heading rename.

## Test plan
- [x] Verified the new GitHub Pages docs section renders correctly in-browser (sidebar nav, mobile nav, code samples, tables) with no console errors
- [x] Grepped the repo for any remaining stale "early-stage"/broken-anchor references — none left
- Docs-only change, no code touched