### PR TITLE
perf(typescript): store edge display flags in a Uint8Array, not a Map (10.3x on real fixtures)

### DIFF
--- a/packages/typescript/src/edge-flags.ts
+++ b/packages/typescript/src/edge-flags.ts
@@ -1,0 +1,111 @@
+/**
+ * Storage for edges' D307 display-flag byte, keyed by edge id.
+ *
+ * The payload is a SINGLE BYTE per edge (base 0x06, plus 0x01 hidden,
+ * 0x08 soft, 0x10 smooth), which a `Map<number, number>` stores at roughly
+ * 30 bytes per entry - about 23x the data itself, once V8's boxed-number
+ * and hash-bucket overhead is counted. On a large model that is tens of
+ * megabytes spent on a value that fits in a `Uint8Array` slot.
+ *
+ * Backed by a `Uint8Array` indexed by `id - baseId`, grown geometrically.
+ * Edge ids are not dense in real files (~39% across this repository's
+ * fixtures), so the array is sized to the observed id SPAN rather than the
+ * edge count - still far smaller than the Map it replaces, because one
+ * slot costs one byte instead of a whole hash entry.
+ *
+ * Semantics match the `Map` exactly, including the distinction the legacy
+ * (pre-2021 MFC) reader relies on: it only records an edge when its flags
+ * are non-zero, so an id that was never written must read back as 0 and
+ * report `has() === false`. A separate presence bitmap keeps that
+ * observable difference intact rather than conflating "absent" with
+ * "stored zero".
+ */
+export class EdgeFlagStore {
+  /** Flag byte per slot; index is `id - baseId`. */
+  private flags: Uint8Array = new Uint8Array(0);
+  /** One bit per slot recording whether that id was ever written. */
+  private present: Uint8Array = new Uint8Array(0);
+  /** Id that maps to slot 0. Set on first write. */
+  private baseId = 0;
+  private initialized = false;
+  private count = 0;
+
+  /** Number of ids actually stored. */
+  get size(): number {
+    return this.count;
+  }
+
+  private slotFor(id: number): number {
+    return id - this.baseId;
+  }
+
+  /** Grow (and, for an id below `baseId`, shift) so `id` has a slot. */
+  private ensureSlot(id: number): number {
+    if (!this.initialized) {
+      this.baseId = id;
+      this.flags = new Uint8Array(64);
+      this.present = new Uint8Array(8);
+      this.initialized = true;
+      return 0;
+    }
+
+    if (id < this.baseId) {
+      // An id below the current base: re-base, shifting existing data up.
+      const shift = this.baseId - id;
+      const needed = shift + this.flags.length;
+      const nextFlags = new Uint8Array(Math.max(needed, this.flags.length * 2));
+      nextFlags.set(this.flags, shift);
+      this.flags = nextFlags;
+
+      const nextPresent = new Uint8Array(Math.ceil(nextFlags.length / 8));
+      // Re-stamp presence bit by bit: the bitmap is not byte-aligned to the
+      // shift, so it cannot simply be block-copied.
+      for (let slot = 0; slot < this.flags.length - shift; slot++) {
+        if ((this.present[slot >> 3] & (1 << (slot & 7))) !== 0) {
+          const moved = slot + shift;
+          nextPresent[moved >> 3] |= 1 << (moved & 7);
+        }
+      }
+      this.present = nextPresent;
+      this.baseId = id;
+      return 0;
+    }
+
+    const slot = this.slotFor(id);
+    if (slot >= this.flags.length) {
+      const nextLength = Math.max(slot + 1, this.flags.length * 2);
+      const nextFlags = new Uint8Array(nextLength);
+      nextFlags.set(this.flags);
+      this.flags = nextFlags;
+
+      const nextPresent = new Uint8Array(Math.ceil(nextLength / 8));
+      nextPresent.set(this.present);
+      this.present = nextPresent;
+    }
+    return slot;
+  }
+
+  set(id: number, flags: number): void {
+    const slot = this.ensureSlot(id);
+    if ((this.present[slot >> 3] & (1 << (slot & 7))) === 0) {
+      this.present[slot >> 3] |= 1 << (slot & 7);
+      this.count++;
+    }
+    this.flags[slot] = flags & 0xff;
+  }
+
+  /** The stored byte, or `undefined` when the id was never written -
+   * matching `Map.prototype.get`, so callers' `?? 0` fallbacks behave
+   * exactly as before. */
+  get(id: number): number | undefined {
+    if (!this.initialized) return undefined;
+    const slot = this.slotFor(id);
+    if (slot < 0 || slot >= this.flags.length) return undefined;
+    if ((this.present[slot >> 3] & (1 << (slot & 7))) === 0) return undefined;
+    return this.flags[slot];
+  }
+
+  has(id: number): boolean {
+    return this.get(id) !== undefined;
+  }
+}

--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -1,5 +1,6 @@
 import { TlvNode, readF64, readU32, parseVarInt, parseTlvRecursive } from './parser';
 import { ParseOptions, emitLog } from './observability';
+import { EdgeFlagStore } from './edge-flags';
 
 export interface GeometryBuilderInstance {
   offset: number;
@@ -35,7 +36,9 @@ export interface GeometryBuilderFace {
 export class GeometryBuilder {
   vertices = new Map<number, [number, number, number]>(); // id -> [x, y, z]
   edges = new Map<number, [number | null, number | null]>(); // id -> [v1, v2]
-  edgeFlags = new Map<number, number>(); // edge id -> display flag byte (D307)
+  /** Edge id -> display flag byte (D307). Backed by a Uint8Array rather
+   * than a Map: the value is one byte, and a Map entry costs ~30. */
+  edgeFlags = new EdgeFlagStore();
   faces = new Map<number, GeometryBuilderFace>(); // id -> face data
   instances: GeometryBuilderInstance[] = [];
   sectionPlanes: { plane: [number, number, number, number]; name: string; label: string; hidden: boolean }[] = [];

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -16,6 +16,7 @@
  */
 
 import { GeometryBuilderFace, GeometryBuilderInstance, ParsedDefinition } from './geometry';
+import { EdgeFlagStore } from './edge-flags';
 import { Material, Texture, ParsedRawData } from './model';
 import { SkpParseError } from './errors';
 import { ParseOptions, PROGRESS_INTERVAL, emitLog, emitProgress } from './observability';
@@ -1181,7 +1182,7 @@ function walkModel(data: Uint8Array, ver: number, start: number, matCount: numbe
 class LegacyBuilder {
   vertices = new Map<number, [number, number, number]>();
   edges = new Map<number, [number | null, number | null]>();
-  edgeFlags = new Map<number, number>();
+  edgeFlags = new EdgeFlagStore();
   faces = new Map<number, GeometryBuilderFace>();
   instances: GeometryBuilderInstance[] = [];
   sectionPlanes: { plane: [number, number, number, number]; name: string; label: string; hidden: boolean }[] = [];

--- a/packages/typescript/tests/edge-flags.test.ts
+++ b/packages/typescript/tests/edge-flags.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { EdgeFlagStore } from '../src/edge-flags';
+
+/**
+ * EdgeFlagStore replaces a `Map<number, number>` that held one byte per
+ * edge. It has to be observationally identical to that Map for every
+ * access pattern the parsers actually produce - including the one the
+ * legacy reader depends on, where an edge with zero flags is never written
+ * at all and must stay distinguishable from one written as zero.
+ */
+
+describe('EdgeFlagStore', () => {
+  it('stores and returns a flag byte', () => {
+    const s = new EdgeFlagStore();
+    s.set(1, 0x06);
+    expect(s.get(1)).toBe(0x06);
+    expect(s.has(1)).toBe(true);
+    expect(s.size).toBe(1);
+  });
+
+  it('returns undefined for an id never written, like Map.get', () => {
+    const s = new EdgeFlagStore();
+    expect(s.get(42)).toBeUndefined();
+    expect(s.has(42)).toBe(false);
+    s.set(1, 0x06);
+    expect(s.get(999)).toBeUndefined();
+    expect(s.get(0)).toBeUndefined();
+  });
+
+  it('distinguishes a stored ZERO from an absent id', () => {
+    // The legacy reader only writes an edge when its flags are non-zero,
+    // so conflating these two would change parsed output.
+    const s = new EdgeFlagStore();
+    s.set(5, 0);
+    expect(s.get(5)).toBe(0);
+    expect(s.has(5)).toBe(true);
+    expect(s.get(6)).toBeUndefined();
+    expect(s.has(6)).toBe(false);
+  });
+
+  it('overwrites without double-counting size', () => {
+    const s = new EdgeFlagStore();
+    s.set(3, 0x06);
+    s.set(3, 0x1e);
+    expect(s.get(3)).toBe(0x1e);
+    expect(s.size).toBe(1);
+  });
+
+  it('handles ids far above the first one written (growth)', () => {
+    const s = new EdgeFlagStore();
+    s.set(1, 0x06);
+    s.set(100_000, 0x11);
+    expect(s.get(1)).toBe(0x06);
+    expect(s.get(100_000)).toBe(0x11);
+    expect(s.get(50_000)).toBeUndefined();
+    expect(s.size).toBe(2);
+  });
+
+  it('handles an id BELOW the first one written (re-base)', () => {
+    // Nothing guarantees ids arrive in ascending order.
+    const s = new EdgeFlagStore();
+    s.set(500, 0x08);
+    s.set(10, 0x10);
+    s.set(1, 0x01);
+    expect(s.get(500)).toBe(0x08);
+    expect(s.get(10)).toBe(0x10);
+    expect(s.get(1)).toBe(0x01);
+    expect(s.get(250)).toBeUndefined();
+    expect(s.size).toBe(3);
+  });
+
+  it('preserves every entry across repeated re-basing and growth', () => {
+    const s = new EdgeFlagStore();
+    const written = new Map<number, number>();
+    // Deliberately jumps below and above the current range repeatedly.
+    const ids = [1000, 5, 2000, 1, 1500, 700, 3, 9999, 250];
+    ids.forEach((id, i) => {
+      const flags = (i * 7 + 6) & 0xff;
+      s.set(id, flags);
+      written.set(id, flags);
+    });
+    for (const [id, flags] of written) {
+      expect(s.get(id)).toBe(flags);
+    }
+    expect(s.size).toBe(written.size);
+    // ids never written stay absent
+    for (const id of [0, 2, 4, 999, 1001, 10_000]) {
+      if (!written.has(id)) expect(s.get(id)).toBeUndefined();
+    }
+  });
+
+  it('masks a value to one byte, as the Map-held D307 byte always was', () => {
+    const s = new EdgeFlagStore();
+    s.set(1, 0x1ff);
+    expect(s.get(1)).toBe(0xff);
+  });
+
+  it('matches a Map exactly on a randomised access pattern', () => {
+    // Deterministic pseudo-random ids; no Math.random, so a failure is
+    // reproducible.
+    const s = new EdgeFlagStore();
+    const ref = new Map<number, number>();
+    let seed = 12345;
+    const next = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed;
+    };
+    for (let i = 0; i < 2000; i++) {
+      const id = next() % 50_000;
+      const flags = next() % 256;
+      s.set(id, flags);
+      ref.set(id, flags);
+    }
+    for (let id = 0; id < 50_000; id += 7) {
+      expect(s.get(id)).toBe(ref.get(id));
+      expect(s.has(id)).toBe(ref.has(id));
+    }
+    expect(s.size).toBe(ref.size);
+  });
+});


### PR DESCRIPTION
## Summary

Item 2 from #201, as greenlit: `GeometryBuilder.edgeFlags` moves from `Map<number, number>` to a `Uint8Array`-backed store.

The payload is a **single byte** per edge (D307 display flags: base `0x06`, plus `0x01` hidden, `0x08` soft, `0x10` smooth). A `Map` entry costs roughly 30 bytes once V8's boxed-number and hash-bucket overhead are counted — about 30x the data itself.

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] New platform implementation
- [x] Performance / internal representation

## Changes

New `src/edge-flags.ts` exporting `EdgeFlagStore`: a `Uint8Array` indexed by `id - baseId`, grown geometrically, and **re-based** when an id arrives below the current base (nothing guarantees ascending id order, so this can't assume it).

The diff to existing files is 6 lines — one field declaration and one import in each of `geometry.ts` and `legacy.ts`. All the complexity is contained in the new module.

### Answering the question you raised: are edge ids dense?

You asked for a real-file number rather than the synthetic one, since sparse ids would mean either wasting memory sized to the max id or clawing back the gain with an id→index indirection. Measured across every fixture in the repo:

| Fixture | Edges | Id span | Density | `Map` | `Uint8Array`+bitmap | Gain |
|---|---:|---:|---:|---:|---:|---:|
| `SU_File.skp` | 84 | 343 | 24.5% | 2.5 KB | 0.4 KB | 6.5x |
| `Untitled.skp` | 12,762 | 26,551 | 48.1% | 373.9 KB | 29.2 KB | 12.8x |
| `capilla_quiroz_v17.skp` | 515 | 2,275 | 22.6% | 15.1 KB | 2.5 KB | 6.0x |
| `gondola_v20.skp` | 9,186 | 29,069 | 31.6% | 269.1 KB | 31.9 KB | 8.4x |
| **Aggregate** | **22,547** | **58,238** | **38.7%** | **660.6 KB** | **64.0 KB** | **10.3x** |

**Conclusion: ids are sparse (~39%), and straight span-indexing still wins by 10.3x — so no indirection is needed here.** One `Uint8Array` slot costs one byte even when unused, versus a whole hash entry per stored edge, so the Map only breaks even below roughly 3% density, which no real file approaches.

I'd rather put the honest 10.3x on the record than the 23x from the synthetic dense benchmark in the issue. The 23x is what you'd get with dense ids; 10.3x is what this actually delivers.

(Same measurement, incidentally, gives the vertex-id density number you wanted before design-approving item 1 — 32.6% aggregate, worst single definition 7.6%. Posted in full on #201; item 1 will need the id→index mapping as you predicted, and its real gain is 2.1–3.9x rather than 4.6x.)

### Preserving a distinction the Map made

The legacy (pre-2021 MFC) reader only records an edge when its flags are **non-zero**:

```ts
const flags = (db.soft ? 0x08 : 0) | (db.smooth ? 0x10 : 0) | (db.hidden ? 0x01 : 0);
if (flags) {
  builder.edgeFlags.set(slot, flags);
}
```

So "absent" and "stored zero" are genuinely different states, and a bare `Uint8Array` (where an untouched slot reads 0) would conflate them and change parsed output. `EdgeFlagStore` keeps a separate presence bitmap — 1 bit per slot, already counted in the table above — so `get()` returns `undefined` for an id never written, exactly as `Map.prototype.get` does. Callers' existing `?? 0` fallbacks behave identically.

## Testing

`npm test` → **256 passed, 32 files** (247 pre-existing all still passing, unchanged + 9 new).

The three existing `parser.test.ts` assertions on `builder.edgeFlags.get(...)` pass **unchanged** — `get`/`set`/`has`/`size` keep Map semantics, so the store is drop-in.

New `tests/edge-flags.test.ts` covers the cases where a hand-rolled typed-array store realistically goes wrong:

- growth far beyond the first id written;
- **re-basing** when an id arrives below the current base, including repeated re-basing interleaved with growth (the bitmap can't be block-copied on a shift, since it isn't byte-aligned to it — that's the subtle one);
- **stored zero vs absent**, per the legacy behaviour above;
- overwrite not double-counting `size`;
- byte masking;
- a deterministic randomised 2,000-write pattern asserted key-by-key against a reference `Map`, so any divergence in semantics fails reproducibly (seeded LCG, no `Math.random`).

Real-file coverage comes for free: both `.skp` container formats route through this field, and the existing legacy/VFF fixture suites plus the `buildScene`/`buildInstancedScene` parity tests all exercise it.

### Verification

```
$ npm run typecheck    # tsc --noEmit — clean
$ npm run build        # tsup — ESM/CJS/DTS success
$ npm test             # Test Files 32 passed (32) / Tests 256 passed (256)
$ npm run lint         # eslint src/ — clean
```

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (256/256)
- [x] Documentation updated (n/a — internal representation, no public API change)
- [x] No breaking changes to the public API

## Notes

- **No public API change.** `GeometryBuilder` is imported into `index.ts` but never re-exported, as you confirmed; `Edge.soft`/`smooth`/`hidden` are still derived exactly as before in `buildDefinition()`. Published consumer types are untouched.
- **No new dependencies**, and nothing lossy — this is representation only, same bytes in and out.
- Scope is `packages/typescript`; the other four ports are untouched.
- Sequenced per your suggestion: this first, item 1 once you've looked at the density number, item 3 last (and I'd understand deferring it given the Worker interaction).
