### PR TITLE
fix(typescript): read v20 filler counts that are multiples of 256

### DIFF
--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -24,10 +24,60 @@ export class LegacyParseError extends Error {}
 
 const STR_MARKER = new Uint8Array([0xff, 0xfe, 0xff]);
 
+/** Widest zero padding seen between the v20 filler's empty string and the
+ * count that follows it (9 and 13 bytes occur in real files; the ceiling
+ * leaves room without letting the probe wander into unrelated records). */
+const MAX_V20_FILLER_PAD = 29;
+
 function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
   return true;
+}
+
+/**
+ * Locates the count that follows a v20 filler record, given the offset the
+ * bad count was read from. Pure byte logic, exported for tests; see
+ * {@link retryCountAfterV20Filler} for how it is used.
+ *
+ * Returns the count and the offset just past it, or null when the bytes do
+ * not match the filler layout.
+ */
+export function findCountAfterV20Filler(
+  data: Uint8Array,
+  countPos: number,
+  limit: number
+): { count: number; next: number } | null {
+  // the marker sits within a handful of bytes of the bad read; the window is
+  // deliberately tight so a coincidental ff-fe-ff further out cannot match
+  let markerAt = -1;
+  for (let i = countPos; i < countPos + 12 && i + 4 <= data.length; i++) {
+    if (data[i] === 0xff && data[i + 1] === 0xfe && data[i + 2] === 0xff) {
+      markerAt = i;
+      break;
+    }
+  }
+  if (markerAt < 0) return null;
+  if (data[markerAt + 3] !== 0) return null; // non-empty string: real data
+
+  // The count sits past a run of zero padding whose length varies per call
+  // site (9 and 13 bytes both occur in real files), but always lands at
+  // `markerAt + 4 + pad` with `pad % 4 === 1`. Step through those candidate
+  // offsets and take the first plausible u32.
+  //
+  // Deliberately NOT "scan forward to the first non-zero byte": a count that
+  // is an exact multiple of 256 has a 0x00 low byte, which such a scan cannot
+  // tell apart from padding, so it would skip into the count and misalign
+  // every later read. Probing whole u32s at 4-byte strides never inspects an
+  // individual byte, so those counts round-trip correctly.
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  for (let pad = 1; pad <= MAX_V20_FILLER_PAD; pad += 4) {
+    const at = markerAt + 4 + pad;
+    if (at + 4 > data.length) break;
+    const count = view.getUint32(at, true);
+    if (count > 0 && count <= limit) return { count, next: at + 4 };
+  }
+  return null;
 }
 
 /**
@@ -51,30 +101,11 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
  * `countPos` is the offset the count was read FROM (i.e. r.pos - 4).
  * Returns the corrected count, or null when this is not the v20 layout.
  */
-function retryCountAfterV20Filler(r: R, countPos: number): number | null {
-  const data = r.data;
-  // the marker sits within a handful of bytes of the bad read; the window is
-  // deliberately tight so a coincidental ff-fe-ff further out cannot match
-  let markerAt = -1;
-  for (let i = countPos; i < countPos + 12 && i + 4 <= data.length; i++) {
-    if (data[i] === 0xff && data[i + 1] === 0xfe && data[i + 2] === 0xff) {
-      markerAt = i;
-      break;
-    }
-  }
-  if (markerAt < 0) return null;
-  if (data[markerAt + 3] !== 0) return null; // non-empty string: real data
-
-  // Skip the zero padding that follows the empty string. The count is
-  // little-endian and non-zero, so the first non-zero byte after the padding
-  // IS its low byte — the run ends exactly on the count.
-  let at = markerAt + 4;
-  while (at < data.length && data[at] === 0) at++;
-  if (at + 4 > data.length) return null;
-  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
-  const count = view.getUint32(at, true);
-  r.pos = at + 4;
-  return count;
+function retryCountAfterV20Filler(r: R, countPos: number, limit: number): number | null {
+  const hit = findCountAfterV20Filler(r.data, countPos, limit);
+  if (hit === null) return null;
+  r.pos = hit.next;
+  return hit.count;
 }
 
 /** Search for `needle` (exact bytes) within [start, end). Returns -1 if absent. */
@@ -794,7 +825,7 @@ function readDefinition(ar: Archive, r: R): any {
   // instead of the count. A genuinely empty definition reads zero with no
   // filler ahead, and retryCountAfterV20Filler leaves those alone.
   if (count > 5_000_000 || count === 0) {
-    const retry = retryCountAfterV20Filler(r, r.pos - 4);
+    const retry = retryCountAfterV20Filler(r, r.pos - 4, 5_000_000);
     if (retry !== null) count = retry;
   }
   if (count > 5_000_000) {
@@ -803,7 +834,7 @@ function readDefinition(ar: Archive, r: R): any {
   const ents = readEntityList(ar, r, count, 'def');
   let nrel = r.u32();
   if (nrel > 100000) {
-    const retry = retryCountAfterV20Filler(r, r.pos - 4);
+    const retry = retryCountAfterV20Filler(r, r.pos - 4, 100_000);
     if (retry !== null) nrel = retry;
   }
   if (nrel > 100000) {
@@ -1107,7 +1138,7 @@ function walkModel(data: Uint8Array, ver: number, start: number, matCount: numbe
   }
   let defCount = r.u32();
   if (defCount > 1_000_000) {
-    const retry = retryCountAfterV20Filler(r, r.pos - 4);
+    const retry = retryCountAfterV20Filler(r, r.pos - 4, 1_000_000);
     if (retry !== null) defCount = retry;
   }
   if (defCount > 1_000_000) {
@@ -1132,7 +1163,7 @@ function walkModel(data: Uint8Array, ver: number, start: number, matCount: numbe
   // root entity list
   let rootCount = r.u32();
   if (rootCount > 5_000_000) {
-    const retry = retryCountAfterV20Filler(r, r.pos - 4);
+    const retry = retryCountAfterV20Filler(r, r.pos - 4, 5_000_000);
     if (retry !== null) rootCount = retry;
   }
   if (rootCount > 5_000_000) {

--- a/packages/typescript/tests/legacy-v20-filler.test.ts
+++ b/packages/typescript/tests/legacy-v20-filler.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { findCountAfterV20Filler } from '../src/legacy';
+
+/**
+ * The v20 filler probe, exercised on synthetic records.
+ *
+ * Follow-up to the review on openskp#155: the original implementation walked
+ * forward to the first non-zero byte and treated it as the count's low byte.
+ * That cannot represent a count which is an exact multiple of 256 - its low
+ * byte IS 0x00, so the scan walks straight into the count and misaligns every
+ * read after it. Probing whole u32s at 4-byte strides fixes that, since no
+ * individual byte is ever inspected.
+ *
+ * Layout (see findCountAfterV20Filler):
+ *   <ff fe ff> <u8 0>   empty UTF-16 string
+ *   <zero padding>      length varies per call site, always pad % 4 === 1
+ *   <u32 count>
+ */
+
+/** Builds a filler record followed by `count`, then a class-record header. */
+function filler(count: number, pad: number): Uint8Array {
+  const bytes = [0xff, 0xfe, 0xff, 0x00];
+  for (let i = 0; i < pad; i++) bytes.push(0x00);
+  bytes.push(count & 0xff, (count >> 8) & 0xff, (count >> 16) & 0xff, (count >>> 24) & 0xff);
+  bytes.push(0xff, 0xff, 0x0b, 0x00); // whatever record comes next
+  return new Uint8Array(bytes);
+}
+
+describe('findCountAfterV20Filler', () => {
+  it('reads the counts and paddings seen in real v20 files', () => {
+    // both padding lengths observed in gondola_v20.skp and a second v20 model
+    expect(findCountAfterV20Filler(filler(20, 9), 0, 1_000_000)).toEqual({ count: 20, next: 17 });
+    expect(findCountAfterV20Filler(filler(5425, 13), 0, 5_000_000)).toEqual({ count: 5425, next: 21 });
+  });
+
+  it('reads a count that is an exact multiple of 256', () => {
+    // the regression this test exists for: a 0x00 low byte is indistinguishable
+    // from padding to a byte-at-a-time scan
+    for (const count of [256, 512, 1024, 65536, 16_777_216 / 16]) {
+      for (const pad of [9, 13]) {
+        const hit = findCountAfterV20Filler(filler(count, pad), 0, 5_000_000);
+        expect(hit, `count=${count} pad=${pad}`).not.toBeNull();
+        expect(hit!.count, `count=${count} pad=${pad}`).toBe(count);
+      }
+    }
+  });
+
+  it('reports where to resume reading', () => {
+    const hit = findCountAfterV20Filler(filler(256, 13), 0, 5_000_000)!;
+    // 4 (marker+len) + 13 (padding) + 4 (the count itself)
+    expect(hit.next).toBe(21);
+  });
+
+  it('ignores a non-empty string record', () => {
+    // a real string here is genuine data; moving the cursor past it would
+    // corrupt the parse
+    const bytes = new Uint8Array([0xff, 0xfe, 0xff, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0]);
+    expect(findCountAfterV20Filler(bytes, 0, 1_000_000)).toBeNull();
+  });
+
+  it('returns null when there is no marker ahead', () => {
+    const bytes = new Uint8Array(32); // all zeros, no ff fe ff
+    expect(findCountAfterV20Filler(bytes, 0, 1_000_000)).toBeNull();
+  });
+
+  it('respects the caller\'s plausibility limit', () => {
+    // nrel's limit is 100_000: a value above it is not the count we want
+    expect(findCountAfterV20Filler(filler(200_000, 13), 0, 100_000)).toBeNull();
+    expect(findCountAfterV20Filler(filler(200_000, 13), 0, 5_000_000)?.count).toBe(200_000);
+  });
+
+  it('does not run past the end of the buffer', () => {
+    const bytes = new Uint8Array([0xff, 0xfe, 0xff, 0x00, 0, 0]);
+    expect(findCountAfterV20Filler(bytes, 0, 1_000_000)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to your review on #155, which flagged this:

> `retryCountAfterV20Filler`'s "skip zero padding, first non-zero byte is the count's low byte" heuristic has a narrow edge case: if the real count is an exact multiple of 256 (its own low byte is `0x00`), the scan can't distinguish that from filler padding and will misalign the read.

You were right. Fixing it.

## Type
- [x] Bug fix

## Changes

The padding length genuinely varies per call site — 9 and 13 bytes both occur in real files, so a fixed offset is not an option. But the count always lands at `markerAt + 4 + pad` with `pad % 4 === 1`, so the probe can step through those candidate offsets and read whole u32s instead of walking byte by byte. No individual byte is ever inspected, which is what made a `0x00` low byte ambiguous.

Two smaller things that came with it:

- **Each call site now passes the plausibility limit it already enforces** (`5_000_000` / `100_000` / `1_000_000`). The probe accepts exactly the range the caller would, rather than hardcoding one bound for all four.
- **The byte logic is split out as `findCountAfterV20Filler` and exported**, following `isClassRef`'s precedent, so the layout can be tested on synthetic records without a fixture.

## Testing

`tests/legacy-v20-filler.test.ts`, 7 cases. Three of them fail on the current implementation:

```
count    256 pad 13 | before: 4278190081 | after: 256
count    512 pad  9 | before: 4278190082 | after: 512
count  65536 pad 13 | before: 4294901761 | after: 65536
```

The other cases cover the paddings seen in real files, the resume offset, a non-empty string record (must be left alone), a missing marker, the per-caller limit, and a truncated buffer.

- 105/105 tests pass, `tsc --noEmit` and eslint clean
- All fixtures — v17, v20, VFF — produce identical results to before

On your note that this "mostly degrades to hitting the implausibility checks and throwing cleanly": that matches what I see, so this is hardening rather than a live bug fix. No file I have trips it.
