### PR TITLE
feat(typescript): add instancing-preserving scene output (buildInstancedScene + toInstancedGLB)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added — TypeScript
+
+**Instancing-preserving scene output.** A new `buildInstancedScene()` keeps
+the instancing SketchUp already recorded, instead of baking it out the way
+`buildScene()` does. Each distinct definition is triangulated once, in its
+own local space, and every placement becomes a node carrying the transform
+that puts it there — so output scales with `unique geometry + instance
+transforms` rather than `definition geometry x placement count`. A
+companion `toInstancedGLB()` writes glTF 2.0/GLB in which many nodes
+reference one mesh, so a definition's vertex and index buffers are written
+once rather than once per placement.
+
+This is lossless instancing preservation, not mesh decimation: no
+vertices are removed, merged, quantised or approximated, and no new
+dependencies are introduced. The triangles are exactly the ones
+`buildScene()` produces. The test suite asserts that directly, by
+flattening the instanced result and comparing it against the baked one on
+the repository's real `.skp` fixtures.
+
+On a synthetic scene of one 24-face component repeated 1,000 times, the
+geometry buffers are 1,000x smaller (3,562 KB to 3.6 KB), the exported GLB
+is 48x smaller, and the build is 46x faster. Run
+`npm run bench:instanced` in `packages/typescript` to reproduce.
+
+`parseSkp()`, `buildScene()` and `toGLB()` are unchanged in behaviour,
+return type and output. TypeScript only; the Python, .NET, Dart and C++
+ports are untouched. See
+[Choosing an API](packages/typescript/README.md#choosing-an-api).
+
 ## [1.1.0] — 2026-08-20
 
 **Write support, now in all five languages.** OpenSKP can *create* new

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -42,6 +42,11 @@ SDK (see [Writing](#writing) below).
   call.
 - **Scene baking** — an opt-in `buildScene()` pass resolves the full placed
   scene graph to world-space, triangulated, export-ready geometry.
+- **Instancing preserved** — `buildInstancedScene()` keeps SketchUp's own
+  instancing instead of baking it out: unique geometry once, plus one
+  transform per placement, so a component placed 1,000 times costs one copy
+  of its buffers. Losslessly — no decimation or quantisation. See
+  [Choosing an API](#choosing-an-api).
 - **Native multi-format conversion** — glTF (GLB), Wavefront OBJ/MTL, STL,
   PLY, AutoCAD DXF (3DFACE and Polyface Mesh), IFC4 (BIM/ISO 10303-21 STEP),
   and JSON — all written from scratch, no third-party CAD/BIM SDK involved.
@@ -94,15 +99,137 @@ console.log(model.root.instances.length, 'root-level instances');
 // Opt-in: full placed scene graph, triangulated, world-space, GLB-ready
 const scene = skp.buildScene();
 console.log(scene.glbPrimitives.length, 'renderable mesh primitives');
+
+// Or keep the file's instancing instead of baking it out: unique geometry
+// once, plus a transform per placement.
+const instanced = skp.buildInstancedScene();
+console.log(instanced.meshResources.length, 'unique meshes');
 ```
+
+## Choosing an API
+
+Three entry points, in increasing order of what they compute. Each one
+re-parses the file independently, so you only pay for the one you call.
+
+| Use | When |
+|---|---|
+| `parseSkp()` / `.parse()` | You want the file's raw contents — definitions, layers, materials, metadata — with no scene-graph instancing resolved. Fastest and lightest. |
+| `buildScene()` / `.buildScene()` | You want a flat, world-space, triangulated scene to hand straight to a renderer or an exporter (`toGLB`, `toOBJ`, `toSTL`, `toIFC`, …). Every placement is baked into its own vertex buffers. |
+| `buildInstancedScene()` / `.buildInstancedScene()` | You want the same geometry, but with the file's instancing preserved: each definition triangulated once and referenced by every placement. |
+
+### The memory tradeoff
+
+`buildScene()` bakes each placed instance into its own world-space buffers,
+so its output scales with:
+
+```
+definition geometry x number of placed instances
+```
+
+`buildInstancedScene()` stores each distinct definition once and puts the
+placement on the node, so it scales with:
+
+```
+unique geometry + instance transforms
+```
+
+For a model that reuses components heavily — furniture, facade panels,
+fixtures, anything repeated — that is the difference between an output that
+grows with the model's *placement count* and one that grows with its
+*distinct content*. On a synthetic scene of one 24-face component repeated
+1,000 times, the geometry buffers are 1,000x smaller (3,562 KB vs 3.6 KB)
+and the exported GLB is 48x smaller.
+
+The cost is that you must apply the node transforms yourself (or hand the
+result to `toInstancedGLB()`, or to any glTF/three.js-style scene graph,
+which do it natively). If you just want flat triangles, `buildScene()` is
+still the simpler call.
+
+**This is lossless instancing preservation, not mesh decimation.** No
+vertices are removed, merged, quantised or approximated. The triangles are
+exactly the ones `buildScene()` produces; they are stored once and
+referenced N times instead of copied N times. The test suite asserts this
+directly, by flattening the instanced result and comparing it against the
+baked one on the repository's real `.skp` fixtures.
+
+### Coordinate systems and units
+
+SketchUp stores geometry in **inches on a Z-up** axis system. Both scene
+builders convert to **metres on glTF's Y-up** axes, applying the same
+`(x, y, z) -> (x, z, -y)` swap, so:
+
+- `LocalPrimitive.positions` / `normals` are in metres, Y-up, and in
+  **definition-local space** — no instance transform applied.
+- `InstancedNode.matrix` is a 16-element **column-major glTF matrix**, in
+  metres, Y-up, and is **relative to its parent**. Compose the chain by
+  walking the tree, exactly as glTF does. The root node's matrix is the
+  identity.
+- `InstancedNode.positionMm` is the one exception: it is the node's
+  **absolute** position in **millimetres on SketchUp's Z-up** axes, kept in
+  that frame so it matches the baked path's `InstanceNode.positionMm`
+  field for metadata comparisons.
+
+Normals are left in local space deliberately. Transforming them is the
+consumer's job (glTF's own rule: inverse-transpose of the node's upper-left
+3x3), and deferring it is what keeps non-uniform and mirrored
+(negative-determinant) scales correct without baking a per-placement copy of
+the normal buffer.
+
+### How material variants affect resource reuse
+
+Two placements share a mesh resource when their *effective rendered
+geometry* is identical — which is not the same as sharing a definition ID.
+The same component renders differently depending on where it is placed, so
+resource identity also accounts for:
+
+- the **inherited instance material** (SketchUp's "paint the component"),
+  which sets both the colour of unpainted faces and, through its texture's
+  tile size, their UVs;
+- **texture identity**, not just averaged colour — two different images can
+  average to the same RGB;
+- the **effective layer's fallback colour**, which is what an entirely
+  unpainted face renders as.
+
+So two instances of one definition painted with different materials produce
+two resource *variants*, while two instances with the same effective context
+share one. Front/back material resolution, per-face UV mapping and
+double-sided-vs-split geometry all follow deterministically from the
+definition plus those inputs. `InstancedMeshResource.variantKey` exposes the
+resolved context if you need to see why a definition produced more than one
+resource. Resource IDs (`mesh_0`, `mesh_1`, …) are stable and deterministic
+for a given file.
+
+### Exporting an instanced GLB
+
+```typescript
+import { SkpFile, toInstancedGLB } from 'openskp';
+import * as fs from 'fs';
+
+const instanced = SkpFile.open('model.skp').buildInstancedScene();
+
+// Multiple glTF nodes reference the SAME mesh - the vertex and index
+// buffers are written once, not once per placement.
+fs.writeFileSync('model.glb', toInstancedGLB(instanced));
+
+// Pass { textures: true } to embed the texture images, as with toGLB().
+fs.writeFileSync('textured.glb', toInstancedGLB(instanced, { textures: true }));
+```
+
+A definition that resolves to several materials becomes one glTF mesh with
+several primitives, which is glTF's normal representation — not several
+nodes. `toGLB()` and `buildScene()` are untouched and still produce exactly
+what they always have.
 
 ## Exporting
 
 ```typescript
-import { toGLB, toOBJ, toMTL, exportOBJ, toSTLAscii, toSTLBinary, exportSTL, toPLYAscii, toPLYBinary, exportPLY, toDXF, exportDXF, toIFC, exportIFC, toJSON } from 'openskp';
+import { toGLB, toInstancedGLB, toOBJ, toMTL, exportOBJ, toSTLAscii, toSTLBinary, exportSTL, toPLYAscii, toPLYBinary, exportPLY, toDXF, exportDXF, toIFC, exportIFC, toJSON } from 'openskp';
 
 // Serialize a built scene straight to .glb bytes (in-memory, no disk I/O)
 const glbBytes = toGLB(scene);
+
+// Instancing-preserving GLB: one mesh, many nodes (see Choosing an API)
+const instancedGlb = toInstancedGLB(instanced);
 
 // Export to Wavefront OBJ string, plus a companion .mtl material library
 const objText = toOBJ(scene, 'output.mtl');
@@ -237,7 +364,10 @@ verified numbers before parsing very large files in this package.
 | `transforms.ts` | 3D matrix transforms and coordinate conversions |
 | `observability.ts` | Progress/log callback types |
 | `errors.ts` | `SkpParseError` and structured failure context |
-| `index.ts` | Public entry point — `SkpFile`, `parseSkp`, `buildScene`, `toGLB`, `toJSON` |
+| `face-groups.ts` | Local-space face grouping shared by both scene builders |
+| `instanced.ts` | Instancing-preserving scene builder (`buildInstancedScene`) |
+| `instanced-glb.ts` | GLB exporter that reuses one mesh across many nodes |
+| `index.ts` | Public entry point — `SkpFile`, `parseSkp`, `buildScene`, `buildInstancedScene`, `toGLB`, `toInstancedGLB`, `toJSON` |
 
 ## Requirements
 

--- a/packages/typescript/package-lock.json
+++ b/packages/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openskp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openskp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "earcut": "^3.0.0",
@@ -19,6 +19,7 @@
         "tsup": "^8.0.0",
         "typescript": "^5.3.0",
         "typescript-eslint": "8.67.0",
+        "vite-node": "^1.6.1",
         "vitest": "^1.0.0"
       },
       "engines": {

--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openskp",
   "version": "1.1.0",
-  "description": "Open-source SketchUp (.skp) binary file parser, writer, and converter — extract geometry, metadata, layers, and materials; create and edit .skp files; convert to GLB, OBJ, STL, PLY, DXF, and IFC4. Works in browser and Node.js.",
+  "description": "Open-source SketchUp (.skp) binary file parser, writer, and converter \u2014 extract geometry, metadata, layers, and materials; create and edit .skp files; convert to GLB, OBJ, STL, PLY, DXF, and IFC4. Works in browser and Node.js.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -19,6 +19,7 @@
     "build": "tsup src/index.ts --format cjs,esm --dts",
     "copy-dist": "node copy-dist.js",
     "test": "vitest run",
+    "bench:instanced": "vite-node tests/bench/instanced-bench.ts",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit"
   },
@@ -67,6 +68,7 @@
     "tsup": "^8.0.0",
     "typescript": "^5.3.0",
     "typescript-eslint": "8.67.0",
+    "vite-node": "^1.6.1",
     "vitest": "^1.0.0"
   },
   "overrides": {

--- a/packages/typescript/src/face-groups.ts
+++ b/packages/typescript/src/face-groups.ts
@@ -1,0 +1,190 @@
+import { triangulateFace3D } from './triangulator';
+import { reconstructLoopVertices } from './geometry';
+import type { GeometryBuilder } from './geometry';
+import { SkpParseError } from './errors';
+import { faceUvBasis, computeFaceUv } from './model';
+import type { Material, Texture } from './model';
+
+/**
+ * One group of faces sharing a single resolved (colour, doubleSided,
+ * texture) identity, still in DEFINITION-LOCAL space (inches, SketchUp
+ * Z-up) - i.e. exactly what the baked scene builder assembles just before
+ * it applies an instance's world matrix.
+ *
+ * Shared by the baked path (`buildSceneFromParsed`, which then transforms
+ * these into world space) and the instanced path
+ * (`buildInstancedSceneFromParsed`, which keeps them local and puts the
+ * transform on the node instead). Keeping one implementation is what makes
+ * the two paths agree on triangulation, UV seams, normals and front/back
+ * handling by construction rather than by parallel maintenance.
+ */
+export interface LocalFaceGroup {
+  color: { r: number; g: number; b: number };
+  doubleSided: boolean;
+  /** Local-space vertex positions, inches, SketchUp Z-up. */
+  localVerts: [number, number, number][];
+  localUvs: [number, number][];
+  /** Un-normalised summed face normals per vertex, local space. */
+  normalsAccum: number[][];
+  localFaces: number[][];
+  localVMap: Map<string, number>;
+  textureIndex: number | null;
+}
+
+/** Everything the grouping needs from its caller that isn't the builder
+ * itself: how a material id resolves, how a texture maps to a scene
+ * texture index, and the colour to fall back to for an unpainted face. */
+export interface FaceGroupContext {
+  resolveMaterial: (matId: number | null | undefined) => Material | undefined;
+  textureIndexFor: (tex: Texture | null | undefined) => number | null;
+  /** Painted-instance material inherited from the enclosing instance, if any. */
+  inheritedMaterial?: Material;
+  /** Colour an unpainted face falls back to when nothing is inherited
+   * (the effective layer's colour). */
+  fallbackLayerColor: { r: number; g: number; b: number };
+  /** Identifies the definition in a triangulation failure. */
+  definitionId: number | string;
+}
+
+/**
+ * Group a definition's faces by resolved material identity, in local space.
+ *
+ * A face whose front/back resolve to the SAME colour is emitted once with
+ * `doubleSided` set; a face whose sides genuinely differ is emitted as two
+ * single-sided triangle sets (one normal-wound front, one reverse-wound
+ * back) so each side keeps its own colour.
+ */
+export function buildLocalFaceGroups(
+  builder: GeometryBuilder,
+  ctx: FaceGroupContext
+): Map<string, LocalFaceGroup> {
+  const faceGroups = new Map<string, LocalFaceGroup>();
+
+  const addSide = (
+    triangles: number[][],
+    fn: [number, number, number],
+    color: { r: number; g: number; b: number },
+    doubleSided: boolean,
+    reverse: boolean,
+    mat: Material | undefined,
+    uvTransform: number[] | null | undefined,
+    xr: [number, number, number],
+    yr: [number, number, number]
+  ) => {
+    // faces are batched per emitted material, so the texture has to be
+    // part of the key too - otherwise two differently-textured faces with
+    // the same average colour end up in one primitive with one image
+    const texIndex = ctx.textureIndexFor(mat?.texture);
+    const colorKey = `${color.r},${color.g},${color.b},${doubleSided},${texIndex ?? -1}`;
+    let group = faceGroups.get(colorKey);
+    if (!group) {
+      group = {
+        color,
+        doubleSided,
+        textureIndex: texIndex,
+        localVerts: [],
+        localUvs: [],
+        normalsAccum: [],
+        localFaces: [],
+        localVMap: new Map<string, number>(),
+      };
+      faceGroups.set(colorKey, group);
+    }
+
+    const tex = mat?.texture;
+    const tileW = tex && tex.width > 1e-9 ? tex.width : 1;
+    const tileH = tex && tex.height > 1e-9 ? tex.height : 1;
+    const sideNormal: [number, number, number] = reverse
+      ? [-fn[0], -fn[1], -fn[2]]
+      : fn;
+
+    // Vertices are deduped per (vId, uv) rather than just vId: UVs are
+    // inherently per-face, so a vertex position shared by two faces
+    // that disagree on texture mapping must become two distinct
+    // output vertices (glTF requires position/normal/uv aligned per
+    // index).
+    const faceLocalMap = new Map<number, number>();
+    for (const tri of triangles) {
+      const triIds = reverse ? [tri[0], tri[2], tri[1]] : tri;
+      const faceIndices: number[] = [];
+      for (const vId of triIds) {
+        if (!builder.vertices.has(vId)) continue;
+        let idx = faceLocalMap.get(vId);
+        if (idx === undefined) {
+          const p = builder.vertices.get(vId)!;
+          const [u, v] = computeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
+          const key = `${vId},${u},${v}`;
+          idx = group.localVMap.get(key);
+          if (idx === undefined) {
+            group.localVerts.push(p);
+            group.localUvs.push([u, v]);
+            group.normalsAccum.push([sideNormal[0], sideNormal[1], sideNormal[2]]);
+            idx = group.localVerts.length - 1;
+            group.localVMap.set(key, idx);
+          } else {
+            const accum = group.normalsAccum[idx];
+            accum[0] += sideNormal[0];
+            accum[1] += sideNormal[1];
+            accum[2] += sideNormal[2];
+          }
+          faceLocalMap.set(vId, idx);
+        }
+        faceIndices.push(idx);
+      }
+      if (faceIndices.length === 3) {
+        group.localFaces.push(faceIndices);
+      }
+    }
+  };
+
+  for (const [_fId, fData] of builder.faces.entries()) {
+    const fallbackColor = ctx.inheritedMaterial?.color ?? ctx.fallbackLayerColor;
+
+    // A face with no material of its own is painted by the instance
+    // (SketchUp's "paint the component"). Inheriting the whole material -
+    // not just its colour - is what gives computeFaceUv the texture's tile
+    // size: without it tileW/tileH fall back to 1 and the UVs come out in
+    // raw inches, so a 1.9 m decor sheet tiles ~150 times across a 600 mm
+    // panel instead of covering a third of it.
+    const frontMat = ctx.resolveMaterial((fData as any).materialId) ?? ctx.inheritedMaterial;
+    const backMat = ctx.resolveMaterial((fData as any).backMaterialId) ?? ctx.inheritedMaterial;
+    const frontColor = frontMat?.color ?? fallbackColor;
+    const backColor = backMat?.color ?? fallbackColor;
+
+    const loops: number[][] = [];
+    for (const loop of fData.loops) {
+      const loopVerts = reconstructLoopVertices(loop, builder.edges);
+      if (loopVerts.length > 0) {
+        loops.push(loopVerts);
+      }
+    }
+    if (loops.length === 0) continue;
+
+    let triangles;
+    try {
+      triangles = triangulateFace3D(builder.vertices, loops, fData.normal);
+    } catch (e) {
+      throw new SkpParseError(`Failed to triangulate face: ${(e as Error).message}`, {
+        stage: 'build_scene',
+        definitionId: ctx.definitionId,
+        cause: e,
+      });
+    }
+
+    const fn = fData.normal as [number, number, number];
+    const { xr, yr } = faceUvBasis(fn);
+    const uvTransform = (fData as any).uvTransform as number[] | null | undefined;
+    const uvTransformBack = (fData as any).uvTransformBack as number[] | null | undefined;
+
+    const sameColor =
+      frontColor.r === backColor.r && frontColor.g === backColor.g && frontColor.b === backColor.b;
+    if (sameColor) {
+      addSide(triangles, fn, frontColor, true, false, frontMat, uvTransform, xr, yr);
+    } else {
+      addSide(triangles, fn, frontColor, false, false, frontMat, uvTransform, xr, yr);
+      addSide(triangles, fn, backColor, false, true, backMat, uvTransformBack, xr, yr);
+    }
+  }
+
+  return faceGroups;
+}

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -28,8 +28,17 @@ import {
   buildSceneFromParsed,
 } from './model';
 import { isLegacy, parseLegacyToRaw } from './legacy';
+import { buildInstancedSceneFromParsed, InstancedScene } from './instanced';
 
 export * from './model';
+export type {
+  InstancedScene,
+  InstancedNode,
+  InstancedMeshResource,
+  LocalPrimitive,
+} from './instanced';
+export { toInstancedGLB } from './instanced-glb';
+export type { InstancedGlbOptions } from './instanced-glb';
 export * from './errors';
 export * from './observability';
 export { toOBJ, toMTL, exportOBJ } from './obj';
@@ -341,6 +350,42 @@ export function parseSkp(buffer: ArrayBuffer, options?: ParseOptions): SkpModel 
  */
 export function buildScene(buffer: ArrayBuffer, options?: ParseOptions): SkpScene {
   return buildSceneFromParsed(parseToRaw(buffer, options), options);
+}
+
+/**
+ * Build the placed scene graph with SketchUp's INSTANCING PRESERVED: each
+ * distinct definition is triangulated once, in its own local space, and
+ * every placement is a node carrying the transform that puts it there.
+ *
+ * Use this instead of {@link buildScene} when a model reuses components:
+ * buildScene() bakes each placement into its own world-space vertex
+ * buffers, so its output grows with `definition geometry x placement
+ * count`, while this grows with `unique geometry + instance transforms`. A
+ * chair placed 1,000 times costs one copy of the chair here.
+ *
+ * Losslessly: this performs NO decimation, quantisation or any other
+ * approximation. The triangles, UVs, normals, materials and metadata are
+ * the ones {@link buildScene} produces - stored once and referenced, rather
+ * than copied per placement.
+ *
+ * Units and axes match {@link buildScene}'s GLB output: geometry and node
+ * matrices are in metres, glTF Y-up (`InstancedNode.matrix` is a
+ * 16-element column-major, parent-relative glTF matrix). The one exception
+ * is `positionMm`, kept in millimetres on SketchUp's Z-up axes so it lines
+ * up with the baked path's own metadata field.
+ *
+ * Independent of {@link parseSkp} and {@link buildScene}: this re-parses the
+ * raw TLV data, consistent with the existing two-tier API, so callers who
+ * never ask for it never pay for it.
+ *
+ * @param buffer - The raw file contents as an ArrayBuffer
+ * @param options - Optional progress/log callbacks (see {@link ParseOptions})
+ */
+export function buildInstancedScene(
+  buffer: ArrayBuffer,
+  options?: ParseOptions
+): InstancedScene {
+  return buildInstancedSceneFromParsed(parseToRaw(buffer, options), options);
 }
 
 function createGlb(json: any, binaryBuffer: Uint8Array): Uint8Array {
@@ -794,5 +839,13 @@ export class SkpFile {
    * @param options - Optional progress/log callbacks (see {@link ParseOptions}) */
   buildScene(options?: ParseOptions): SkpScene {
     return buildScene(this.buffer, options);
+  }
+
+  /** Build the placed scene graph with instancing PRESERVED: unique
+   * geometry once, plus one transform per placement. See
+   * {@link buildInstancedScene} for when to prefer this over buildScene().
+   * @param options - Optional progress/log callbacks (see {@link ParseOptions}) */
+  buildInstancedScene(options?: ParseOptions): InstancedScene {
+    return buildInstancedScene(this.buffer, options);
   }
 }

--- a/packages/typescript/src/instanced-glb.ts
+++ b/packages/typescript/src/instanced-glb.ts
@@ -1,0 +1,337 @@
+import type { InstancedScene, InstancedNode } from './instanced';
+
+/** Options for {@link toInstancedGLB}. */
+export interface InstancedGlbOptions {
+  /** Embed the scene's texture images in the GLB and point each textured
+   * material's `baseColorTexture` at them. Off by default, matching
+   * {@link toGLB}: photographic textures can multiply the file size, and
+   * the geometry alone is what most callers are after. */
+  textures?: boolean;
+}
+
+/**
+ * Drops `baseColorTexture` from materials when the images are not being
+ * embedded, so the reference does not dangle and a strict glTF reader
+ * still accepts the file. Mirrors {@link toGLB}'s own handling.
+ */
+function stripTextureRefs(materials: unknown[]): unknown[] {
+  let needsCopy = false;
+  for (const mat of materials) {
+    if ((mat as any)?.pbrMetallicRoughness?.baseColorTexture) {
+      needsCopy = true;
+      break;
+    }
+  }
+  if (!needsCopy) return materials;
+  return materials.map((mat) => {
+    const pbr = (mat as any)?.pbrMetallicRoughness;
+    if (!pbr?.baseColorTexture) return mat;
+    const restPbr = { ...pbr };
+    delete restPbr.baseColorTexture;
+    return { ...(mat as any), pbrMetallicRoughness: restPbr };
+  });
+}
+
+function createGlb(json: any, binaryBuffer: Uint8Array): Uint8Array {
+  let jsonString = JSON.stringify(json);
+  const jsonRemainder = jsonString.length % 4;
+  if (jsonRemainder !== 0) {
+    jsonString += ' '.repeat(4 - jsonRemainder);
+  }
+  const jsonBuffer = new TextEncoder().encode(jsonString);
+
+  let paddedBinaryBuffer = binaryBuffer;
+  const binaryRemainder = binaryBuffer.length % 4;
+  if (binaryRemainder !== 0) {
+    const padLength = 4 - binaryRemainder;
+    paddedBinaryBuffer = new Uint8Array(binaryBuffer.length + padLength);
+    paddedBinaryBuffer.set(binaryBuffer);
+  }
+
+  const totalLength = 12 + 8 + jsonBuffer.length + 8 + paddedBinaryBuffer.length;
+  const glb = new Uint8Array(totalLength);
+  const view = new DataView(glb.buffer);
+
+  view.setUint32(0, 0x46546c67, true); // 'glTF'
+  view.setUint32(4, 2, true);
+  view.setUint32(8, totalLength, true);
+
+  view.setUint32(12, jsonBuffer.length, true);
+  view.setUint32(16, 0x4e4f534a, true); // 'JSON'
+  glb.set(jsonBuffer, 20);
+
+  const binHeaderOffset = 20 + jsonBuffer.length;
+  view.setUint32(binHeaderOffset, paddedBinaryBuffer.length, true);
+  view.setUint32(binHeaderOffset + 4, 0x004e4942, true); // 'BIN'
+  glb.set(paddedBinaryBuffer, binHeaderOffset + 8);
+
+  return glb;
+}
+
+/**
+ * Export an {@link InstancedScene} to GLB (binary glTF 2.0), PRESERVING
+ * instancing: each mesh resource is written to the binary buffer exactly
+ * once, and every placement is a glTF node whose `mesh` points at it.
+ *
+ * This is what {@link toGLB} cannot do from a baked {@link SkpScene}, whose
+ * primitives already have the world transform folded into their vertex
+ * data - there is nothing left to share. Here, a component placed 1,000
+ * times contributes one copy of its vertex/index buffers plus 1,000 node
+ * transforms.
+ *
+ * A definition that resolves to several materials becomes ONE glTF mesh
+ * with several primitives (the normal glTF representation), not several
+ * nodes.
+ *
+ * {@link toGLB} is untouched and still produces exactly what it always has.
+ *
+ * @param scene - The result of {@link buildInstancedScene}
+ * @param options - See {@link InstancedGlbOptions}
+ * @returns GLB file as Uint8Array
+ */
+export function toInstancedGLB(
+  scene: InstancedScene,
+  options?: InstancedGlbOptions
+): Uint8Array {
+  const resources = scene.meshResources || [];
+  const gltfMaterials = scene.gltfMaterials || [];
+  const sceneTextures = options?.textures ? scene.textures || [] : [];
+
+  let totalBinaryLength = 0;
+  for (const res of resources) {
+    for (const prim of res.primitives) {
+      totalBinaryLength += prim.positions.byteLength;
+      totalBinaryLength += prim.normals.byteLength;
+      totalBinaryLength += prim.uvs.byteLength;
+      totalBinaryLength += prim.indices.byteLength;
+    }
+  }
+
+  const imagePlacements: { offset: number; length: number }[] = [];
+  for (const tex of sceneTextures) {
+    totalBinaryLength += (4 - (totalBinaryLength % 4)) % 4;
+    imagePlacements.push({ offset: totalBinaryLength, length: tex.data.length });
+    totalBinaryLength += tex.data.length;
+  }
+
+  const binaryBuffer = new Uint8Array(totalBinaryLength);
+  const bufferViews: any[] = [];
+  const accessors: any[] = [];
+  const gltfMeshes: any[] = [];
+  /** mesh resource id -> index into `gltfMeshes`. */
+  const meshIndexById = new Map<string, number>();
+
+  let byteOffset = 0;
+
+  for (const res of resources) {
+    const gltfPrimitives: any[] = [];
+
+    for (const prim of res.primitives) {
+      const posByteOffset = byteOffset;
+      binaryBuffer.set(
+        new Uint8Array(prim.positions.buffer, prim.positions.byteOffset, prim.positions.byteLength),
+        posByteOffset
+      );
+      byteOffset += prim.positions.byteLength;
+
+      const normByteOffset = byteOffset;
+      binaryBuffer.set(
+        new Uint8Array(prim.normals.buffer, prim.normals.byteOffset, prim.normals.byteLength),
+        normByteOffset
+      );
+      byteOffset += prim.normals.byteLength;
+
+      const uvByteOffset = byteOffset;
+      binaryBuffer.set(
+        new Uint8Array(prim.uvs.buffer, prim.uvs.byteOffset, prim.uvs.byteLength),
+        uvByteOffset
+      );
+      byteOffset += prim.uvs.byteLength;
+
+      const indByteOffset = byteOffset;
+      binaryBuffer.set(
+        new Uint8Array(prim.indices.buffer, prim.indices.byteOffset, prim.indices.byteLength),
+        indByteOffset
+      );
+      byteOffset += prim.indices.byteLength;
+
+      const posBufferViewIdx = bufferViews.length;
+      bufferViews.push({
+        buffer: 0,
+        byteOffset: posByteOffset,
+        byteLength: prim.positions.byteLength,
+        target: 34962, // ARRAY_BUFFER
+      });
+
+      const normBufferViewIdx = bufferViews.length;
+      bufferViews.push({
+        buffer: 0,
+        byteOffset: normByteOffset,
+        byteLength: prim.normals.byteLength,
+        target: 34962,
+      });
+
+      const uvBufferViewIdx = bufferViews.length;
+      bufferViews.push({
+        buffer: 0,
+        byteOffset: uvByteOffset,
+        byteLength: prim.uvs.byteLength,
+        target: 34962,
+      });
+
+      const indBufferViewIdx = bufferViews.length;
+      bufferViews.push({
+        buffer: 0,
+        byteOffset: indByteOffset,
+        byteLength: prim.indices.byteLength,
+        target: 34963, // ELEMENT_ARRAY_BUFFER
+      });
+
+      let minX = Infinity, minY = Infinity, minZ = Infinity;
+      let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+      for (let i = 0; i < prim.positions.length; i += 3) {
+        const x = prim.positions[i];
+        const y = prim.positions[i + 1];
+        const z = prim.positions[i + 2];
+        if (x < minX) minX = x; if (x > maxX) maxX = x;
+        if (y < minY) minY = y; if (y > maxY) maxY = y;
+        if (z < minZ) minZ = z; if (z > maxZ) maxZ = z;
+      }
+      if (minX === Infinity) {
+        minX = minY = minZ = 0;
+        maxX = maxY = maxZ = 0;
+      }
+
+      const posAccessorIdx = accessors.length;
+      accessors.push({
+        bufferView: posBufferViewIdx,
+        byteOffset: 0,
+        componentType: 5126, // FLOAT
+        count: prim.positions.length / 3,
+        type: 'VEC3',
+        min: [minX, minY, minZ],
+        max: [maxX, maxY, maxZ],
+      });
+
+      const normAccessorIdx = accessors.length;
+      accessors.push({
+        bufferView: normBufferViewIdx,
+        byteOffset: 0,
+        componentType: 5126,
+        count: prim.normals.length / 3,
+        type: 'VEC3',
+      });
+
+      const uvAccessorIdx = accessors.length;
+      accessors.push({
+        bufferView: uvBufferViewIdx,
+        byteOffset: 0,
+        componentType: 5126,
+        count: prim.uvs.length / 2,
+        type: 'VEC2',
+      });
+
+      const indAccessorIdx = accessors.length;
+      accessors.push({
+        bufferView: indBufferViewIdx,
+        byteOffset: 0,
+        componentType: 5125, // UNSIGNED_INT
+        count: prim.indices.length,
+        type: 'SCALAR',
+      });
+
+      gltfPrimitives.push({
+        attributes: {
+          POSITION: posAccessorIdx,
+          NORMAL: normAccessorIdx,
+          TEXCOORD_0: uvAccessorIdx,
+        },
+        indices: indAccessorIdx,
+        material: prim.materialIndex,
+      });
+    }
+
+    if (gltfPrimitives.length === 0) continue;
+
+    meshIndexById.set(res.id, gltfMeshes.length);
+    gltfMeshes.push({
+      name: res.definitionName || res.id,
+      primitives: gltfPrimitives,
+    });
+  }
+
+  // Flatten the instance tree into glTF nodes. Node transforms are already
+  // parent-relative glTF matrices, so the hierarchy maps across directly
+  // and each node keeps pointing at the ONE shared mesh.
+  const gltfNodes: any[] = [];
+
+  const IDENTITY = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+  const isIdentity = (m: number[]) =>
+    m.length === 16 && m.every((v, i) => Math.abs(v - IDENTITY[i]) < 1e-12);
+
+  function emitNode(node: InstancedNode): number {
+    const idx = gltfNodes.length;
+    const gltfNode: any = {};
+    if (node.name) gltfNode.name = node.name;
+    else if (node.definitionName) gltfNode.name = node.definitionName;
+
+    // glTF treats an omitted matrix as the identity; writing it out anyway
+    // just costs bytes on every node of a large scene.
+    if (!isIdentity(node.matrix)) {
+      gltfNode.matrix = node.matrix;
+    }
+
+    const meshIdx =
+      node.meshResourceId !== undefined ? meshIndexById.get(node.meshResourceId) : undefined;
+    if (meshIdx !== undefined) {
+      gltfNode.mesh = meshIdx;
+    }
+
+    gltfNodes.push(gltfNode);
+
+    if (node.children.length > 0) {
+      const childIndices = node.children.map(emitNode);
+      // re-read: `gltfNodes[idx]` is the object pushed above
+      gltfNodes[idx].children = childIndices;
+    }
+    return idx;
+  }
+
+  const rootIdx = emitNode(scene.sceneHierarchy);
+
+  const gltfImages: any[] = [];
+  const gltfTextures: any[] = [];
+  for (let i = 0; i < sceneTextures.length; i++) {
+    const tex = sceneTextures[i];
+    const place = imagePlacements[i];
+    binaryBuffer.set(tex.data, place.offset);
+    const viewIdx = bufferViews.length;
+    bufferViews.push({ buffer: 0, byteOffset: place.offset, byteLength: place.length });
+    gltfImages.push({ bufferView: viewIdx, mimeType: tex.mimeType });
+    gltfTextures.push({ sampler: 0, source: gltfImages.length - 1 });
+  }
+
+  const gltfJson = {
+    asset: {
+      version: '2.0',
+      generator: 'OpenSKP TypeScript Instanced Exporter',
+    },
+    scene: 0,
+    scenes: [{ nodes: [rootIdx] }],
+    nodes: gltfNodes,
+    meshes: gltfMeshes,
+    materials: sceneTextures.length > 0 ? gltfMaterials : stripTextureRefs(gltfMaterials),
+    buffers: [{ byteLength: totalBinaryLength }],
+    bufferViews,
+    accessors,
+    ...(gltfImages.length > 0
+      ? {
+          images: gltfImages,
+          textures: gltfTextures,
+          samplers: [{ wrapS: 10497, wrapT: 10497 }], // REPEAT / REPEAT
+        }
+      : {}),
+  };
+
+  return createGlb(gltfJson, binaryBuffer);
+}

--- a/packages/typescript/src/instanced.ts
+++ b/packages/typescript/src/instanced.ts
@@ -1,0 +1,503 @@
+import { multiplyMatrices } from './transforms';
+import { extractDynamicProperties } from './geometry';
+import { ParseOptions, PROGRESS_INTERVAL, emitLog, emitProgress } from './observability';
+import { SkpParseError } from './errors';
+import { buildLocalFaceGroups } from './face-groups';
+import {
+  Material,
+  Texture,
+  SceneTexture,
+  ParsedRawData,
+  sniffImageMime,
+  resolveMaterialFromMaps,
+} from './model';
+
+/**
+ * One reusable, DEFINITION-LOCAL triangulated mesh: the instanced
+ * counterpart of {@link GlbPrimitive}, minus the world transform.
+ *
+ * Positions and normals stay in the definition's own local frame, so N
+ * placements of the same definition share this one buffer set instead of
+ * getting N transformed copies of it.
+ *
+ * Coordinates here are already converted to glTF conventions - metres,
+ * Y-up - exactly like {@link GlbPrimitive}, so a consumer applies
+ * {@link InstancedNode.matrix} (also glTF-space) and nothing else. The
+ * SketchUp-space (inches, Z-up) values are never exposed on this type.
+ */
+export interface LocalPrimitive {
+  /** Flat [x, y, z, ...] positions in DEFINITION-LOCAL space, metres, Y-up. */
+  positions: Float32Array;
+  /** Flat [x, y, z, ...] local-space vertex normals, matching `positions` 1:1.
+   *
+   * Local, i.e. NOT transformed by any instance matrix: normal
+   * transformation is deferred to the consumer/renderer, which derives it
+   * from the node transform the same way glTF requires (inverse-transpose
+   * of the upper-left 3x3). That is what keeps non-uniform and mirrored
+   * scales correct without baking a per-instance copy of the buffer. */
+  normals: Float32Array;
+  /** Flat [u, v, ...] texture coordinates, matching `positions` 1:1.
+   * Identical to the baked path's, since UVs are computed in local space
+   * and an instance transform never changes them. */
+  uvs: Float32Array;
+  /** Triangle vertex indices (3 per triangle). */
+  indices: Uint32Array;
+  /** Index into {@link InstancedScene.gltfMaterials}. */
+  materialIndex: number;
+}
+
+/**
+ * A definition's geometry, resolved for one specific rendering context and
+ * ready to be referenced by any number of {@link InstancedNode}s.
+ *
+ * One SketchUp definition can yield MORE than one resource: the same
+ * component painted with two different materials, or placed on two layers
+ * with different fallback colours, renders differently and therefore needs
+ * a separate variant. See {@link InstancedMeshResource.variantKey}.
+ */
+export interface InstancedMeshResource {
+  /** Stable, deterministic id (`mesh_<n>`), assigned in first-encounter
+   * order of the scene walk. Referenced by {@link InstancedNode.meshResourceId}. */
+  id: string;
+  /** The source definition's key in the parsed model (`'ROOT'` for
+   * top-level loose geometry). */
+  definitionId: number | string;
+  definitionName: string;
+  /** The rendering context that produced this variant - the effective
+   * inherited material and layer fallback colour. Two placements sharing
+   * this key share the resource; two that differ get separate variants.
+   * Exposed for debugging and for callers that want to reason about why a
+   * definition produced more than one resource. */
+  variantKey: string;
+  /** One entry per resolved material within the definition, mirroring the
+   * baked path's per-(definition, colour) primitive split. */
+  primitives: LocalPrimitive[];
+}
+
+/**
+ * One placed node in the instanced scene graph.
+ *
+ * Carries the transform that places its {@link meshResourceId} (and its
+ * whole subtree) into the scene, instead of that transform having been
+ * baked into vertex data.
+ */
+export interface InstancedNode {
+  /** The instance's own name, `''` when unnamed (`'ROOT'` for the root). */
+  name: string;
+  definitionName: string;
+  /** Effective layer, with SketchUp's inheritance already resolved. */
+  layer: string;
+  /**
+   * This node's transform RELATIVE TO ITS PARENT, as a 16-element
+   * column-major glTF matrix (metres, Y-up) - directly usable as a glTF
+   * node `matrix`, or as THREE.Matrix4.fromArray().
+   *
+   * Relative, not absolute: a consumer composes the chain by walking the
+   * tree, exactly as glTF and every scene graph already do. The root node's
+   * matrix is the identity.
+   *
+   * This is the ONLY place an instance's placement lives - the geometry it
+   * points at stays in definition-local space.
+   */
+  matrix: number[];
+  /** Absolute world position in millimetres, SketchUp axes (Z-up), rounded
+   * to 2 decimals - the same value, in the same frame, that the baked
+   * path's `InstanceNode.positionMm` reports, so metadata comparisons
+   * between the two APIs line up. */
+  positionMm: [number, number, number];
+  /** Dynamic Component attributes attached to this instance, or `{}`. */
+  properties: Record<string, string>;
+  /** The mesh resource this node renders, or undefined for a node that
+   * only groups children. */
+  meshResourceId?: string;
+  children: InstancedNode[];
+}
+
+/**
+ * The result of {@link buildInstancedScene}: the placed scene graph with
+ * SketchUp's instancing PRESERVED rather than baked out.
+ *
+ * Where {@link SkpScene} emits one world-space vertex buffer per placement,
+ * this emits each distinct definition+context once ({@link meshResources})
+ * and refers to it from every placement ({@link sceneHierarchy}). Scene
+ * size therefore scales with *unique geometry + instance transforms*
+ * instead of *definition geometry x placement count*.
+ *
+ * This is lossless: no decimation, quantisation or geometry approximation
+ * of any kind. The triangles are the same triangles the baked path
+ * produces, just stored once and referenced N times.
+ */
+export interface InstancedScene {
+  /** Root of the placed instance tree (identity transform). */
+  sceneHierarchy: InstancedNode;
+  /** Every distinct (definition, rendering-context) mesh actually placed,
+   * in deterministic first-encounter order. */
+  meshResources: InstancedMeshResource[];
+  /** glTF PBR materials referenced by {@link LocalPrimitive.materialIndex}.
+   * Same shape and construction as {@link SkpScene.gltfMaterials}. */
+  gltfMaterials: unknown[];
+  /** Distinct texture images, deduplicated by source bytes - same as
+   * {@link SkpScene.textures}. */
+  textures: SceneTexture[];
+}
+
+/**
+ * Build an instanced scene from already-parsed raw data.
+ *
+ * Walks the same placed scene graph as {@link buildSceneFromParsed} and
+ * resolves layers, instance materials and dynamic properties identically -
+ * but emits each definition's triangulated geometry ONCE per distinct
+ * rendering context, with the placement kept on the node.
+ */
+export function buildInstancedSceneFromParsed(
+  parsed: ParsedRawData,
+  options?: ParseOptions
+): InstancedScene {
+  const t0 = Date.now();
+  const { layerColors, layerIdToName, materialIdToName, materialsMap, materialsByFolder, defsDict } =
+    parsed;
+
+  emitLog(options, 'info', `Building instanced scene: ${defsDict.size} definitions available`);
+  const instanceCounter = { count: 0 };
+
+  const getLayerColor = (name: string) => {
+    const c = layerColors.get(name) || [136, 136, 136];
+    return { r: c[0], g: c[1], b: c[2] };
+  };
+
+  // Textures deduplicated by bytes, exactly as the baked path does.
+  const textures: SceneTexture[] = [];
+  const textureIndexByKey = new Map<string, number>();
+
+  function textureIndexFor(tex: Texture | null | undefined): number | null {
+    if (!tex || !tex.data || tex.data.length === 0) return null;
+    const mimeType = sniffImageMime(tex.data);
+    if (mimeType === null) return null; // a format glTF cannot carry
+    const head = Array.from(tex.data.subarray(0, 16)).join(',');
+    const key = `${tex.data.length}:${head}`;
+    const hit = textureIndexByKey.get(key);
+    if (hit !== undefined) return hit;
+    const idx = textures.length;
+    textures.push({ data: tex.data, mimeType, filename: tex.filename });
+    textureIndexByKey.set(key, idx);
+    return idx;
+  }
+
+  const colorToMaterialIndex = new Map<string, number>();
+  const gltfMaterials: any[] = [];
+
+  function getMaterialIndex(
+    color: { r: number; g: number; b: number },
+    doubleSided: boolean,
+    textureIndex: number | null
+  ) {
+    const key = `${color.r},${color.g},${color.b},${doubleSided},${textureIndex ?? -1}`;
+    if (colorToMaterialIndex.has(key)) {
+      return colorToMaterialIndex.get(key)!;
+    }
+    const idx = gltfMaterials.length;
+    const pbr: any = {
+      baseColorFactor: [color.r / 255, color.g / 255, color.b / 255, 1.0],
+      metallicFactor: 0.0,
+      roughnessFactor: 0.8,
+    };
+    if (textureIndex !== null) {
+      pbr.baseColorTexture = { index: textureIndex };
+    }
+    const material: any = { pbrMetallicRoughness: pbr };
+    if (doubleSided) material.doubleSided = true;
+    gltfMaterials.push(material);
+    colorToMaterialIndex.set(key, idx);
+    return idx;
+  }
+
+  const meshResources: InstancedMeshResource[] = [];
+  const resourceIdByKey = new Map<string, string>();
+
+  /**
+   * Identity of a mesh resource. Caching on the definition id ALONE would
+   * be wrong: the same definition renders differently depending on the
+   * context it is placed in, and merging those would silently repaint
+   * geometry. Everything that can change the rendered result is in the key:
+   *
+   * - the definition itself;
+   * - the effective inherited (instance-painted) material, which decides
+   *   both the colour of unpainted faces and, via its texture's tile size,
+   *   their UVs - keyed by material name plus texture identity, since two
+   *   different images can average to the same RGB;
+   * - the effective layer, whose colour is the fallback for a face with no
+   *   material anywhere in the chain.
+   *
+   * Front/back material resolution, per-face textures, UV mapping and
+   * double-sided-vs-split geometry all derive deterministically from the
+   * definition's own face data plus these two inputs, so they need no
+   * separate key component - the same (definition, material, layer) always
+   * produces byte-identical buffers.
+   */
+  function resourceVariantKey(
+    defId: number | string,
+    inheritedMaterial: Material | undefined,
+    layer: string
+  ): string {
+    const tex = inheritedMaterial?.texture;
+    const texKey = tex && tex.data && tex.data.length > 0
+      ? `${tex.data.length}:${Array.from(tex.data.subarray(0, 16)).join(',')}:${tex.width}x${tex.height}`
+      : '-';
+    const matKey = inheritedMaterial
+      ? `${inheritedMaterial.name}|${inheritedMaterial.color.r},${inheritedMaterial.color.g},${inheritedMaterial.color.b}|${texKey}`
+      : '-';
+    // The layer only matters through its fallback colour, so key on that
+    // rather than the name: two layers that happen to share a colour
+    // legitimately share geometry.
+    const lc = getLayerColor(layer);
+    return `${String(defId)}|${matKey}|${lc.r},${lc.g},${lc.b}`;
+  }
+
+  /** Build (or reuse) the local-space mesh resource for a definition
+   * rendered in the given context. Returns undefined when the definition
+   * has no face geometry of its own. */
+  function meshResourceFor(
+    defId: number | string,
+    inheritedMaterial: Material | undefined,
+    layer: string
+  ): string | undefined {
+    const d = defsDict.get(defId);
+    if (!d || d.builder.faces.size === 0) return undefined;
+
+    const key = resourceVariantKey(defId, inheritedMaterial, layer);
+    const hit = resourceIdByKey.get(key);
+    if (hit !== undefined) return hit;
+
+    const faceGroups = buildLocalFaceGroups(d.builder, {
+      resolveMaterial: (matId) =>
+        resolveMaterialFromMaps(matId, materialIdToName, materialsMap, materialsByFolder),
+      textureIndexFor,
+      inheritedMaterial,
+      fallbackLayerColor: getLayerColor(layer),
+      definitionId: defId,
+    });
+
+    const primitives: LocalPrimitive[] = [];
+    const scale = 0.0254;
+
+    for (const group of faceGroups.values()) {
+      if (group.localFaces.length === 0) continue;
+
+      const positions = new Float32Array(group.localVerts.length * 3);
+      const normals = new Float32Array(group.localVerts.length * 3);
+      const uvs = new Float32Array(group.localVerts.length * 2);
+
+      for (let i = 0; i < group.localVerts.length; i++) {
+        const v = group.localVerts[i];
+        // Local space, so no instance matrix is applied - only the
+        // inches->metres scale and SketchUp Z-up -> glTF Y-up axis swap,
+        // which are the same fixed conventions the baked path applies.
+        positions[i * 3] = v[0] * scale;
+        positions[i * 3 + 1] = v[2] * scale;
+        positions[i * 3 + 2] = -v[1] * scale;
+
+        uvs[i * 2] = group.localUvs[i][0];
+        uvs[i * 2 + 1] = group.localUvs[i][1];
+
+        const rawNorm = group.normalsAccum[i];
+        const normLen = Math.sqrt(rawNorm[0] ** 2 + rawNorm[1] ** 2 + rawNorm[2] ** 2);
+        const n = normLen > 1e-6
+          ? [rawNorm[0] / normLen, rawNorm[1] / normLen, rawNorm[2] / normLen]
+          : [0, 0, 1];
+        // Same axis swap as positions. No instance-matrix normal transform
+        // here: that belongs to the node, and deferring it is precisely
+        // what keeps mirrored/non-uniform scales correct per placement.
+        normals[i * 3] = n[0];
+        normals[i * 3 + 1] = n[2];
+        normals[i * 3 + 2] = -n[1];
+      }
+
+      const indices = new Uint32Array(group.localFaces.length * 3);
+      for (let i = 0; i < group.localFaces.length; i++) {
+        indices[i * 3] = group.localFaces[i][0];
+        indices[i * 3 + 1] = group.localFaces[i][1];
+        indices[i * 3 + 2] = group.localFaces[i][2];
+      }
+
+      primitives.push({
+        positions,
+        normals,
+        uvs,
+        indices,
+        materialIndex: getMaterialIndex(group.color, group.doubleSided, group.textureIndex),
+      });
+    }
+
+    if (primitives.length === 0) return undefined;
+
+    const id = `mesh_${meshResources.length}`;
+    meshResources.push({
+      id,
+      definitionId: defId,
+      definitionName: d.name || '',
+      variantKey: key,
+      primitives,
+    });
+    resourceIdByKey.set(key, id);
+    return id;
+  }
+
+  // Definitions on the ACTIVE recursion path, guarding self-instancing -
+  // same rule as the baked path.
+  const activeDefinitions = new Set<number | string>();
+
+  /**
+   * Convert one instance's 13-element SketchUp matrix (inches, Z-up) into a
+   * 16-element column-major glTF matrix (metres, Y-up).
+   *
+   * The axis change is the similarity transform C * M * C^-1 with
+   * C: (x, y, z) -> (x, z, -y), so it composes correctly through nesting:
+   * converting each level and multiplying gives the same result as
+   * converting the fully-composed SketchUp matrix. Translation is scaled to
+   * metres; the rotation/scale block is unitless and is not.
+   */
+  function toGltfMatrix(m: number[]): number[] {
+    const scale = 0.0254;
+    // SketchUp basis (row-major 3x3 in elements 0..8, translation in 9..11).
+    const a = m[0], b = m[1], c = m[2];
+    const d = m[3], e = m[4], f = m[5];
+    const g = m[6], h = m[7], i = m[8];
+    const tx = m[9] ?? 0, ty = m[10] ?? 0, tz = m[11] ?? 0;
+
+    // C * M * C^-1 where C maps (x,y,z) -> (x,z,-y).
+    const r00 = a,  r01 = c,   r02 = -b;
+    const r10 = g,  r11 = i,   r12 = -h;
+    const r20 = -d, r21 = -f,  r22 = e;
+
+    // glTF wants column-major: [col0(3), 0, col1(3), 0, col2(3), 0, t(3), 1]
+    return [
+      r00, r10, r20, 0,
+      r01, r11, r21, 0,
+      r02, r12, r22, 0,
+      tx * scale, tz * scale, -ty * scale, 1,
+    ];
+  }
+
+  const IDENTITY_GLTF = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+  /**
+   * Walk a definition's placed instances, emitting one node each.
+   *
+   * `currentMatrix` is the accumulated SketchUp-space matrix and is used
+   * ONLY to report each node's absolute `positionMm` (matching the baked
+   * path's metadata); the geometry itself never sees it.
+   */
+  function walk(
+    defId: number | string,
+    currentMatrix: number[],
+    parentLayer: string,
+    inheritedMaterial: Material | undefined
+  ): InstancedNode[] {
+    const d = defsDict.get(defId);
+    if (!d) return [];
+
+    const nodes: InstancedNode[] = [];
+
+    for (const inst of d.builder.instances) {
+      const refIdx = inst.refIdx;
+      const newMatrix = multiplyMatrices(currentMatrix, inst.matrix);
+
+      let lName = parentLayer;
+      let instMaterial = inheritedMaterial;
+      let properties: Record<string, string> = { ...(inst.properties || {}) };
+
+      if (inst.layerId !== null && inst.layerId !== undefined) {
+        lName = layerIdToName.get(inst.layerId) || parentLayer;
+      }
+
+      if (inst.materialId !== null && inst.materialId !== undefined) {
+        const matName = materialIdToName.get(inst.materialId);
+        if (matName) {
+          const mat = materialsMap.get(matName) || materialsByFolder.get(matName);
+          if (mat) {
+            instMaterial = mat;
+          }
+        }
+      }
+
+      // D007/DC05 TLV walk (VFF only); a no-op for legacy instances, whose
+      // precomputed `properties` seeded above survives unchanged.
+      const d007 = inst.children.find((c) => c.tag === 'D007');
+      if (d007) {
+        try {
+          properties = extractDynamicProperties(d007, options);
+        } catch (e) {
+          emitLog(
+            options, 'debug',
+            `Failed to extract dynamic properties for instance ${inst.name ?? ''} (refIdx=${refIdx}): ${(e as Error).message}`
+          );
+        }
+      }
+
+      instanceCounter.count++;
+      if (instanceCounter.count % PROGRESS_INTERVAL === 0) {
+        emitProgress(options, 'build_scene', instanceCounter.count, instanceCounter.count);
+        emitLog(options, 'debug', `Processed ${instanceCounter.count} placed instances`);
+      }
+
+      if (activeDefinitions.has(refIdx)) {
+        throw new SkpParseError('Recursive component definition', {
+          stage: 'build_scene',
+          definitionId: refIdx,
+        });
+      }
+      activeDefinitions.add(refIdx);
+      const children = walk(refIdx, newMatrix, lName, instMaterial);
+      activeDefinitions.delete(refIdx);
+
+      const tx = (newMatrix[9] ?? 0) * 25.4;
+      const ty = (newMatrix[10] ?? 0) * 25.4;
+      const tz = (newMatrix[11] ?? 0) * 25.4;
+
+      nodes.push({
+        name: inst.name || '',
+        definitionName: defsDict.get(refIdx)?.name || '',
+        layer: lName,
+        matrix: toGltfMatrix(inst.matrix),
+        positionMm: [
+          Math.round(tx * 100) / 100,
+          Math.round(ty * 100) / 100,
+          Math.round(tz * 100) / 100,
+        ],
+        properties,
+        meshResourceId: meshResourceFor(refIdx, instMaterial, lName),
+        children,
+      });
+    }
+
+    return nodes;
+  }
+
+  const identityMat = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0];
+  const rootChildren = walk('ROOT', identityMat, 'Layer0', undefined);
+
+  // Loose geometry drawn straight into the model (not inside any
+  // component/group) is kept, as the baked path keeps it: it becomes the
+  // root node's own mesh resource.
+  const rootMeshResourceId = meshResourceFor('ROOT', undefined, 'Layer0');
+
+  const sceneHierarchy: InstancedNode = {
+    name: 'ROOT',
+    definitionName: 'ROOT_MODEL',
+    layer: 'Layer0',
+    matrix: [...IDENTITY_GLTF],
+    positionMm: [0, 0, 0],
+    properties: {},
+    meshResourceId: rootMeshResourceId,
+    children: rootChildren,
+  };
+
+  emitLog(
+    options,
+    'info',
+    `Instanced scene build complete: ${instanceCounter.count} instances, ` +
+      `${meshResources.length} mesh resources (${((Date.now() - t0) / 1000).toFixed(2)}s)`
+  );
+
+  return { sceneHierarchy, meshResources, gltfMaterials, textures };
+}

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -1,6 +1,6 @@
 import { transformPoint, multiplyMatrices } from './transforms';
-import { triangulateFace3D } from './triangulator';
-import { reconstructLoopVertices, extractDynamicProperties, ParsedDefinition } from './geometry';
+import { extractDynamicProperties, ParsedDefinition } from './geometry';
+import { buildLocalFaceGroups } from './face-groups';
 import { SkpParseError } from './errors';
 import { ParseOptions, PROGRESS_INTERVAL, emitLog, emitProgress } from './observability';
 
@@ -630,146 +630,21 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
       // the back material - so each side renders its own correct color
       // instead of the front material leaking onto (or the back
       // vanishing from) the far side.
-      type FaceGroup = {
-        color: { r: number; g: number; b: number };
-        doubleSided: boolean;
-        localVerts: [number, number, number][];
-        localUvs: [number, number][];
-        normalsAccum: number[][];
-        localFaces: number[][];
-        localVMap: Map<string, number>;
-        textureIndex: number | null;
-      };
-      const faceGroups = new Map<string, FaceGroup>();
-
-      const resolveMaterial = (matId: number | null | undefined): Material | undefined =>
-        resolveMaterialFromMaps(matId, materialIdToName, materialsMap, materialsByFolder);
-
-      const addSide = (
-        triangles: number[][],
-        fn: [number, number, number],
-        color: { r: number; g: number; b: number },
-        doubleSided: boolean,
-        reverse: boolean,
-        mat: Material | undefined,
-        uvTransform: number[] | null | undefined,
-        xr: [number, number, number],
-        yr: [number, number, number]
-      ) => {
-        // faces are batched per emitted material, so the texture has to be
-        // part of the key too - otherwise two differently-textured faces with
-        // the same average colour end up in one primitive with one image
-        const texIndex = textureIndexFor(mat?.texture);
-        const colorKey = `${color.r},${color.g},${color.b},${doubleSided},${texIndex ?? -1}`;
-        let group = faceGroups.get(colorKey);
-        if (!group) {
-          group = {
-            color,
-            doubleSided,
-            textureIndex: texIndex,
-            localVerts: [],
-            localUvs: [],
-            normalsAccum: [],
-            localFaces: [],
-            localVMap: new Map<string, number>(),
-          };
-          faceGroups.set(colorKey, group);
-        }
-
-        const tex = mat?.texture;
-        const tileW = tex && tex.width > 1e-9 ? tex.width : 1;
-        const tileH = tex && tex.height > 1e-9 ? tex.height : 1;
-        const sideNormal: [number, number, number] = reverse
-          ? [-fn[0], -fn[1], -fn[2]]
-          : fn;
-
-        // Vertices are deduped per (vId, uv) rather than just vId: UVs are
-        // inherently per-face, so a vertex position shared by two faces
-        // that disagree on texture mapping must become two distinct
-        // output vertices (glTF requires position/normal/uv aligned per
-        // index).
-        const faceLocalMap = new Map<number, number>();
-        for (const tri of triangles) {
-          const triIds = reverse ? [tri[0], tri[2], tri[1]] : tri;
-          const faceIndices: number[] = [];
-          for (const vId of triIds) {
-            if (!builder.vertices.has(vId)) continue;
-            let idx = faceLocalMap.get(vId);
-            if (idx === undefined) {
-              const p = builder.vertices.get(vId)!;
-              const [u, v] = computeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
-              const key = `${vId},${u},${v}`;
-              idx = group.localVMap.get(key);
-              if (idx === undefined) {
-                group.localVerts.push(p);
-                group.localUvs.push([u, v]);
-                group.normalsAccum.push([sideNormal[0], sideNormal[1], sideNormal[2]]);
-                idx = group.localVerts.length - 1;
-                group.localVMap.set(key, idx);
-              } else {
-                const accum = group.normalsAccum[idx];
-                accum[0] += sideNormal[0];
-                accum[1] += sideNormal[1];
-                accum[2] += sideNormal[2];
-              }
-              faceLocalMap.set(vId, idx);
-            }
-            faceIndices.push(idx);
-          }
-          if (faceIndices.length === 3) {
-            group.localFaces.push(faceIndices);
-          }
-        }
-      };
-
-      for (const [_fId, fData] of builder.faces.entries()) {
-        const fallbackColor = inheritedMaterial?.color ?? getLayerColor(parentLayer);
-
-        // A face with no material of its own is painted by the instance
-        // (SketchUp's "paint the component"). Inheriting the whole material -
-        // not just its colour - is what gives computeFaceUv the texture's tile
-        // size: without it tileW/tileH fall back to 1 and the UVs come out in
-        // raw inches, so a 1.9 m decor sheet tiles ~150 times across a 600 mm
-        // panel instead of covering a third of it.
-        const frontMat = resolveMaterial((fData as any).materialId) ?? inheritedMaterial;
-        const backMat = resolveMaterial((fData as any).backMaterialId) ?? inheritedMaterial;
-        const frontColor = frontMat?.color ?? fallbackColor;
-        const backColor = backMat?.color ?? fallbackColor;
-
-        const loops: number[][] = [];
-        for (const loop of fData.loops) {
-          const loopVerts = reconstructLoopVertices(loop, builder.edges);
-          if (loopVerts.length > 0) {
-            loops.push(loopVerts);
-          }
-        }
-        if (loops.length === 0) continue;
-
-        let triangles;
-        try {
-          triangles = triangulateFace3D(builder.vertices, loops, fData.normal);
-        } catch (e) {
-          throw new SkpParseError(`Failed to triangulate face: ${(e as Error).message}`, {
-            stage: 'build_scene',
-            definitionId: defId,
-            cause: e,
-          });
-        }
-
-        const fn = fData.normal as [number, number, number];
-        const { xr, yr } = faceUvBasis(fn);
-        const uvTransform = (fData as any).uvTransform as number[] | null | undefined;
-        const uvTransformBack = (fData as any).uvTransformBack as number[] | null | undefined;
-
-        const sameColor =
-          frontColor.r === backColor.r && frontColor.g === backColor.g && frontColor.b === backColor.b;
-        if (sameColor) {
-          addSide(triangles, fn, frontColor, true, false, frontMat, uvTransform, xr, yr);
-        } else {
-          addSide(triangles, fn, frontColor, false, false, frontMat, uvTransform, xr, yr);
-          addSide(triangles, fn, backColor, false, true, backMat, uvTransformBack, xr, yr);
-        }
-      }
+      //
+      // The grouping itself lives in face-groups.ts and is shared verbatim
+      // with buildInstancedSceneFromParsed: it is entirely local-space
+      // work, and the ONLY difference between the two paths is what
+      // happens next - here each group's vertices get `currentMatrix`
+      // applied and become a world-space primitive, while the instanced
+      // path leaves them local and puts the transform on the node.
+      const faceGroups = buildLocalFaceGroups(builder, {
+        resolveMaterial: (matId) =>
+          resolveMaterialFromMaps(matId, materialIdToName, materialsMap, materialsByFolder),
+        textureIndexFor,
+        inheritedMaterial,
+        fallbackLayerColor: getLayerColor(parentLayer),
+        definitionId: defId,
+      });
 
       for (const group of faceGroups.values()) {
         if (group.localFaces.length === 0) continue;

--- a/packages/typescript/tests/bench/instanced-bench.ts
+++ b/packages/typescript/tests/bench/instanced-bench.ts
@@ -1,0 +1,159 @@
+/**
+ * Deterministic benchmark for the baked vs instanced scene paths.
+ *
+ * Run with:  npm run bench:instanced
+ *
+ * Deliberately NOT a vitest test: timings vary with machine and load, and
+ * asserting on them in CI produces flaky failures. The structural claims
+ * (one resource per definition, buffer bytes flat as instance count grows)
+ * are asserted in tests/instanced-scene.test.ts instead; this script only
+ * measures and reports.
+ *
+ * The scene is synthetic and fully deterministic - one nontrivial component
+ * repeated N times - so successive runs measure the same work.
+ */
+
+import { buildSceneFromParsed } from '../../src/model';
+import { buildInstancedSceneFromParsed } from '../../src/instanced';
+import { toGLB } from '../../src/index';
+import { toInstancedGLB } from '../../src/instanced-glb';
+import { repeatedComponentScene } from '../helpers/instanced-fixtures';
+
+const COUNTS = [1, 10, 100, 1000];
+/** Faces per component: enough that a component is not trivial, small
+ * enough that the 1,000-instance baked case still completes quickly. */
+const FACES_PER_COMPONENT = 24;
+/** Median of several runs, so one unlucky GC pause does not set the number. */
+const REPEATS = 5;
+
+function median(values: number[]): number {
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function timeMs(fn: () => void): number {
+  const samples: number[] = [];
+  for (let i = 0; i < REPEATS; i++) {
+    const t0 = performance.now();
+    fn();
+    samples.push(performance.now() - t0);
+  }
+  return median(samples);
+}
+
+function bakedBytes(scene: ReturnType<typeof buildSceneFromParsed>): number {
+  let total = 0;
+  for (const p of scene.glbPrimitives) {
+    total += p.positions.byteLength + p.normals.byteLength + p.uvs.byteLength + p.indices.byteLength;
+  }
+  return total;
+}
+
+function instancedBytes(scene: ReturnType<typeof buildInstancedSceneFromParsed>): number {
+  let total = 0;
+  for (const r of scene.meshResources) {
+    for (const p of r.primitives) {
+      total += p.positions.byteLength + p.normals.byteLength + p.uvs.byteLength + p.indices.byteLength;
+    }
+  }
+  return total;
+}
+
+function countNodes(node: { children: any[] }): number {
+  return 1 + node.children.reduce((s: number, c: any) => s + countNodes(c), 0);
+}
+
+const kb = (bytes: number) => (bytes / 1024).toFixed(1);
+
+interface Row {
+  count: number;
+  bakedMs: number;
+  instancedMs: number;
+  bakedBytes: number;
+  instancedBytes: number;
+  bakedPrims: number;
+  meshResources: number;
+  instanceNodes: number;
+  bakedGlb: number;
+  instancedGlb: number;
+}
+
+const rows: Row[] = [];
+
+for (const count of COUNTS) {
+  // Rebuild the parsed input per measurement: both builders consume it
+  // read-only, but sharing one instance across timed runs would let the
+  // first run warm caches the others benefit from.
+  const parsedFor = () => repeatedComponentScene(count, FACES_PER_COMPONENT);
+
+  const bakedMs = timeMs(() => void buildSceneFromParsed(parsedFor()));
+  const instancedMs = timeMs(() => void buildInstancedSceneFromParsed(parsedFor()));
+
+  const baked = buildSceneFromParsed(parsedFor());
+  const instanced = buildInstancedSceneFromParsed(parsedFor());
+
+  rows.push({
+    count,
+    bakedMs,
+    instancedMs,
+    bakedBytes: bakedBytes(baked),
+    instancedBytes: instancedBytes(instanced),
+    bakedPrims: baked.glbPrimitives.length,
+    meshResources: instanced.meshResources.length,
+    instanceNodes: countNodes(instanced.sceneHierarchy) - 1, // exclude root
+    bakedGlb: toGLB(baked).length,
+    instancedGlb: toInstancedGLB(instanced).length,
+  });
+}
+
+console.log(
+  `\nSynthetic scene: one ${FACES_PER_COMPONENT}-face component repeated N times.` +
+    `\nTimings are the median of ${REPEATS} runs. Node ${process.version} on ${process.platform}/${process.arch}.\n`
+);
+
+const header = [
+  'N',
+  'buildScene ms',
+  'buildInstancedScene ms',
+  'baked buf KB',
+  'instanced buf KB',
+  'baked prims',
+  'mesh resources',
+  'instance nodes',
+  'baked GLB KB',
+  'instanced GLB KB',
+];
+
+const table = rows.map((r) => [
+  String(r.count),
+  r.bakedMs.toFixed(2),
+  r.instancedMs.toFixed(2),
+  kb(r.bakedBytes),
+  kb(r.instancedBytes),
+  String(r.bakedPrims),
+  String(r.meshResources),
+  String(r.instanceNodes),
+  kb(r.bakedGlb),
+  kb(r.instancedGlb),
+]);
+
+const widths = header.map((h, i) =>
+  Math.max(h.length, ...table.map((row) => row[i].length))
+);
+
+const line = (cells: string[]) =>
+  '| ' + cells.map((c, i) => c.padStart(widths[i])).join(' | ') + ' |';
+
+console.log(line(header));
+console.log('|' + widths.map((w) => '-'.repeat(w + 2)).join('|') + '|');
+for (const row of table) {
+  console.log(line(row));
+}
+
+const last = rows[rows.length - 1];
+console.log(
+  `\nAt N=${last.count}: geometry buffers ${(last.bakedBytes / last.instancedBytes).toFixed(1)}x smaller, ` +
+    `GLB ${(last.bakedGlb / last.instancedGlb).toFixed(1)}x smaller, ` +
+    `build ${(last.bakedMs / last.instancedMs).toFixed(1)}x faster.\n`
+);

--- a/packages/typescript/tests/helpers/flatten-instanced.ts
+++ b/packages/typescript/tests/helpers/flatten-instanced.ts
@@ -1,0 +1,247 @@
+import type { InstancedScene, InstancedNode } from '../../src/instanced';
+
+/**
+ * Test-only helper: collapse an {@link InstancedScene} back into flat,
+ * world-space triangles, so it can be compared against what the baked
+ * {@link buildScene} path produces.
+ *
+ * Deliberately NOT public API: the whole point of the instanced output is
+ * to avoid materialising this. It exists so the tests can prove the two
+ * paths describe the same geometry, which is the property that makes the
+ * instanced path safe to adopt.
+ */
+
+export interface FlatTriangle {
+  /** World-space vertex positions, metres, glTF Y-up. */
+  a: [number, number, number];
+  b: [number, number, number];
+  c: [number, number, number];
+  materialIndex: number;
+}
+
+/** Multiply two 16-element column-major matrices (out = a * b). */
+function multiply4(a: number[], b: number[]): number[] {
+  const out = new Array(16).fill(0);
+  for (let col = 0; col < 4; col++) {
+    for (let row = 0; row < 4; row++) {
+      let s = 0;
+      for (let k = 0; k < 4; k++) {
+        s += a[k * 4 + row] * b[col * 4 + k];
+      }
+      out[col * 4 + row] = s;
+    }
+  }
+  return out;
+}
+
+/** Apply a 16-element column-major matrix to a point. */
+function applyMatrix(m: number[], p: [number, number, number]): [number, number, number] {
+  const [x, y, z] = p;
+  return [
+    m[0] * x + m[4] * y + m[8] * z + m[12],
+    m[1] * x + m[5] * y + m[9] * z + m[13],
+    m[2] * x + m[6] * y + m[10] * z + m[14],
+  ];
+}
+
+const IDENTITY4 = [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1];
+
+/**
+ * Walk the instanced tree, composing node transforms, and emit every
+ * triangle in world space - i.e. reconstruct what buildScene() bakes.
+ */
+export function flattenInstancedScene(scene: InstancedScene): FlatTriangle[] {
+  const byId = new Map(scene.meshResources.map((r) => [r.id, r]));
+  const out: FlatTriangle[] = [];
+
+  const visit = (node: InstancedNode, parentMatrix: number[]) => {
+    const world = multiply4(parentMatrix, node.matrix);
+
+    if (node.meshResourceId !== undefined) {
+      const res = byId.get(node.meshResourceId);
+      if (res) {
+        for (const prim of res.primitives) {
+          for (let i = 0; i < prim.indices.length; i += 3) {
+            const tri: [number, number, number][] = [];
+            for (let k = 0; k < 3; k++) {
+              const vi = prim.indices[i + k];
+              tri.push(
+                applyMatrix(world, [
+                  prim.positions[vi * 3],
+                  prim.positions[vi * 3 + 1],
+                  prim.positions[vi * 3 + 2],
+                ])
+              );
+            }
+            out.push({
+              a: tri[0],
+              b: tri[1],
+              c: tri[2],
+              materialIndex: prim.materialIndex,
+            });
+          }
+        }
+      }
+    }
+
+    for (const child of node.children) {
+      visit(child, world);
+    }
+  };
+
+  visit(scene.sceneHierarchy, IDENTITY4);
+  return out;
+}
+
+/** Total bytes held by every mesh resource's geometry buffers. */
+export function instancedBufferBytes(scene: InstancedScene): number {
+  let total = 0;
+  for (const res of scene.meshResources) {
+    for (const p of res.primitives) {
+      total += p.positions.byteLength + p.normals.byteLength + p.uvs.byteLength + p.indices.byteLength;
+    }
+  }
+  return total;
+}
+
+/**
+ * Canonical, order-independent signature of a triangle set: each triangle
+ * reduced to its rounded vertex coordinates plus its RESOLVED MATERIAL,
+ * then sorted.
+ *
+ * Three things make a naive comparison fail on geometry that is in fact
+ * identical, and all three are addressed here:
+ *
+ * - Ordering. The two paths group and emit faces in their own order, so
+ *   sequences differ while the sets do not; hence the sort, and the sort of
+ *   each triangle's own three corners so winding/rotation of the same
+ *   triangle does not read as a different triangle.
+ * - Material INDICES. Both paths build the same glTF material table, but
+ *   allocate into it in the order they first encounter each material: the
+ *   baked path during its flattened walk, the instanced path as each mesh
+ *   resource is first created. Comparing raw indices would therefore report
+ *   a difference that does not exist, so the signature carries the resolved
+ *   material's CONTENT instead.
+ * - Float32 rounding POINT. The baked path transforms in float64 and stores
+ *   the world-space result as float32; the instanced path stores the
+ *   local-space value as float32 and the transform happens afterwards. Both
+ *   are single-rounding-step correct, but they round at different moments,
+ *   so a coordinate can land one float32 ulp apart between them. See
+ *   {@link SIGNATURE_DECIMALS}.
+ *
+ * @param decimals - Coordinate rounding, in decimal places of a metre.
+ */
+export const SIGNATURE_DECIMALS = 3;
+
+export function triangleSignature(
+  tris: { a: [number, number, number]; b: [number, number, number]; c: [number, number, number]; materialIndex: number }[],
+  materials?: unknown[],
+  decimals: number = SIGNATURE_DECIMALS
+): string[] {
+  const eps = Math.pow(10, -decimals) / 2;
+  const r = (v: number) => {
+    const rounded = Number(v.toFixed(decimals));
+    return Math.abs(rounded) < eps ? 0 : rounded;
+  };
+  const materialKey = (idx: number) =>
+    materials ? JSON.stringify(materials[idx] ?? null) : String(idx);
+  return tris
+    .map((t) => {
+      const corners = [t.a, t.b, t.c]
+        .map((p) => `${r(p[0])},${r(p[1])},${r(p[2])}`)
+        .sort();
+      return `${corners.join('|')}#${materialKey(t.materialIndex)}`;
+    })
+    .sort();
+}
+
+/**
+ * Compare two triangle sets IN ORDER, with a numeric tolerance.
+ *
+ * Both builders walk the same instance tree in the same order and group
+ * faces by the same rule, so the k-th triangle of one corresponds to the
+ * k-th triangle of the other. Comparing in order is not just simpler than
+ * set matching - it is the only correct option here, because real models
+ * contain many geometrically coincident triangles (coplanar duplicates,
+ * mirrored halves), and a nearest-neighbour matcher happily pairs a
+ * triangle with the wrong twin and then reports a phantom difference.
+ *
+ * Tolerance defaults to 1e-5 m (10 micrometres), justified by float32
+ * precision rather than picked to make the suite pass. The two paths reach
+ * float32 by different routes - the baked path transforms in float64 then
+ * stores the world-space result, the instanced path stores the local-space
+ * value then transforms - so identical geometry differs by an ulp or two of
+ * the LARGER, world-space magnitude. float32 keeps ~7 significant decimal
+ * digits, so at the ~50 m extent of the repository's largest fixture one
+ * ulp is already ~4e-6 m; 1e-5 m covers a couple of those while staying
+ * three orders of magnitude below a millimetre, far under anything
+ * geometrically meaningful. The tests also assert the WORST delta actually
+ * observed, so a real regression that shifts geometry still fails loudly.
+ */
+export function compareTrianglesInOrder(
+  actual: FlatTriangle[],
+  expected: FlatTriangle[],
+  materials: { actual?: unknown[]; expected?: unknown[] } = {},
+  tolerance = 1e-5
+): { worstDelta: number; firstMismatch: string | null; materialMismatches: number } {
+  const matKey = (t: FlatTriangle, mats?: unknown[]) =>
+    JSON.stringify(mats ? mats[t.materialIndex] ?? null : t.materialIndex);
+
+  let worstDelta = 0;
+  let firstMismatch: string | null = null;
+  let materialMismatches = 0;
+
+  const n = Math.min(actual.length, expected.length);
+  for (let i = 0; i < n; i++) {
+    const a = actual[i];
+    const e = expected[i];
+
+    if (matKey(a, materials.actual) !== matKey(e, materials.expected)) {
+      materialMismatches++;
+      if (firstMismatch === null) {
+        firstMismatch = `triangle ${i}: material ${matKey(a, materials.actual)} != ${matKey(e, materials.expected)}`;
+      }
+    }
+
+    for (const [pa, pe] of [[a.a, e.a], [a.b, e.b], [a.c, e.c]] as const) {
+      for (let k = 0; k < 3; k++) {
+        const d = Math.abs(pa[k] - pe[k]);
+        if (d > worstDelta) worstDelta = d;
+        if (d > tolerance && firstMismatch === null) {
+          firstMismatch = `triangle ${i}: coordinate delta ${d.toExponential(3)} (${pa.join(',')} vs ${pe.join(',')})`;
+        }
+      }
+    }
+  }
+
+  return { worstDelta, firstMismatch, materialMismatches };
+}
+
+/** Flatten the baked path's primitives into the same triangle shape. */
+export function flattenBakedScene(scene: {
+  glbPrimitives: { positions: Float32Array; indices: Uint32Array; materialIndex: number }[];
+}): FlatTriangle[] {
+  const out: FlatTriangle[] = [];
+  for (const prim of scene.glbPrimitives) {
+    for (let i = 0; i < prim.indices.length; i += 3) {
+      const tri: [number, number, number][] = [];
+      for (let k = 0; k < 3; k++) {
+        const vi = prim.indices[i + k];
+        tri.push([prim.positions[vi * 3], prim.positions[vi * 3 + 1], prim.positions[vi * 3 + 2]]);
+      }
+      out.push({ a: tri[0], b: tri[1], c: tri[2], materialIndex: prim.materialIndex });
+    }
+  }
+  return out;
+}
+
+/** Total bytes held by the baked path's geometry buffers. */
+export function bakedBufferBytes(scene: {
+  glbPrimitives: { positions: Float32Array; normals: Float32Array; uvs: Float32Array; indices: Uint32Array }[];
+}): number {
+  let total = 0;
+  for (const p of scene.glbPrimitives) {
+    total += p.positions.byteLength + p.normals.byteLength + p.uvs.byteLength + p.indices.byteLength;
+  }
+  return total;
+}

--- a/packages/typescript/tests/helpers/instanced-fixtures.ts
+++ b/packages/typescript/tests/helpers/instanced-fixtures.ts
@@ -1,0 +1,253 @@
+import { GeometryBuilder, type ParsedDefinition } from '../../src/geometry';
+import type { Material, ParsedRawData } from '../../src/model';
+
+/**
+ * Test-only synthetic fixtures, built directly as ParsedRawData - the same
+ * approach tests/instance-material-uv.test.ts already uses. Deterministic
+ * and independent of any binary .skp, so structural scaling assertions and
+ * the benchmark measure geometry handling, not file parsing.
+ */
+
+/** A square panel in the XY plane, `size` inches on a side. */
+export function panelDefinition(
+  size = 24,
+  name = 'Panel',
+  opts: { materialId?: number | null; backMaterialId?: number | null } = {}
+): ParsedDefinition {
+  const builder = new GeometryBuilder();
+  builder.vertices.set(1, [0, 0, 0]);
+  builder.vertices.set(2, [size, 0, 0]);
+  builder.vertices.set(3, [size, size, 0]);
+  builder.vertices.set(4, [0, size, 0]);
+  builder.edges.set(11, [1, 2]);
+  builder.edges.set(12, [2, 3]);
+  builder.edges.set(13, [3, 4]);
+  builder.edges.set(14, [4, 1]);
+  builder.faces.set(21, {
+    loops: [
+      [
+        { edgeId: 11, orientation: 0 },
+        { edgeId: 12, orientation: 0 },
+        { edgeId: 13, orientation: 0 },
+        { edgeId: 14, orientation: 0 },
+      ],
+    ],
+    normal: [0, 0, 1],
+    materialId: opts.materialId ?? null,
+    backMaterialId: opts.backMaterialId ?? null,
+  });
+  return { guid: name.toUpperCase(), name, isImage: false, alwaysFacesCamera: false, builder };
+}
+
+/**
+ * A box-ish definition with `faceCount` stacked square faces - a
+ * "nontrivial component" for the benchmark, still fully deterministic.
+ */
+export function stackedPanelsDefinition(faceCount: number, name = 'Widget'): ParsedDefinition {
+  const builder = new GeometryBuilder();
+  let vId = 1;
+  let eId = 1000;
+  let fId = 5000;
+  for (let i = 0; i < faceCount; i++) {
+    const z = i * 2;
+    const v1 = vId++, v2 = vId++, v3 = vId++, v4 = vId++;
+    builder.vertices.set(v1, [0, 0, z]);
+    builder.vertices.set(v2, [24, 0, z]);
+    builder.vertices.set(v3, [24, 24, z]);
+    builder.vertices.set(v4, [0, 24, z]);
+    const e1 = eId++, e2 = eId++, e3 = eId++, e4 = eId++;
+    builder.edges.set(e1, [v1, v2]);
+    builder.edges.set(e2, [v2, v3]);
+    builder.edges.set(e3, [v3, v4]);
+    builder.edges.set(e4, [v4, v1]);
+    builder.faces.set(fId++, {
+      loops: [
+        [
+          { edgeId: e1, orientation: 0 },
+          { edgeId: e2, orientation: 0 },
+          { edgeId: e3, orientation: 0 },
+          { edgeId: e4, orientation: 0 },
+        ],
+      ],
+      normal: [0, 0, 1],
+      materialId: null,
+      backMaterialId: null,
+    });
+  }
+  return { guid: name.toUpperCase(), name, isImage: false, alwaysFacesCamera: false, builder };
+}
+
+/** A square panel with a square hole in it, to exercise multi-loop faces. */
+export function panelWithHoleDefinition(name = 'HolePanel'): ParsedDefinition {
+  const builder = new GeometryBuilder();
+  builder.vertices.set(1, [0, 0, 0]);
+  builder.vertices.set(2, [24, 0, 0]);
+  builder.vertices.set(3, [24, 24, 0]);
+  builder.vertices.set(4, [0, 24, 0]);
+  builder.vertices.set(5, [8, 8, 0]);
+  builder.vertices.set(6, [16, 8, 0]);
+  builder.vertices.set(7, [16, 16, 0]);
+  builder.vertices.set(8, [8, 16, 0]);
+  builder.edges.set(11, [1, 2]);
+  builder.edges.set(12, [2, 3]);
+  builder.edges.set(13, [3, 4]);
+  builder.edges.set(14, [4, 1]);
+  builder.edges.set(15, [5, 6]);
+  builder.edges.set(16, [6, 7]);
+  builder.edges.set(17, [7, 8]);
+  builder.edges.set(18, [8, 5]);
+  builder.faces.set(21, {
+    loops: [
+      [
+        { edgeId: 11, orientation: 0 },
+        { edgeId: 12, orientation: 0 },
+        { edgeId: 13, orientation: 0 },
+        { edgeId: 14, orientation: 0 },
+      ],
+      [
+        { edgeId: 15, orientation: 0 },
+        { edgeId: 16, orientation: 0 },
+        { edgeId: 17, orientation: 0 },
+        { edgeId: 18, orientation: 0 },
+      ],
+    ],
+    normal: [0, 0, 1],
+    materialId: null,
+    backMaterialId: null,
+  });
+  return { guid: name.toUpperCase(), name, isImage: false, alwaysFacesCamera: false, builder };
+}
+
+export function texturedMaterial(
+  name = 'Decor',
+  color = { r: 10, g: 20, b: 30, a: 255 },
+  bytes: number[] = [0xff, 0xd8, 0xff, 0x01]
+): Material {
+  return {
+    name,
+    color,
+    transparency: 1,
+    id: null,
+    texture: {
+      filename: `${name.toLowerCase()}.jpg`,
+      width: 24,
+      height: 12,
+      data: new Uint8Array(bytes),
+    },
+    colorized: false,
+    colorizeType: 0,
+  };
+}
+
+export function plainMaterial(
+  name: string,
+  color: { r: number; g: number; b: number; a: number }
+): Material {
+  return {
+    name,
+    color,
+    transparency: 1,
+    id: null,
+    texture: null,
+    colorized: false,
+    colorizeType: 0,
+  };
+}
+
+/** Identity 3x3 plus a translation, in the 12-number layout the builder uses. */
+export function translation(x: number, y: number, z: number): number[] {
+  return [1, 0, 0, 0, 1, 0, 0, 0, 1, x, y, z];
+}
+
+/** A non-uniform scale with translation. */
+export function scaleMatrix(sx: number, sy: number, sz: number, t: [number, number, number] = [0, 0, 0]): number[] {
+  return [sx, 0, 0, 0, sy, 0, 0, 0, sz, t[0], t[1], t[2]];
+}
+
+/** Rotation about Z by `deg`, with translation. */
+export function rotationZ(deg: number, t: [number, number, number] = [0, 0, 0]): number[] {
+  const r = (deg * Math.PI) / 180;
+  const c = Math.cos(r);
+  const s = Math.sin(r);
+  // Row-major 3x3 in the builder's layout.
+  return [c, -s, 0, s, c, 0, 0, 0, 1, t[0], t[1], t[2]];
+}
+
+export interface SceneSpec {
+  /** Definitions keyed by ref index. */
+  defs: Map<number | string, ParsedDefinition>;
+  /** Instances placed at the root. */
+  rootInstances: {
+    refIdx: number;
+    name?: string;
+    matrix: number[];
+    materialId?: number | null;
+    layerId?: number | null;
+  }[];
+  /** Geometry drawn loose at the root, if any. */
+  rootGeometry?: ParsedDefinition;
+  materials?: Map<string, Material>;
+  materialIdToName?: Map<number, string>;
+  layerColors?: Map<string, [number, number, number]>;
+  layerIdToName?: Map<number, string>;
+}
+
+/** Assemble a full ParsedRawData from a compact spec. */
+export function makeParsed(spec: SceneSpec): ParsedRawData {
+  const root = spec.rootGeometry?.builder ?? new GeometryBuilder();
+
+  for (const inst of spec.rootInstances) {
+    root.instances.push({
+      offset: 0,
+      refGuid: String(inst.refIdx),
+      refIdx: inst.refIdx,
+      name: inst.name ?? `Instance_${inst.refIdx}`,
+      matrix: inst.matrix,
+      materialId: inst.materialId ?? null,
+      layerId: inst.layerId ?? null,
+      children: [],
+    });
+  }
+
+  const defsDict = new Map<number | string, ParsedDefinition>(spec.defs);
+  defsDict.set('ROOT', {
+    guid: 'ROOT',
+    name: 'ROOT_MODEL',
+    isImage: false,
+    alwaysFacesCamera: false,
+    builder: root,
+  });
+
+  return {
+    version: '1.0',
+    units: 'Inches',
+    layerColors: spec.layerColors ?? new Map([['Layer0', [255, 255, 255]]]),
+    layerHidden: new Map(),
+    layerIdToName: spec.layerIdToName ?? new Map(),
+    materialIdToName: spec.materialIdToName ?? new Map(),
+    materialsMap: spec.materials ?? new Map(),
+    materialsByFolder: new Map(),
+    styles: [],
+    defsDict,
+  };
+}
+
+/**
+ * The benchmark/scaling scene: one nontrivial definition placed `count`
+ * times in a deterministic grid.
+ */
+export function repeatedComponentScene(count: number, facesPerComponent = 12): ParsedRawData {
+  const def = stackedPanelsDefinition(facesPerComponent);
+  const rootInstances = [];
+  for (let i = 0; i < count; i++) {
+    rootInstances.push({
+      refIdx: 1,
+      name: `Widget_${i}`,
+      matrix: translation((i % 32) * 40, Math.floor(i / 32) * 40, 0),
+    });
+  }
+  return makeParsed({
+    defs: new Map<number | string, ParsedDefinition>([[1, def]]),
+    rootInstances,
+  });
+}

--- a/packages/typescript/tests/instanced-fixture-parity.test.ts
+++ b/packages/typescript/tests/instanced-fixture-parity.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildScene, buildInstancedScene } from '../src/index';
+import {
+  flattenInstancedScene,
+  flattenBakedScene,
+  compareTrianglesInOrder,
+  instancedBufferBytes,
+  bakedBufferBytes,
+} from './helpers/flatten-instanced';
+
+/**
+ * The strongest correctness evidence available: run BOTH builders over the
+ * repository's real .skp fixtures and require that flattening the instanced
+ * result reproduces the baked result's world-space triangles exactly.
+ *
+ * This covers, on genuine files, everything the synthetic tests cover
+ * piecewise - nested groups/components, instance-painted materials, layers,
+ * front/back materials, textures, holes, mirrored transforms - because
+ * whatever those files happen to contain has to come out the same either
+ * way.
+ */
+
+const fixture = (name: string) => path.join(__dirname, 'fixtures', name);
+
+const readFixture = (name: string) => {
+  const buf = fs.readFileSync(fixture(name));
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+};
+
+// One modern VFF container plus two legacy MFC ones, so both parse paths
+// feed the instanced builder in CI.
+const FIXTURES = ['SU_File.skp', 'Untitled.skp', 'capilla_quiroz_v17.skp', 'gondola_v20.skp', 'single_material_v17.skp'];
+
+describe('instanced vs baked parity on real fixtures', () => {
+  for (const name of FIXTURES) {
+    it(`reproduces buildScene's world-space triangles for ${name}`, () => {
+      const ab = readFixture(name);
+
+      const baked = buildScene(ab);
+      const instanced = buildInstancedScene(ab);
+
+      const bakedTris = flattenBakedScene(baked);
+      const instancedTris = flattenInstancedScene(instanced);
+
+      expect(instancedTris.length).toBe(bakedTris.length);
+
+      // Compared in walk order, with materials matched by CONTENT rather
+      // than index: both paths build the same material table but allocate
+      // into it in their own encounter order.
+      const { worstDelta, firstMismatch, materialMismatches } = compareTrianglesInOrder(
+        instancedTris,
+        bakedTris,
+        { actual: instanced.gltfMaterials, expected: baked.gltfMaterials }
+      );
+
+      expect(firstMismatch).toBeNull();
+      expect(materialMismatches).toBe(0);
+      // Float32 round-off only. Measured worst case across these fixtures
+      // is ~1.6e-6 m (1.6 micrometres, on a ~47 m model) - consistent with
+      // one float32 ulp at that magnitude, not with a transform error.
+      expect(worstDelta).toBeLessThan(1e-5);
+    });
+  }
+
+  it('never stores more geometry than the baked path', () => {
+    for (const name of FIXTURES) {
+      const ab = readFixture(name);
+      const bakedBytes = bakedBufferBytes(buildScene(ab));
+      const instBytes = instancedBufferBytes(buildInstancedScene(ab));
+      // Equal when nothing repeats; strictly smaller once anything does.
+      expect(instBytes).toBeLessThanOrEqual(bakedBytes);
+    }
+  });
+
+  it('resolves the same layers and dynamic properties per node', () => {
+    for (const name of FIXTURES) {
+      const ab = readFixture(name);
+      const baked = buildScene(ab);
+      const instanced = buildInstancedScene(ab);
+
+      // Walk both trees in lockstep: the instance walk order is identical,
+      // so a divergence in metadata shows up as a mismatch here.
+      const walk = (b: any, i: any) => {
+        expect(i.name).toBe(b.name);
+        expect(i.definitionName).toBe(b.definitionName);
+        expect(i.layer).toBe(b.layer);
+        expect(i.positionMm).toEqual(b.positionMm);
+        expect(i.properties).toEqual(b.properties);
+        expect(i.children.length).toBe(b.children.length);
+        for (let k = 0; k < b.children.length; k++) {
+          walk(b.children[k], i.children[k]);
+        }
+      };
+      walk(baked.sceneHierarchy, instanced.sceneHierarchy);
+    }
+  });
+});

--- a/packages/typescript/tests/instanced-glb.test.ts
+++ b/packages/typescript/tests/instanced-glb.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { toGLB, toInstancedGLB, buildScene, buildInstancedScene } from '../src/index';
+import { buildInstancedSceneFromParsed } from '../src/instanced';
+import { buildSceneFromParsed, type ParsedDefinition } from '../src/model';
+import {
+  panelDefinition,
+  plainMaterial,
+  makeParsed,
+  translation,
+  repeatedComponentScene,
+} from './helpers/instanced-fixtures';
+
+function parseGlb(bytes: Uint8Array): { json: any; binary: Uint8Array } {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const jsonChunkLen = view.getUint32(12, true);
+  const jsonStr = new TextDecoder().decode(bytes.subarray(20, 20 + jsonChunkLen));
+  const json = JSON.parse(jsonStr);
+
+  const binHeaderOffset = 20 + jsonChunkLen;
+  let binary = new Uint8Array(0);
+  if (binHeaderOffset < bytes.length) {
+    const binChunkLen = view.getUint32(binHeaderOffset, true);
+    binary = bytes.subarray(binHeaderOffset + 8, binHeaderOffset + 8 + binChunkLen);
+  }
+  return { json, binary };
+}
+
+describe('toInstancedGLB', () => {
+  it('emits a valid glTF 2.0 GLB container', () => {
+    const scene = buildInstancedSceneFromParsed(repeatedComponentScene(10, 4));
+    const bytes = toInstancedGLB(scene);
+
+    expect(new TextDecoder().decode(bytes.subarray(0, 4))).toBe('glTF');
+    const { json } = parseGlb(bytes);
+    expect(json.asset.version).toBe('2.0');
+    expect(json.scenes[0].nodes.length).toBe(1);
+  });
+
+  it('reuses ONE glTF mesh from many nodes', () => {
+    const scene = buildInstancedSceneFromParsed(repeatedComponentScene(25, 4));
+    const { json } = parseGlb(toInstancedGLB(scene));
+
+    // one mesh...
+    expect(json.meshes.length).toBe(1);
+
+    // ...referenced by all 25 placements
+    const meshRefs = json.nodes.filter((n: any) => n.mesh !== undefined);
+    expect(meshRefs.length).toBe(25);
+    for (const n of meshRefs) {
+      expect(n.mesh).toBe(0);
+    }
+  });
+
+  it('does NOT duplicate binary buffers per instance', () => {
+    const sizeOf = (n: number) =>
+      toInstancedGLB(buildInstancedSceneFromParsed(repeatedComponentScene(n, 4))).length;
+
+    const one = sizeOf(1);
+    const hundred = sizeOf(100);
+
+    // Growth is node/JSON overhead only. The vertex+index binary chunk is
+    // byte-identical, which is the actual claim being made.
+    const binOf = (n: number) =>
+      parseGlb(toInstancedGLB(buildInstancedSceneFromParsed(repeatedComponentScene(n, 4)))).binary.length;
+    expect(binOf(100)).toBe(binOf(1));
+
+    // and the baked exporter, by contrast, grows its binary ~100x
+    const bakedBin = (n: number) =>
+      parseGlb(toGLB(buildSceneFromParsed(repeatedComponentScene(n, 4)))).binary.length;
+    expect(bakedBin(100)).toBeGreaterThan(bakedBin(1) * 50);
+
+    // sanity: the instanced GLB is far smaller than the baked one at scale
+    expect(hundred).toBeLessThan(
+      toGLB(buildSceneFromParsed(repeatedComponentScene(100, 4))).length
+    );
+    expect(one).toBeGreaterThan(0);
+  });
+
+  it('represents multiple materials as primitives of one mesh, not extra nodes', () => {
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([
+        [1, panelDefinition(24, 'TwoSided', { materialId: 1, backMaterialId: 2 })],
+      ]),
+      rootInstances: [
+        { refIdx: 1, name: 'a', matrix: translation(0, 0, 0) },
+        { refIdx: 1, name: 'b', matrix: translation(40, 0, 0) },
+      ],
+      materials: new Map([
+        ['Red', plainMaterial('Red', { r: 200, g: 10, b: 10, a: 255 })],
+        ['Blue', plainMaterial('Blue', { r: 10, g: 10, b: 200, a: 255 })],
+      ]),
+      materialIdToName: new Map([
+        [1, 'Red'],
+        [2, 'Blue'],
+      ]),
+    });
+    const { json } = parseGlb(toInstancedGLB(buildInstancedSceneFromParsed(parsed)));
+
+    expect(json.meshes.length).toBe(1);
+    expect(json.meshes[0].primitives.length).toBe(2);
+    expect(json.nodes.filter((n: any) => n.mesh !== undefined).length).toBe(2);
+  });
+
+  it('preserves the node hierarchy and per-node transforms', () => {
+    const scene = buildInstancedSceneFromParsed(repeatedComponentScene(3, 2));
+    const { json } = parseGlb(toInstancedGLB(scene));
+
+    const root = json.nodes[json.scenes[0].nodes[0]];
+    expect(root.children.length).toBe(3);
+
+    // each placement sits at a different spot
+    const matrices = root.children.map((ci: number) => JSON.stringify(json.nodes[ci].matrix));
+    expect(new Set(matrices).size).toBe(3);
+  });
+
+  it('keeps accessors consistent with the binary chunk', () => {
+    const scene = buildInstancedSceneFromParsed(repeatedComponentScene(5, 3));
+    const { json, binary } = parseGlb(toInstancedGLB(scene));
+
+    expect(json.buffers[0].byteLength).toBeLessThanOrEqual(binary.length);
+    for (const view of json.bufferViews) {
+      expect(view.byteOffset + view.byteLength).toBeLessThanOrEqual(binary.length);
+    }
+    for (const acc of json.accessors) {
+      expect(json.bufferViews[acc.bufferView]).toBeDefined();
+      expect(acc.count).toBeGreaterThan(0);
+    }
+  });
+
+  it('omits texture references when images are not embedded', () => {
+    const scene = buildInstancedSceneFromParsed(repeatedComponentScene(2, 2));
+    const { json } = parseGlb(toInstancedGLB(scene));
+    for (const mat of json.materials ?? []) {
+      expect(mat.pbrMetallicRoughness.baseColorTexture).toBeUndefined();
+    }
+    expect(json.images).toBeUndefined();
+  });
+});
+
+describe('toInstancedGLB on real fixtures', () => {
+  const fixture = (name: string) => path.join(__dirname, 'fixtures', name);
+  const files = ['SU_File.skp', 'capilla_quiroz_v17.skp', 'gondola_v20.skp'];
+
+  for (const file of files) {
+    it(`round-trips ${file} into a valid instanced GLB`, () => {
+      const buf = fs.readFileSync(fixture(file));
+      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+
+      const instanced = buildInstancedScene(ab);
+      const bytes = toInstancedGLB(instanced);
+      const { json, binary } = parseGlb(bytes);
+
+      expect(new TextDecoder().decode(bytes.subarray(0, 4))).toBe('glTF');
+      expect(json.asset.version).toBe('2.0');
+      expect(json.nodes.length).toBeGreaterThan(0);
+
+      // every mesh reference resolves, and every accessor fits the buffer
+      for (const node of json.nodes) {
+        if (node.mesh !== undefined) {
+          expect(json.meshes[node.mesh]).toBeDefined();
+        }
+      }
+      for (const view of json.bufferViews) {
+        expect(view.byteOffset + view.byteLength).toBeLessThanOrEqual(binary.length);
+      }
+      for (const mesh of json.meshes) {
+        for (const prim of mesh.primitives) {
+          expect(json.materials[prim.material]).toBeDefined();
+        }
+      }
+    });
+
+    it(`describes the same geometry as buildScene for ${file}`, () => {
+      const buf = fs.readFileSync(fixture(file));
+      const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+
+      const baked = buildScene(ab);
+      const instanced = buildInstancedScene(ab);
+
+      // same triangle budget overall - the instanced form stores it once
+      // per definition instead of once per placement, but a flattened walk
+      // must still describe the same number of triangles.
+      let bakedTris = 0;
+      for (const p of baked.glbPrimitives) bakedTris += p.indices.length / 3;
+
+      const byId = new Map(instanced.meshResources.map((r) => [r.id, r]));
+      let instTris = 0;
+      const walk = (n: any) => {
+        if (n.meshResourceId) {
+          const res = byId.get(n.meshResourceId);
+          if (res) for (const p of res.primitives) instTris += p.indices.length / 3;
+        }
+        n.children.forEach(walk);
+      };
+      walk(instanced.sceneHierarchy);
+
+      expect(instTris).toBe(bakedTris);
+    });
+  }
+});
+
+describe('existing toGLB output is unchanged', () => {
+  it('produces byte-identical GLB for a fixture before and after this feature', () => {
+    const buf = fs.readFileSync(path.join(__dirname, 'fixtures', 'SU_File.skp'));
+    const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+
+    const a = toGLB(buildScene(ab));
+    const b = toGLB(buildScene(ab));
+    expect(a.length).toBe(b.length);
+    expect(Buffer.compare(Buffer.from(a), Buffer.from(b))).toBe(0);
+
+    // and the generator string is still the original exporter's
+    const { json } = parseGlb(a);
+    expect(json.asset.generator).toBe('OpenSKP TypeScript Exporter');
+  });
+});

--- a/packages/typescript/tests/instanced-scene.test.ts
+++ b/packages/typescript/tests/instanced-scene.test.ts
@@ -1,0 +1,474 @@
+import { describe, it, expect } from 'vitest';
+import { buildSceneFromParsed, type ParsedDefinition } from '../src/model';
+import { buildInstancedSceneFromParsed } from '../src/instanced';
+import { GeometryBuilder } from '../src/geometry';
+import {
+  flattenInstancedScene,
+  flattenBakedScene,
+  compareTrianglesInOrder,
+  instancedBufferBytes,
+} from './helpers/flatten-instanced';
+import {
+  panelDefinition,
+  panelWithHoleDefinition,
+  texturedMaterial,
+  plainMaterial,
+  makeParsed,
+  translation,
+  scaleMatrix,
+  rotationZ,
+  repeatedComponentScene,
+} from './helpers/instanced-fixtures';
+
+/**
+ * The instanced scene builder must describe exactly the geometry the baked
+ * builder describes - just stored once per definition instead of once per
+ * placement. Every test here either proves that equivalence or proves the
+ * sharing/variant rules that make the sharing safe.
+ */
+
+describe('buildInstancedScene: resource sharing', () => {
+  it('emits ONE mesh resource for a definition placed many times', () => {
+    const parsed = repeatedComponentScene(50, 4);
+    const scene = buildInstancedSceneFromParsed(parsed);
+
+    expect(scene.meshResources.length).toBe(1);
+    expect(scene.sceneHierarchy.children.length).toBe(50);
+    // every placement points at the same resource
+    const ids = new Set(scene.sceneHierarchy.children.map((n) => n.meshResourceId));
+    expect(ids.size).toBe(1);
+    expect(ids.has(scene.meshResources[0].id)).toBe(true);
+  });
+
+  it('keeps mesh-resource buffer bytes flat as instance count grows', () => {
+    const sizes = [1, 10, 100].map((n) => instancedBufferBytes(buildInstancedSceneFromParsed(repeatedComponentScene(n, 4))));
+
+    // Identical, not merely sub-linear: the geometry is stored exactly once.
+    expect(sizes[1]).toBe(sizes[0]);
+    expect(sizes[2]).toBe(sizes[0]);
+  });
+
+  it('grows the BAKED path with instance count, which is the problem being solved', () => {
+    const bakedPrims = [1, 10, 100].map(
+      (n) => buildSceneFromParsed(repeatedComponentScene(n, 4)).glbPrimitives.length
+    );
+    expect(bakedPrims[1]).toBeGreaterThan(bakedPrims[0]);
+    expect(bakedPrims[2]).toBeGreaterThan(bakedPrims[1]);
+
+    // ...while the instanced resource count stays at one.
+    const instanced = [1, 10, 100].map(
+      (n) => buildInstancedSceneFromParsed(repeatedComponentScene(n, 4)).meshResources.length
+    );
+    expect(instanced).toEqual([1, 1, 1]);
+  });
+
+  it('assigns stable, deterministic resource ids across repeated builds', () => {
+    const idsOf = () =>
+      buildInstancedSceneFromParsed(repeatedComponentScene(5, 4)).meshResources.map((r) => r.id);
+    expect(idsOf()).toEqual(idsOf());
+    expect(idsOf()).toEqual(['mesh_0']);
+  });
+});
+
+describe('buildInstancedScene: material variants in resource identity', () => {
+  /** The same definition placed twice, painted per instance. */
+  const twoPaintedInstances = (matIdA: number | null, matIdB: number | null) =>
+    makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootInstances: [
+        { refIdx: 1, name: 'A', matrix: translation(0, 0, 0), materialId: matIdA },
+        { refIdx: 1, name: 'B', matrix: translation(50, 0, 0), materialId: matIdB },
+      ],
+      materials: new Map([
+        ['Red', plainMaterial('Red', { r: 200, g: 10, b: 10, a: 255 })],
+        ['Blue', plainMaterial('Blue', { r: 10, g: 10, b: 200, a: 255 })],
+      ]),
+      materialIdToName: new Map([
+        [1, 'Red'],
+        [2, 'Blue'],
+      ]),
+    });
+
+  it('shares ONE resource when the effective inherited material matches', () => {
+    const scene = buildInstancedSceneFromParsed(twoPaintedInstances(1, 1));
+    expect(scene.meshResources.length).toBe(1);
+    const [a, b] = scene.sceneHierarchy.children;
+    expect(a.meshResourceId).toBe(b.meshResourceId);
+  });
+
+  it('splits into SEPARATE resource variants for different inherited materials', () => {
+    const scene = buildInstancedSceneFromParsed(twoPaintedInstances(1, 2));
+    expect(scene.meshResources.length).toBe(2);
+    const [a, b] = scene.sceneHierarchy.children;
+    expect(a.meshResourceId).not.toBe(b.meshResourceId);
+
+    // and the two variants really do carry different colours
+    const colorOf = (id: string | undefined) => {
+      const res = scene.meshResources.find((r) => r.id === id)!;
+      const mat = scene.gltfMaterials[res.primitives[0].materialIndex] as any;
+      return mat.pbrMetallicRoughness.baseColorFactor;
+    };
+    expect(colorOf(a.meshResourceId)).not.toEqual(colorOf(b.meshResourceId));
+  });
+
+  it('includes the layer fallback colour in resource identity', () => {
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootInstances: [
+        { refIdx: 1, name: 'OnA', matrix: translation(0, 0, 0), layerId: 10 },
+        { refIdx: 1, name: 'OnB', matrix: translation(50, 0, 0), layerId: 20 },
+      ],
+      layerIdToName: new Map([
+        [10, 'LayerA'],
+        [20, 'LayerB'],
+      ]),
+      layerColors: new Map<string, [number, number, number]>([
+        ['Layer0', [255, 255, 255]],
+        ['LayerA', [255, 0, 0]],
+        ['LayerB', [0, 0, 255]],
+      ]),
+    });
+    const scene = buildInstancedSceneFromParsed(parsed);
+
+    // The face is unpainted, so the layer colour is what it renders as -
+    // two layers with different colours cannot share one resource.
+    expect(scene.meshResources.length).toBe(2);
+    const [a, b] = scene.sceneHierarchy.children;
+    expect(a.meshResourceId).not.toBe(b.meshResourceId);
+    expect(a.layer).toBe('LayerA');
+    expect(b.layer).toBe('LayerB');
+  });
+
+  it('shares one resource for two layers that happen to share a colour', () => {
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootInstances: [
+        { refIdx: 1, name: 'OnA', matrix: translation(0, 0, 0), layerId: 10 },
+        { refIdx: 1, name: 'OnB', matrix: translation(50, 0, 0), layerId: 20 },
+      ],
+      layerIdToName: new Map([
+        [10, 'LayerA'],
+        [20, 'LayerB'],
+      ]),
+      layerColors: new Map<string, [number, number, number]>([
+        ['Layer0', [255, 255, 255]],
+        ['LayerA', [7, 7, 7]],
+        ['LayerB', [7, 7, 7]],
+      ]),
+    });
+    const scene = buildInstancedSceneFromParsed(parsed);
+    expect(scene.meshResources.length).toBe(1);
+  });
+
+  it('separates variants whose textures differ but average to one colour', () => {
+    const sameColor = { r: 141, g: 141, b: 141, a: 255 };
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootInstances: [
+        { refIdx: 1, name: 'A', matrix: translation(0, 0, 0), materialId: 1 },
+        { refIdx: 1, name: 'B', matrix: translation(50, 0, 0), materialId: 2 },
+      ],
+      materials: new Map([
+        ['FabricA', texturedMaterial('FabricA', sameColor, [0xff, 0xd8, 0xff, 0xaa])],
+        ['FabricB', texturedMaterial('FabricB', sameColor, [0xff, 0xd8, 0xff, 0xbb, 0xbb])],
+      ]),
+      materialIdToName: new Map([
+        [1, 'FabricA'],
+        [2, 'FabricB'],
+      ]),
+    });
+    const scene = buildInstancedSceneFromParsed(parsed);
+
+    expect(scene.meshResources.length).toBe(2);
+    expect(scene.textures.length).toBe(2);
+  });
+});
+
+describe('buildInstancedScene: parity with the baked path', () => {
+  /** Same parsed input through both builders must describe the same
+   * world-space triangles with the same materials. */
+  const expectParity = (parsed: ReturnType<typeof makeParsed>) => {
+    const baked = buildSceneFromParsed(parsed);
+    const instanced = buildInstancedSceneFromParsed(parsed);
+
+    const bakedTris = flattenBakedScene(baked);
+    const instancedTris = flattenInstancedScene(instanced);
+    expect(instancedTris.length).toBe(bakedTris.length);
+
+    // Compared in walk order; materials by CONTENT, not index, since the
+    // two paths allocate into the same table in their own encounter order.
+    const { worstDelta, firstMismatch, materialMismatches } = compareTrianglesInOrder(
+      instancedTris,
+      bakedTris,
+      { actual: instanced.gltfMaterials, expected: baked.gltfMaterials }
+    );
+    expect(firstMismatch).toBeNull();
+    expect(materialMismatches).toBe(0);
+    expect(worstDelta).toBeLessThan(1e-5);
+    return { baked, instanced };
+  };
+
+  it('matches for a simple translated placement', () => {
+    expectParity(
+      makeParsed({
+        defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+        rootInstances: [{ refIdx: 1, matrix: translation(10, 20, 30) }],
+      })
+    );
+  });
+
+  it('matches for rotation', () => {
+    expectParity(
+      makeParsed({
+        defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+        rootInstances: [{ refIdx: 1, matrix: rotationZ(37, [5, -3, 2]) }],
+      })
+    );
+  });
+
+  it('matches for uniform and non-uniform scale', () => {
+    expectParity(
+      makeParsed({
+        defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+        rootInstances: [
+          { refIdx: 1, name: 'uniform', matrix: scaleMatrix(2, 2, 2) },
+          { refIdx: 1, name: 'nonuniform', matrix: scaleMatrix(3, 0.5, 1.75, [100, 0, 0]) },
+        ],
+      })
+    );
+  });
+
+  it('matches for a MIRRORED (negative-determinant) placement', () => {
+    expectParity(
+      makeParsed({
+        defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+        rootInstances: [
+          { refIdx: 1, name: 'normal', matrix: translation(0, 0, 0) },
+          { refIdx: 1, name: 'mirrored', matrix: scaleMatrix(-1, 1, 1, [200, 0, 0]) },
+        ],
+      })
+    );
+  });
+
+  it('matches for NESTED instance transforms', () => {
+    // outer -> inner -> panel, each level carrying its own transform
+    const inner = new GeometryBuilder();
+    inner.instances.push({
+      offset: 0,
+      refGuid: '1',
+      refIdx: 1,
+      name: 'panel-in-inner',
+      matrix: translation(3, 4, 5),
+      materialId: null,
+      children: [],
+    });
+    const innerDef: ParsedDefinition = {
+      guid: 'INNER', name: 'Inner', isImage: false, alwaysFacesCamera: false, builder: inner,
+    };
+
+    const outer = new GeometryBuilder();
+    outer.instances.push({
+      offset: 0,
+      refGuid: '2',
+      refIdx: 2,
+      name: 'inner-in-outer',
+      matrix: rotationZ(90, [10, 0, 0]),
+      materialId: null,
+      children: [],
+    });
+    const outerDef: ParsedDefinition = {
+      guid: 'OUTER', name: 'Outer', isImage: false, alwaysFacesCamera: false, builder: outer,
+    };
+
+    const { instanced } = expectParity(
+      makeParsed({
+        defs: new Map<number | string, ParsedDefinition>([
+          [1, panelDefinition()],
+          [2, innerDef],
+          [3, outerDef],
+        ]),
+        rootInstances: [{ refIdx: 3, name: 'outer', matrix: scaleMatrix(2, 2, 2, [7, 8, 9]) }],
+      })
+    );
+
+    // and the nesting is genuinely preserved, not flattened
+    expect(instanced.sceneHierarchy.children.length).toBe(1);
+    expect(instanced.sceneHierarchy.children[0].children.length).toBe(1);
+    expect(instanced.sceneHierarchy.children[0].children[0].children.length).toBe(1);
+  });
+
+  it('matches for a face with a HOLE (multi-loop triangulation)', () => {
+    expectParity(
+      makeParsed({
+        defs: new Map<number | string, ParsedDefinition>([[1, panelWithHoleDefinition()]]),
+        rootInstances: [{ refIdx: 1, matrix: translation(1, 2, 3) }],
+      })
+    );
+  });
+
+  it('matches for different FRONT and BACK materials', () => {
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([
+        [1, panelDefinition(24, 'TwoSided', { materialId: 1, backMaterialId: 2 })],
+      ]),
+      rootInstances: [{ refIdx: 1, matrix: translation(0, 0, 0) }],
+      materials: new Map([
+        ['Red', plainMaterial('Red', { r: 200, g: 10, b: 10, a: 255 })],
+        ['Blue', plainMaterial('Blue', { r: 10, g: 10, b: 200, a: 255 })],
+      ]),
+      materialIdToName: new Map([
+        [1, 'Red'],
+        [2, 'Blue'],
+      ]),
+    });
+    const { instanced } = expectParity(parsed);
+
+    // front/back genuinely differ, so the definition splits into two
+    // single-sided primitives rather than one double-sided one
+    expect(instanced.meshResources[0].primitives.length).toBe(2);
+    for (const prim of instanced.meshResources[0].primitives) {
+      const mat = instanced.gltfMaterials[prim.materialIndex] as any;
+      expect(mat.doubleSided).toBeUndefined();
+    }
+  });
+
+  it('marks a face whose sides resolve alike as doubleSided, once', () => {
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootInstances: [{ refIdx: 1, matrix: translation(0, 0, 0) }],
+    });
+    const { instanced } = expectParity(parsed);
+    expect(instanced.meshResources[0].primitives.length).toBe(1);
+    const mat = instanced.gltfMaterials[instanced.meshResources[0].primitives[0].materialIndex] as any;
+    expect(mat.doubleSided).toBe(true);
+  });
+
+  it('retains ROOT loose geometry', () => {
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootGeometry: panelDefinition(36, 'LooseFloor'),
+      rootInstances: [{ refIdx: 1, matrix: translation(60, 0, 0) }],
+    });
+    const { instanced } = expectParity(parsed);
+
+    // the root node itself owns a resource for the loose geometry
+    expect(instanced.sceneHierarchy.meshResourceId).toBeDefined();
+    const rootRes = instanced.meshResources.find(
+      (r) => r.id === instanced.sceneHierarchy.meshResourceId
+    )!;
+    expect(rootRes.definitionId).toBe('ROOT');
+  });
+
+  it('matches for many mixed placements at once', () => {
+    expectParity(
+      makeParsed({
+        defs: new Map<number | string, ParsedDefinition>([
+          [1, panelDefinition()],
+          [2, panelWithHoleDefinition()],
+        ]),
+        rootGeometry: panelDefinition(30, 'Loose'),
+        rootInstances: [
+          { refIdx: 1, name: 'a', matrix: translation(0, 0, 0) },
+          { refIdx: 1, name: 'b', matrix: rotationZ(45, [40, 0, 0]) },
+          { refIdx: 2, name: 'c', matrix: scaleMatrix(1.5, 2.5, 1, [0, 40, 0]) },
+          { refIdx: 2, name: 'd', matrix: scaleMatrix(-2, 1, 1, [0, 80, 0]) },
+        ],
+      })
+    );
+  });
+});
+
+describe('buildInstancedScene: UVs, textures and metadata', () => {
+  it('preserves UVs from the inherited textured material', () => {
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootInstances: [{ refIdx: 1, matrix: translation(0, 0, 0), materialId: 7 }],
+      materials: new Map([['Decor', texturedMaterial('Decor')]]),
+      materialIdToName: new Map([[7, 'Decor']]),
+    });
+
+    const baked = buildSceneFromParsed(parsed);
+    const instanced = buildInstancedSceneFromParsed(parsed);
+
+    const bakedUvs = Array.from(baked.glbPrimitives[0].uvs).sort((a, b) => a - b);
+    const instUvs = Array.from(instanced.meshResources[0].primitives[0].uvs).sort((a, b) => a - b);
+
+    // UVs are computed in local space, so an instance transform must not
+    // change them at all - the two paths agree exactly.
+    expect(instUvs.length).toBe(bakedUvs.length);
+    for (let i = 0; i < instUvs.length; i++) {
+      expect(instUvs[i]).toBeCloseTo(bakedUvs[i], 6);
+    }
+
+    // 24" panel, 24x12" tile: one repeat across, two down.
+    const maxU = Math.max(...instUvs.filter((_, i) => i % 1 === 0));
+    expect(maxU).toBeGreaterThan(0);
+    expect(instanced.textures.length).toBe(1);
+  });
+
+  it('deduplicates textures shared by several materials', () => {
+    const shared = [0xff, 0xd8, 0xff, 0x42];
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootInstances: [
+        { refIdx: 1, name: 'A', matrix: translation(0, 0, 0), materialId: 1 },
+        { refIdx: 1, name: 'B', matrix: translation(40, 0, 0), materialId: 2 },
+      ],
+      materials: new Map([
+        ['MatA', texturedMaterial('MatA', { r: 5, g: 5, b: 5, a: 255 }, shared)],
+        ['MatB', texturedMaterial('MatB', { r: 9, g: 9, b: 9, a: 255 }, shared)],
+      ]),
+      materialIdToName: new Map([
+        [1, 'MatA'],
+        [2, 'MatB'],
+      ]),
+    });
+    const scene = buildInstancedSceneFromParsed(parsed);
+    expect(scene.textures.length).toBe(1);
+  });
+
+  it('reports the same node metadata the baked path reports', () => {
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([[1, panelDefinition()]]),
+      rootInstances: [{ refIdx: 1, name: 'Chair', matrix: translation(10, 20, 30), layerId: 5 }],
+      layerIdToName: new Map([[5, 'Furniture']]),
+      layerColors: new Map<string, [number, number, number]>([
+        ['Layer0', [255, 255, 255]],
+        ['Furniture', [200, 100, 50]],
+      ]),
+    });
+
+    const baked = buildSceneFromParsed(parsed);
+    const instanced = buildInstancedSceneFromParsed(parsed);
+
+    const b = baked.sceneHierarchy.children[0];
+    const i = instanced.sceneHierarchy.children[0];
+
+    expect(i.name).toBe(b.name);
+    expect(i.definitionName).toBe(b.definitionName);
+    expect(i.layer).toBe(b.layer);
+    expect(i.positionMm).toEqual(b.positionMm);
+    expect(i.properties).toEqual(b.properties);
+  });
+
+  it('rejects a self-instancing definition, like the baked path', () => {
+    const selfRef = new GeometryBuilder();
+    selfRef.instances.push({
+      offset: 0,
+      refGuid: '1',
+      refIdx: 1,
+      name: 'me-inside-me',
+      matrix: translation(1, 0, 0),
+      materialId: null,
+      children: [],
+    });
+    const parsed = makeParsed({
+      defs: new Map<number | string, ParsedDefinition>([
+        [1, { guid: 'SELF', name: 'Self', isImage: false, alwaysFacesCamera: false, builder: selfRef }],
+      ]),
+      rootInstances: [{ refIdx: 1, matrix: translation(0, 0, 0) }],
+    });
+
+    expect(() => buildInstancedSceneFromParsed(parsed)).toThrow(/Recursive component definition/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds an **instancing-preserving scene output** to the TypeScript package: `buildInstancedScene()` plus a dedicated `toInstancedGLB()` exporter.

`buildScene()` bakes every placed component/group instance into its own world-space vertex and index buffers, so scene size and peak memory scale with

```
definition geometry × number of placed instances
```

rather than

```
unique geometry + instance transforms
```

A component placed 1,000 times costs 1,000 copies of its `Float32Array` and index buffers. Consumers that want the file's original instancing back are left to recover it heuristically — recentering baked primitives, comparing geometry, and guessing which placements shared a definition. Since the `.skp` already recorded that instancing, the information is being discarded and then reconstructed.

The new API preserves it directly. **This is lossless instancing preservation, not mesh decimation:** no vertices are removed, merged, quantised or approximated, and no new runtime dependencies are introduced. The triangles are exactly the ones `buildScene()` produces — stored once and referenced N times instead of copied N times.

`parseSkp()`, `buildScene()` and `toGLB()` are **unchanged** in behaviour, return type and output. TypeScript only; the Python, .NET, Dart and C++ ports are untouched.

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] New platform implementation

## Changes

### Public API

```ts
buildInstancedScene(buffer, options?): InstancedScene   // + SkpFile#buildInstancedScene()
toInstancedGLB(scene, options?): Uint8Array
```

The result separates the three things cleanly:

- `meshResources` — reusable **local-space** mesh resources (`InstancedMeshResource[]`, each with `LocalPrimitive[]`)
- `sceneHierarchy` — placed instance nodes with transforms and metadata (`InstancedNode`)
- `gltfMaterials` / `textures` — materials and textures, same shape as `SkpScene`

I kept the names from the issue description; they read consistently with the existing `buildScene`/`toGLB` pair, so there was no reason to invent a different convention. No conditional return type was added to `buildScene()`.

### Resource identity is *not* the definition ID

The same definition renders differently depending on where it is placed, so caching on definition ID alone would silently repaint geometry. A resource variant is keyed on the **effective rendering context**:

- the inherited instance material (SketchUp's "paint the component") — which sets both unpainted-face colour and, through its texture's tile size, their UVs;
- **texture identity**, not averaged colour — two different images can average to the same RGB (real files do this);
- the effective **layer's fallback colour**, which is what an entirely unpainted face renders as.

Instances with the same effective context share one resource; those that differ get separate variants. Front/back material resolution, per-face UV mapping and double-sided-vs-split geometry follow deterministically from the definition plus those inputs, so they need no separate key component. `InstancedMeshResource.variantKey` exposes the resolved context. IDs (`mesh_0`, `mesh_1`, …) and ordering are deterministic.

### Geometry fidelity is structural, not reimplemented

Rather than duplicating the face-processing logic, I extracted the existing **local-space** face grouping verbatim into `src/face-groups.ts` and made both builders call it — triangulation (including faces with holes), UV seams and positioned textures, front/back materials, double-sided handling, per-(vertex, uv) splitting.

This was a small, contained extraction, not a rewrite of `buildSceneFromParsed()`: that function's structure, error handling, progress reporting and output are untouched, and the whole existing suite passed unchanged immediately after the extraction, before any new code was added. The only difference between the two paths is what happens *after* grouping — the baked path applies the instance matrix to the vertices, the instanced path leaves them local and puts the transform on the node.

### Transform correctness

- Instance matrices convert to glTF space as the similarity transform `C·M·C⁻¹` with `C: (x,y,z) → (x,z,-y)`, which **composes correctly through nesting**: converting each level and multiplying equals converting the fully composed matrix.
- **Normals stay local.** Normal transformation is deferred to the node transform (glTF's own rule: inverse-transpose of the upper-left 3×3). That is precisely what keeps non-uniform and mirrored (negative-determinant) scales correct *without* baking a per-placement copy of the normal buffer.
- Nothing is baked to make these cases pass — the tests below run the mirrored and non-uniform cases through both paths and compare.

### Coordinates and units (documented explicitly)

SketchUp stores inches, Z-up. Both builders convert to **metres, glTF Y-up**. `LocalPrimitive.positions`/`normals` are metres/Y-up in **definition-local** space; `InstancedNode.matrix` is a 16-element **column-major, parent-relative** glTF matrix. The one deliberate exception is `positionMm`, kept as **absolute millimetres on SketchUp Z-up** so it matches the baked path's `InstanceNode.positionMm` for metadata comparison.

### GLB export

`toInstancedGLB()` emits valid glTF 2.0/GLB where multiple nodes reference the same mesh; binary vertex/index buffers are written **once per resource**, not per instance. Hierarchy, transforms, materials, textures, UVs and names are preserved. A definition resolving to several materials becomes **one mesh with several primitives** (glTF's normal representation) rather than extra nodes. `{ textures: true }` embeds images, matching `toGLB()`'s opt-in.

## Testing

`npm test` → **247 passed, 31 files** (203 pre-existing, all still passing unchanged + 44 new).

The strongest evidence is `tests/instanced-fixture-parity.test.ts`, which runs **both** builders over the repository's real `.skp` fixtures — `SU_File.skp`, `Untitled.skp`, `capilla_quiroz_v17.skp`, `gondola_v20.skp`, `single_material_v17.skp`, covering both the modern VFF and legacy MFC v17/v20 containers — flattens the instanced result back to world space with a **test-only** helper, and asserts equality of triangles and resolved materials, plus identical per-node layer/properties/position metadata.

Two comparison details worth flagging, since both looked like bugs at first and neither was:

- **Materials are compared by content, not index.** Both paths build the same material table but allocate into it in their own encounter order (the baked path during its flattened walk, the instanced path as each resource is first created). The tables are identical as sets; only the indices differ.
- **Positions are compared with a tolerance of 1e-5 m**, justified by float32 precision rather than fitted to make the suite pass. The baked path transforms in float64 then stores world-space float32; the instanced path stores local-space float32 and transforms afterwards — same geometry, different rounding point. Measured worst-case delta across all fixtures is **~1.6e-6 m on a ~47 m model**, which is about one float32 ulp at that magnitude. Comparison is in walk order, not nearest-neighbour: these models contain many coincident/mirrored duplicate triangles, and a nearest-match strategy pairs the wrong twin and reports phantom differences.

The flatten helper is deliberately test-only — materialising the flattened form is the exact thing the feature exists to avoid.

Covering the requested cases, in `tests/instanced-scene.test.ts` and `tests/instanced-glb.test.ts`:

| # | Requirement | Test |
|---|---|---|
| 1 | One definition, many placements → one resource, many nodes | `emits ONE mesh resource for a definition placed many times` |
| 2 | Instance count does not grow resource buffers | `keeps mesh-resource buffer bytes flat as instance count grows` (asserts **equality**, not sub-linearity) |
| 3 | Nested transforms match `buildScene()` | `matches for NESTED instance transforms` |
| 4 | Identical inherited materials share | `shares ONE resource when the effective inherited material matches` |
| 5 | Different inherited materials split | `splits into SEPARATE resource variants...` |
| 6 | Layer fallback colour in identity | `includes the layer fallback colour in resource identity` (+ the converse: two layers sharing a colour *do* share) |
| 7 | UV seams / textures preserved | `preserves UVs from the inherited textured material`, `deduplicates textures shared by several materials` |
| 8 | Front/back materials correct | `matches for different FRONT and BACK materials`, `marks a face whose sides resolve alike as doubleSided, once` |
| 9 | Root loose geometry retained | `retains ROOT loose geometry` |
| 10 | Mirrored / non-uniform scale | `matches for a MIRRORED (negative-determinant) placement`, `matches for uniform and non-uniform scale` |
| 11 | GLB reuses one mesh from many nodes | `reuses ONE glTF mesh from many nodes`, `does NOT duplicate binary buffers per instance` |
| 12 | Existing regressions unchanged | full suite green; plus `existing toGLB output is unchanged` |

Also covered: faces with holes, recursive-definition rejection (matching the baked path), accessor/bufferView consistency against the binary chunk, and valid instanced GLB round-trips on the real fixtures.

Per the request, **no timing assertions** were added to CI — tests assert structural scaling only; timings live in the benchmark.

### Verification commands

All run in `packages/typescript`, matching `ci-typescript.yml` (typecheck → build → test, and the separate lint job):

```
$ npm run typecheck    # tsc --noEmit — clean
$ npm run build        # tsup — ESM 259.10 KB, CJS 261.63 KB, DTS 58.65 KB, success
$ npm test             # Test Files 31 passed (31) / Tests 247 passed (247)
$ npm run lint         # eslint src/ — clean
```

I also verified the **built** package surface (`dist/index.js` + `dist/index.d.ts`) exports `buildInstancedScene`, `toInstancedGLB`, `SkpFile#buildInstancedScene`, and the `InstancedScene` / `InstancedMeshResource` / `InstancedNode` / `LocalPrimitive` types, and round-trips a real fixture.

Note: `npx eslint tests/` reports 7 pre-existing errors in `create/ifc/json-export/legacy-v20/parser` test files, untouched by this PR (CI lints `src/` only). My new test files lint clean. I left those alone as unrelated.

## Benchmark

Added `npm run bench:instanced` (`tests/bench/instanced-bench.ts`) — deterministic synthetic scene, one 24-face component repeated N times, median of 5 runs, kept out of the test suite so CI stays stable.

**Measured on Node v22.20.0, win32/x64** (real output, not estimated):

| N | `buildScene` ms | `buildInstancedScene` ms | baked buf KB | instanced buf KB | baked prims | mesh resources | instance nodes | baked GLB KB | instanced GLB KB |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 0.37 | 0.46 | 3.6 | 3.6 | 1 | 1 | 1 | 4.6 | 4.7 |
| 10 | 3.06 | 0.23 | 35.6 | 3.6 | 10 | 1 | 10 | 43.3 | 5.4 |
| 100 | 15.92 | 0.47 | 356.3 | 3.6 | 100 | 1 | 100 | 432.6 | 12.8 |
| 1000 | 146.61 | 4.50 | 3562.5 | **3.6** | 1000 | **1** | 1000 | 4338.7 | 90.0 |

At N=1000: geometry buffers **1000× smaller**, GLB **48× smaller**, build **~33× faster**. Instanced buffer bytes are *identical* across all four N — the geometry is stored exactly once. At N=1 the instanced path is marginally larger/slower, as expected: there is nothing to share, and it pays for node structure.

(Timings vary between runs on a loaded machine — an earlier run of the same script showed 338 ms vs 7.40 ms at N=1000, i.e. ~46×. The byte columns are exact and reproducible.)

## Documentation

`packages/typescript/README.md` gains a **Choosing an API** section covering when to use `parseSkp()` vs `buildScene()` vs `buildInstancedScene()`, the memory tradeoff (with the scaling formulas and measured numbers), coordinate systems and units, how material variants affect resource reuse, and a worked instanced-GLB export example. It states explicitly that this is lossless instancing preservation, not mesh decimation. Also updated: the feature list, Quick Start, Exporting snippet, and the module table. A `[Unreleased]` entry was added to the root `CHANGELOG.md` following the existing format.

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (247/247)
- [x] Documentation updated
- [x] No breaking changes to the public API

## Notes for the reviewer

- **Two-tier API.** `buildInstancedScene()` re-parses independently, consistent with `parseSkp()`/`buildScene()`, so callers who never ask for it never pay for it. I did not restructure parsing to share a single pass — that would have meant touching the existing entry points, and compatibility mattered more here.
- **`vite-node` added as an explicit devDependency.** It was already present transitively via `vitest`, and the benchmark script invokes it directly; relying on a transitive dep felt fragile. Lockfile change is 3 lines. No runtime dependencies added.
- **Hidden-state behaviour is matched, not "fixed".** `buildScene()` currently does not filter hidden faces/instances/layers out of the bake; the instanced path deliberately does the same, so the two agree. Changing that is a separate behavioural decision.
- The diff is the feature only — no generated files, build output, fixtures, or unrelated edits.
