### PR TITLE
Write and read annotations in legacy .skp: linear dimensions and leader texts

### DIFF
--- a/docs/dimension-record-notes.md
+++ b/docs/dimension-record-notes.md
@@ -89,6 +89,22 @@ A second SDK helper (`mktext`) settled the text record. Key findings:
 - `_read_skfont` consumed the pid MASK but not the pid bytes it
   declares — fixed; SDK-written fonts also carry a longer tail, which
   the text reader's delimiter scan absorbs.
-- Leader VECTORS did not persist through `SUTextSetLeaderVector` in the
-  harness (records carry only the anchor point); point-labels are what
-  `add_text()` writes, which matches IngeTrazo's text entities.
+- Leader VECTORS never persist through the SDK — not even when the
+  text is anchored to real geometry via `SUInstancePath` (a second
+  harness, `mktext2`, proved it: face- and vertex-anchored records
+  save fine but the leader stays zeroed, and face+leader texts are
+  silently DROPPED from the file). The SDK can only author SCREEN
+  texts: the two doubles after the font are SCREEN FRACTIONS (0.5,
+  0.5 = view centre) and SketchUp renders every such text superimposed
+  there, detached from the model.
+- Human-drawn LEADER texts (casa bueno, quiroz) settle the real
+  grammar. Connection types: 1 = free 3D anchor inline, 2 = anchored
+  to an entity back-ref (like dimensions), 7 = attached to a FACE
+  (two u,v bbox fractions + face ref). The placement tail after the
+  connection is `[12B zeros][point3d LABEL world position][16B zeros]
+  [f64 1.0][u32 LEADER TYPE (0 none / 2 pushpin)][delimiter]` — the
+  leader line joins the label position to the anchor.
+- `add_text()` therefore writes the HUMAN shape, not the SDK's:
+  screen slot zeroed, free connection with the anchor, label position
+  at ``point + leader``, leader type 2, closed arrow (3). The reader
+  extracts both points (``TextEntity.point`` / ``label_point``).

--- a/docs/dimension-record-notes.md
+++ b/docs/dimension-record-notes.md
@@ -1,0 +1,49 @@
+# CDimensionLinear (legacy v17/v18) — field notes for the writer
+
+Harvested from real files (quiroz: 28 dims, casa bueno: 16, yanque 661MB)
+while building the reader fixes (PR #194). Basis for `add_dimension()`.
+
+## Record layout (after the class tag)
+
+```
+preamble                  attrs ref (null) + pid mask/bytes (v17+)
+drawbase                  10 bytes (mat u16, hidden, soft, smooth, layer u16)
+text     utf16            EMPTY on every auto-computed dimension observed
+font     object           CSkFont — new on first use, back-ref after
+B37      37 bytes         u8 + u32(=3 v18 / 1 v17?) + 32 bytes zeros
+ref1     MFC tag          connection 1 → CVertex back-ref (2 or 6 bytes)
+B42      42 bytes         u16 + 40 bytes: u32(=2) + u32(=4) + zeros
+ref2     MFC tag          connection 2 → CVertex back-ref
+B82      82 bytes         u16 + f64×7 + u32 + f64(OFFSET, inches, signed)
+                          + f64(0) + u32(=3)
+```
+
+- NO coordinates are cached: geometry comes 100% from the two vertex
+  back-refs. Anchored dims in v17 (quiroz) burn NO MapObject indices —
+  writing anchored dims is safe for slot accounting.
+- The B82 offset f64 (bytes 62..69) is the dimension-line offset from
+  the measured edge, inches, signed.
+- The u32 at B82+58 varies (1/2/3) — placement/alignment mode?
+- The 7 doubles at B82+2..57 are the unsolved part: values are 0/±1
+  (plus float-noise) and DO vary with orientation, but the samples are
+  too axis-aligned to fix the semantics:
+    quiroz  (dir ±Z): (0, 0,  1, 0, -1, 0, 0)   u32=2
+    casa#0  (dir +X): (0, 0,  0, -1, -1, 0, 0)  u32=1
+    casa#2  (dir +Y): (0, ~0, ~0, -1, -1, ~0, ~0) u32=2
+  Candidate readings: two 2D unit attachment points + spare, or a plane
+  basis with per-axis sign flags. TO RESOLVE: template-write dims in
+  varied orientations and check rendering in real SketchUp (Web) — the
+  same controlled-file method the July texture calibration used.
+
+## CSkFont
+
+Small record (~34 bytes) with the face name; one per file re-used by
+back-ref. Template from quiroz.
+
+## Writer strategy
+
+Template + patch: emit quiroz's byte template, patching refs (our
+vertex slots), offset, font ref, pid bytes; leave the 7 doubles as a
+per-orientation hypothesis to be calibrated against SketchUp Web
+rendering. Validate every generated file by round-tripping through the
+(fixed) legacy reader before human inspection.

--- a/docs/dimension-record-notes.md
+++ b/docs/dimension-record-notes.md
@@ -47,3 +47,26 @@ vertex slots), offset, font ref, pid bytes; leave the 7 doubles as a
 per-orientation hypothesis to be calibrated against SketchUp Web
 rendering. Validate every generated file by round-tripping through the
 (fixed) legacy reader before human inspection.
+
+## RESOLVED — SDK ground truth (2026-08-20)
+
+A MinGW-built helper (`mkdim`) drove the real SketchUpAPI.dll under
+Wine to CREATE dimensions in every orientation and save as SU2017
+(`SUModelSaveToFileWithVersion`, version enum: 6={13} … 10={17} 11={18}).
+The harvested records settle everything:
+
+- B37 / B42 are the CONNECTION blocks: `[flags][u32 TYPE][u32 4]
+  [point3d]` with TYPE **1 = free point stored inline** (object ref is
+  null) and **2 = anchored** (point zeroed, back-ref follows) — the same
+  1/2 enum as VFF connections.
+- The placement head for FREE dimensions is a constant SketchUp
+  default: seven doubles `(0,0,0, 1,1,0, 0)`, mode u32 = 0, trailing
+  u32 = 1. The offset lives at B82+62 and can be patched in.
+- The orientation-specific heads seen in human-drawn corpus files
+  (quiroz) apply to ANCHORED dimensions; decoding those fully would be
+  the follow-up if anchored writing is wanted (extend mkdim with
+  anchored creates).
+
+`add_dimension()` writes byte-exact SDK-shaped free dimensions;
+verified by SDK acceptance, reader round-trip, and rendering in real
+SketchUp (Web) across X/Y/Z/diagonal orientations.

--- a/docs/dimension-record-notes.md
+++ b/docs/dimension-record-notes.md
@@ -70,3 +70,25 @@ The harvested records settle everything:
 `add_dimension()` writes byte-exact SDK-shaped free dimensions;
 verified by SDK acceptance, reader round-trip, and rendering in real
 SketchUp (Web) across X/Y/Z/diagonal orientations.
+
+## CText (leader texts) — same Rosetta method (2026-08-20)
+
+A second SDK helper (`mktext`) settled the text record. Key findings:
+
+- A `SUTextRef` needs a FONT assigned (`SUTextSetFont` with a font from
+  `SUModelGetFonts`) or the model fails to serialize (SUResult 7) in
+  every version — the failure is the text, not the target version.
+- Record layout: preamble + drawbase + font (inline first use /
+  back-ref) + two f64 0.5 + the SAME free-connection block dimensions
+  use (`[u32 1][u32 4][point3d]`) + a fixed 75-byte tail + string +
+  5 zero bytes.
+- The reader's "text delimiter" block encodes the ARROW TYPE in its
+  u32 (values 0-4 seen); the old predicate hard-required 3 and silently
+  dropped any text with a different arrow (root-list tolerance ate the
+  error). Now any arrow ≤ 8 matches.
+- `_read_skfont` consumed the pid MASK but not the pid bytes it
+  declares — fixed; SDK-written fonts also carry a longer tail, which
+  the text reader's delimiter scan absorbs.
+- Leader VECTORS did not persist through `SUTextSetLeaderVector` in the
+  harness (records carry only the anchor point); point-labels are what
+  `add_text()` writes, which matches IngeTrazo's text entities.

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -505,6 +505,11 @@ _DIM_FONT_PAYLOAD = bytes.fromhex(
     "0000" "08000000" "00"
     "ecf57abd5eaf2340"                # height f64
 )
+_TEXT_HALVES = bytes.fromhex("000000000000e03f000000000000e03f")
+_TEXT_TAIL75 = bytes.fromhex(
+    "0000000000000000000000000000000000000000000000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000f03f00000000"
+    "0100000001000100000001")
 _DIM_DRAWBASE = bytes.fromhex("00000001010000000000")
 _DIM_B37 = bytes.fromhex("0101000000020000000400000000000000"
                          "0000000000000000000000000000000000000000")
@@ -2582,6 +2587,37 @@ class SkpBuilder:
             w.buf += _f64(val)
         w.buf += _u32(0)
         w.buf += _f64(float(offset)) + _f64(0.0) + _u32(1)
+        self._new_entity_count += 1
+        self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
+
+    def add_text(self, text: str, point: Point3) -> None:
+        """Add a screen-facing text label (SketchUp's Text tool) anchored
+        at ``point`` (inches, world space).
+
+        The record is the byte-exact one the REAL SketchUp SDK writes for
+        a point text (generated via SketchUpAPI and harvested): the same
+        free-connection block dimensions use — [u32 type=1][u32 4]
+        [point3d] — plus a fixed placement tail whose u32 at the end of
+        the delimiter block is the arrow type. Leader vectors are not
+        supported yet (the SDK create drops them too).
+        """
+        self._ensure_geometry_writer()
+        w = self._geometry_writer
+        p = (float(point[0]), float(point[1]), float(point[2]))
+        w._new_of_known_class("CText", schema=9)
+        w._preamble()
+        w.buf += _DIM_DRAWBASE
+        if self._dim_font_slot is None:
+            self._dim_font_slot = w._new_of_known_class("CSkFont", schema=1)
+            w.buf += _DIM_FONT_PAYLOAD
+        else:
+            w._backref(self._dim_font_slot)
+        w.buf += _TEXT_HALVES
+        w.buf += _u32(1) + _u32(4)           # free connection + constant
+        w.buf += _f64(p[0]) + _f64(p[1]) + _f64(p[2])
+        w.buf += _TEXT_TAIL75
+        w._write_str(text)
+        w.buf += bytes(5)
         self._new_entity_count += 1
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -2578,26 +2578,28 @@ class SkpBuilder:
         w._backref(s1)
         w.buf += _DIM_B42
         w._backref(s2)
-        # B82 head: u16 + measure direction U (3×f64) + offset direction V
-        # (3×f64) + spare f64 + placement mode u32. Calibrated against real
-        # SketchUp rendering: the vertical-dimension corpus template is
-        # U=(0,0,1), V=(0,-1,0); a template mismatched to the measured
-        # direction renders the dimension collapsed onto the edge, so U/V
-        # are computed per dimension.
+        # B82 head: seven doubles + a mode u32. The values are NOT free —
+        # the real SketchUp SDK rejects some combinations outright (probed
+        # against SketchUpAPI via skp2dae) — so both accepted variants come
+        # verbatim from real SketchUp-written files: the vertical corpus
+        # template (capilla quiroz, dir ±Z) and the horizontal pattern
+        # (casa bueno, dir ±X/±Y, near-zero head).
         dx = (k2[0] - k1[0], k2[1] - k1[1], k2[2] - k1[2])
         ln = math.sqrt(dx[0] ** 2 + dx[1] ** 2 + dx[2] ** 2)
         if ln < 1e-9:
             raise SkpWriteError("add_dimension endpoints coincide")
         u = (dx[0] / ln, dx[1] / ln, dx[2] / ln)
-        if abs(u[0]) < 1e-9 and abs(u[1]) < 1e-9:
-            v = (0.0, -1.0, 0.0)             # vertical: corpus convention
-        else:
-            hl = math.hypot(u[0], u[1])      # Z×U, normalized in plan
-            v = (-u[1] / hl, u[0] / hl, 0.0)
         w.buf += bytes(2)
-        w.buf += _f64(u[0]) + _f64(u[1]) + _f64(u[2])
-        w.buf += _f64(v[0]) + _f64(v[1]) + _f64(v[2])
-        w.buf += _f64(0.0) + _u32(2)
+        if abs(u[0]) < 1e-9 and abs(u[1]) < 1e-9:
+            # vertical: U=(0,0,1), V=(0,-1,0), mode 2
+            for val in (0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0):
+                w.buf += _f64(val)
+            w.buf += _u32(2)
+        else:
+            # horizontal / in-plan: casa bueno pattern
+            for val in (0.0, 0.0, 0.0, -1.0, -1.0, 0.0, 0.0):
+                w.buf += _f64(val)
+            w.buf += _u32(2)
         w.buf += _f64(float(offset)) + _f64(0.0) + _u32(3)
         self._new_entity_count += 1
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -505,11 +505,8 @@ _DIM_FONT_PAYLOAD = bytes.fromhex(
     "0000" "08000000" "00"
     "ecf57abd5eaf2340"                # height f64
 )
-_TEXT_HALVES = bytes.fromhex("000000000000e03f000000000000e03f")
-_TEXT_TAIL75 = bytes.fromhex(
-    "0000000000000000000000000000000000000000000000000000000000000000"
-    "0000000000000000000000000000000000000000000000000000f03f00000000"
-    "0100000001000100000001")
+# Leader-text delimiter block: [u32 1][u8 flag=1][u8 0][u32 ARROW=3 closed][u8 1]
+_TEXT_DELIM = bytes.fromhex("0100000001000300000001")
 _DIM_DRAWBASE = bytes.fromhex("00000001010000000000")
 _DIM_B37 = bytes.fromhex("0101000000020000000400000000000000"
                          "0000000000000000000000000000000000000000")
@@ -2590,20 +2587,24 @@ class SkpBuilder:
         self._new_entity_count += 1
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 
-    def add_text(self, text: str, point: Point3) -> None:
-        """Add a screen-facing text label (SketchUp's Text tool) anchored
-        at ``point`` (inches, world space).
+    def add_text(self, text: str, point: Point3,
+                 leader: Point3 = (15.0, 15.0, 15.0)) -> None:
+        """Add a leader text (SketchUp's Text tool) anchored at ``point``
+        (inches, world space), with the label floating at ``point +
+        leader`` and a leader line joining them.
 
-        The record is the byte-exact one the REAL SketchUp SDK writes for
-        a point text (generated via SketchUpAPI and harvested): the same
-        free-connection block dimensions use — [u32 type=1][u32 4]
-        [point3d] — plus a fixed placement tail whose u32 at the end of
-        the delimiter block is the arrow type. Leader vectors are not
-        supported yet (the SDK create drops them too).
+        The record mirrors human-drawn leader texts harvested from real
+        files (the SDK's own create only produces SCREEN texts — its
+        two 0.5 doubles are screen fractions and SketchUp renders them
+        superimposed at view centre): screen slot zeroed, the free-
+        connection block dimensions use ([u32 1][u32 4][point3d]), the
+        label's world position in the placement tail, and leader type 2
+        (pushpin) before the arrow delimiter.
         """
         self._ensure_geometry_writer()
         w = self._geometry_writer
         p = (float(point[0]), float(point[1]), float(point[2]))
+        lb = tuple(p[i] + float(leader[i]) for i in range(3))
         w._new_of_known_class("CText", schema=9)
         w._preamble()
         w.buf += _DIM_DRAWBASE
@@ -2612,10 +2613,15 @@ class SkpBuilder:
             w.buf += _DIM_FONT_PAYLOAD
         else:
             w._backref(self._dim_font_slot)
-        w.buf += _TEXT_HALVES
+        w.buf += _f64(0.0) + _f64(0.0)       # screen-fraction slot (unused)
         w.buf += _u32(1) + _u32(4)           # free connection + constant
         w.buf += _f64(p[0]) + _f64(p[1]) + _f64(p[2])
-        w.buf += _TEXT_TAIL75
+        w.buf += bytes(12)
+        w.buf += _f64(lb[0]) + _f64(lb[1]) + _f64(lb[2])   # label position
+        w.buf += bytes(16)
+        w.buf += _f64(1.0)
+        w.buf += _u32(2)                     # leader type: pushpin
+        w.buf += _TEXT_DELIM
         w._write_str(text)
         w.buf += bytes(5)
         self._new_entity_count += 1

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -2588,18 +2588,22 @@ class SkpBuilder:
         ln = math.sqrt(dx[0] ** 2 + dx[1] ** 2 + dx[2] ** 2)
         if ln < 1e-9:
             raise SkpWriteError("add_dimension endpoints coincide")
-        u = (dx[0] / ln, dx[1] / ln, dx[2] / ln)
+        u = (abs(dx[0] / ln), abs(dx[1] / ln), abs(dx[2] / ln))
+        # The head's seven doubles are a CONSTANT — (0,0,1, 0,-1,0, 0) on
+        # every root-level dimension SketchUp itself wrote, horizontal and
+        # vertical alike — and the u32 after them is the dimension TYPE:
+        # 1 = horizontal, 2 = vertical (both harvested from real files),
+        # 0 = aligned (anything not axis-aligned).
         w.buf += bytes(2)
-        if abs(u[0]) < 1e-9 and abs(u[1]) < 1e-9:
-            # vertical: U=(0,0,1), V=(0,-1,0), mode 2
-            for val in (0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0):
-                w.buf += _f64(val)
-            w.buf += _u32(2)
+        for val in (0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0):
+            w.buf += _f64(val)
+        if u[2] > 1 - 1e-9:
+            mode = 2                          # vertical
+        elif u[2] < 1e-9 and (u[0] > 1 - 1e-9 or u[1] > 1 - 1e-9):
+            mode = 1                          # horizontal, axis-aligned
         else:
-            # horizontal / in-plan: casa bueno pattern
-            for val in (0.0, 0.0, 0.0, -1.0, -1.0, 0.0, 0.0):
-                w.buf += _f64(val)
-            w.buf += _u32(2)
+            mode = 0                          # aligned
+        w.buf += _u32(mode)
         w.buf += _f64(float(offset)) + _f64(0.0) + _u32(3)
         self._new_entity_count += 1
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -492,6 +492,30 @@ def _u32(v: int) -> bytes:
     return struct.pack("<I", v)
 
 
+# ── dimension record templates ───────────────────────────────────────────
+# Byte-exact templates harvested from a real SketchUp 2017 file (28
+# dimensions, capilla quiroz corpus model); see
+# docs/dimension-record-notes.md for the full layout. Geometry comes from
+# the vertex back-refs, so these fixed blocks are safe to reuse verbatim;
+# the 7 doubles in the B82 head are the orientation/placement fields still
+# under calibration against real SketchUp rendering.
+_DIM_FONT_PAYLOAD = bytes.fromhex(
+    "000000"                          # preamble: null attrs + pid mask 0
+    "fffeff065400610068006f006d006100"  # "Tahoma"
+    "0000" "08000000" "00"
+    "ecf57abd5eaf2340"                # height f64
+)
+_DIM_DRAWBASE = bytes.fromhex("00000001010000000000")
+_DIM_B37 = bytes.fromhex("0101000000020000000400000000000000"
+                         "0000000000000000000000000000000000000000")
+_DIM_B42 = bytes.fromhex("00000000000000000000020000000400000000000000"
+                         "0000000000000000000000000000000000000000")
+_DIM_B82_HEAD = (bytes(2 + 16)
+                 + bytes.fromhex("000000000000f03f") + bytes(8)
+                 + bytes.fromhex("000000000000f0bf") + bytes(16)
+                 + bytes.fromhex("02000000"))
+
+
 def _f64(v: float) -> bytes:
     return struct.pack("<d", v)
 
@@ -1946,6 +1970,7 @@ class SkpBuilder:
         self._edge_registry: Dict[FrozenSet[int], Tuple[int, int]] = {}
         self._new_entity_count = 0
         self._face_count = 0
+        self._dim_font_slot: Optional[int] = None
 
     def add_material(self, name: str, rgba: Sequence[int]) -> int:
         """Register a solid-color material and return a handle to pass as
@@ -2515,6 +2540,51 @@ class SkpBuilder:
             points, self._vertex_slots, self._edge_registry,
             closed, hidden_edges, soft_edges, smooth_edges,
         )
+        self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
+
+    def add_dimension(self, p1: Point3, p2: Point3, offset: float = 10.0) -> None:
+        """Add an ANCHORED linear dimension between two points of already-
+        written root geometry (both must be vertices of a previous
+        ``add_face``/``add_circle`` call — the record references their
+        vertex objects, so the dimension stays associative in SketchUp).
+        ``offset`` is the dimension line's offset from the measured edge,
+        in inches (signed).
+
+        Record layout harvested byte-exact from real SketchUp 2017 files
+        (see docs/dimension-record-notes.md): the geometry comes entirely
+        from the two vertex back-refs; the fixed blocks are templates from
+        the calibration corpus. The auto-computed measurement text is the
+        empty string, exactly as SketchUp writes it.
+        """
+        self._ensure_geometry_writer()
+        w = self._geometry_writer
+        k1 = (float(p1[0]), float(p1[1]), float(p1[2]))
+        k2 = (float(p2[0]), float(p2[1]), float(p2[2]))
+        s1 = self._vertex_slots.get(k1)
+        s2 = self._vertex_slots.get(k2)
+        if s1 is None or s2 is None:
+            raise SkpWriteError(
+                "add_dimension endpoints must coincide with vertices of "
+                "already-added root geometry")
+        w._new_of_known_class("CDimensionLinear", schema=6)
+        w._preamble()
+        w.buf += _DIM_DRAWBASE
+        w._write_str("")                     # auto-computed measurement text
+        if self._dim_font_slot is None:
+            # one CSkFont per file, serialized INLINE at the first
+            # dimension's font field (exactly as SketchUp writes it) and
+            # re-used by back-ref afterwards (template: Tahoma)
+            self._dim_font_slot = w._new_of_known_class("CSkFont", schema=1)
+            w.buf += _DIM_FONT_PAYLOAD
+        else:
+            w._backref(self._dim_font_slot)
+        w.buf += _DIM_B37
+        w._backref(s1)
+        w.buf += _DIM_B42
+        w._backref(s2)
+        w.buf += _DIM_B82_HEAD
+        w.buf += _f64(float(offset)) + _f64(0.0) + _u32(3)
+        self._new_entity_count += 1
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 
     def to_bytes(self) -> bytes:

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -510,10 +510,6 @@ _DIM_B37 = bytes.fromhex("0101000000020000000400000000000000"
                          "0000000000000000000000000000000000000000")
 _DIM_B42 = bytes.fromhex("00000000000000000000020000000400000000000000"
                          "0000000000000000000000000000000000000000")
-_DIM_B82_HEAD = (bytes(2 + 16)
-                 + bytes.fromhex("000000000000f03f") + bytes(8)
-                 + bytes.fromhex("000000000000f0bf") + bytes(16)
-                 + bytes.fromhex("02000000"))
 
 
 def _f64(v: float) -> bytes:
@@ -2582,7 +2578,26 @@ class SkpBuilder:
         w._backref(s1)
         w.buf += _DIM_B42
         w._backref(s2)
-        w.buf += _DIM_B82_HEAD
+        # B82 head: u16 + measure direction U (3×f64) + offset direction V
+        # (3×f64) + spare f64 + placement mode u32. Calibrated against real
+        # SketchUp rendering: the vertical-dimension corpus template is
+        # U=(0,0,1), V=(0,-1,0); a template mismatched to the measured
+        # direction renders the dimension collapsed onto the edge, so U/V
+        # are computed per dimension.
+        dx = (k2[0] - k1[0], k2[1] - k1[1], k2[2] - k1[2])
+        ln = math.sqrt(dx[0] ** 2 + dx[1] ** 2 + dx[2] ** 2)
+        if ln < 1e-9:
+            raise SkpWriteError("add_dimension endpoints coincide")
+        u = (dx[0] / ln, dx[1] / ln, dx[2] / ln)
+        if abs(u[0]) < 1e-9 and abs(u[1]) < 1e-9:
+            v = (0.0, -1.0, 0.0)             # vertical: corpus convention
+        else:
+            hl = math.hypot(u[0], u[1])      # Z×U, normalized in plan
+            v = (-u[1] / hl, u[0] / hl, 0.0)
+        w.buf += bytes(2)
+        w.buf += _f64(u[0]) + _f64(u[1]) + _f64(u[2])
+        w.buf += _f64(v[0]) + _f64(v[1]) + _f64(v[2])
+        w.buf += _f64(0.0) + _u32(2)
         w.buf += _f64(float(offset)) + _f64(0.0) + _u32(3)
         self._new_entity_count += 1
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -2539,29 +2539,23 @@ class SkpBuilder:
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 
     def add_dimension(self, p1: Point3, p2: Point3, offset: float = 10.0) -> None:
-        """Add an ANCHORED linear dimension between two points of already-
-        written root geometry (both must be vertices of a previous
-        ``add_face``/``add_circle`` call — the record references their
-        vertex objects, so the dimension stays associative in SketchUp).
-        ``offset`` is the dimension line's offset from the measured edge,
-        in inches (signed).
+        """Add a FREE linear dimension between two explicit points (inches,
+        world space). ``offset`` is the dimension line's offset from the
+        measured segment, in inches (signed).
 
-        Record layout harvested byte-exact from real SketchUp 2017 files
-        (see docs/dimension-record-notes.md): the geometry comes entirely
-        from the two vertex back-refs; the fixed blocks are templates from
-        the calibration corpus. The auto-computed measurement text is the
-        empty string, exactly as SketchUp writes it.
+        The record layout is the byte-exact one the REAL SketchUp SDK
+        writes for free dimensions (generated via SketchUpAPI and
+        harvested — see docs/dimension-record-notes.md): connection type 1
+        with the point stored inline in each connection block and null
+        object refs. Free dimensions render in any orientation; anchored
+        (type 2) dimensions are a future refinement.
         """
         self._ensure_geometry_writer()
         w = self._geometry_writer
         k1 = (float(p1[0]), float(p1[1]), float(p1[2]))
         k2 = (float(p2[0]), float(p2[1]), float(p2[2]))
-        s1 = self._vertex_slots.get(k1)
-        s2 = self._vertex_slots.get(k2)
-        if s1 is None or s2 is None:
-            raise SkpWriteError(
-                "add_dimension endpoints must coincide with vertices of "
-                "already-added root geometry")
+        if k1 == k2:
+            raise SkpWriteError("add_dimension endpoints coincide")
         w._new_of_known_class("CDimensionLinear", schema=6)
         w._preamble()
         w.buf += _DIM_DRAWBASE
@@ -2574,37 +2568,20 @@ class SkpBuilder:
             w.buf += _DIM_FONT_PAYLOAD
         else:
             w._backref(self._dim_font_slot)
-        w.buf += _DIM_B37
-        w._backref(s1)
-        w.buf += _DIM_B42
-        w._backref(s2)
-        # B82 head: seven doubles + a mode u32. The values are NOT free —
-        # the real SketchUp SDK rejects some combinations outright (probed
-        # against SketchUpAPI via skp2dae) — so both accepted variants come
-        # verbatim from real SketchUp-written files: the vertical corpus
-        # template (capilla quiroz, dir ±Z) and the horizontal pattern
-        # (casa bueno, dir ±X/±Y, near-zero head).
-        dx = (k2[0] - k1[0], k2[1] - k1[1], k2[2] - k1[2])
-        ln = math.sqrt(dx[0] ** 2 + dx[1] ** 2 + dx[2] ** 2)
-        if ln < 1e-9:
-            raise SkpWriteError("add_dimension endpoints coincide")
-        u = (abs(dx[0] / ln), abs(dx[1] / ln), abs(dx[2] / ln))
-        # The head's seven doubles are a CONSTANT — (0,0,1, 0,-1,0, 0) on
-        # every root-level dimension SketchUp itself wrote, horizontal and
-        # vertical alike — and the u32 after them is the dimension TYPE:
-        # 1 = horizontal, 2 = vertical (both harvested from real files),
-        # 0 = aligned (anything not axis-aligned).
+        # connection 1: [u8 0][u32 0][u32 type=1][u32 4][point A], null ref
+        w.buf += bytes(5) + _u32(1) + _u32(4)
+        w.buf += _f64(k1[0]) + _f64(k1[1]) + _f64(k1[2])
+        w.buf += struct.pack("<H", 0)
+        # connection 2: [u16 0][f64 0][u32 type=1][u32 4][point B], null ref
+        w.buf += bytes(10) + _u32(1) + _u32(4)
+        w.buf += _f64(k2[0]) + _f64(k2[1]) + _f64(k2[2])
+        w.buf += struct.pack("<H", 0)
+        # placement block: SDK free-dimension defaults + our offset
         w.buf += bytes(2)
-        for val in (0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0):
+        for val in (0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0):
             w.buf += _f64(val)
-        if u[2] > 1 - 1e-9:
-            mode = 2                          # vertical
-        elif u[2] < 1e-9 and (u[0] > 1 - 1e-9 or u[1] > 1 - 1e-9):
-            mode = 1                          # horizontal, axis-aligned
-        else:
-            mode = 0                          # aligned
-        w.buf += _u32(mode)
-        w.buf += _f64(float(offset)) + _f64(0.0) + _u32(3)
+        w.buf += _u32(0)
+        w.buf += _f64(float(offset)) + _f64(0.0) + _u32(1)
         self._new_entity_count += 1
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -782,7 +782,8 @@ def _read_sectionplane(ar, r):
 def _read_skfont(ar, r):
     ar.read_object(r, expect='CAttributeContainer')
     if ar.has_pid:
-        r.u8()
+        mask = r.u8()
+        r.raw(bin(mask).count('1'))  # consume the pid bytes the mask declares
     r.utf16()
     r.raw(15)
     return {'k': 'font'}
@@ -852,9 +853,10 @@ def _read_text(ar, r):
         if idx < 0:
             raise LegacyParseError(f"text delimiter not found {r.ctx()}")
         blk = r.data[idx - 11:idx]
+        arrow = struct.unpack_from('<I', blk, 6)[0]
         if (blk[:4] == b'\x01\x00\x00\x00'
-                and blk[6:10] == b'\x03\x00\x00\x00' and blk[10] == 1):
-            break
+                and arrow <= 8 and blk[10] == 1):
+            break                    # blk[6:10] is the ARROW TYPE (0-4 seen)
         p = idx + 3
     r.raw(idx - r.pos)
     text = r.utf16()

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -863,10 +863,18 @@ def _read_text(ar, r):
     # (world inches); anchored texts (type 2) zero the point, so only
     # type 1 is trusted.
     point = None
+    label = None
     mid = r.data[r.pos:idx]
     off = mid.find(b'\x01\x00\x00\x00\x04\x00\x00\x00')
     if off >= 0 and off + 32 <= len(mid):
         point = struct.unpack_from('<3d', mid, off + 8)
+        # placement tail: [12B zeros][point3d LABEL][16B zeros][f64 1.0]
+        # [u32 leader type][delimiter]; all-zero label = screen text
+        lo = off + 32 + 12
+        if lo + 24 <= len(mid):
+            lp = struct.unpack_from('<3d', mid, lo)
+            if any(abs(c) > 1e-12 for c in lp):
+                label = lp
     r.raw(idx - r.pos)
     text = r.utf16()
     r.raw(5)
@@ -885,7 +893,7 @@ def _read_text(ar, r):
         r.raw(6)
         attach.append(val)
     return {'k': 'text', 'text': text, 'db': db, 'attach': attach,
-            'p': point}
+            'p': point, 'lp': label}
 
 
 def _read_entity_list(ar, r, count, owner):
@@ -1372,6 +1380,7 @@ def _fill_builder(builder, ents, slots):
                 'text': v.get('text', ''),
                 'hidden': bool(v.get('db', {}).get('hidden', False)),
                 'p': v.get('p'),
+                'lp': v.get('lp'),
             })
         elif k == 'dimension':
             dim = {

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -820,16 +820,24 @@ def _read_dimlinear(ar, r):
     # escape kicks in — so a fixed-size skip walks off the rails exactly
     # on large models (found on a real 17 MB SketchUp 2018 file whose
     # dimension sat past object #517k).
-    r.raw(37)
+    b37 = r.raw(37)
     c1 = _entity_ref(ar, r)          # connection point 1 (may be null)
-    r.raw(42)
+    b42 = r.raw(42)
     c2 = _entity_ref(ar, r)          # connection point 2 (may be null)
     b82 = r.raw(82)
     # the dimension-line offset (inches, signed) sits at a fixed position
     # of the trailing block on every sample (v17 and v18 alike)
     offset = struct.unpack_from('<d', b82, 62)[0]
-    return {'k': 'dimension', 'db': db, 'text': text,
-            'connect': (c1, c2), 'offset': offset}
+    out = {'k': 'dimension', 'db': db, 'text': text,
+           'connect': (c1, c2), 'offset': offset}
+    # connection blocks: [.. u32 TYPE ..][u32 4][point3d]. Type 1 = a FREE
+    # point stored inline (SDK-generated ground truth); type 2 = anchored
+    # to the referenced entity, point zeroed.
+    if struct.unpack_from('<I', b37, 5)[0] == 1:
+        out['a'] = struct.unpack_from('<3d', b37, 13)
+    if struct.unpack_from('<I', b42, 10)[0] == 1:
+        out['b'] = struct.unpack_from('<3d', b42, 18)
+    return out
 
 
 def _read_text(ar, r):
@@ -1358,14 +1366,16 @@ def _fill_builder(builder, ents, slots):
                 'hidden': bool(v.get('db', {}).get('hidden', False)),
                 'offset': v.get('offset', 0.0),
             }
-            # resolve the anchored connection points to their vertices so
-            # model-level dimensions carry real endpoints (inches)
-            pts = []
-            for cs in v.get('connect', ()):
+            # endpoints: FREE connections carry them inline; anchored ones
+            # resolve to their vertices (inches)
+            pts = [v.get('a'), v.get('b')]
+            for i, cs in enumerate(v.get('connect', ())[:2]):
+                if pts[i] is not None:
+                    continue
                 ent = slots.get(cs) if cs is not None else None
                 val = ent[2] if ent and ent[0] == 'obj' else None
-                pts.append(tuple(val['xyz']) if isinstance(val, dict)
-                           and 'xyz' in val else None)
+                if isinstance(val, dict) and 'xyz' in val:
+                    pts[i] = tuple(val['xyz'])
             if len(pts) == 2 and pts[0] and pts[1]:
                 dim['a'], dim['b'] = pts[0], pts[1]
             builder.dimensions.append(dim)

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -858,6 +858,15 @@ def _read_text(ar, r):
                 and arrow <= 8 and blk[10] == 1):
             break                    # blk[6:10] is the ARROW TYPE (0-4 seen)
         p = idx + 3
+    # The variant middle carries the same free-connection block dimensions
+    # use: [u32 type=1][u32 4][point3d]. Type 1 stores the anchor inline
+    # (world inches); anchored texts (type 2) zero the point, so only
+    # type 1 is trusted.
+    point = None
+    mid = r.data[r.pos:idx]
+    off = mid.find(b'\x01\x00\x00\x00\x04\x00\x00\x00')
+    if off >= 0 and off + 32 <= len(mid):
+        point = struct.unpack_from('<3d', mid, off + 8)
     r.raw(idx - r.pos)
     text = r.utf16()
     r.raw(5)
@@ -875,7 +884,8 @@ def _read_text(ar, r):
             break                    # new-object tag — the next entity
         r.raw(6)
         attach.append(val)
-    return {'k': 'text', 'text': text, 'db': db, 'attach': attach}
+    return {'k': 'text', 'text': text, 'db': db, 'attach': attach,
+            'p': point}
 
 
 def _read_entity_list(ar, r, count, owner):
@@ -1360,7 +1370,8 @@ def _fill_builder(builder, ents, slots):
         elif k == 'text':
             builder.texts.append({
                 'text': v.get('text', ''),
-                'hidden': bool(v.get('db', {}).get('hidden', False))
+                'hidden': bool(v.get('db', {}).get('hidden', False)),
+                'p': v.get('p'),
             })
         elif k == 'dimension':
             dim = {

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -824,9 +824,12 @@ def _read_dimlinear(ar, r):
     c1 = _entity_ref(ar, r)          # connection point 1 (may be null)
     r.raw(42)
     c2 = _entity_ref(ar, r)          # connection point 2 (may be null)
-    r.raw(82)
+    b82 = r.raw(82)
+    # the dimension-line offset (inches, signed) sits at a fixed position
+    # of the trailing block on every sample (v17 and v18 alike)
+    offset = struct.unpack_from('<d', b82, 62)[0]
     return {'k': 'dimension', 'db': db, 'text': text,
-            'connect': (c1, c2)}
+            'connect': (c1, c2), 'offset': offset}
 
 
 def _read_text(ar, r):
@@ -1350,10 +1353,22 @@ def _fill_builder(builder, ents, slots):
                 'hidden': bool(v.get('db', {}).get('hidden', False))
             })
         elif k == 'dimension':
-            builder.dimensions.append({
+            dim = {
                 'text': v.get('text', ''),
-                'hidden': bool(v.get('db', {}).get('hidden', False))
-            })
+                'hidden': bool(v.get('db', {}).get('hidden', False)),
+                'offset': v.get('offset', 0.0),
+            }
+            # resolve the anchored connection points to their vertices so
+            # model-level dimensions carry real endpoints (inches)
+            pts = []
+            for cs in v.get('connect', ()):
+                ent = slots.get(cs) if cs is not None else None
+                val = ent[2] if ent and ent[0] == 'obj' else None
+                pts.append(tuple(val['xyz']) if isinstance(val, dict)
+                           and 'xyz' in val else None)
+            if len(pts) == 2 and pts[0] and pts[1]:
+                dim['a'], dim['b'] = pts[0], pts[1]
+            builder.dimensions.append(dim)
 
 
 def _add_edge(builder, slot, e, slots):
@@ -1478,6 +1493,8 @@ def full_parse_legacy(skp_path: str) -> Dict[str, Any]:
 
     return {
         'version': version,
+        'dimensions': [d for d in root_builder.dimensions
+                       if d.get('a') and d.get('b')],
         'layer_colors': layer_colors,
         'layer_hidden': layer_hidden,
         'layer_id_to_name': layer_id_to_name,

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -315,8 +315,19 @@ class SectionPlane:
 
 @dataclass
 class TextEntity:
+    """A leader-text label (SketchUp's Text tool).
+
+    Attributes:
+        text: The displayed string.
+        hidden: Whether the label is hidden.
+        point: Anchor point ``(x, y, z)`` in inches (world space for
+            model-root texts), or ``None`` when the record anchors to
+            geometry instead of a free point (not resolved yet).
+    """
+
     text: str = ""
     hidden: bool = False
+    point: Optional[Tuple[float, float, float]] = None
 
 
 @dataclass
@@ -602,6 +613,7 @@ class SkpFile:
                 defn.texts.append(TextEntity(
                     text=txt.get("text", ""),
                     hidden=txt.get("hidden", False),
+                    point=tuple(txt["p"]) if txt.get("p") else None,
                 ))
             # Populate dimensions
             for dim in getattr(builder, "dimensions", []):

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -323,11 +323,14 @@ class TextEntity:
         point: Anchor point ``(x, y, z)`` in inches (world space for
             model-root texts), or ``None`` when the record anchors to
             geometry instead of a free point (not resolved yet).
+        label_point: Where the label text floats (the leader line joins
+            it to ``point``), or ``None`` for screen texts / unknown.
     """
 
     text: str = ""
     hidden: bool = False
     point: Optional[Tuple[float, float, float]] = None
+    label_point: Optional[Tuple[float, float, float]] = None
 
 
 @dataclass
@@ -614,6 +617,7 @@ class SkpFile:
                     text=txt.get("text", ""),
                     hidden=txt.get("hidden", False),
                     point=tuple(txt["p"]) if txt.get("p") else None,
+                    label_point=tuple(txt["lp"]) if txt.get("lp") else None,
                 ))
             # Populate dimensions
             for dim in getattr(builder, "dimensions", []):


### PR DESCRIPTION
Follow-up to #194/#199, adding **annotation support to both sides of the legacy pipeline**: `create.SkpBuilder` gains `add_dimension()` and `add_text()`, and the reader now surfaces dimension geometry and text anchors on the model (`SkpModel.dimensions`, `TextEntity.point` / `label_point`).

## The method: SDK-generated ground truth ("Rosetta" files)

Rather than guessing at record layouts from human files (arbitrary floats, hard to align), we built two MinGW helpers that drive the **real SketchUpAPI.dll** under Wine to create entities with controlled, greppable values and save as SU2017 — then harvested the byte-exact records. Notes with the full decoded layouts are in `docs/dimension-record-notes.md`. Highlights:

- **CDimensionLinear**: the B37/B42 blocks are *connection blocks* — `[flags][u32 type][u32 4][point3d]` with type 1 = free point inline, 2 = anchored back-ref (same enum as VFF). The free-dimension placement head is a constant; the offset patches in at B82+62.
- **CText**: the SDK itself can only author *screen* texts (its two doubles after the font are screen fractions — SketchUp renders them superimposed at view centre, detached from the model; leader vectors never serialize, even anchored via `SUInstancePath`). Real leader texts were decoded from human-drawn corpus files instead: screen slot zeroed, free-connection anchor, the label's world position in the placement tail, and a leader-type u32 (2 = pushpin) before the arrow delimiter. `add_text()` writes that shape.

## Reader fixes the ground truth exposed

- `_read_text`'s delimiter predicate hard-required arrow type 3, silently dropping any text drawn with a different arrow (the root-list tolerance ate the error).
- `_read_skfont` consumed the pid mask but not the pid bytes it declares.
- Dimensions/texts now resolve their endpoints (explicit or via entity refs) and reach the model — the `connect`/`refs` data #194 preserved is finally wired into `_fill_builder`.

## Validation

- Every generated file passes the official SDK (skp2dae accepts) **and** was verified visually in SketchUp Web: dimensions in X/Y/Z/diagonal orientations render with correct values; leader texts hang anchored with their leader lines. Round-trips through our own reader are exact.
- Upstream suite green (320 passed), and the 186-file real-project corpus from #194/#199 stays byte-identical on fingerprints (casa bueno's own human-drawn leader text now yields both its anchor and label position).

Consumed in production by IngeTrazo's .skp exporter/importer (dimensions and leader texts now survive the trip both ways between IngeTrazo and SketchUp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)