### PR TITLE
feat(typescript): embed texture images in GLB export (opt-in)

### DIFF
--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -366,9 +366,49 @@ function createGlb(json: any, binaryBuffer: Uint8Array): Uint8Array {
  * @param scene - The result of buildScene()
  * @returns GLB file as Uint8Array
  */
-export function toGLB(scene: SkpScene): Uint8Array {
+/** Options for {@link toGLB}. */
+export interface GlbOptions {
+  /** Embed the scene's texture images in the GLB and point each textured
+   * material's `baseColorTexture` at them.
+   *
+   * Off by default because it is not free: a model with photographic
+   * textures can be several times larger with the images than without, and
+   * the geometry alone is what most callers are after. When off, textured
+   * materials fall back to their averaged base colour, which is what this
+   * exporter has always produced.
+   */
+  textures?: boolean;
+}
+
+/**
+ * Drops `baseColorTexture` from materials when the images are not being
+ * embedded. The reference would otherwise dangle - `textures[0]` would not
+ * exist - and a strict glTF reader rejects the file outright.
+ */
+function stripTextureRefs(materials: unknown[]): unknown[] {
+  let needsCopy = false;
+  for (const mat of materials) {
+    if ((mat as any)?.pbrMetallicRoughness?.baseColorTexture) {
+      needsCopy = true;
+      break;
+    }
+  }
+  if (!needsCopy) return materials;
+  return materials.map((mat) => {
+    const pbr = (mat as any)?.pbrMetallicRoughness;
+    if (!pbr?.baseColorTexture) return mat;
+    const restPbr = { ...pbr };
+    delete restPbr.baseColorTexture;
+    return { ...(mat as any), pbrMetallicRoughness: restPbr };
+  });
+}
+
+export function toGLB(scene: SkpScene, options?: GlbOptions): Uint8Array {
   const prims = scene.glbPrimitives || [];
   const gltfMaterials = scene.gltfMaterials || [];
+  // Off by default: embedding the images makes the export several times
+  // larger, and a caller who only wants geometry should not pay for it.
+  const sceneTextures = options?.textures ? scene.textures || [] : [];
 
   let totalBinaryLength = 0;
   for (const prim of prims) {
@@ -376,6 +416,14 @@ export function toGLB(scene: SkpScene): Uint8Array {
     totalBinaryLength += prim.normals.byteLength;
     totalBinaryLength += prim.uvs.byteLength;
     totalBinaryLength += prim.indices.byteLength;
+  }
+
+  // images go after the vertex data, each aligned to 4 bytes as glTF requires
+  const imagePlacements: { offset: number; length: number }[] = [];
+  for (const tex of sceneTextures) {
+    totalBinaryLength += (4 - (totalBinaryLength % 4)) % 4;
+    imagePlacements.push({ offset: totalBinaryLength, length: tex.data.length });
+    totalBinaryLength += tex.data.length;
   }
 
   const binaryBuffer = new Uint8Array(totalBinaryLength);
@@ -499,6 +547,20 @@ export function toGLB(scene: SkpScene): Uint8Array {
     });
   }
 
+  const gltfImages: any[] = [];
+  const gltfTextures: any[] = [];
+  for (let i = 0; i < sceneTextures.length; i++) {
+    const tex = sceneTextures[i];
+    const place = imagePlacements[i];
+    binaryBuffer.set(tex.data, place.offset);
+    const viewIdx = bufferViews.length;
+    bufferViews.push({ buffer: 0, byteOffset: place.offset, byteLength: place.length });
+    gltfImages.push({ bufferView: viewIdx, mimeType: tex.mimeType });
+    // one sampler for all of them: SketchUp tiles a material's texture across
+    // the face, which is REPEAT on both axes
+    gltfTextures.push({ sampler: 0, source: gltfImages.length - 1 });
+  }
+
   const gltfMeshes: any[] = [];
   if (gltfPrimitives.length > 0) {
     gltfMeshes.push({
@@ -523,7 +585,7 @@ export function toGLB(scene: SkpScene): Uint8Array {
       },
     ] : [],
     meshes: gltfMeshes,
-    materials: gltfMaterials,
+    materials: sceneTextures.length > 0 ? gltfMaterials : stripTextureRefs(gltfMaterials),
     buffers: [
       {
         byteLength: totalBinaryLength,
@@ -531,6 +593,13 @@ export function toGLB(scene: SkpScene): Uint8Array {
     ],
     bufferViews,
     accessors,
+    ...(gltfImages.length > 0
+      ? {
+          images: gltfImages,
+          textures: gltfTextures,
+          samplers: [{ wrapS: 10497, wrapT: 10497 }], // REPEAT / REPEAT
+        }
+      : {}),
   };
 
   return createGlb(gltfJson, binaryBuffer);

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -234,8 +234,49 @@ export interface SkpScene {
   /** The actual triangulated mesh data, one entry per unique
    * (definition, resolved color) combination actually placed in the scene. */
   glbPrimitives: GlbPrimitive[];
-  /** glTF PBR material definitions referenced by `GlbPrimitive.materialIndex`. */
+  /** glTF PBR material definitions referenced by `GlbPrimitive.materialIndex`.
+   * A material whose source had a texture image carries a `baseColorTexture`
+   * whose `index` points into {@link SkpScene.textures}. */
   gltfMaterials: unknown[];
+  /** The distinct texture images the placed materials use, deduplicated by
+   * source bytes. Empty when nothing placed in the scene is textured.
+   *
+   * Kept out of `gltfMaterials` so a caller can decide whether to pay for
+   * them: {@link toGLB} embeds these only when asked, since a model with a
+   * handful of photographic textures is several times larger with them than
+   * without. */
+  textures: SceneTexture[];
+}
+
+/**
+ * Image type from the file's magic bytes. glTF only carries PNG and JPEG, so
+ * anything else (TIFF from older SketchUp, say) reports null and the material
+ * keeps its flat colour instead of embedding an image no viewer would read.
+ */
+export function sniffImageMime(data: Uint8Array): 'image/png' | 'image/jpeg' | null {
+  if (data.length >= 3 && data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  if (
+    data.length >= 8 &&
+    data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4e && data[3] === 0x47 &&
+    data[4] === 0x0d && data[5] === 0x0a && data[6] === 0x1a && data[7] === 0x0a
+  ) {
+    return 'image/png';
+  }
+  return null;
+}
+
+/** One texture image referenced by {@link SkpScene.gltfMaterials}. */
+export interface SceneTexture {
+  /** The image file's raw bytes, exactly as they were stored in the .skp. */
+  data: Uint8Array;
+  /** Sniffed from the bytes, not from `filename`: SketchUp records the
+   * authoring machine's path, whose extension can disagree with the content. */
+  mimeType: 'image/png' | 'image/jpeg';
+  /** The material's texture path as recorded in the file. Informational: it
+   * is usually an absolute path on the machine that authored the model. */
+  filename: string;
 }
 
 /** Raw parsed data, source-agnostic (populated by either the VFF/ZIP path
@@ -478,6 +519,28 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
     return { r: c[0], g: c[1], b: c[2] };
   };
 
+  // Textures are deduplicated by their bytes: the same image routinely backs
+  // several materials, and re-embedding it per material would multiply the
+  // export size for nothing.
+  const textures: SceneTexture[] = [];
+  const textureIndexByKey = new Map<string, number>();
+
+  function textureIndexFor(tex: Texture | null | undefined): number | null {
+    if (!tex || !tex.data || tex.data.length === 0) return null;
+    const mimeType = sniffImageMime(tex.data);
+    if (mimeType === null) return null; // a format glTF cannot carry
+    // length plus a short byte prefix is enough to tell real images apart
+    // without hashing megabytes on every face
+    const head = Array.from(tex.data.subarray(0, 16)).join(',');
+    const key = `${tex.data.length}:${head}`;
+    const hit = textureIndexByKey.get(key);
+    if (hit !== undefined) return hit;
+    const idx = textures.length;
+    textures.push({ data: tex.data, mimeType, filename: tex.filename });
+    textureIndexByKey.set(key, idx);
+    return idx;
+  }
+
   const colorToMaterialIndex = new Map<string, number>();
   const gltfMaterials: any[] = [];
 
@@ -488,19 +551,33 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
   // the stack overflows.
   const activeDefinitions = new Set<number | string>();
 
-  function getMaterialIndex(color: { r: number; g: number; b: number }, doubleSided: boolean) {
-    const key = `${color.r},${color.g},${color.b},${doubleSided}`;
+  function getMaterialIndex(
+    color: { r: number; g: number; b: number },
+    doubleSided: boolean,
+    textureIndex: number | null
+  ) {
+    // The texture is part of the identity, not just the colour: two different
+    // images can average to the same RGB (real files do this - two fabrics
+    // both resolving to 141,141,141), and keying on colour alone would merge
+    // them into one material and lose one of the images.
+    const key = `${color.r},${color.g},${color.b},${doubleSided},${textureIndex ?? -1}`;
     if (colorToMaterialIndex.has(key)) {
       return colorToMaterialIndex.get(key)!;
     }
     const idx = gltfMaterials.length;
-    const material: any = {
-      pbrMetallicRoughness: {
-        baseColorFactor: [color.r / 255, color.g / 255, color.b / 255, 1.0],
-        metallicFactor: 0.0,
-        roughnessFactor: 0.8,
-      },
+    const pbr: any = {
+      baseColorFactor: [color.r / 255, color.g / 255, color.b / 255, 1.0],
+      metallicFactor: 0.0,
+      roughnessFactor: 0.8,
     };
+    // baseColorFactor stays as the resolved colour even with a texture
+    // attached: glTF multiplies the two, and SketchUp's own colorized
+    // materials rely on exactly that tint. Overwriting it with white would
+    // also drop the colour every existing consumer of this exporter reads.
+    if (textureIndex !== null) {
+      pbr.baseColorTexture = { index: textureIndex };
+    }
+    const material: any = { pbrMetallicRoughness: pbr };
     if (doubleSided) material.doubleSided = true;
     gltfMaterials.push(material);
     colorToMaterialIndex.set(key, idx);
@@ -539,6 +616,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         normalsAccum: number[][];
         localFaces: number[][];
         localVMap: Map<string, number>;
+        textureIndex: number | null;
       };
       const faceGroups = new Map<string, FaceGroup>();
 
@@ -556,12 +634,17 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         xr: [number, number, number],
         yr: [number, number, number]
       ) => {
-        const colorKey = `${color.r},${color.g},${color.b},${doubleSided}`;
+        // faces are batched per emitted material, so the texture has to be
+        // part of the key too - otherwise two differently-textured faces with
+        // the same average colour end up in one primitive with one image
+        const texIndex = textureIndexFor(mat?.texture);
+        const colorKey = `${color.r},${color.g},${color.b},${doubleSided},${texIndex ?? -1}`;
         let group = faceGroups.get(colorKey);
         if (!group) {
           group = {
             color,
             doubleSided,
+            textureIndex: texIndex,
             localVerts: [],
             localUvs: [],
             normalsAccum: [],
@@ -736,7 +819,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
           indices[i * 3 + 2] = group.localFaces[i][2];
         }
 
-        const materialIndex = getMaterialIndex(group.color, group.doubleSided);
+        const materialIndex = getMaterialIndex(group.color, group.doubleSided, group.textureIndex);
 
         glbPrimitives.push({
           positions,
@@ -880,7 +963,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
       `${glbPrimitives.length} primitives (${((Date.now() - t0) / 1000).toFixed(2)}s)`
   );
 
-  return { sceneHierarchy, meshIndex, glbPrimitives, gltfMaterials };
+  return { sceneHierarchy, meshIndex, glbPrimitives, gltfMaterials, textures };
 }
 
 export function resolveMaterialFromMaps(

--- a/packages/typescript/tests/glb-textures.test.ts
+++ b/packages/typescript/tests/glb-textures.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildScene, toGLB } from '../src/index';
+import { sniffImageMime } from '../src/model';
+
+/**
+ * Texture images in the GLB export.
+ *
+ * The parser has extracted texture bytes for a while, and every baked
+ * primitive already carries UVs, but `toGLB` never wrote `images`/`textures`,
+ * so an exported model lost its textures and fell back to each material's
+ * averaged colour. Embedding them is opt-in: the images dominate the file
+ * size, and a caller who only wants geometry should not pay for them.
+ *
+ * Fixture: capilla_quiroz_v17.skp, which carries three distinct JPEG textures
+ * across four materials.
+ */
+function readFixture(name: string): ArrayBuffer {
+  const buf = fs.readFileSync(path.join(__dirname, 'fixtures', name));
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
+
+/** Reads a GLB's JSON chunk (12-byte header + 8-byte chunk header). */
+function glbJson(glb: Uint8Array): any {
+  const view = new DataView(glb.buffer, glb.byteOffset, glb.byteLength);
+  const jsonLen = view.getUint32(12, true);
+  return JSON.parse(new TextDecoder().decode(glb.slice(20, 20 + jsonLen)));
+}
+
+/** Reads a GLB's BIN chunk. */
+function glbBin(glb: Uint8Array): Uint8Array {
+  const view = new DataView(glb.buffer, glb.byteOffset, glb.byteLength);
+  const jsonLen = view.getUint32(12, true);
+  const binStart = 20 + jsonLen;
+  return glb.slice(binStart + 8, binStart + 8 + view.getUint32(binStart, true));
+}
+
+describe('sniffImageMime', () => {
+  it('identifies PNG and JPEG by their magic bytes', () => {
+    expect(sniffImageMime(new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 1, 2]))).toBe('image/jpeg');
+    expect(sniffImageMime(new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toBe('image/png');
+  });
+
+  it('rejects anything glTF cannot carry', () => {
+    // e.g. TIFF, which older SketchUp files do contain
+    expect(sniffImageMime(new Uint8Array([0x49, 0x49, 0x2a, 0x00, 1, 2, 3, 4]))).toBeNull();
+    expect(sniffImageMime(new Uint8Array([]))).toBeNull();
+  });
+});
+
+describe('buildScene texture collection', () => {
+  const scene = buildScene(readFixture('capilla_quiroz_v17.skp'));
+
+  it('collects the distinct texture images', () => {
+    expect(scene.textures.length).toBe(3);
+    for (const tex of scene.textures) {
+      expect(tex.mimeType).toBe('image/jpeg');
+      expect(tex.data.length).toBeGreaterThan(0);
+      expect(typeof tex.filename).toBe('string');
+    }
+  });
+
+  it('points textured materials at them', () => {
+    const textured = (scene.gltfMaterials as any[]).filter(
+      (m) => m.pbrMetallicRoughness?.baseColorTexture
+    );
+    expect(textured.length).toBe(4);
+    for (const mat of textured) {
+      const idx = mat.pbrMetallicRoughness.baseColorTexture.index;
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(idx).toBeLessThan(scene.textures.length);
+      // the resolved colour is kept alongside the image: glTF multiplies the
+      // two, which is what SketchUp's colorized materials expect
+      expect(mat.pbrMetallicRoughness.baseColorFactor).toHaveLength(4);
+    }
+  });
+
+  it('keeps two textures apart when their average colours collide', () => {
+    // Materials used to be deduplicated on colour alone, so two different
+    // images that average to the same RGB collapsed into one material and one
+    // of the images was lost. Real files do this - two fabrics both resolving
+    // to 141,141,141 - so the texture has to be part of the key.
+    const seen = new Set<number>();
+    for (const mat of scene.gltfMaterials as any[]) {
+      const tex = mat.pbrMetallicRoughness?.baseColorTexture;
+      if (tex) seen.add(tex.index);
+    }
+    expect(seen.size).toBe(scene.textures.length);
+  });
+
+  it('does not fragment the mesh (same primitive count as before)', () => {
+    // adding the texture to the grouping key must not split primitives that
+    // were previously batched together
+    expect(scene.glbPrimitives.length).toBe(21);
+  });
+});
+
+describe('toGLB texture embedding', () => {
+  const scene = buildScene(readFixture('capilla_quiroz_v17.skp'));
+
+  it('omits the images by default', () => {
+    const json = glbJson(toGLB(scene));
+    expect(json.images).toBeUndefined();
+    expect(json.textures).toBeUndefined();
+    expect(json.samplers).toBeUndefined();
+    // and leaves no dangling reference behind - a strict reader would reject it
+    for (const mat of json.materials) {
+      expect(mat.pbrMetallicRoughness.baseColorTexture).toBeUndefined();
+    }
+  });
+
+  it('embeds them when asked', () => {
+    const glb = toGLB(scene, { textures: true });
+    const json = glbJson(glb);
+    expect(json.images.length).toBe(3);
+    expect(json.textures.length).toBe(3);
+    expect(json.samplers.length).toBe(1);
+    expect(json.materials.filter((m: any) => m.pbrMetallicRoughness?.baseColorTexture).length).toBe(4);
+
+    // the bytes are really in the BIN chunk, not just declared
+    const bin = glbBin(glb);
+    for (let i = 0; i < json.images.length; i++) {
+      const view = json.bufferViews[json.images[i].bufferView];
+      const bytes = bin.slice(view.byteOffset, view.byteOffset + view.byteLength);
+      expect(bytes.length).toBe(scene.textures[i].data.length);
+      expect(bytes[0]).toBe(scene.textures[i].data[0]);
+      // every bufferView must start 4-byte aligned
+      expect(view.byteOffset % 4).toBe(0);
+    }
+  });
+
+  it('produces a structurally valid GLB either way', () => {
+    for (const glb of [toGLB(scene), toGLB(scene, { textures: true })]) {
+      const view = new DataView(glb.buffer, glb.byteOffset, glb.byteLength);
+      expect(view.getUint32(0, true)).toBe(0x46546c67); // "glTF"
+      expect(view.getUint32(8, true)).toBe(glb.byteLength);
+      const jsonLen = view.getUint32(12, true);
+      expect(jsonLen % 4).toBe(0);
+      const binStart = 20 + jsonLen;
+      expect(view.getUint32(binStart + 4, true)).toBe(0x004e4942); // "BIN"
+      const declared = glbJson(glb).buffers[0].byteLength;
+      const chunkLen = view.getUint32(binStart, true);
+      // the chunk may be padded up to 3 bytes past the declared length
+      expect(declared).toBeLessThanOrEqual(chunkLen);
+      expect(chunkLen - declared).toBeLessThan(4);
+    }
+  });
+
+  it('is a no-op on a model with no textures', () => {
+    const plain = buildScene(readFixture('Untitled.skp'));
+    expect(plain.textures.length).toBe(0);
+    expect(toGLB(plain, { textures: true })).toEqual(toGLB(plain));
+  });
+});


### PR DESCRIPTION
## Summary

The parser has extracted texture bytes for a while (#4, #13) and every baked primitive already carries UVs (#6), but `toGLB` never wrote `images` or `textures` — so an exported model loses its textures and every textured material falls back to its averaged colour. A wood-veneer cabinet exports as a flat brown block.

This wires up the last step. Since it changes the export's public shape and its size, it is **opt-in**.

## Type
- [x] New feature
- [x] Bug fix (the material-identity part below)

## Changes

**`toGLB(scene, { textures: true })` embeds the images** and points each textured material's `baseColorTexture` at them. Off by default because it is not free — a real fixture here goes 0.82 MB → 3.41 MB. With the option off the output is byte-identical to before, and `baseColorTexture` is stripped so no reference dangles into a `textures` array that isn't there.

**Material identity was also wrong, independently of the export.** `getMaterialIndex` deduplicated on colour alone, so two materials with *different images* but the same average RGB collapsed into one and one image was lost. Real files hit this: a store model here has two fabrics that both resolve to `141,141,141`. The texture is now part of the key, for both the material map and the face grouping. Primitive counts are unchanged (21 on the v17 fixture), so this does not fragment the mesh.

**`baseColorFactor` deliberately keeps the resolved colour** instead of being reset to white. glTF multiplies factor by texture, which is what SketchUp's colorized materials rely on — and zeroing it broke the existing `item 14 regression` test, which was right to complain.

**`SkpScene` gains `textures`**, deduplicated by image bytes. The mime type is sniffed from the magic bytes rather than the filename: SketchUp records the authoring machine's path (`H:/Drives compartilhados/.../Tauari.jpg`) and its extension can disagree with the content. A format glTF cannot carry (TIFF, from older files) is skipped and the material keeps its flat colour.

## Testing

`tests/glb-textures.test.ts`, 10 cases on `capilla_quiroz_v17.skp` (3 distinct JPEGs across 4 materials): collection and dedup, the default staying clean, the images really landing in the BIN chunk at 4-byte-aligned offsets, GLB structural validity both ways, and a no-op on an untextured model.

- 108/108 tests pass, `tsc --noEmit` and eslint clean
- Verified on real files by round-tripping the output through `@gltf-transform`: escrivaninha 0.82 → 3.41 MB with 7 textured materials, a store model 16.64 → 18.36 MB with 14, every image's bytes intact

## Notes for other platforms

Per CONTRIBUTING's parity note: Python, Dart, .NET and C++ have the same gap — none of their GLB writers emit `images`/`textures`, and their material dedup is colour-only too. The expected behavior is the above: texture as part of the material key, images deduplicated by bytes, mime sniffed from magic bytes, embedding gated behind a caller-supplied flag. I only have TypeScript set up here, so I have not ported it.

## Open question

I picked opt-in with the flag defaulting to off, so nobody's export changes size without asking. If you'd rather have it on by default (textures are arguably what most people expect from a GLB) or named differently, happy to change it — the mechanism is the same either way.
