### PR TITLE
perf(typescript): write 16-bit glTF indices where they fit (−7.8% GLB, −12.6% instanced)

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -225,7 +225,9 @@ what they always have.
 ```typescript
 import { toGLB, toInstancedGLB, toOBJ, toMTL, exportOBJ, toSTLAscii, toSTLBinary, exportSTL, toPLYAscii, toPLYBinary, exportPLY, toDXF, exportDXF, toIFC, exportIFC, toJSON } from 'openskp';
 
-// Serialize a built scene straight to .glb bytes (in-memory, no disk I/O)
+// Serialize a built scene straight to .glb bytes (in-memory, no disk I/O).
+// Index buffers are written as UNSIGNED_SHORT when every index fits, which
+// is the usual case - roughly halving the index data at no loss.
 const glbBytes = toGLB(scene);
 
 // Instancing-preserving GLB: one mesh, many nodes (see Choosing an API)

--- a/packages/typescript/src/gltf-indices.ts
+++ b/packages/typescript/src/gltf-indices.ts
@@ -1,0 +1,64 @@
+/**
+ * glTF index-buffer narrowing.
+ *
+ * Both GLB exporters previously wrote every index as UNSIGNED_INT (4
+ * bytes), regardless of how small the primitive was. glTF 2.0 also allows
+ * UNSIGNED_SHORT, and every renderer supports it - it is in fact what GPUs
+ * prefer, since a 16-bit index buffer halves the bandwidth of the most
+ * frequently-fetched buffer in a draw call.
+ *
+ * Real primitives sit far below the 65,536-vertex limit: across this
+ * repository's fixtures the largest is 2,742 vertices, so every primitive
+ * qualifies and the index data halves.
+ *
+ * This is purely an encoding choice at the export boundary. The in-memory
+ * `GlbPrimitive.indices` / `LocalPrimitive.indices` stay `Uint32Array`, so
+ * no public type changes and no consumer has to care.
+ */
+
+/** Largest vertex index addressable by UNSIGNED_SHORT. */
+export const UINT16_INDEX_LIMIT = 65535;
+
+/** glTF `componentType` for UNSIGNED_SHORT. */
+export const COMPONENT_TYPE_UNSIGNED_SHORT = 5123;
+/** glTF `componentType` for UNSIGNED_INT. */
+export const COMPONENT_TYPE_UNSIGNED_INT = 5125;
+
+/**
+ * The narrowest glTF index encoding that represents `indices` losslessly.
+ *
+ * Keyed on the largest VALUE present, not on the primitive's vertex count:
+ * narrowing is only safe if every index actually stored fits, and keying on
+ * the value is correct even if a caller hands over indices that don't start
+ * at zero.
+ *
+ * Returns the componentType alongside a view ready to copy into the binary
+ * chunk. When narrowing isn't possible the original array is returned
+ * as-is, so the 32-bit path costs no extra allocation.
+ */
+export function encodeIndices(indices: Uint32Array): {
+  componentType: number;
+  data: Uint16Array | Uint32Array;
+  bytesPerIndex: number;
+} {
+  let max = 0;
+  for (let i = 0; i < indices.length; i++) {
+    if (indices[i] > max) max = indices[i];
+  }
+
+  if (max <= UINT16_INDEX_LIMIT) {
+    const narrowed = new Uint16Array(indices.length);
+    narrowed.set(indices);
+    return {
+      componentType: COMPONENT_TYPE_UNSIGNED_SHORT,
+      data: narrowed,
+      bytesPerIndex: 2,
+    };
+  }
+
+  return {
+    componentType: COMPONENT_TYPE_UNSIGNED_INT,
+    data: indices,
+    bytesPerIndex: 4,
+  };
+}

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -28,6 +28,7 @@ import {
   buildSceneFromParsed,
 } from './model';
 import { isLegacy, parseLegacyToRaw } from './legacy';
+import { encodeIndices } from './gltf-indices';
 import { buildInstancedSceneFromParsed, InstancedScene } from './instanced';
 
 export * from './model';
@@ -478,12 +479,23 @@ export function toGLB(scene: SkpScene, options?: GlbOptions): Uint8Array {
   // larger, and a caller who only wants geometry should not pay for it.
   const sceneTextures = options?.textures ? scene.textures || [] : [];
 
+  // Narrow each index buffer to UNSIGNED_SHORT where every index fits,
+  // which is the overwhelmingly common case and halves the index data.
+  // Computed up front because the sizes decide the binary layout below.
+  const encodedIndices = prims.map((prim) => encodeIndices(prim.indices));
+
   let totalBinaryLength = 0;
-  for (const prim of prims) {
+  for (let i = 0; i < prims.length; i++) {
+    const prim = prims[i];
     totalBinaryLength += prim.positions.byteLength;
     totalBinaryLength += prim.normals.byteLength;
     totalBinaryLength += prim.uvs.byteLength;
-    totalBinaryLength += prim.indices.byteLength;
+    totalBinaryLength += encodedIndices[i].data.byteLength;
+    // A 16-bit index buffer of odd length leaves the offset 2-byte
+    // aligned; the next primitive's POSITION accessor is float32 and glTF
+    // requires 4-byte alignment, so pad here rather than emitting an
+    // invalid file.
+    totalBinaryLength += (4 - (totalBinaryLength % 4)) % 4;
   }
 
   // images go after the vertex data, each aligned to 4 bytes as glTF requires
@@ -501,7 +513,8 @@ export function toGLB(scene: SkpScene, options?: GlbOptions): Uint8Array {
 
   let byteOffset = 0;
 
-  for (const prim of prims) {
+  for (let primIndex = 0; primIndex < prims.length; primIndex++) {
+    const prim = prims[primIndex];
     const posByteOffset = byteOffset;
     binaryBuffer.set(new Uint8Array(prim.positions.buffer, prim.positions.byteOffset, prim.positions.byteLength), posByteOffset);
     byteOffset += prim.positions.byteLength;
@@ -514,9 +527,14 @@ export function toGLB(scene: SkpScene, options?: GlbOptions): Uint8Array {
     binaryBuffer.set(new Uint8Array(prim.uvs.buffer, prim.uvs.byteOffset, prim.uvs.byteLength), uvByteOffset);
     byteOffset += prim.uvs.byteLength;
 
+    const encoded = encodedIndices[primIndex];
     const indByteOffset = byteOffset;
-    binaryBuffer.set(new Uint8Array(prim.indices.buffer, prim.indices.byteOffset, prim.indices.byteLength), indByteOffset);
-    byteOffset += prim.indices.byteLength;
+    binaryBuffer.set(
+      new Uint8Array(encoded.data.buffer, encoded.data.byteOffset, encoded.data.byteLength),
+      indByteOffset
+    );
+    byteOffset += encoded.data.byteLength;
+    byteOffset += (4 - (byteOffset % 4)) % 4;
 
     const posBufferViewIdx = bufferViews.length;
     bufferViews.push({
@@ -546,7 +564,7 @@ export function toGLB(scene: SkpScene, options?: GlbOptions): Uint8Array {
     bufferViews.push({
       buffer: 0,
       byteOffset: indByteOffset,
-      byteLength: prim.indices.byteLength,
+      byteLength: encoded.data.byteLength,
       target: 34963, // ELEMENT_ARRAY_BUFFER
     });
 
@@ -599,7 +617,7 @@ export function toGLB(scene: SkpScene, options?: GlbOptions): Uint8Array {
     accessors.push({
       bufferView: indBufferViewIdx,
       byteOffset: 0,
-      componentType: 5125, // UNSIGNED_INT
+      componentType: encoded.componentType,
       count: prim.indices.length,
       type: 'SCALAR',
     });

--- a/packages/typescript/src/instanced-glb.ts
+++ b/packages/typescript/src/instanced-glb.ts
@@ -1,4 +1,5 @@
 import type { InstancedScene, InstancedNode } from './instanced';
+import { encodeIndices } from './gltf-indices';
 
 /** Options for {@link toInstancedGLB}. */
 export interface InstancedGlbOptions {
@@ -97,13 +98,26 @@ export function toInstancedGLB(
   const gltfMaterials = scene.gltfMaterials || [];
   const sceneTextures = options?.textures ? scene.textures || [] : [];
 
+  // Narrow each index buffer to UNSIGNED_SHORT where every index fits.
+  // Keyed by resource id + primitive position so the layout pass and the
+  // write pass below agree exactly.
+  const encodedIndices = new Map<string, ReturnType<typeof encodeIndices>>();
+  const encodedKey = (resId: string, primIdx: number) => `${resId}:${primIdx}`;
+
   let totalBinaryLength = 0;
   for (const res of resources) {
-    for (const prim of res.primitives) {
+    for (let i = 0; i < res.primitives.length; i++) {
+      const prim = res.primitives[i];
+      const encoded = encodeIndices(prim.indices);
+      encodedIndices.set(encodedKey(res.id, i), encoded);
       totalBinaryLength += prim.positions.byteLength;
       totalBinaryLength += prim.normals.byteLength;
       totalBinaryLength += prim.uvs.byteLength;
-      totalBinaryLength += prim.indices.byteLength;
+      totalBinaryLength += encoded.data.byteLength;
+      // A 16-bit index buffer of odd length leaves the offset 2-byte
+      // aligned; the next primitive's POSITION accessor is float32 and
+      // glTF requires 4-byte alignment.
+      totalBinaryLength += (4 - (totalBinaryLength % 4)) % 4;
     }
   }
 
@@ -126,7 +140,9 @@ export function toInstancedGLB(
   for (const res of resources) {
     const gltfPrimitives: any[] = [];
 
-    for (const prim of res.primitives) {
+    for (let primIdx = 0; primIdx < res.primitives.length; primIdx++) {
+      const prim = res.primitives[primIdx];
+      const encoded = encodedIndices.get(encodedKey(res.id, primIdx))!;
       const posByteOffset = byteOffset;
       binaryBuffer.set(
         new Uint8Array(prim.positions.buffer, prim.positions.byteOffset, prim.positions.byteLength),
@@ -150,10 +166,11 @@ export function toInstancedGLB(
 
       const indByteOffset = byteOffset;
       binaryBuffer.set(
-        new Uint8Array(prim.indices.buffer, prim.indices.byteOffset, prim.indices.byteLength),
+        new Uint8Array(encoded.data.buffer, encoded.data.byteOffset, encoded.data.byteLength),
         indByteOffset
       );
-      byteOffset += prim.indices.byteLength;
+      byteOffset += encoded.data.byteLength;
+      byteOffset += (4 - (byteOffset % 4)) % 4;
 
       const posBufferViewIdx = bufferViews.length;
       bufferViews.push({
@@ -183,7 +200,7 @@ export function toInstancedGLB(
       bufferViews.push({
         buffer: 0,
         byteOffset: indByteOffset,
-        byteLength: prim.indices.byteLength,
+        byteLength: encoded.data.byteLength,
         target: 34963, // ELEMENT_ARRAY_BUFFER
       });
 
@@ -235,7 +252,7 @@ export function toInstancedGLB(
       accessors.push({
         bufferView: indBufferViewIdx,
         byteOffset: 0,
-        componentType: 5125, // UNSIGNED_INT
+        componentType: encoded.componentType,
         count: prim.indices.length,
         type: 'SCALAR',
       });

--- a/packages/typescript/tests/gltf-indices.test.ts
+++ b/packages/typescript/tests/gltf-indices.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { toGLB, toInstancedGLB, buildScene, buildInstancedScene } from '../src/index';
+import {
+  encodeIndices,
+  UINT16_INDEX_LIMIT,
+  COMPONENT_TYPE_UNSIGNED_SHORT,
+  COMPONENT_TYPE_UNSIGNED_INT,
+} from '../src/gltf-indices';
+
+/**
+ * glTF allows UNSIGNED_SHORT indices, and real primitives are far below
+ * the 65,536 limit, so writing every index as UNSIGNED_INT wasted half the
+ * index bytes. Narrowing is an encoding choice at the export boundary: the
+ * in-memory Uint32Array buffers and every public type are unchanged.
+ *
+ * The correctness risk is alignment, not the values: a 16-bit index buffer
+ * of odd length leaves the running offset 2-byte aligned, and the next
+ * primitive's POSITION accessor is float32, which glTF requires to be
+ * 4-byte aligned. These tests check that on real multi-primitive files.
+ */
+
+function parseGlb(bytes: Uint8Array): { json: any; binary: Uint8Array } {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const jsonChunkLen = view.getUint32(12, true);
+  const json = JSON.parse(new TextDecoder().decode(bytes.subarray(20, 20 + jsonChunkLen)));
+  const binHeaderOffset = 20 + jsonChunkLen;
+  let binary = new Uint8Array(0);
+  if (binHeaderOffset < bytes.length) {
+    const binChunkLen = view.getUint32(binHeaderOffset, true);
+    binary = bytes.subarray(binHeaderOffset + 8, binHeaderOffset + 8 + binChunkLen);
+  }
+  return { json, binary };
+}
+
+const readFixture = (name: string) => {
+  const buf = fs.readFileSync(path.join(__dirname, 'fixtures', name));
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+};
+
+const FIXTURES = ['SU_File.skp', 'Untitled.skp', 'capilla_quiroz_v17.skp', 'gondola_v20.skp'];
+
+/** Component-type -> byte width, for accessor validation. */
+const WIDTH: Record<number, number> = { 5123: 2, 5125: 4, 5126: 4 };
+
+describe('encodeIndices', () => {
+  it('narrows to UNSIGNED_SHORT when every index fits', () => {
+    const r = encodeIndices(new Uint32Array([0, 1, 2, 65535]));
+    expect(r.componentType).toBe(COMPONENT_TYPE_UNSIGNED_SHORT);
+    expect(r.data).toBeInstanceOf(Uint16Array);
+    expect(r.bytesPerIndex).toBe(2);
+    expect(Array.from(r.data)).toEqual([0, 1, 2, 65535]);
+  });
+
+  it('keeps UNSIGNED_INT when any index exceeds the limit', () => {
+    const r = encodeIndices(new Uint32Array([0, 1, UINT16_INDEX_LIMIT + 1]));
+    expect(r.componentType).toBe(COMPONENT_TYPE_UNSIGNED_INT);
+    expect(r.data).toBeInstanceOf(Uint32Array);
+    expect(r.bytesPerIndex).toBe(4);
+  });
+
+  it('keys on the largest VALUE, not the array length', () => {
+    // A short array can still hold a large index.
+    const r = encodeIndices(new Uint32Array([70000, 1, 2]));
+    expect(r.componentType).toBe(COMPONENT_TYPE_UNSIGNED_INT);
+  });
+
+  it('handles an empty array', () => {
+    const r = encodeIndices(new Uint32Array([]));
+    expect(r.componentType).toBe(COMPONENT_TYPE_UNSIGNED_SHORT);
+    expect(r.data.length).toBe(0);
+  });
+
+  it('round-trips values losslessly at the boundary', () => {
+    for (const v of [0, 1, 65534, UINT16_INDEX_LIMIT]) {
+      const r = encodeIndices(new Uint32Array([v]));
+      expect(r.data[0]).toBe(v);
+    }
+  });
+});
+
+/** Every accessor must sit at an offset that is a multiple of its
+ * component width, per the glTF 2.0 spec. */
+function expectAlignedAccessors(json: any) {
+  for (const acc of json.accessors) {
+    const view = json.bufferViews[acc.bufferView];
+    const width = WIDTH[acc.componentType];
+    expect(width).toBeDefined();
+    const absolute = (view.byteOffset ?? 0) + (acc.byteOffset ?? 0);
+    expect(absolute % width).toBe(0);
+  }
+}
+
+describe('index narrowing in the GLB exporters', () => {
+  for (const name of FIXTURES) {
+    it(`emits UNSIGNED_SHORT indices and stays aligned for ${name} (toGLB)`, () => {
+      const { json, binary } = parseGlb(toGLB(buildScene(readFixture(name))));
+
+      const indexAccessors = json.meshes.flatMap((m: any) =>
+        m.primitives.map((p: any) => json.accessors[p.indices])
+      );
+      expect(indexAccessors.length).toBeGreaterThan(0);
+      // Every fixture's primitives are far below 65k vertices.
+      for (const acc of indexAccessors) {
+        expect(acc.componentType).toBe(COMPONENT_TYPE_UNSIGNED_SHORT);
+      }
+
+      expectAlignedAccessors(json);
+      for (const view of json.bufferViews) {
+        expect((view.byteOffset ?? 0) + view.byteLength).toBeLessThanOrEqual(binary.length);
+      }
+    });
+
+    it(`emits UNSIGNED_SHORT indices and stays aligned for ${name} (toInstancedGLB)`, () => {
+      const { json, binary } = parseGlb(toInstancedGLB(buildInstancedScene(readFixture(name))));
+
+      const indexAccessors = json.meshes.flatMap((m: any) =>
+        m.primitives.map((p: any) => json.accessors[p.indices])
+      );
+      expect(indexAccessors.length).toBeGreaterThan(0);
+      for (const acc of indexAccessors) {
+        expect(acc.componentType).toBe(COMPONENT_TYPE_UNSIGNED_SHORT);
+      }
+
+      expectAlignedAccessors(json);
+      for (const view of json.bufferViews) {
+        expect((view.byteOffset ?? 0) + view.byteLength).toBeLessThanOrEqual(binary.length);
+      }
+    });
+
+    it(`preserves index VALUES exactly for ${name}`, () => {
+      // The narrowing must not renumber or reorder anything: read the
+      // indices back out of the binary chunk and compare to the source.
+      const scene = buildScene(readFixture(name));
+      const { json, binary } = parseGlb(toGLB(scene));
+
+      const prims = json.meshes.flatMap((m: any) => m.primitives);
+      expect(prims.length).toBe(scene.glbPrimitives.length);
+
+      prims.forEach((p: any, i: number) => {
+        const acc = json.accessors[p.indices];
+        const view = json.bufferViews[acc.bufferView];
+        const start = (view.byteOffset ?? 0) + (acc.byteOffset ?? 0);
+        const source = scene.glbPrimitives[i].indices;
+
+        expect(acc.count).toBe(source.length);
+        const read =
+          acc.componentType === COMPONENT_TYPE_UNSIGNED_SHORT
+            ? new Uint16Array(binary.buffer, binary.byteOffset + start, acc.count)
+            : new Uint32Array(binary.buffer, binary.byteOffset + start, acc.count);
+
+        for (let k = 0; k < source.length; k++) {
+          expect(read[k]).toBe(source[k]);
+        }
+      });
+    });
+  }
+
+  it('shrinks the binary chunk relative to 32-bit indices', () => {
+    // Index data halves; positions/normals/uvs are unchanged, so the
+    // saving shows up as a smaller binary chunk overall.
+    const scene = buildScene(readFixture('gondola_v20.skp'));
+    const { binary } = parseGlb(toGLB(scene));
+
+    let indexBytes32 = 0;
+    let attrBytes = 0;
+    for (const p of scene.glbPrimitives) {
+      indexBytes32 += p.indices.byteLength;
+      attrBytes += p.positions.byteLength + p.normals.byteLength + p.uvs.byteLength;
+    }
+
+    // Allow for per-primitive 4-byte alignment padding.
+    const padding = scene.glbPrimitives.length * 4;
+    expect(binary.length).toBeLessThanOrEqual(attrBytes + indexBytes32 / 2 + padding);
+    expect(binary.length).toBeLessThan(attrBytes + indexBytes32);
+  });
+});


### PR DESCRIPTION
## Summary

Both GLB exporters wrote every index as `UNSIGNED_INT` (4 bytes) regardless of primitive size. glTF 2.0 also allows `UNSIGNED_SHORT`, which every renderer supports and GPUs prefer — the index buffer is the most frequently-fetched buffer in a draw call, so halving it halves that bandwidth.

Real primitives sit far below the 65,536-vertex limit. Across this repository's fixtures **all 266 primitives qualify**, the largest being 2,742 vertices, so in practice the index data always halves.

Purely an encoding choice at the export boundary: in-memory `GlbPrimitive.indices` / `LocalPrimitive.indices` stay `Uint32Array`, so **no public type changes** and no consumer has to care. The other exporters (OBJ/STL/PLY/DXF/IFC) read the same in-memory arrays and are untouched.

## Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] New platform implementation
- [x] Performance

## Changes

New `src/gltf-indices.ts` with `encodeIndices()`, used by both `toGLB()` and `toInstancedGLB()`.

Narrowing is keyed on the **largest index value**, not the vertex count — correct even for indices that don't start at zero — and falls back to `UNSIGNED_INT` with the original array untouched (no extra allocation) when anything exceeds the limit.

### The alignment consequence, handled explicitly

This is the real risk in the change, and it's why the diff touches the layout pass as well as the write pass. A 16-bit index buffer of **odd length** leaves the running byte offset 2-byte aligned. The next primitive's `POSITION` accessor is float32, which glTF requires to be 4-byte aligned — so writing 16-bit indices naively produces a spec-invalid file that many loaders still happen to accept.

Both exporters now pad to 4 bytes after each index buffer, in the size-computation pass and the write pass alike, so the two stay in agreement.

## Measurements

| Fixture | `toGLB` before → after | `toInstancedGLB` before → after |
|---|---|---|
| `SU_File.skp` | 7.5 → 6.9 KB (−8.1%) | 7.6 → 6.9 KB (−8.1%) |
| `Untitled.skp` | 717.7 → 607.7 KB (−15.3%) | 721.6 → 611.6 KB (−15.2%) |
| `capilla_quiroz_v17.skp` | 67.1 → 61.6 KB (−8.2%) | 61.8 → 56.7 KB (−8.3%) |
| `gondola_v20.skp` | 5023.0 → 4686.0 KB (−6.7%) | 298.5 → 277.1 KB (−7.2%) |
| **Total** | **5815.3 → 5362.2 KB (−7.8%)** | **1089.4 → 952.3 KB (−12.6%)** |

The percentage varies with the ratio of index data to vertex data — it's larger on the instanced exporter precisely because instancing already removed the duplicated vertex buffers, leaving indices a bigger share of what's left.

## Testing

`npm test` → **274 passed, 33 files** (256 pre-existing, all unchanged + 18 new).

### Validated against the official Khronos validator

Rather than relying only on my own assertions about spec compliance, I ran both exporters' output through `gltf-validator@2.0.0-dev.3.10`, on all four fixtures, with textures embedded:

```
VALID  SU_File.skp.baked.glb              err=0 warn=0
VALID  SU_File.skp.inst.glb               err=0 warn=0
VALID  Untitled.skp.baked.glb             err=0 warn=0
VALID  Untitled.skp.inst.glb              err=0 warn=0
VALID  capilla_quiroz_v17.skp.baked.glb   err=0 warn=0
VALID  capilla_quiroz_v17.skp.inst.glb    err=0 warn=0
VALID  gondola_v20.skp.baked.glb          err=0 warn=0
VALID  gondola_v20.skp.inst.glb           err=0 warn=0
```

8/8 files, **zero errors and zero warnings**. Happy to add this as a dev-dependency-backed test if you'd want it in CI, though it pulls a fairly heavy package for one check.

`tests/gltf-indices.test.ts` covers the encoder in isolation (boundary values at exactly 65535, keying on value rather than length, empty input, fallback above the limit) and then, per fixture and per exporter: that indices really are emitted as `UNSIGNED_SHORT`, that **every accessor's absolute offset is a multiple of its component width** (the spec rule the padding exists to satisfy), and that index values **round-trip byte-exactly** when read back out of the binary chunk — so narrowing provably doesn't renumber or reorder anything.

```
$ npm run typecheck   # clean
$ npm run build       # ESM/CJS/DTS success
$ npm test            # 274 passed (33 files)
$ npm run lint        # clean
```

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (274/274)
- [x] Documentation updated (README note on the GLB exporters)
- [x] No breaking changes to the public API

## Notes

- Branches off `main` and is independent of #205 (no file conflicts); the test count above is against `main` without it.
- **Two related ideas I measured and am NOT proposing**, since the data didn't support them:
  - *Deduplicating vertices shared between primitives of one definition.* Looked promising (692 of 1,548 vertices in one `gondola` resource share a position) but only **32** are identical in position **and** normal **and** UV. The rest legitimately differ per-face and glTF requires them separate. Worse, the primitives they span carry different materials, and an indexed vertex belongs to exactly one primitive — so there is essentially nothing to merge.
  - *Interleaving attributes into one buffer.* Doesn't change byte count at all; it would halve the bufferView count (104 → 52 on `gondola`, shrinking a JSON chunk that's 13% of the file) and improve GPU cache locality. Real but modest, and it changes the exporter's output layout more invasively than this. Worth its own issue if you're interested; I didn't want to bundle it here.
- Scope is `packages/typescript`; other four ports untouched.
