### PR TITLE
feat(typescript): opt-in visibility filtering — isDrawableEdge + respectEdgeVisibility

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -199,6 +199,43 @@ resolved context if you need to see why a definition produced more than one
 resource. Resource IDs (`mesh_0`, `mesh_1`, …) are stable and deterministic
 for a given file.
 
+### Edge and face visibility
+
+SketchUp does not draw every edge it stores. Three flags suppress an edge:
+`hidden` (explicitly hidden), and `soft`/`smooth` — the smoothing flags
+that make a faceted surface read as curved. That last pair is why a
+rounded model carries far more edges than it appears to: every curve is
+triangles stitched by edges that define the shape and are never shown.
+
+These are parsed and exposed on `Edge`, but acting on them is opt-in.
+
+```typescript
+import { parseSkp, isDrawableEdge } from 'openskp';
+
+const model = parseSkp(buffer);
+const visible = model.root.edges.filter(isDrawableEdge);
+```
+
+How much that saves is strongly model-dependent — measured across this
+repository's fixtures, 27.3% of edges are non-drawable on aggregate, but
+that ranges from **0.2% on a mostly-flat model to 66.1% on a
+curved-surface one**. Use it in wireframe/hidden-line renderers built on
+`parseSkp()` output, where drawing suppressed edges is both slower and
+visually wrong.
+
+For faces, both scene builders take an opt-in flag:
+
+```typescript
+const scene = buildScene(buffer, { respectEdgeVisibility: true });
+```
+
+This skips faces carrying SketchUp's "Hide" flag. It does **not** filter
+edges, because neither scene builder emits edges — their output is face
+triangles. Hidden faces are rare in practice (none in this repository's
+fixtures), so expect this to be correct rather than dramatic; the edge
+helper above is where the real saving lives. Off by default, since what
+SketchUp draws is a display policy rather than a parsing fact.
+
 ### Exporting an instanced GLB
 
 ```typescript

--- a/packages/typescript/src/face-groups.ts
+++ b/packages/typescript/src/face-groups.ts
@@ -44,6 +44,10 @@ export interface FaceGroupContext {
   fallbackLayerColor: { r: number; g: number; b: number };
   /** Identifies the definition in a triangulation failure. */
   definitionId: number | string;
+  /** Skip faces SketchUp itself would not draw (see
+   * {@link SceneOptions.respectEdgeVisibility}). Off by default, matching
+   * the behaviour every existing consumer already relies on. */
+  respectVisibility?: boolean;
 }
 
 /**
@@ -138,6 +142,11 @@ export function buildLocalFaceGroups(
   };
 
   for (const [_fId, fData] of builder.faces.entries()) {
+    // A face explicitly hidden in SketchUp. Skipped only on request: the
+    // baked output every existing consumer reads includes these, so
+    // filtering by default would silently change what they render.
+    if (ctx.respectVisibility && fData.hidden) continue;
+
     const fallbackColor = ctx.inheritedMaterial?.color ?? ctx.fallbackLayerColor;
 
     // A face with no material of its own is painted by the instance

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -26,6 +26,7 @@ import {
   ParsedRawData,
   buildModelFromParsed,
   buildSceneFromParsed,
+  SceneOptions,
 } from './model';
 import { isLegacy, parseLegacyToRaw } from './legacy';
 import { buildInstancedSceneFromParsed, InstancedScene } from './instanced';
@@ -348,7 +349,10 @@ export function parseSkp(buffer: ArrayBuffer, options?: ParseOptions): SkpModel 
  *
  * @param options - Optional progress/log callbacks (see {@link ParseOptions})
  */
-export function buildScene(buffer: ArrayBuffer, options?: ParseOptions): SkpScene {
+export function buildScene(
+  buffer: ArrayBuffer,
+  options?: ParseOptions & SceneOptions
+): SkpScene {
   return buildSceneFromParsed(parseToRaw(buffer, options), options);
 }
 
@@ -383,7 +387,7 @@ export function buildScene(buffer: ArrayBuffer, options?: ParseOptions): SkpScen
  */
 export function buildInstancedScene(
   buffer: ArrayBuffer,
-  options?: ParseOptions
+  options?: ParseOptions & SceneOptions
 ): InstancedScene {
   return buildInstancedSceneFromParsed(parseToRaw(buffer, options), options);
 }
@@ -837,7 +841,7 @@ export class SkpFile {
    * than reusing a prior parse() call, so calling only parse() never pays
    * for this heavier computation.
    * @param options - Optional progress/log callbacks (see {@link ParseOptions}) */
-  buildScene(options?: ParseOptions): SkpScene {
+  buildScene(options?: ParseOptions & SceneOptions): SkpScene {
     return buildScene(this.buffer, options);
   }
 
@@ -845,7 +849,7 @@ export class SkpFile {
    * geometry once, plus one transform per placement. See
    * {@link buildInstancedScene} for when to prefer this over buildScene().
    * @param options - Optional progress/log callbacks (see {@link ParseOptions}) */
-  buildInstancedScene(options?: ParseOptions): InstancedScene {
+  buildInstancedScene(options?: ParseOptions & SceneOptions): InstancedScene {
     return buildInstancedScene(this.buffer, options);
   }
 }

--- a/packages/typescript/src/instanced.ts
+++ b/packages/typescript/src/instanced.ts
@@ -7,6 +7,7 @@ import {
   Material,
   Texture,
   SceneTexture,
+  SceneOptions,
   ParsedRawData,
   sniffImageMime,
   resolveMaterialFromMaps,
@@ -151,7 +152,7 @@ export interface InstancedScene {
  */
 export function buildInstancedSceneFromParsed(
   parsed: ParsedRawData,
-  options?: ParseOptions
+  options?: ParseOptions & SceneOptions
 ): InstancedScene {
   const t0 = Date.now();
   const { layerColors, layerIdToName, materialIdToName, materialsMap, materialsByFolder, defsDict } =
@@ -275,6 +276,7 @@ export function buildInstancedSceneFromParsed(
       inheritedMaterial,
       fallbackLayerColor: getLayerColor(layer),
       definitionId: defId,
+      respectVisibility: options?.respectEdgeVisibility,
     });
 
     const primitives: LocalPrimitive[] = [];

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -109,6 +109,36 @@ export interface Face {
   hidden: boolean;
 }
 
+/**
+ * Whether SketchUp itself would DRAW this edge.
+ *
+ * SketchUp hides three kinds of edge: `hidden` (explicitly hidden), and
+ * `soft`/`smooth` (the smoothing flags that make a faceted surface read as
+ * curved). The last two are why a rounded model carries far more edges
+ * than it appears to: every curve is triangles stitched together by edges
+ * that exist to define the shape and are never shown.
+ *
+ * The flags are parsed and exposed on {@link Edge}, but nothing in this
+ * library acts on them - an edge-consuming consumer (a wireframe or
+ * hidden-line renderer built on {@link parseSkp} output) has to make the
+ * call itself, and `edge.soft || edge.smooth || edge.hidden` is not
+ * obvious as "SketchUp does not draw this" unless you already know the
+ * format. Hence this helper.
+ *
+ * Measured across this repository's fixtures, 27.3% of edges are
+ * non-drawable on aggregate - but that ranges from 0.2% on a mostly-flat
+ * model to 66.1% on a curved-surface one, so the saving is concentrated
+ * exactly where geometry is heaviest.
+ *
+ * ```ts
+ * const model = parseSkp(buffer);
+ * const visible = model.root.edges.filter(isDrawableEdge);
+ * ```
+ */
+export function isDrawableEdge(edge: Pick<Edge, 'soft' | 'smooth' | 'hidden'>): boolean {
+  return !edge.soft && !edge.smooth && !edge.hidden;
+}
+
 export interface CoEdge {
   edgeId: number;
   orientation: number;
@@ -263,6 +293,24 @@ export interface SkpScene {
    * handful of photographic textures is several times larger with them than
    * without. */
   textures: SceneTexture[];
+}
+
+/** Options shared by {@link buildScene} and {@link buildInstancedScene}. */
+export interface SceneOptions {
+  /**
+   * Skip geometry SketchUp itself would not draw.
+   *
+   * Today this means faces carrying SketchUp's "Hide" flag. It does NOT
+   * filter edges, because neither scene builder emits edges: their output
+   * is face triangles, and an edge's soft/smooth/hidden flags never reach
+   * it. For edge-level filtering - which is where the real saving lives on
+   * curved models - use {@link isDrawableEdge} on {@link parseSkp} output
+   * directly.
+   *
+   * Off by default: what SketchUp draws is a display policy, not a parsing
+   * fact, and some consumers legitimately want every face regardless.
+   */
+  respectEdgeVisibility?: boolean;
 }
 
 /**
@@ -524,7 +572,10 @@ export function computeFaceUv(
  * that's why it's a separate, opt-in step from {@link buildModelFromParsed}
  * rather than something every parse() pays for.
  */
-export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptions): SkpScene {
+export function buildSceneFromParsed(
+  parsed: ParsedRawData,
+  options?: ParseOptions & SceneOptions
+): SkpScene {
   const t0 = Date.now();
   const { layerColors, layerIdToName, materialIdToName, materialsMap, materialsByFolder, defsDict } = parsed;
 
@@ -644,6 +695,7 @@ export function buildSceneFromParsed(parsed: ParsedRawData, options?: ParseOptio
         inheritedMaterial,
         fallbackLayerColor: getLayerColor(parentLayer),
         definitionId: defId,
+        respectVisibility: options?.respectEdgeVisibility,
       });
 
       for (const group of faceGroups.values()) {

--- a/packages/typescript/tests/edge-visibility.test.ts
+++ b/packages/typescript/tests/edge-visibility.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseSkp, buildScene, buildInstancedScene, isDrawableEdge } from '../src/index';
+import { buildSceneFromParsed } from '../src/model';
+import { buildInstancedSceneFromParsed } from '../src/instanced';
+import { GeometryBuilder, type ParsedDefinition } from '../src/geometry';
+import { makeParsed, translation } from './helpers/instanced-fixtures';
+
+/**
+ * SketchUp does not draw edges flagged soft/smooth/hidden, nor faces
+ * flagged hidden. The flags are parsed; acting on them is opt-in.
+ *
+ * Two separate mechanisms, deliberately: `isDrawableEdge` for edge
+ * consumers reading parseSkp() output (where the real saving is, on curved
+ * models), and `respectEdgeVisibility` on the scene builders for hidden
+ * FACES (which is all that can reach their output, since neither builder
+ * emits edges).
+ */
+
+const readFixture = (name: string) => {
+  const buf = fs.readFileSync(path.join(__dirname, 'fixtures', name));
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+};
+
+describe('isDrawableEdge', () => {
+  it('accepts a plain edge and rejects each hidden kind', () => {
+    const base = { soft: false, smooth: false, hidden: false };
+    expect(isDrawableEdge(base)).toBe(true);
+    expect(isDrawableEdge({ ...base, soft: true })).toBe(false);
+    expect(isDrawableEdge({ ...base, smooth: true })).toBe(false);
+    expect(isDrawableEdge({ ...base, hidden: true })).toBe(false);
+  });
+
+  it('filters real fixture edges without touching the parsed model', () => {
+    const model = parseSkp(readFixture('gondola_v20.skp'));
+    const all: any[] = [];
+    const scan = (d: any) => all.push(...d.edges);
+    scan(model.root);
+    for (const [, d] of model.definitions) scan(d);
+
+    const drawable = all.filter(isDrawableEdge);
+
+    // gondola is a curved-surface model: most of its edges are smoothing
+    // seams SketchUp never shows.
+    expect(all.length).toBeGreaterThan(0);
+    expect(drawable.length).toBeLessThan(all.length);
+    expect(drawable.length).toBe(all.filter((e) => !e.soft && !e.smooth && !e.hidden).length);
+
+    // the model itself is untouched - this is a read-only helper
+    expect(all.length).toBe(
+      [model.root, ...model.definitions.values()].reduce((n, d) => n + d.edges.length, 0)
+    );
+  });
+
+  it('is a no-op on a model whose edges are nearly all drawable', () => {
+    const model = parseSkp(readFixture('Untitled.skp'));
+    const all: any[] = [];
+    const scan = (d: any) => all.push(...d.edges);
+    scan(model.root);
+    for (const [, d] of model.definitions) scan(d);
+
+    // ~99.8% drawable here - the saving is model-dependent, not universal.
+    const drawable = all.filter(isDrawableEdge);
+    expect(drawable.length / all.length).toBeGreaterThan(0.9);
+  });
+});
+
+/** One square face, optionally flagged hidden. */
+function faceDefinition(hidden: boolean, name = 'Panel'): ParsedDefinition {
+  const builder = new GeometryBuilder();
+  builder.vertices.set(1, [0, 0, 0]);
+  builder.vertices.set(2, [24, 0, 0]);
+  builder.vertices.set(3, [24, 24, 0]);
+  builder.vertices.set(4, [0, 24, 0]);
+  builder.edges.set(11, [1, 2]);
+  builder.edges.set(12, [2, 3]);
+  builder.edges.set(13, [3, 4]);
+  builder.edges.set(14, [4, 1]);
+  builder.faces.set(21, {
+    loops: [
+      [
+        { edgeId: 11, orientation: 0 },
+        { edgeId: 12, orientation: 0 },
+        { edgeId: 13, orientation: 0 },
+        { edgeId: 14, orientation: 0 },
+      ],
+    ],
+    normal: [0, 0, 1],
+    materialId: null,
+    backMaterialId: null,
+    hidden,
+  });
+  return { guid: name.toUpperCase(), name, isImage: false, alwaysFacesCamera: false, builder };
+}
+
+/** A visible face plus a hidden one, as two placed definitions. */
+const mixedScene = () =>
+  makeParsed({
+    defs: new Map<number | string, ParsedDefinition>([
+      [1, faceDefinition(false, 'Visible')],
+      [2, faceDefinition(true, 'Hidden')],
+    ]),
+    rootInstances: [
+      { refIdx: 1, name: 'visible', matrix: translation(0, 0, 0) },
+      { refIdx: 2, name: 'hidden', matrix: translation(50, 0, 0) },
+    ],
+  });
+
+describe('respectEdgeVisibility on the scene builders', () => {
+  it('is OFF by default: hidden faces are still baked', () => {
+    const scene = buildSceneFromParsed(mixedScene());
+    expect(scene.glbPrimitives.length).toBe(2);
+  });
+
+  it('drops hidden faces when enabled', () => {
+    const scene = buildSceneFromParsed(mixedScene(), { respectEdgeVisibility: true });
+    expect(scene.glbPrimitives.length).toBe(1);
+    // the surviving primitive is the visible definition's
+    expect(scene.glbPrimitives[0].geomName).toContain('visible');
+  });
+
+  it('applies identically on the instanced path', () => {
+    const off = buildInstancedSceneFromParsed(mixedScene());
+    const on = buildInstancedSceneFromParsed(mixedScene(), { respectEdgeVisibility: true });
+
+    expect(off.meshResources.length).toBe(2);
+    expect(on.meshResources.length).toBe(1);
+    expect(on.meshResources[0].definitionName).toBe('Visible');
+
+    // the hidden definition's NODE survives - only its geometry is gone,
+    // so hierarchy and metadata stay intact
+    expect(on.sceneHierarchy.children.length).toBe(2);
+    expect(on.sceneHierarchy.children[1].meshResourceId).toBeUndefined();
+  });
+
+  it('keeps both scene builders in agreement when enabled', () => {
+    const baked = buildSceneFromParsed(mixedScene(), { respectEdgeVisibility: true });
+    const instanced = buildInstancedSceneFromParsed(mixedScene(), { respectEdgeVisibility: true });
+
+    let bakedTris = 0;
+    for (const p of baked.glbPrimitives) bakedTris += p.indices.length / 3;
+    let instTris = 0;
+    for (const r of instanced.meshResources) {
+      for (const p of r.primitives) instTris += p.indices.length / 3;
+    }
+    expect(instTris).toBe(bakedTris);
+  });
+
+  it('changes nothing on real fixtures, which carry no hidden faces', () => {
+    // Documents the honest scope: the option is correct but rarely bites,
+    // because Face.hidden is rare in practice. If a future fixture DOES
+    // carry hidden faces, this test will notice.
+    for (const name of ['gondola_v20.skp', 'Untitled.skp', 'capilla_quiroz_v17.skp']) {
+      const ab = readFixture(name);
+      const off = buildScene(ab);
+      const on = buildScene(ab, { respectEdgeVisibility: true });
+      expect(on.glbPrimitives.length).toBe(off.glbPrimitives.length);
+
+      const offInst = buildInstancedScene(ab);
+      const onInst = buildInstancedScene(ab, { respectEdgeVisibility: true });
+      expect(onInst.meshResources.length).toBe(offInst.meshResources.length);
+    }
+  });
+});


### PR DESCRIPTION
Implements #204. Two of your three suggestions landed as proposed; the third didn't survive contact with the source, and I'd rather flag that than quietly ship something that doesn't do what the PR claims.

## One correction: `toDXF()` can't act on edge flags

You suggested `toDXF()` as the primary target, since it's "a real edge-consuming exporter that would show the actual 3x." I checked before implementing — it isn't one:

```ts
export function toDXF(scene: SkpScene, scale = METRES_TO_INCHES, mode: '3dface' | 'polyface' = 'polyface')
```

It takes a baked `SkpScene` and reads `scene.glbPrimitives`, emitting 3DFACE / Polyface Mesh entities built from **face triangles**. It never sees an edge, so it has no flags to consult — the `POLYLINE`/`VERTEX` records it writes are Polyface Mesh structure, not SketchUp edges.

That holds for every exporter: `toDXF`, `toOBJ`, `toPLY`, `toSTL` and `toIFC` all take `SkpScene`, and `grep '\.edges' src/{dxf,obj,ply,stl,ifc}.ts` returns nothing. **There is no edge-consuming path inside the library today** — the only edge consumers are downstream users reading `parseSkp()` output.

So an opt-in on `toDXF()` would have been the same "correctly implemented but decorative" problem you correctly identified for the scene builders, just relocated. Adding one would have meant either threading raw edges into an exporter that's built around baked scenes, or emitting a different entity type — both much larger than this issue warrants, and neither obviously right.

Your point stands, though; it just lands on item 2 instead. The 3x case is real and it belongs to consumers, so the helper is doing the load-bearing work here.

## What's in the PR

**1. `isDrawableEdge(edge)` — exported, documented.** For consumers working directly with `parseSkp()` output. `edge.soft || edge.smooth || edge.hidden` isn't self-evidently "SketchUp doesn't draw this" unless you know the format, so the intent gets a name.

```ts
const model = parseSkp(buffer);
const visible = model.root.edges.filter(isDrawableEdge);
```

Takes a structural type (`Pick<Edge, 'soft'|'smooth'|'hidden'>`), so it works on anything edge-shaped.

**2. `SceneOptions.respectEdgeVisibility` on both scene builders — for hidden faces.** Per your item 3: real and correct, and the docs say plainly that it won't move the aggregate number. Both builders share `face-groups.ts`, so it's one filter site, and the #200 parity test guards that they stay in agreement. On the instanced path a hidden definition's **node survives** with no `meshResourceId` — geometry drops, hierarchy and metadata stay intact.

**3. README section** covering both, with the honest per-model spread rather than the headline.

Off by default throughout. No behaviour, return-type or output change.

## Measurements

Non-drawable edges, per fixture:

| Fixture | Edges | Non-drawable | Effect |
|---|---:|---:|---:|
| `Untitled.skp` | 12,762 | 0.2% | ~1.0x |
| `capilla_quiroz_v17.skp` | 515 | 5.6% | ~1.1x |
| `SU_File.skp` | 84 | 28.6% | ~1.4x |
| `gondola_v20.skp` | 9,186 | **66.1%** | **~3.0x** |
| **Aggregate** | 22,547 | **27.3%** | ~1.4x |

Hidden faces: **0** across every fixture — which is why item 3's honest framing matters, and why there's a test asserting the option changes nothing on real files today (it'll notice if a future fixture does carry one).

## Testing

`npm test` → **264 passed, 33 files** (256 pre-existing unchanged + 8 new).

`tests/edge-visibility.test.ts` covers: the helper's four flag combinations; filtering real fixture edges without mutating the model; the near-no-op case on a flat model (documenting that the win isn't universal); default-off behaviour; hidden faces dropping when enabled on both builders; both builders agreeing on triangle count when enabled; and the option being a no-op on real fixtures.

```
$ npm run typecheck   # clean
$ npm run build       # ESM/CJS/DTS success
$ npm test            # 264 passed (33 files)
$ npm run lint        # clean
```

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (264/264)
- [x] Documentation updated
- [x] No breaking changes to the public API

## Notes

- `packages/typescript` only; other four ports untouched.
- Not proposing a default change or parse-time filtering — the flags stay exposed raw so a consumer can decide differently.
- If you'd still like edge-level output from an exporter, that's a genuinely bigger design question (which entity type, and whether an exporter should take `SkpModel` alongside `SkpScene`) and I'd rather scope it separately than bolt it on here.
