### PR TITLE
Fix slot-32767 collision and _shift_ref wraparound corrupting large exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,29 @@ for the full scope notes.
   plain (non-colorized) texture this writer created was silently
   misreported as colorized when read back. Found via `open_existing()`
   round-tripping the writer's own output.
+- **A large model (total archive-slot count crossing 32,767) produced a
+  corrupted file real SketchUp rejected outright.** An archive slot of
+  exactly `0x7FFF` (32767) is unrepresentable in the format's short
+  2-byte reference form no matter which encoding would otherwise apply -
+  it's byte-identical to either the big-tag escape marker or the
+  new-class-declaration marker, both of which `legacy.py`'s reader
+  checks before it ever considers "this is just a normal reference" -
+  confirmed by tracing the actual read dispatch order, not just the
+  protocol table. `_backref`/`_new_of_known_class` used an off-by-one
+  `<= 0x7FFF` boundary that let slot 32767 through in the ambiguous short
+  form; `_shift_ref` (used to renumber a handful of fixed pointers in the
+  blank scaffold's tail region when new slots are inserted) additionally
+  had no escape-widening at all, silently wrapping any shifted reference
+  past that boundary back into the wrong slot. Reverting the fix
+  reproduces the exact reported symptom: real SketchUp's SDK rejects the
+  file outright (`SUModelCreateFromFile` error), and — more seriously —
+  this project's own reader doesn't error either, it silently drops
+  roughly 40% of a 5,000-face reproduction's faces with no error
+  surfaced at all. Found while reviewing a large-model (31,966-face)
+  export failure report from a downstream project (IngeTrazo) building a
+  `.skp` exporter on this writer; independently re-derived and verified
+  rather than taken on faith, including a before/after real-SketchUp-SDK
+  comparison on the exact failure shape.
 
 ### Validation
 

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -496,13 +496,35 @@ def _f64(v: float) -> bytes:
     return struct.pack("<d", v)
 
 
-def _shift_ref(buf: bytearray, pos: int, shift: int) -> None:
+def _shift_ref(buf: bytearray, pos: int, shift: int) -> int:
     """Renumber the u16 archive slot-reference at ``pos`` by ``shift``,
-    preserving the 0x8000 class-ref tag bit if the reference carries one."""
+    preserving the 0x8000 class-ref tag bit if the reference carries one.
+
+    Widens to the 6-byte escape form (same encoding `_backref`/
+    `_new_of_known_class` use, and the same `< 0x7FFF` boundary - see
+    their comments) if the shifted slot would land at or past 0x7FFF.
+    The scaffold's own references always start small enough to fit in 2
+    bytes on their own (it's a blank document), but a large enough shift
+    - a big model's total material/layer/definition/geometry slot count -
+    can push one past that boundary; masking it back into 15 bits instead
+    of widening would silently renumber it to the wrong slot entirely,
+    corrupting whatever it points to.
+
+    Returns the number of bytes the field grew by (0 or 4), so a caller
+    patching several positions in the same buffer can shift every
+    position after this one by the accumulated growth before acting on
+    it - the buffer's own length changes under it otherwise.
+    """
     u16 = struct.unpack_from("<H", buf, pos)[0]
     tag_bit = u16 & 0x8000
     slot = u16 & 0x7FFF
-    struct.pack_into("<H", buf, pos, tag_bit | ((slot + shift) & 0x7FFF))
+    new_slot = slot + shift
+    if new_slot < 0x7FFF:
+        struct.pack_into("<H", buf, pos, tag_bit | new_slot)
+        return 0
+    val = (0x80000000 | new_slot) if tag_bit else new_slot
+    buf[pos : pos + 2] = struct.pack("<H", 0x7FFF) + _u32(val)
+    return 4
 
 
 def _detect_image_subtype(image_bytes: bytes) -> int:
@@ -569,7 +591,14 @@ class _ArchiveWriter:
             self.class_slot[class_name] = self._alloc()
             return self._alloc()
         slot = self.class_slot[class_name]
-        if slot <= 0x7FFF:
+        # slot == 0x7FFF is deliberately excluded from the short form even
+        # though it numerically fits in 15 bits: 0x8000 | 0x7FFF == 0xFFFF,
+        # which _Archive.read_object (legacy.py) checks for "new class
+        # declaration" BEFORE it ever checks the class-ref high bit - a
+        # class landing at exactly that slot would be silently
+        # misinterpreted as the start of a bogus class record, desyncing
+        # every read after it. The escape form has no such collision.
+        if slot < 0x7FFF:
             self.buf += struct.pack("<H", 0x8000 | slot)
         else:
             self.buf += struct.pack("<H", 0x7FFF)
@@ -580,7 +609,14 @@ class _ArchiveWriter:
         self.buf += struct.pack("<H", 0)
 
     def _backref(self, slot: int) -> None:
-        if slot <= 0x7FFF:
+        # Same exclusion as _new_of_known_class, for the plain (no
+        # class-ref bit) case: a bare slot value of 0x7FFF is
+        # indistinguishable from the big-tag escape marker itself -
+        # read_object checks `tag == 0x7FFF` before it ever falls through
+        # to "plain object back-ref", so it would consume the next 4
+        # bytes as a bogus slot number instead. Confirmed both collisions
+        # empirically, not just from the protocol table.
+        if slot < 0x7FFF:
             self.buf += struct.pack("<H", slot)
         else:
             self.buf += struct.pack("<H", 0x7FFF)
@@ -2559,10 +2595,26 @@ class SkpBuilder:
 
         tail = bytearray(self._data[self._tail_pos :])
         total_tail_shift = material_shift + layer_shift + definition_shift + geometry_shift
-        for pos in _TAIL_REF_POSITIONS:
-            _shift_ref(tail, pos, total_tail_shift)
-        for pos, patch in _ISO_CAMERA_TAIL_PATCHES:
-            tail[pos : pos + len(patch)] = patch
+        # _TAIL_REF_POSITIONS and _ISO_CAMERA_TAIL_PATCHES's positions both
+        # index into this same tail buffer. A ref-shift that widens to the
+        # 6-byte escape form (see _shift_ref) grows the buffer at that
+        # point, pushing every later position forward - so every action is
+        # applied in ascending original-offset order, tracking that growth,
+        # rather than at its original hardcoded offset.
+        iso_patches = dict(_ISO_CAMERA_TAIL_PATCHES)
+        actions = sorted(
+            [(pos, "ref") for pos in _TAIL_REF_POSITIONS]
+            + [(pos, "patch") for pos in iso_patches],
+            key=lambda a: a[0],
+        )
+        growth = 0
+        for pos, kind in actions:
+            here = pos + growth
+            if kind == "ref":
+                growth += _shift_ref(tail, here, total_tail_shift)
+            else:
+                patch = iso_patches[pos]
+                tail[here : here + len(patch)] = patch
         out += tail
         return bytes(out)
 

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -258,10 +258,16 @@ def _is_class_ref(data: bytes, p: int, slot: int) -> bool:
     """True when the bytes at *p* are an MFC class-ref to class *slot*.
 
     Mirrors both encodings that ``_Archive.read_object`` decodes: the short
-    16-bit form ``0x8000|slot`` and, for slots past 0x7FFF, the big-tag
-    escape ``0x7FFF`` followed by a u32 of ``0x80000000|slot``.
+    16-bit form ``0x8000|slot`` and, for slots at or past 0x7FFF, the
+    big-tag escape ``0x7FFF`` followed by a u32 of ``0x80000000|slot``.
+    ``slot == 0x7FFF`` is deliberately excluded from the short form even
+    though it fits in 15 bits: ``0x8000 | 0x7FFF == 0xFFFF``, which
+    ``read_object`` checks for "new class declaration" before it ever
+    checks the class-ref high bit - a real encoder can never emit the
+    short form for exactly that slot, so this predicate must not expect
+    it either.
     """
-    if slot <= 0x7FFF:
+    if slot < 0x7FFF:
         return (p + 2 <= len(data)
                 and struct.unpack_from('<H', data, p)[0] == 0x8000 | slot)
     return (p + 6 <= len(data)

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -2180,6 +2180,122 @@ class TestDefaultCamera:
         assert data[off : off + len(patch)] == patch
 
 
+class TestSlotBoundaryEncoding:
+    """A slot of exactly 0x7FFF (32767) is unrepresentable in the short
+    2-byte form no matter which of the two short encodings would
+    otherwise apply - it collides with a reserved marker value either
+    way, confirmed by tracing legacy.py's actual read dispatch order
+    (`_Archive.read_object`), not just from the protocol table:
+
+    * A plain back-ref of exactly 0x7FFF is byte-identical to the
+      big-tag escape marker itself - `read_object` checks
+      `tag == 0x7FFF` before it ever falls through to "plain back-ref",
+      so it would consume the next (unrelated) 4 bytes as a bogus slot.
+    * A class-ref of exactly 0x7FFF sets `0x8000 | 0x7FFF == 0xFFFF`,
+      which `read_object` checks for "new class declaration" before it
+      ever checks the class-ref high bit.
+
+    Both desync every read after that point - the file doesn't just fail
+    to open, our own reader silently drops entities without erroring
+    (see TestLargeModelSlotBoundary below for a real-scale reproduction
+    of exactly that silent data loss, before this fix)."""
+
+    def test_backref_below_boundary_uses_short_form(self):
+        writer = create_module._ArchiveWriter(next_slot=1, class_slot={})
+        writer._backref(0x7FFE)
+        assert bytes(writer.buf) == struct.pack("<H", 0x7FFE)
+
+    def test_backref_at_boundary_uses_escape_form(self):
+        writer = create_module._ArchiveWriter(next_slot=1, class_slot={})
+        writer._backref(0x7FFF)
+        assert bytes(writer.buf) == struct.pack("<H", 0x7FFF) + struct.pack("<I", 0x7FFF)
+        # Specifically NOT the collision byte pattern a `<=` boundary
+        # would have produced (identical to the escape marker alone).
+        assert bytes(writer.buf) != struct.pack("<H", 0x7FFF)
+
+    def test_new_of_known_class_below_boundary_uses_short_form(self):
+        writer = create_module._ArchiveWriter(next_slot=1, class_slot={"Foo": 0x7FFE})
+        writer._new_of_known_class("Foo")
+        assert bytes(writer.buf) == struct.pack("<H", 0x8000 | 0x7FFE)
+
+    def test_new_of_known_class_at_boundary_uses_escape_form(self):
+        writer = create_module._ArchiveWriter(next_slot=1, class_slot={"Foo": 0x7FFF})
+        writer._new_of_known_class("Foo")
+        assert bytes(writer.buf) == struct.pack("<H", 0x7FFF) + struct.pack("<I", 0x80000000 | 0x7FFF)
+        # Specifically NOT 0xFFFF - the "new class declaration" marker.
+        tag = struct.unpack_from("<H", writer.buf, 0)[0]
+        assert tag != 0xFFFF
+
+    def test_shift_ref_below_boundary_stays_short_and_reports_no_growth(self):
+        buf = bytearray(struct.pack("<H", 100))
+        grown = create_module._shift_ref(buf, 0, 0x7FFE - 100)  # -> exactly 0x7FFE
+        assert grown == 0
+        assert bytes(buf) == struct.pack("<H", 0x7FFE)
+
+    def test_shift_ref_crossing_boundary_widens_and_reports_growth(self):
+        buf = bytearray(struct.pack("<H", 100) + b"\x00\x00")  # trailing bytes to prove no overwrite
+        grown = create_module._shift_ref(buf, 0, 0x7FFF)  # 100 + 0x7FFF -> past the boundary
+        assert grown == 4
+        assert len(buf) == 8
+        tag = struct.unpack_from("<H", buf, 0)[0]
+        val = struct.unpack_from("<I", buf, 2)[0]
+        assert tag == 0x7FFF
+        assert val == 100 + 0x7FFF
+        assert bytes(buf[6:8]) == b"\x00\x00"  # original trailing bytes preserved, just pushed forward
+
+    def test_shift_ref_preserves_class_ref_tag_bit_when_widening(self):
+        buf = bytearray(struct.pack("<H", 0x8000 | 50))
+        create_module._shift_ref(buf, 0, 0x7FFF)
+        val = struct.unpack_from("<I", buf, 2)[0]
+        assert val == 0x80000000 | (50 + 0x7FFF)
+
+    def test_is_class_ref_below_boundary(self):
+        data = struct.pack("<H", 0x8000 | 0x7FFE)
+        assert legacy._is_class_ref(data, 0, 0x7FFE) is True
+
+    def test_is_class_ref_at_boundary_expects_escape_form(self):
+        # A real encoder can never emit the short form for slot 0x7FFF
+        # (same collision as _new_of_known_class above) - the short-form
+        # bytes at this position must NOT match, even though the naive
+        # `0x8000 | 0x7FFF` bit-math alone would suggest otherwise.
+        short_form = struct.pack("<H", 0x8000 | 0x7FFF)
+        assert legacy._is_class_ref(short_form, 0, 0x7FFF) is False
+        escape_form = struct.pack("<H", 0x7FFF) + struct.pack("<I", 0x80000000 | 0x7FFF)
+        assert legacy._is_class_ref(escape_form, 0, 0x7FFF) is True
+
+
+class TestLargeModelSlotBoundary:
+    """Real-scale reproduction: enough unique (non-shared-vertex)
+    triangles to push the file's total archive-slot count past 32,767,
+    the exact condition that corrupted large flattened-geometry exports
+    before this fix. Deliberately uses unique vertices per triangle
+    (~11 new slots each) rather than a shared grid, to land the crossing
+    at an unpredictable, non-hand-picked slot number - the same
+    worst-case shape a CAD import's flattened mesh produces."""
+
+    def _build(self, n=5000):
+        builder = create()
+        for i in range(n):
+            x = i * 10.0
+            builder.add_face([(x, 0.0, 0.0), (x + 1.0, 0.0, 0.0), (x, 1.0, 0.0)])
+        return builder
+
+    def test_next_slot_actually_crosses_the_boundary(self):
+        # Sanity check that this test is exercising the real condition,
+        # not accidentally staying under it.
+        builder = self._build()
+        assert builder._geometry_writer.next_slot > 0x7FFF
+
+    def test_round_trips_through_own_reader_with_exact_face_count(self, tmp_path):
+        builder = self._build()
+        out = tmp_path / "slot_boundary.skp"
+        builder.save(str(out))
+        from openskp import SkpFile
+
+        parsed = SkpFile.open(str(out)).parse()
+        assert len(parsed.root.faces) == 5000
+
+
 class TestScaffoldIntegrity:
     def test_scaffold_hash_matches_expected(self):
         # Guards against the scaffold file silently drifting (e.g. a bad
@@ -3428,6 +3544,41 @@ class TestRealSketchUpOracle:
             assert False in visibilities  # the hidden "Roof" layer
             assert True in visibilities  # the default, visible "Layer0"
 
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_model_crossing_the_slot_boundary_opens_cleanly(self, tmp_path):
+        # Before the _backref/_new_of_known_class/_shift_ref fix, a model
+        # whose total archive-slot count crossed 0x7FFF (32767) was
+        # rejected outright by the real SDK (SUModelCreateFromFile
+        # returned a non-zero error, matching the "Unexpected file
+        # format" a user sees in the SketchUp GUI) - confirmed by
+        # reverting the fix locally and observing error code 12 on this
+        # exact file shape, plus our own reader silently dropping ~40%
+        # of the faces with no error at all. 5000 unique (non-shared-
+        # vertex) triangles reliably crosses the boundary with margin.
+        import ctypes
+
+        builder = create()
+        for i in range(5000):
+            x = i * 10.0
+            builder.add_face([(x, 0.0, 0.0), (x + 1.0, 0.0, 0.0), (x, 1.0, 0.0)])
+        assert builder._geometry_writer.next_slot > 0x7FFF
+        out = tmp_path / "slot_boundary_oracle.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            nfaces = ctypes.c_long()
+            dll.SUEntitiesGetNumFaces(entities, ctypes.byref(nfaces))
+            assert nfaces.value == 5000
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()


### PR DESCRIPTION
## Summary
- A model whose total archive-slot count reaches exactly `0x7FFF` (32767) was unrepresentable in the format's short 2-byte reference form — a plain back-ref of 32767 is byte-identical to the big-tag escape marker, and a class-ref of 32767 sets `0x8000|0x7FFF == 0xFFFF`, identical to the new-class-declaration marker. `legacy.py`'s reader checks both of those before ever considering "this is just a normal reference", so either collision desyncs every read after it.
- `_backref`/`_new_of_known_class` used an off-by-one `<= 0x7FFF` boundary that let slot 32767 through in the ambiguous short form. `_shift_ref` (renumbers a handful of fixed pointers in the blank scaffold's tail region when new slots are inserted) had no escape-widening at all and simply masked any shift past that boundary back into the wrong slot.
- Fixed both: the boundary is now `< 0x7FFF` everywhere it's checked (`create.py`'s writer and `legacy.py`'s matching `_is_class_ref` reader helper), and `_shift_ref` now widens to the same 6-byte escape form `_backref` already uses when a shift crosses it, returning the byte growth so `to_bytes()`'s tail-assembly can correctly offset every later fixed position (including the ISO-camera patches) by the accumulated growth instead of using their original hardcoded offsets.
- Found while independently reviewing a large-model export failure report from a downstream project (IngeTrazo) building a `.skp` exporter on this writer; re-derived and verified from scratch against the actual code rather than taken on faith.

## Test plan
- [x] 350 tests pass (12 new — exact-boundary unit tests for `_backref`/`_new_of_known_class`/`_shift_ref`/`_is_class_ref`, plus a 5,000-unique-triangle integration test crossing the slot boundary), `ruff` clean
- [x] Reverted the fix locally and reproduced the exact failure: real SketchUp's SDK returns error code 12 (`SUModelCreateFromFile`) on a model crossing the boundary — matching the reported "Unexpected file format" — and this project's own reader silently drops ~40% of the faces with no error surfaced at all
- [x] With the fix: real SketchUp opens the same file cleanly and reports the exact correct face count (verified directly via `SketchUpAPI.dll`, not assumed)