### PR TITLE
feat(python): parse VFF scenes (pages) and linear dimensions

### DIFF
--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -273,6 +273,279 @@ def find_child_tag(nodes, target):
             return res
     return None
 
+
+def _tlv_items(buf):
+    """Parse ``buf`` as a flat run of (u16 tag, u32 len, payload) records
+    covering the whole buffer, or ``None`` when it doesn't fit — the page
+    (scene) container nests plain TLV runs inside leaf payloads."""
+    items = []
+    off = 0
+    n = len(buf)
+    while off < n:
+        if off + 6 > n:
+            return None
+        tag = struct.unpack_from('<H', buf, off)[0]
+        ln = struct.unpack_from('<I', buf, off + 2)[0]
+        if tag == 0 or off + 6 + ln > n:
+            return None
+        items.append((tag, buf[off + 6:off + 6 + ln]))
+        off += 6 + ln
+    return items
+
+
+def _tlv_find(items, tag):
+    """First payload with ``tag`` in a ``_tlv_items`` list, or ``None``."""
+    for t, p in items or ():
+        if t == tag:
+            return p
+    return None
+
+
+def _scan_vertex_positions(top, id2pos):
+    """Accumulate every vertex's persistent id (hex) → ``(x, y, z)`` inches.
+
+    A vertex is a ``C409`` record: ``DC05`` holds its persistent id (the
+    ``DE05`` var-int payload), ``C509`` its 3×f64 position. Dimension
+    connection points reference geometry by this id (see
+    :func:`_parse_dimensions`). Ids are unique file-wide, so a single flat map
+    resolves a reference to the exact vertex regardless of which context holds
+    it — model-root dimensions reference model-root vertices (world space).
+    Called once per top-level record: full_parse streams the TLV tree and
+    never holds it whole."""
+
+    def walk(nodes):
+        for el in nodes:
+            if el['tag'] == 'C409':
+                dc05 = find_child_tag(el['children'], 'DC05')
+                c509 = find_child_tag(el['children'], 'C509')
+                if dc05 and c509 and len(c509['payload']) == 24:
+                    p = dc05['payload']
+                    if p[:2] == b'\xde\x05':
+                        idlen = read_u32(p, 2)
+                        idb = p[6:6 + idlen]
+                    else:
+                        idb = p
+                    id2pos[idb.hex()] = struct.unpack('<3d', c509['payload'])
+            if el['children']:
+                walk(el['children'])
+
+    walk([top])
+
+
+def _scan_instance_transforms(top, world):
+    """Accumulate each instance's persistent id (hex) → its WORLD transform
+    (a 13-float matrix), walking the instance tree and composing
+    parent × local at every ``6419``.  Per top-level record, like
+    :func:`_scan_vertex_positions` — an instance chain never crosses
+    top-level records.
+
+    A dimension connects to geometry INSIDE a placed component; its connection
+    reference names the vertex AND the instance holding it (see
+    :func:`_parse_dimensions`). The vertex position is definition-local, so it
+    must be lifted to world by the instance's transform for the dimension to
+    land where the author drew it."""
+
+    def walk(nodes, parent):
+        for el in nodes:
+            if el['tag'] == '6419':
+                d007 = find_child_tag(el['children'], 'D007')
+                dc05 = find_child_tag(d007['children'], 'DC05') if d007 else None
+                iid = None
+                if dc05:
+                    p = dc05['payload']
+                    idb = p[6:6 + read_u32(p, 2)] if p[:2] == b'\xde\x05' else p
+                    iid = idb.hex()
+                m = find_child_tag(el['children'], '6619')
+                mat = list(struct.unpack('<13d', m['payload'])) \
+                    if m and len(m['payload']) == 104 else None
+                here = multiply_matrices(parent, mat) if mat else parent
+                if iid:
+                    world[iid] = here
+                walk(el['children'], here)
+            elif el['children']:
+                walk(el['children'], parent)
+
+    walk([top], None)
+
+
+def _parse_dimensions(model_dat, id2pos, inst_world):
+    """Linear dimensions (SketchUp's Dimension tool).
+
+    A dimension entity is a ``5BCC`` record (raw bytes ``cc 5b``) holding:
+
+    * ``5BCD`` / ``5BCE`` — the two connection points. Each wraps a ``5208``
+      whose ``5209`` is the connection TYPE (1 = a free explicit point in
+      ``520A``, already world space; 2 = connected to geometry, ``520A`` is
+      zero and ``520B → 53FC`` names the target: ``53FD`` = the vertex by
+      persistent id, ``53FE`` = a length-prefixed persistent id of the
+      INSTANCE holding it — the vertex position is definition-local, so it is
+      lifted to world by that instance's transform).
+    * ``5BCF`` — the dimension plane's x-axis; ``5BD0`` — its normal.
+    * ``5BD2`` — the offset distance (inches): how far the dimension line sits
+      from the measured segment, along the in-plane perpendicular.
+
+    The measured value is auto-computed from the two points (no cached text on
+    the samples seen), so callers format it themselves. Endpoints come out in
+    WORLD space (inches). A connection point that cannot be resolved drops the
+    whole dimension (fail-safe)."""
+    dims = []
+    i = 0
+    n = len(model_dat)
+    while True:
+        j = model_dat.find(b'\xcc\x5b', i)
+        if j < 0:
+            break
+        i = j + 1
+        if j + 6 > n:
+            continue
+        ln = struct.unpack_from('<I', model_dat, j + 2)[0]
+        if ln < 40 or j + 6 + ln > n:
+            continue
+        body = _tlv_items(model_dat[j + 6:j + 6 + ln])
+        if body is None:
+            continue
+        tags = [t for t, _ in body]
+        if 0x5BCD not in tags or 0x5BCE not in tags:
+            continue
+
+        def _point(block_payload):
+            blk = _tlv_find(_tlv_items(block_payload) or [], 0x5208)
+            if blk is None:
+                return None
+            sub = _tlv_items(blk) or []
+            typ = _tlv_find(sub, 0x5209)
+            typ = struct.unpack('<I', typ)[0] if typ and len(typ) == 4 else None
+            if typ == 1:
+                pos = _tlv_find(sub, 0x520A)
+                return struct.unpack('<3d', pos) if pos and len(pos) == 24 \
+                    else None
+            # type 2: resolve the geometry reference (vertex + instance).
+            ref = _tlv_find(sub, 0x520B)
+            f53fc = _tlv_find(_tlv_items(ref) or [], 0x53FC) if ref else None
+            fi = _tlv_items(f53fc) or [] if f53fc else []
+            vid = _tlv_find(fi, 0x53FD)
+            iid = _tlv_find(fi, 0x53FE)
+            if not vid:
+                return None
+            local = id2pos.get(vid.hex())
+            if local is None:
+                return None
+            if iid and len(iid) >= 1 and iid[0] > 0 \
+                    and 1 + iid[0] <= len(iid):
+                w = inst_world.get(iid[1:1 + iid[0]].hex())
+                if w:
+                    return transform_point(local, w)
+            return local           # model-root vertex — already world
+
+        a = _point(_tlv_find(body, 0x5BCD))
+        b = _point(_tlv_find(body, 0x5BCE))
+        if a is None or b is None:
+            continue
+        xaxis = _tlv_find(body, 0x5BCF)
+        normal = _tlv_find(body, 0x5BD0)
+        off = _tlv_find(body, 0x5BD2)
+        dims.append({
+            'a': a, 'b': b,
+            'plane_x': struct.unpack('<3d', xaxis)
+            if xaxis and len(xaxis) == 24 else None,
+            'normal': struct.unpack('<3d', normal)
+            if normal and len(normal) == 24 else None,
+            'offset': struct.unpack('<d', off)[0]
+            if off and len(off) == 8 else 0.0,
+        })
+    return dims
+
+
+def _find_page_node(top):
+    """Return the ``0702`` scenes node inside *top*'s subtree, or ``None``.
+
+    Called per top-level record; retaining the (small) 0702 subtree is the
+    only thing kept alive past the streaming loop."""
+    def find(nodes):
+        for el in nodes:
+            if el['tag'] == '0702':
+                return el
+            r = find(el['children'])
+            if r is not None:
+                return r
+        return None
+    return find([top])
+
+
+def _parse_pages(node):
+    """Scenes ("pages"). The 0702 node's payload nests 6D60 > 6D61 > one
+    7148 record per page:
+
+    * 6F54 > 6F55 — page name (UTF-8)
+    * 714A > 34BC — camera: 34BD eye, 34BE target, 34BF up (3×f64, inches),
+      34C4 field of view (degrees), 34C2 u8 = PERSPECTIVE flag (00 =
+      parallel projection — calibrated against the bundled scene
+      thumbnails: parallel plans/elevations carry 00 and their 34C3
+      visible height matches the thumbnail framing exactly, while
+      perspective scenes carry 01 with a stale 34C3),
+      34C3 f64 = visible height when parallel (inches)
+    * 7150 — layers hidden in this page: (u8 length, var-int layer id) runs
+    """
+    if node is None:
+        return []
+
+    def sub(items, tag):
+        for t, p in items or []:
+            if t == tag:
+                return p
+        return None
+
+    def vec3(p):
+        return struct.unpack('<3d', p) if p is not None and len(p) == 24 \
+            else None
+
+    pages = []
+    for t60, p60 in _tlv_items(node['payload']) or []:
+        if t60 != 0x6D60:
+            continue
+        for t61, p61 in _tlv_items(p60) or []:
+            if t61 != 0x6D61:
+                continue
+            for t48, p48 in _tlv_items(p61) or []:
+                if t48 != 0x7148:
+                    continue
+                items = _tlv_items(p48)
+                if items is None:
+                    continue
+                page = {'name': '', 'eye': None, 'target': None, 'up': None,
+                        'fov': 35.0, 'parallel': False, 'ortho_height': 0.0,
+                        'hidden_layer_ids': []}
+                head = _tlv_items(sub(items, 0x6F54))
+                name = sub(head, 0x6F55)
+                if name:
+                    page['name'] = name.decode('utf-8', errors='replace')
+                cam_wrap = _tlv_items(sub(items, 0x714A))
+                cam = _tlv_items(sub(cam_wrap, 0x34BC)) if cam_wrap else None
+                if cam:
+                    page['eye'] = vec3(sub(cam, 0x34BD))
+                    page['target'] = vec3(sub(cam, 0x34BE))
+                    page['up'] = vec3(sub(cam, 0x34BF))
+                    fov = sub(cam, 0x34C4)
+                    if fov is not None and len(fov) == 8:
+                        page['fov'] = struct.unpack('<d', fov)[0]
+                    flag = sub(cam, 0x34C2)
+                    page['parallel'] = bool(flag) and flag[0] == 0
+                    height = sub(cam, 0x34C3)
+                    if height is not None and len(height) == 8:
+                        page['ortho_height'] = struct.unpack('<d', height)[0]
+                hidden = sub(items, 0x7150)
+                off = 0
+                while hidden and off + 1 <= len(hidden):
+                    ln = hidden[off]
+                    if ln == 0 or off + 1 + ln > len(hidden):
+                        break
+                    page['hidden_layer_ids'].append(
+                        parse_var_int(hidden, off + 1, ln))
+                    off += 1 + ln
+                if page['eye'] is not None and page['target'] is not None:
+                    pages.append(page)
+    return pages
+
 def find_all_nodes_rec(nodes, target_tag, results):
     for n in nodes:
         if n['tag'] == target_tag:
@@ -1022,12 +1295,19 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
             collect_defs(el['children'])
 
     root_builder = _GeometryBuilder()
+    vertex_positions = {}
+    instance_world = {}
+    page_node = None
 
     for index, total, el in iter_top_level_lazy(model_dat, 0, len(model_dat), CONTAINER_TAGS):
         try:
             collect_layers([el])
             collect_material_ids([el])
             collect_defs([el])
+            _scan_vertex_positions(el, vertex_positions)
+            _scan_instance_transforms(el, instance_world)
+            if page_node is None:
+                page_node = _find_page_node(el)
             if el['tag'] == 'F601':
                 _extract_geometry_from_nodes(el['children'], root_builder)
         except Exception as e:
@@ -1060,6 +1340,9 @@ def full_parse(skp_path: str) -> Dict[str, Any]:
         'layer_colors': layer_colors,
         'layer_hidden': layer_hidden,
         'layer_id_to_name': layer_id_to_name,
+        'pages': _parse_pages(page_node),
+        'dimensions': _parse_dimensions(
+            model_dat, vertex_positions, instance_world),
         'material_id_to_name': material_id_to_name,
         'materials': materials,
         'materials_by_folder': materials_by_folder,

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -321,8 +321,58 @@ class TextEntity:
 
 @dataclass
 class Dimension:
+    """A linear dimension (SketchUp's Dimension tool).
+
+    The legacy (pre-2021) reader recovers only ``text``/``hidden``. The VFF
+    reader (2021+) recovers the full geometry — see :attr:`SkpModel.dimensions`
+    for the model-level, world-space list.
+
+    Attributes:
+        text: The displayed text. Empty when the dimension shows its
+            auto-computed measured value (the caller formats ``|b − a|``).
+        hidden: Whether the dimension is hidden.
+        a: First measured point ``(x, y, z)`` in inches (world space), or
+            ``None`` when only the text was recovered.
+        b: Second measured point.
+        offset: Offset distance (inches) — how far the dimension line sits
+            from the ``a``–``b`` segment, along the in-plane perpendicular.
+        plane_x: The dimension plane's x-axis, or ``None``.
+        normal: The dimension plane's normal, or ``None``.
+    """
+
     text: str = ""
     hidden: bool = False
+    a: Optional[Tuple[float, float, float]] = None
+    b: Optional[Tuple[float, float, float]] = None
+    offset: float = 0.0
+    plane_x: Optional[Tuple[float, float, float]] = None
+    normal: Optional[Tuple[float, float, float]] = None
+
+
+@dataclass
+class Page:
+    """A saved scene (SketchUp's "Scenes" tabs; "pages" in the SDK).
+
+    Attributes:
+        name: Scene name as shown on its tab.
+        eye: Camera position ``(x, y, z)`` in inches, or ``None``.
+        target: Point the camera looks at, in inches.
+        up: Camera up vector.
+        fov: Field of view in degrees (SketchUp default 35).
+        parallel: ``True`` when the scene uses parallel (orthographic)
+            projection; ``fov`` still holds the stored perspective angle.
+        ortho_height: Visible height in inches when ``parallel``.
+        hidden_layers: Names of the layers this scene hides.
+    """
+
+    name: str = ""
+    eye: Optional[Tuple[float, float, float]] = None
+    target: Optional[Tuple[float, float, float]] = None
+    up: Optional[Tuple[float, float, float]] = None
+    fov: float = 35.0
+    parallel: bool = False
+    ortho_height: float = 0.0
+    hidden_layers: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -381,6 +431,11 @@ class SkpModel:
             are geometry drawn directly at the top level. Corresponds to
             TypeScript/.NET/Dart/C++'s ``root``/``Root``.
         layers: List of :class:`Layer` objects found in the file.
+        pages: List of :class:`Page` objects — the file's saved scenes
+            (VFF files; classic pre-2021 files import with none).
+        dimensions: Model-level linear dimensions with world-space
+            endpoints (VFF files). Legacy files surface text-only
+            dimensions per definition instead (``Definition.dimensions``).
         materials: List of :class:`Material` objects found in the file.
         materials_by_id: Mapping of TLV material ID → :class:`Material`,
             the join table for :attr:`Face.material_id`.  Several IDs may
@@ -403,6 +458,8 @@ class SkpModel:
     definitions: Dict[int, Definition] = field(default_factory=dict)
     root: Definition = field(default_factory=Definition)
     layers: List[Layer] = field(default_factory=list)
+    pages: List[Page] = field(default_factory=list)
+    dimensions: List[Dimension] = field(default_factory=list)
     materials: List[Material] = field(default_factory=list)
     materials_by_id: Dict[int, Material] = field(default_factory=dict)
     styles: List[Style] = field(default_factory=list)
@@ -563,6 +620,31 @@ class SkpFile:
             model.layers.append(
                 Layer(name=name, color_r=r, color_g=g, color_b=b, hidden=layer_hidden.get(name, False))
             )
+
+        # Convert pages (saved scenes) — hidden layer ids resolve to names;
+        # unknown ids (stale refs) are dropped.
+        for pg in parsed.get("pages") or []:
+            model.pages.append(Page(
+                name=pg.get("name", ""),
+                eye=pg.get("eye"),
+                target=pg.get("target"),
+                up=pg.get("up"),
+                fov=pg.get("fov", 35.0),
+                parallel=pg.get("parallel", False),
+                ortho_height=pg.get("ortho_height", 0.0),
+                hidden_layers=[layer_id_to_name[i]
+                               for i in pg.get("hidden_layer_ids", [])
+                               if i in layer_id_to_name],
+            ))
+
+        # Convert model-level linear dimensions (VFF; world space).
+        for dm in parsed.get("dimensions") or []:
+            model.dimensions.append(Dimension(
+                a=tuple(dm["a"]), b=tuple(dm["b"]),
+                offset=dm.get("offset", 0.0),
+                plane_x=dm.get("plane_x"), normal=dm.get("normal"),
+                text=dm.get("text", ""),
+            ))
 
         # Convert materials
         mat_for_data: Dict[int, Material] = {}   # id(raw dict) -> Material

--- a/packages/python/tests/test_pages_dimensions.py
+++ b/packages/python/tests/test_pages_dimensions.py
@@ -1,0 +1,134 @@
+"""VFF scenes (pages) and linear dimensions.
+
+Dimensions are exercised against the repository's own ``Untitled.skp``
+fixture (drawn in SketchUp 2025, it carries 13 linear dimensions); scenes
+have no fixture yet, so their parser is exercised on a synthetic ``0702``
+record byte-for-byte shaped like the real ones (the layout was decoded
+from production survey files and calibrated against the scene thumbnails
+SketchUp embeds in the ``.skp`` itself).
+"""
+import math
+import struct
+from pathlib import Path
+
+from openskp import _core
+from openskp.model import SkpFile
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ── helpers: build TLV runs in the flat (u16-LE tag, u32 len) form ────────
+
+def tlv(tag: int, payload: bytes) -> bytes:
+    return struct.pack('<HI', tag, len(payload)) + payload
+
+
+def vec3(x: float, y: float, z: float) -> bytes:
+    return struct.pack('<3d', x, y, z)
+
+
+# ── linear dimensions ─────────────────────────────────────────────────────
+
+def test_untitled_fixture_has_13_dimensions():
+    model = SkpFile.open(str(FIXTURES / "Untitled.skp")).parse()
+    assert len(model.dimensions) == 13
+    for d in model.dimensions:
+        assert d.a is not None and d.b is not None
+        assert len(d.a) == 3 and len(d.b) == 3
+        assert math.dist(d.a, d.b) > 0.0        # a real measured segment
+        assert d.normal is not None and d.plane_x is not None
+
+
+def test_dimension_free_points_synthetic():
+    """A 5BCC record with two type-1 (free, world-space) connection points."""
+    def point_block(wrap_tag: int, x: float, y: float, z: float) -> bytes:
+        inner = (tlv(0x5209, struct.pack('<I', 1))     # type 1: explicit point
+                 + tlv(0x520A, vec3(x, y, z)))
+        return tlv(wrap_tag, tlv(0x5208, inner))
+
+    body = (point_block(0x5BCD, 0.0, 0.0, 0.0)
+            + point_block(0x5BCE, 100.0, 0.0, 0.0)
+            + tlv(0x5BCF, vec3(1.0, 0.0, 0.0))         # plane x-axis
+            + tlv(0x5BD0, vec3(0.0, 0.0, 1.0))         # plane normal
+            + tlv(0x5BD2, struct.pack('<d', 15.5)))    # offset
+    blob = b'\x00' * 8 + tlv(0x5BCC, body) + b'\x00' * 8
+
+    dims = _core._parse_dimensions(blob, {}, {})
+    assert len(dims) == 1
+    d = dims[0]
+    assert d['a'] == (0.0, 0.0, 0.0) and d['b'] == (100.0, 0.0, 0.0)
+    assert d['offset'] == 15.5
+    assert d['plane_x'] == (1.0, 0.0, 0.0)
+    assert d['normal'] == (0.0, 0.0, 1.0)
+
+
+def test_dimension_connected_point_resolves_through_instance():
+    """A type-2 connection (vertex id + instance id): the vertex position is
+    definition-local and must be lifted to world by the instance's
+    transform. An unresolvable reference drops the dimension (fail-safe)."""
+    vid = bytes.fromhex('aabb01')
+    iid = bytes.fromhex('ccdd02')
+
+    def connected(wrap_tag: int) -> bytes:
+        ref = tlv(0x53FC, tlv(0x53FD, vid)
+                  + tlv(0x53FE, bytes([len(iid)]) + iid))
+        inner = (tlv(0x5209, struct.pack('<I', 2))
+                 + tlv(0x520B, ref))
+        return tlv(wrap_tag, tlv(0x5208, inner))
+
+    def free(wrap_tag: int) -> bytes:
+        inner = (tlv(0x5209, struct.pack('<I', 1))
+                 + tlv(0x520A, vec3(0.0, 0.0, 0.0)))
+        return tlv(wrap_tag, tlv(0x5208, inner))
+
+    body = connected(0x5BCD) + free(0x5BCE) + tlv(0x5BD2, struct.pack('<d', 0.0))
+    blob = tlv(0x5BCC, body)
+
+    # Identity-ish transform that translates by (10, 20, 30).
+    world = [1, 0, 0, 0, 1, 0, 0, 0, 1, 10.0, 20.0, 30.0, 1.0]
+    dims = _core._parse_dimensions(
+        blob, {vid.hex(): (1.0, 2.0, 3.0)}, {iid.hex(): world})
+    assert len(dims) == 1
+    assert dims[0]['a'] == (11.0, 22.0, 33.0)   # local + translation
+
+    # Same record, but the vertex id is unknown: the dimension is dropped.
+    assert _core._parse_dimensions(blob, {}, {}) == []
+
+
+# ── scenes (pages) ────────────────────────────────────────────────────────
+
+def _page_record(name: str, parallel: bool, hidden_ids=()) -> bytes:
+    cam = (tlv(0x34BD, vec3(100.0, -200.0, 50.0))      # eye
+           + tlv(0x34BE, vec3(0.0, 0.0, 0.0))          # target
+           + tlv(0x34BF, vec3(0.0, 0.0, 1.0))          # up
+           + tlv(0x34C4, struct.pack('<d', 35.0))      # fov
+           + tlv(0x34C2, bytes([0 if parallel else 1]))
+           + tlv(0x34C3, struct.pack('<d', 240.0)))    # ortho height
+    hidden = b''.join(bytes([1]) + bytes([i]) for i in hidden_ids)
+    body = (tlv(0x6F54, tlv(0x6F55, name.encode()))
+            + tlv(0x714A, tlv(0x34BC, cam))
+            + tlv(0x7150, hidden))
+    return tlv(0x7148, body)
+
+
+def test_parse_pages_synthetic():
+    payload = tlv(0x6D60, tlv(0x6D61,
+                              _page_record("Planta", True, hidden_ids=(2,))
+                              + _page_record("Vista 3D", False)))
+    pages = _core._parse_pages({'payload': payload})
+    assert [p['name'] for p in pages] == ["Planta", "Vista 3D"]
+
+    planta = pages[0]
+    assert planta['parallel'] is True
+    assert planta['ortho_height'] == 240.0
+    assert planta['eye'] == (100.0, -200.0, 50.0)
+    assert planta['up'] == (0.0, 0.0, 1.0)
+    assert planta['hidden_layer_ids'] == [2]
+    assert pages[1]['parallel'] is False
+    assert pages[1]['fov'] == 35.0
+
+
+def test_pages_absent_is_empty():
+    assert _core._parse_pages(None) == []
+    model = SkpFile.open(str(FIXTURES / "SU_File.skp")).parse()
+    assert model.pages == []


### PR DESCRIPTION
Hi Ahsan — giving back some of what IngeTrazo's fork has been running in production since July: the two VFF entity families the Python reader doesn't surface yet.

## Scenes (pages)

The `0702` record nests `6D60 › 6D61 ›` one `7148` per page:

- `6F54 › 6F55` — page name (UTF-8)
- `714A › 34BC` — camera: `34BD`/`34BE`/`34BF` eye/target/up (3×f64, inches), `34C4` field of view, `34C2` u8 **perspective flag** (`00` = parallel projection), `34C3` f64 visible height when parallel
- `7150` — hidden layers as (u8 length, var-int layer id) runs

The projection flag and ortho height were calibrated against the scene thumbnails SketchUp embeds inside the `.skp` itself — parallel plans/elevations carry `00` and their `34C3` matches the thumbnail framing exactly, while perspective scenes carry `01` with a stale `34C3`.

Surfaces as `SkpModel.pages` (new `Page` dataclass); hidden layer ids resolve to layer names via the existing `layer_id_to_name` map.

## Linear dimensions

The `5BCC` record: `5BCD`/`5BCE` are the two connection points — type 1 is an explicit world-space point in `520A`; **type 2 is connected to geometry**: `520B › 53FC` names the vertex by persistent id (`53FD`) and the instance holding it (`53FE`, length-prefixed), so the definition-local vertex position is lifted to world by that instance's transform. `5BCF`/`5BD0` give the dimension plane, `5BD2` the offset. An unresolvable connection drops the whole dimension (fail-safe).

Two new per-record scans (`_scan_vertex_positions`, `_scan_instance_transforms`) accumulate the persistent-id maps the resolution needs — same streaming discipline as the rest of `full_parse`, nothing retained beyond two flat dicts.

Surfaces as `SkpModel.dimensions` with world-space endpoints in inches. The existing per-definition, text-only `Dimension` fields are untouched, so the legacy reader's output is unchanged (its dimensions simply have `a is None`).

## Validation

- Your own `tests/fixtures/Untitled.skp` turns out to carry **13 linear dimensions** — now parsed with full geometry, and the new tests pin them.
- On a 607 MB production survey file (7 scenes, mixed parallel/perspective, 5 hidden layers each), output is **identical** to the fork implementation IngeTrazo has been shipping, with no measurable parse-time cost (23.7 s vs 25.2 s on the same machine).
- Full suite: **309 passed, 29 skipped** (the optional-deps skips).

Classic (pre-2021) files import with `pages=[]` — I don't have a repro file with legacy scenes yet; the CPage walker can follow when one shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)