### PR TITLE
Decode the last legacy-corpus failures: v20 layer separators and per-build guide-line tails

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -242,7 +242,22 @@ class _Archive:
         return slot, ent[1], ent[2]
 
 
-def _retry_count_after_v20_filler(r: _R, count_pos: int) -> Optional[int]:
+def _plausible_list_tag(ar, data, at) -> bool:
+    """True when the u16 at ``at`` can legally start an object read: a
+    null, an escape, a class definition, a class-ref to a KNOWN class, or
+    an object back-ref within the allocated range."""
+    if at + 2 > len(data):
+        return False
+    t = struct.unpack_from('<H', data, at)[0]
+    if t in (0x0000, 0x7FFF, 0xFFFF):
+        return True
+    if t & 0x8000:
+        ent = ar.slots.get(t & 0x7FFF)
+        return ent is not None and ent[0] == 'class'
+    return t < ar.next_slot
+
+
+def _retry_count_after_v20_filler(r: _R, count_pos: int, ar=None) -> Optional[int]:
     """SketchUp 2020 (v20) writes an extra, undocumented record ahead of some
     counts that v17 does not have, which leaves the reader a few bytes early
     and makes it read garbage as the count. The filler is an empty UTF-16
@@ -274,17 +289,27 @@ def _retry_count_after_v20_filler(r: _R, count_pos: int) -> Optional[int]:
     if data[marker_at + 3] != 0:          # non-empty string: real data
         return None
 
-    # Skip the zero padding that follows the empty string. The count is
-    # little-endian and non-zero, so the first non-zero byte after the
-    # padding IS its low byte - the run ends exactly on the count.
+    # Skip the zero padding that follows the empty string. The count's
+    # LOW byte is usually the first non-zero byte after the padding — but
+    # a count divisible by 256 (e.g. 4608 entities) has a zero low byte,
+    # which the padding run swallows. Try the first non-zero byte and up
+    # to three positions before it, taking the first candidate that is
+    # plausible AND is followed by a legitimate list tag.
     at = marker_at + 4
     while at < len(data) and data[at] == 0:
         at += 1
-    if at + 4 > len(data):
-        return None
-    count = struct.unpack_from('<I', data, at)[0]
-    r.pos = at + 4
-    return count
+    for back in range(0, 4):
+        at2 = at - back
+        if at2 < marker_at + 4 or at2 + 4 > len(data):
+            continue
+        count = struct.unpack_from('<I', data, at2)[0]
+        if not (0 < count <= 5_000_000):
+            continue
+        if ar is not None and not _plausible_list_tag(ar, data, at2 + 4):
+            continue
+        r.pos = at2 + 4
+        return count
+    return None
 
 
 # ── shared record blocks ─────────────────────────────────────────────────
@@ -676,16 +701,55 @@ def _read_relationship(ar, r):
     return {'k': 'relationship', 'refs': (a, b)}
 
 
+def _strict_next_tag(ar, data, at, allow_null=True) -> bool:
+    """True when the u16 at ``at`` starts an object read in one of the
+    UNAMBIGUOUS forms: null, escape, class definition, or a class-ref to a
+    class already known. Plain object back-refs are excluded on purpose —
+    any 2-byte junk below 0x8000 would qualify, which is exactly the
+    ambiguity this check exists to avoid."""
+    if at + 2 > len(data):
+        return False
+    t = struct.unpack_from('<H', data, at)[0]
+    if t == 0x0000:
+        return allow_null
+    if t in (0x7FFF, 0xFFFF):
+        return True
+    if t & 0x8000:
+        ent = ar.slots.get(t & 0x7FFF)
+        return ent is not None and ent[0] == 'class'
+    return False
+
+
 def _read_constructionline(ar, r):
     _preamble(ar, r)
     _drawbase(ar, r)
     r.f64s(3)
     r.f64s(3)
-    r.f64s(2)
-    # trailing block: 4 bytes on v16 and v18 (measured on a real 2018
-    # file whose guide lines sit 84 bytes apart), 7 on v17 (validated on
-    # the 661 MB v17 corpus model)
-    r.raw(7 if ar.ver == 17 else 4)
+    r.f64s(2)                        # line params (±~4.4e29 = infinite)
+    # The trailing block varies by the WRITING BUILD, not cleanly by
+    # version: 7 bytes on the v17 calibration corpus, 4 on v16 and on a
+    # real v18, 0 on another real v17. Self-calibrate on the first guide
+    # line of the file — the length that lands on a legitimate next tag
+    # (strict forms only) — and cache it for the rest of the file.
+    k = getattr(ar, '_cline_tail', None)
+    if k is None:
+        default = 7 if ar.ver == 17 else 4
+        order = [default] + [c for c in (0, 4, 7) if c != default]
+        # two passes: a zero tail full of padding can mimic a null tag, so
+        # only accept a null-anchored candidate when no candidate lands on
+        # a STRONG form (escape / known class / class definition)
+        for allow_null in (False, True):
+            for cand in order:
+                if _strict_next_tag(ar, r.data, r.pos + cand,
+                                    allow_null=allow_null):
+                    k = cand
+                    break
+            if k is not None:
+                break
+        if k is None:
+            k = default
+        ar._cline_tail = k
+    r.raw(k)
     return {'k': 'cline'}
 
 
@@ -851,19 +915,34 @@ def _read_definition(ar, r):
     nlayers = r.u32()
     if nlayers > 10000:
         raise LegacyParseError(f"implausible def layer count {r.ctx()}")
-    for _ in range(nlayers):
+    # like the model-level layer list, the count is REAL layers (new records
+    # or back-refs); SketchUp 2020 interleaves null separators between them
+    got = 0
+    while got < nlayers:
+        if r.peek_u16() == 0:
+            r.pos += 2
+            continue
         ar.read_object(r, expect='CLayer')
+        got += 1
     decl = r.u16()
     if decl == 0x7FFF:
         decl = r.u32()
-    r.u32()
-    count = r.u32()
+    # v20 can drop its undocumented filler right here, swallowing the u32
+    # field (and, behind a layer-separator null, even the decl itself): if
+    # the empty-string marker sits in the next few bytes, the real count is
+    # the first non-zero u32 after its padding.
+    count = None
+    if ar.ver >= 20:
+        count = _retry_count_after_v20_filler(r, r.pos, ar)
+    if count is None:
+        r.u32()
+        count = r.u32()
     # A zero count is as much a symptom of the v20 filler as an implausibly
     # large one: the reader lands on the leading zero bytes of the filler
     # instead of the count. A genuinely empty definition reads zero with no
     # filler ahead, and _retry_count_after_v20_filler leaves those alone.
     if count > 5_000_000 or count == 0:
-        retry = _retry_count_after_v20_filler(r, r.pos - 4)
+        retry = _retry_count_after_v20_filler(r, r.pos - 4, ar)
         if retry is not None:
             count = retry
     if count > 5_000_000:
@@ -871,7 +950,7 @@ def _read_definition(ar, r):
     ents = _read_entity_list(ar, r, count, 'def')
     nrel = r.u32()
     if nrel > 100000:
-        retry = _retry_count_after_v20_filler(r, r.pos - 4)
+        retry = _retry_count_after_v20_filler(r, r.pos - 4, ar)
         if retry is not None:
             nrel = retry
     if nrel > 100000:
@@ -1090,17 +1169,37 @@ def _walk_model(data: bytes, ver: int, start: int, mat_count: int,
     layer_count = r.u32()
     if layer_count > 100000:
         raise LegacyParseError("implausible layer count")
+    # ``layer_count`` counts REAL layers. SketchUp 2020 interleaves a null
+    # object-ref after each layer record (a separator, not a layer), so
+    # counting reads walks off mid-list on files with several layers; count
+    # parsed layers instead, skip the separators, and stop early if the
+    # next tag is a back-ref (the definition-list anchor) — a v20 variant
+    # where the count over-includes separators.
     layers = []
-    for _ in range(layer_count):
+    while len(layers) < layer_count:
+        tag = r.peek_u16()
+        if tag == 0:
+            r.pos += 2
+            continue
+        if tag != 0xFFFF and not (tag & 0x8000):
+            break
         s, _, v = ar.read_object(r, expect='CLayer')
-        # A null object-ref occupies a slot in the list without carrying a
-        # layer record (seen in SketchUp 2020 files, where layer_count
-        # includes it). Keeping it would push a None into the list and blow
-        # up downstream on v['rgba']; read_object has still consumed the
-        # ref from the stream.
         if v is None:
             continue
         layers.append((s, v))
+    # trailing separators (and any layer records past the declared count)
+    lay_cls = ar.class_slot.get('CLayer')
+    while True:
+        tag = r.peek_u16()
+        if tag == 0:
+            r.pos += 2
+            continue
+        if lay_cls is not None and tag == (0x8000 | lay_cls):
+            s, _, v = ar.read_object(r, expect='CLayer')
+            if v is not None:
+                layers.append((s, v))
+            continue
+        break
 
     # definition list: object pointer to the ACTIVE layer, then count
     _, dn, _ = ar.read_object(r)
@@ -1108,7 +1207,7 @@ def _walk_model(data: bytes, ver: int, start: int, mat_count: int,
         raise LegacyParseError(f"definition-list anchor is {dn}, not a layer")
     def_count = r.u32()
     if def_count > 1_000_000:
-        retry = _retry_count_after_v20_filler(r, r.pos - 4)
+        retry = _retry_count_after_v20_filler(r, r.pos - 4, ar)
         if retry is not None:
             def_count = retry
     if def_count > 1_000_000:
@@ -1131,7 +1230,7 @@ def _walk_model(data: bytes, ver: int, start: int, mat_count: int,
     # root entity list
     root_count = r.u32()
     if root_count > 5_000_000:
-        retry = _retry_count_after_v20_filler(r, r.pos - 4)
+        retry = _retry_count_after_v20_filler(r, r.pos - 4, ar)
         if retry is not None:
             root_count = retry
     if root_count > 5_000_000:

--- a/packages/python/tests/test_legacy_v20.py
+++ b/packages/python/tests/test_legacy_v20.py
@@ -48,10 +48,14 @@ class TestLegacyV20Parse:
         assert len(model.definitions) == 20
         assert len(model.materials) == 24
 
-        # v20 writes a null object-ref into the layer list, which the layer
-        # count includes. It must not reach model.layers as a null entry.
+        # v20 interleaves a null object-ref after EACH layer record; the
+        # count is the number of REAL layers. The old reader counted the
+        # separators as items and dropped every layer after the first —
+        # this fixture really does carry "Gondulas Laterais" (visible in
+        # SketchUp), which the previous assertion enshrined as missing.
+        # Nulls must still never reach model.layers.
         names = [layer.name for layer in model.layers]
-        assert names == ["Layer0"]
+        assert names == ["Layer0", "Gondulas Laterais"]
         for layer in model.layers:
             assert layer is not None
             assert isinstance(layer.name, str)


### PR DESCRIPTION
## Summary

Marco's follow-up to #194 — he kept sweeping the 186-file real-project corpus after that PR was already merged and pushed a 6th commit to his fork's `fix-legacy-bugs` branch, but since the PR was closed by then it never landed. Cherry-picked here (author preserved) to get it into `main`.

Closes out the last remaining corpus failures — the three 2020 "salinas" files and the 2017 "Iglesia la Barrera Final" file, all in `packages/python/src/openskp/legacy.py`:

1. **v20 layer lists** (model-level and per-definition) interleave a null object-ref after each layer record; the declared count is the number of real layers, not items. The old counting walked off mid-list on any v20 file with several layers (surfaced as "definition-list anchor is None" / "implausible definition count"). Now counts parsed layers, skips the separators, and stops early if a back-ref (the anchor) arrives.

2. **v20 can drop its undocumented filler right after a definition's decl field**, swallowing the u32 that normally follows the count. The filler helper now also runs there (v20 only), and the count anchor is hardened to try up to three earlier positions since the count's low byte can legitimately be zero.

3. **`CConstructionLine`'s trailing block varies by SketchUp's writing build**, not cleanly by version (7 bytes on the v17 calibration corpus, 4 on v16 and a real v18, 0 on another real v17). Now self-calibrated per archive on the file's first guide line instead of assumed from the version number.

Also corrects a real bug in the existing v20 fixture test: `gondola_v20.skp` genuinely carries a second layer ("Gondulas Laterais") that the old counting silently dropped — the test had enshrined the bug as correct behavior.

## Validation (from Marco's PR #194 comment)

- Corpus now **186/186** (up from 182/186 after #194) — the 3 "salinas" project files (309/192/186 defs, up to 113,875 faces and 3,396 instances) and the "Iglesia la Barrera Final" file (295 defs, 42,820 faces, 123 layers) all parse completely.
- Previously-passing corpus fingerprint-identical.
- All six files that ever failed also verified visually in IngeTrazo against SketchUp Web, side by side.

Independently re-run before opening this PR: `pytest` (350 passed) and `ruff check src/ tests/` (clean) on this exact branch.

Co-authored-by: Marco Sumari Tellez <ing.sumari@gmail.com>