### PR TITLE
feat(typescript): expose embedded thumbnails and scene bounds

### DIFF
--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -236,6 +236,45 @@ fixtures), so expect this to be correct rather than dramatic; the edge
 helper above is where the real saving lives. Off by default, since what
 SketchUp draws is a display policy rather than a parsing fact.
 
+### Cataloguing models
+
+Two things an asset browser or block library needs, without paying for a
+full parse or a render:
+
+```typescript
+import { extractThumbnail, buildScene } from 'openskp';
+
+// The preview image SketchUp already saved inside the file. Reads
+// container metadata only - no geometry parsing, no renderer.
+const thumb = extractThumbnail(buffer);
+if (thumb) {
+  // thumb.data (raw bytes), thumb.mimeType, thumb.width, thumb.height
+  fs.writeFileSync('cover.png', thumb.data);
+}
+
+// The model's overall size, computed during the bake.
+const scene = buildScene(buffer);
+if (scene.bounds) {
+  const [w, h, d] = scene.bounds.size;       // metres, glTF Y-up
+  console.log(`${w.toFixed(2)} x ${h.toFixed(2)} x ${d.toFixed(2)} m`);
+  console.log('centre:', scene.bounds.center); // e.g. to frame a camera
+}
+```
+
+`extractThumbnail()` prefers SketchUp's clean `model_thumbnail` over
+`preview_thumbnail`, which has the red/green/blue axis lines drawn in and
+reads as clutter on a catalogue card; `thumb.source` says which was used.
+
+It returns `null` rather than throwing when there is no usable preview.
+That includes **legacy (pre-2021 MFC) files**: those embed PNGs too, but
+the container stores them without entry names, so a thumbnail cannot be
+distinguished from a material's texture image without guessing.
+
+`scene.bounds` is `null` for a model with no geometry, so an empty model
+stays distinguishable from one sitting at the origin.
+`buildInstancedScene()` exposes the same field, computed from the placed
+node transforms so both builders agree.
+
 ### Exporting an instanced GLB
 
 ```typescript

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -31,6 +31,7 @@ import {
 import { isLegacy, parseLegacyToRaw } from './legacy';
 import { encodeIndices } from './gltf-indices';
 import { buildInstancedSceneFromParsed, InstancedScene } from './instanced';
+import { extractThumbnail, SkpThumbnail } from './thumbnail';
 
 export * from './model';
 export type {
@@ -40,6 +41,8 @@ export type {
   LocalPrimitive,
 } from './instanced';
 export { toInstancedGLB } from './instanced-glb';
+export { extractThumbnail } from './thumbnail';
+export type { SkpThumbnail } from './thumbnail';
 export type { InstancedGlbOptions } from './instanced-glb';
 export * from './errors';
 export * from './observability';
@@ -869,5 +872,12 @@ export class SkpFile {
    * @param options - Optional progress/log callbacks (see {@link ParseOptions}) */
   buildInstancedScene(options?: ParseOptions & SceneOptions): InstancedScene {
     return buildInstancedScene(this.buffer, options);
+  }
+
+  /** The preview image SketchUp stored in the file, or null when it has
+   * none. Cheap: reads container metadata only, never geometry.
+   * @param options - Optional progress/log callbacks */
+  thumbnail(options?: ParseOptions): SkpThumbnail | null {
+    return extractThumbnail(this.buffer, options);
   }
 }

--- a/packages/typescript/src/instanced.ts
+++ b/packages/typescript/src/instanced.ts
@@ -8,6 +8,7 @@ import {
   Texture,
   SceneTexture,
   SceneOptions,
+  SceneBounds,
   ParsedRawData,
   sniffImageMime,
   resolveMaterialFromMaps,
@@ -129,6 +130,16 @@ export interface InstancedNode {
  * produces, just stored once and referenced N times.
  */
 export interface InstancedScene {
+  /**
+   * Axis-aligned bounds of the scene as PLACED, metres and Y-up, or `null`
+   * when nothing is placed.
+   *
+   * Computed by walking the node tree and transforming each referenced
+   * resource's corners, so it describes where the model actually sits -
+   * not the union of the local-space resources, which would be meaningless
+   * as a model size. Matches {@link SkpScene.bounds} for the same file.
+   */
+  bounds: SceneBounds | null;
   /** Root of the placed instance tree (identity transform). */
   sceneHierarchy: InstancedNode;
   /** Every distinct (definition, rendering-context) mesh actually placed,
@@ -494,6 +505,86 @@ export function buildInstancedSceneFromParsed(
     children: rootChildren,
   };
 
+  // Bounds of the scene AS PLACED: walk the tree, transform each
+  // resource's local corners by the accumulated node matrix. Only the 8
+  // corners of each resource's local box are transformed rather than every
+  // vertex - an affine transform maps the box's corners to the corners of
+  // the transformed box, so the result is exact for the axis-aligned
+  // bounds, at a fraction of the cost.
+  const bMin: [number, number, number] = [Infinity, Infinity, Infinity];
+  const bMax: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+  const resourceById = new Map(meshResources.map((r) => [r.id, r]));
+  const localBoxCache = new Map<string, { min: number[]; max: number[] } | null>();
+
+  const localBox = (id: string) => {
+    const cached = localBoxCache.get(id);
+    if (cached !== undefined) return cached;
+    const res = resourceById.get(id);
+    let box: { min: number[]; max: number[] } | null = null;
+    if (res) {
+      const lo = [Infinity, Infinity, Infinity];
+      const hi = [-Infinity, -Infinity, -Infinity];
+      for (const prim of res.primitives) {
+        for (let i = 0; i < prim.positions.length; i += 3) {
+          for (let k = 0; k < 3; k++) {
+            const v = prim.positions[i + k];
+            if (v < lo[k]) lo[k] = v;
+            if (v > hi[k]) hi[k] = v;
+          }
+        }
+      }
+      if (Number.isFinite(lo[0])) box = { min: lo, max: hi };
+    }
+    localBoxCache.set(id, box);
+    return box;
+  };
+
+  const mul4 = (a: number[], b: number[]) => {
+    const out = new Array(16).fill(0);
+    for (let col = 0; col < 4; col++) {
+      for (let row = 0; row < 4; row++) {
+        let acc = 0;
+        for (let k = 0; k < 4; k++) acc += a[k * 4 + row] * b[col * 4 + k];
+        out[col * 4 + row] = acc;
+      }
+    }
+    return out;
+  };
+
+  const accumulate = (node: InstancedNode, parent: number[]) => {
+    const world = mul4(parent, node.matrix);
+    if (node.meshResourceId !== undefined) {
+      const box = localBox(node.meshResourceId);
+      if (box) {
+        for (let c = 0; c < 8; c++) {
+          const x = c & 1 ? box.max[0] : box.min[0];
+          const y = c & 2 ? box.max[1] : box.min[1];
+          const z = c & 4 ? box.max[2] : box.min[2];
+          const wx = world[0] * x + world[4] * y + world[8] * z + world[12];
+          const wy = world[1] * x + world[5] * y + world[9] * z + world[13];
+          const wz = world[2] * x + world[6] * y + world[10] * z + world[14];
+          if (wx < bMin[0]) bMin[0] = wx;
+          if (wy < bMin[1]) bMin[1] = wy;
+          if (wz < bMin[2]) bMin[2] = wz;
+          if (wx > bMax[0]) bMax[0] = wx;
+          if (wy > bMax[1]) bMax[1] = wy;
+          if (wz > bMax[2]) bMax[2] = wz;
+        }
+      }
+    }
+    for (const child of node.children) accumulate(child, world);
+  };
+  accumulate(sceneHierarchy, [...IDENTITY_GLTF]);
+
+  const bounds: SceneBounds | null = Number.isFinite(bMin[0])
+    ? {
+        min: [bMin[0], bMin[1], bMin[2]],
+        max: [bMax[0], bMax[1], bMax[2]],
+        size: [bMax[0] - bMin[0], bMax[1] - bMin[1], bMax[2] - bMin[2]],
+        center: [(bMin[0] + bMax[0]) / 2, (bMin[1] + bMax[1]) / 2, (bMin[2] + bMax[2]) / 2],
+      }
+    : null;
+
   emitLog(
     options,
     'info',
@@ -501,5 +592,5 @@ export function buildInstancedSceneFromParsed(
       `${meshResources.length} mesh resources (${((Date.now() - t0) / 1000).toFixed(2)}s)`
   );
 
-  return { sceneHierarchy, meshResources, gltfMaterials, textures };
+  return { sceneHierarchy, meshResources, gltfMaterials, textures, bounds };
 }

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -272,6 +272,20 @@ export interface GlbPrimitive {
  * more data than the file's raw (per-definition, un-instanced) geometry, so
  * callers who only need the raw model data never pay for it.
  */
+/**
+ * Axis-aligned bounds of a scene's geometry, in the same frame as the
+ * vertex data it summarises: metres, glTF Y-up.
+ */
+export interface SceneBounds {
+  min: [number, number, number];
+  max: [number, number, number];
+  /** `max - min` per axis. The model's overall size, which is what a
+   * catalogue listing or a fit-to-view camera actually wants. */
+  size: [number, number, number];
+  /** Midpoint of `min` and `max`. */
+  center: [number, number, number];
+}
+
 export interface SkpScene {
   /** The root of the world-space instance tree. */
   sceneHierarchy: InstanceNode;
@@ -285,6 +299,11 @@ export interface SkpScene {
    * A material whose source had a texture image carries a `baseColorTexture`
    * whose `index` points into {@link SkpScene.textures}. */
   gltfMaterials: unknown[];
+  /** Axis-aligned bounds over every baked primitive, metres and Y-up, or
+   * `null` when the scene has no geometry. Computed during the bake, so
+   * reading it costs nothing extra - every consumer previously had to walk
+   * the position buffers itself to get the model's size. */
+  bounds: SceneBounds | null;
   /** The distinct texture images the placed materials use, deduplicated by
    * source bytes. Empty when nothing placed in the scene is textured.
    *
@@ -617,6 +636,11 @@ export function buildSceneFromParsed(
   const colorToMaterialIndex = new Map<string, number>();
   const gltfMaterials: any[] = [];
 
+  // Accumulated while positions are written, so bounds cost no extra pass
+  // over the vertex data.
+  const boundsMin: [number, number, number] = [Infinity, Infinity, Infinity];
+  const boundsMax: [number, number, number] = [-Infinity, -Infinity, -Infinity];
+
   // Definitions currently being instantiated on the active recursion path
   // (not "ever visited" - the same definition legitimately reused by
   // sibling instances is fine). Guards against a component that directly
@@ -737,6 +761,21 @@ export function buildSceneFromParsed(
           positions[i * 3] = pt[0] * scale;
           positions[i * 3 + 1] = pt[2] * scale;
           positions[i * 3 + 2] = -pt[1] * scale;
+
+          // Read back out of the Float32Array rather than using the float64
+          // values above: bounds must describe the vertex data as STORED, so
+          // that a consumer sweeping `positions` itself gets the identical
+          // answer rather than one off by a float32 ulp.
+          const wx = positions[i * 3];
+          const wy = positions[i * 3 + 1];
+          const wz = positions[i * 3 + 2];
+
+          if (wx < boundsMin[0]) boundsMin[0] = wx;
+          if (wy < boundsMin[1]) boundsMin[1] = wy;
+          if (wz < boundsMin[2]) boundsMin[2] = wz;
+          if (wx > boundsMax[0]) boundsMax[0] = wx;
+          if (wy > boundsMax[1]) boundsMax[1] = wy;
+          if (wz > boundsMax[2]) boundsMax[2] = wz;
 
           uvs[i * 2] = group.localUvs[i][0];
           uvs[i * 2 + 1] = group.localUvs[i][1];
@@ -912,7 +951,24 @@ export function buildSceneFromParsed(
       `${glbPrimitives.length} primitives (${((Date.now() - t0) / 1000).toFixed(2)}s)`
   );
 
-  return { sceneHierarchy, meshIndex, glbPrimitives, gltfMaterials, textures };
+  const bounds: SceneBounds | null = Number.isFinite(boundsMin[0])
+    ? {
+        min: [boundsMin[0], boundsMin[1], boundsMin[2]],
+        max: [boundsMax[0], boundsMax[1], boundsMax[2]],
+        size: [
+          boundsMax[0] - boundsMin[0],
+          boundsMax[1] - boundsMin[1],
+          boundsMax[2] - boundsMin[2],
+        ],
+        center: [
+          (boundsMin[0] + boundsMax[0]) / 2,
+          (boundsMin[1] + boundsMax[1]) / 2,
+          (boundsMin[2] + boundsMax[2]) / 2,
+        ],
+      }
+    : null;
+
+  return { sceneHierarchy, meshIndex, glbPrimitives, gltfMaterials, textures, bounds };
 }
 
 export function resolveMaterialFromMaps(

--- a/packages/typescript/src/thumbnail.ts
+++ b/packages/typescript/src/thumbnail.ts
@@ -1,0 +1,125 @@
+import { extractSkpContents } from './vff';
+import { isLegacy } from './legacy';
+import { SkpParseError } from './errors';
+import { ParseOptions, emitLog } from './observability';
+import { sniffImageMime } from './model';
+
+/**
+ * The preview image SketchUp saves inside the file itself.
+ *
+ * Every model saved by SketchUp carries a rendered thumbnail, so a catalogue
+ * or asset browser can show what a `.skp` contains without parsing its
+ * geometry, spinning up a renderer, or generating a preview offline.
+ */
+export interface SkpThumbnail {
+  /** The image file's raw bytes, exactly as stored in the `.skp`. */
+  data: Uint8Array;
+  /** Sniffed from the bytes rather than the entry name. */
+  mimeType: 'image/png' | 'image/jpeg';
+  width: number;
+  height: number;
+  /**
+   * Which stored image this came from.
+   *
+   * `model` is the model on a clean background - the one to show in a
+   * catalogue. `preview` is the same view WITH SketchUp's red/green/blue
+   * axis lines drawn in, which reads as clutter on a product card. `model`
+   * is preferred and `preview` is only a fallback for a file that somehow
+   * lacks it.
+   */
+  source: 'model' | 'preview';
+}
+
+/** Entry names SketchUp writes, in preference order. */
+const THUMBNAIL_ENTRIES: { name: string; source: SkpThumbnail['source'] }[] = [
+  { name: 'meta/model_thumbnail.png', source: 'model' },
+  { name: 'meta/preview_thumbnail.png', source: 'preview' },
+];
+
+/**
+ * Read a PNG's IHDR dimensions. Returns null if the bytes are not a PNG
+ * whose header is intact - the caller then reports no usable thumbnail
+ * rather than inventing a size.
+ */
+function readPngSize(data: Uint8Array): { width: number; height: number } | null {
+  // 8-byte signature + 4-byte length + "IHDR" + 8 bytes of width/height
+  if (data.length < 24) return null;
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const width = view.getUint32(16);
+  const height = view.getUint32(20);
+  if (width === 0 || height === 0) return null;
+  return { width, height };
+}
+
+/**
+ * Extract the preview image SketchUp stored in a `.skp`.
+ *
+ * Cheap by design: this reads the container's own metadata entries and
+ * never touches geometry, so listing a directory of models costs nothing
+ * like {@link parseSkp} or {@link buildScene}.
+ *
+ * Returns `null` rather than throwing when the file simply has no usable
+ * thumbnail, which includes two real cases:
+ *
+ * - **Legacy (pre-2021 MFC) files.** Those carry embedded PNGs too, but the
+ *   container has no entry names, so a thumbnail cannot be told apart from
+ *   a material's texture image without guessing. Returning `null` is
+ *   honest; handing back a texture and calling it a preview would not be.
+ * - **Modern files with no thumbnail entry**, e.g. one written by a tool
+ *   other than SketchUp.
+ *
+ * A malformed container still throws {@link SkpParseError}, matching the
+ * rest of the library.
+ *
+ * @param buffer - The raw file contents
+ * @param options - Optional progress/log callbacks
+ */
+export function extractThumbnail(
+  buffer: ArrayBuffer,
+  options?: ParseOptions
+): SkpThumbnail | null {
+  const data = new Uint8Array(buffer);
+
+  if (!(data.length >= 4 && data[0] === 0xff && data[1] === 0xfe && data[2] === 0xff && data[3] === 0x0e)) {
+    throw new SkpParseError('Not a valid SketchUp file (bad header magic)', { stage: 'header' });
+  }
+
+  if (isLegacy(data)) {
+    // See the doc comment: the legacy container stores images without
+    // names, so there is no reliable way to identify the thumbnail.
+    emitLog(options, 'debug', 'Legacy container: no named thumbnail entry available');
+    return null;
+  }
+
+  let contents;
+  try {
+    contents = extractSkpContents(data, options);
+  } catch (e) {
+    throw new SkpParseError(`Failed to extract SKP contents: ${(e as Error).message}`, {
+      stage: 'zip_extract',
+      cause: e,
+    });
+  }
+
+  for (const { name, source } of THUMBNAIL_ENTRIES) {
+    const bytes = contents.materialFiles[name];
+    if (!bytes || bytes.length === 0) continue;
+
+    const mimeType = sniffImageMime(bytes);
+    if (mimeType === null) {
+      emitLog(options, 'debug', `${name} is not a PNG or JPEG; skipping`);
+      continue;
+    }
+
+    const size = mimeType === 'image/png' ? readPngSize(bytes) : null;
+    if (!size) {
+      emitLog(options, 'debug', `${name} has no readable image header; skipping`);
+      continue;
+    }
+
+    return { data: bytes, mimeType, width: size.width, height: size.height, source };
+  }
+
+  emitLog(options, 'debug', 'No thumbnail entry found in container');
+  return null;
+}

--- a/packages/typescript/tests/thumbnail-bounds.test.ts
+++ b/packages/typescript/tests/thumbnail-bounds.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  extractThumbnail,
+  buildScene,
+  buildInstancedScene,
+  parseSkp,
+  SkpFile,
+} from '../src/index';
+
+/**
+ * Two things a catalogue or asset browser needs and previously had to
+ * reconstruct itself: the preview image SketchUp already stored in the
+ * file, and the model's overall size.
+ */
+
+const fixturePath = (name: string) => path.join(__dirname, 'fixtures', name);
+const readFixture = (name: string) => {
+  const buf = fs.readFileSync(fixturePath(name));
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+};
+
+/** Modern VFF containers, which carry named thumbnail entries. */
+const VFF_FIXTURES = ['SU_File.skp', 'Untitled.skp'];
+/** Legacy MFC containers, which store images without entry names. */
+const LEGACY_FIXTURES = [
+  'gondola_v20.skp',
+  'capilla_quiroz_v17.skp',
+  'single_material_v17.skp',
+  'blank_v17.skp',
+];
+
+describe('extractThumbnail', () => {
+  for (const name of VFF_FIXTURES) {
+    it(`returns the stored preview for ${name}`, () => {
+      const thumb = extractThumbnail(readFixture(name));
+
+      expect(thumb).not.toBeNull();
+      expect(thumb!.mimeType).toBe('image/png');
+      expect(thumb!.width).toBe(256);
+      expect(thumb!.height).toBe(256);
+      expect(thumb!.data.length).toBeGreaterThan(0);
+
+      // real PNG signature, not just something that parsed
+      expect(Array.from(thumb!.data.subarray(0, 8))).toEqual([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      ]);
+    });
+
+    it(`prefers the clean model image over the axes preview for ${name}`, () => {
+      // preview_thumbnail.png has SketchUp's red/green/blue axis lines
+      // drawn in, which is clutter on a catalogue card. Both exist in
+      // these fixtures, so the preference is observable.
+      const thumb = extractThumbnail(readFixture(name));
+      expect(thumb!.source).toBe('model');
+    });
+  }
+
+  for (const name of LEGACY_FIXTURES) {
+    it(`returns null for the legacy container ${name}`, () => {
+      // Legacy files do embed PNGs, but with no entry names a thumbnail
+      // cannot be told apart from a material texture. null is honest;
+      // returning a texture as a "preview" would not be.
+      expect(extractThumbnail(readFixture(name))).toBeNull();
+    });
+  }
+
+  it('throws on a file that is not a SketchUp file at all', () => {
+    const notSkp = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
+    expect(() => extractThumbnail(notSkp)).toThrow(/bad header magic/);
+  });
+
+  it('does not require parsing geometry', () => {
+    // The whole point: a catalogue lists thousands of files, and paying
+    // parseSkp()/buildScene() per file to get a cover image would be
+    // absurd. Guard the cheap path by timing it against a full parse.
+    const ab = readFixture('Untitled.skp');
+
+    const t0 = performance.now();
+    for (let i = 0; i < 5; i++) extractThumbnail(ab);
+    const thumbMs = performance.now() - t0;
+
+    const t1 = performance.now();
+    parseSkp(ab);
+    const parseMs = performance.now() - t1;
+
+    // Deliberately loose - this asserts an order-of-magnitude property,
+    // not a benchmark, so it does not turn into a flaky CI failure.
+    expect(thumbMs / 5).toBeLessThan(parseMs);
+  });
+
+  it('is reachable from SkpFile', () => {
+    const thumb = SkpFile.open(fixturePath('SU_File.skp')).thumbnail();
+    expect(thumb).not.toBeNull();
+    expect(thumb!.width).toBe(256);
+  });
+});
+
+describe('scene bounds', () => {
+  const GEOMETRY_FIXTURES = [
+    'SU_File.skp',
+    'Untitled.skp',
+    'capilla_quiroz_v17.skp',
+    'gondola_v20.skp',
+  ];
+
+  for (const name of GEOMETRY_FIXTURES) {
+    it(`matches a manual sweep of the baked positions for ${name}`, () => {
+      const scene = buildScene(readFixture(name));
+      expect(scene.bounds).not.toBeNull();
+
+      const min = [Infinity, Infinity, Infinity];
+      const max = [-Infinity, -Infinity, -Infinity];
+      for (const prim of scene.glbPrimitives) {
+        for (let i = 0; i < prim.positions.length; i += 3) {
+          for (let k = 0; k < 3; k++) {
+            const v = prim.positions[i + k];
+            if (v < min[k]) min[k] = v;
+            if (v > max[k]) max[k] = v;
+          }
+        }
+      }
+
+      for (let k = 0; k < 3; k++) {
+        expect(scene.bounds!.min[k]).toBeCloseTo(min[k], 6);
+        expect(scene.bounds!.max[k]).toBeCloseTo(max[k], 6);
+        expect(scene.bounds!.size[k]).toBeCloseTo(max[k] - min[k], 6);
+        expect(scene.bounds!.center[k]).toBeCloseTo((min[k] + max[k]) / 2, 6);
+      }
+    });
+
+    it(`agrees between the baked and instanced builders for ${name}`, () => {
+      // The instanced builder keeps geometry in local space, so its bounds
+      // must come from transforming resources by their node matrices. If it
+      // reported the union of local boxes instead, this would diverge.
+      const baked = buildScene(readFixture(name));
+      const instanced = buildInstancedScene(readFixture(name));
+
+      expect(instanced.bounds).not.toBeNull();
+      for (let k = 0; k < 3; k++) {
+        // 1e-5 m, the same float32 tolerance the parity tests use: the two
+        // paths reach float32 at different points in the pipeline.
+        expect(instanced.bounds!.min[k]).toBeCloseTo(baked.bounds!.min[k], 5);
+        expect(instanced.bounds!.max[k]).toBeCloseTo(baked.bounds!.max[k], 5);
+      }
+    });
+  }
+
+  it('is null for a model with no geometry', () => {
+    // blank_v17 has no faces, so an empty scene must be distinguishable
+    // from one sitting at the origin.
+    const scene = buildScene(readFixture('blank_v17.skp'));
+    expect(scene.glbPrimitives.length).toBe(0);
+    expect(scene.bounds).toBeNull();
+    expect(buildInstancedScene(readFixture('blank_v17.skp')).bounds).toBeNull();
+  });
+
+  it('reports a usable model size', () => {
+    // The catalogue use case: "how big is this block?"
+    const scene = buildScene(readFixture('gondola_v20.skp'));
+    const { size } = scene.bounds!;
+    for (const s of size) {
+      expect(s).toBeGreaterThan(0);
+      expect(Number.isFinite(s)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Two things an asset browser or block library needs from a `.skp` — both of which the library already had internally but never surfaced, so every consumer rebuilt them.

**`extractThumbnail(buffer)`** returns the preview image SketchUp already saved inside the file. A catalogue can show what a model contains without parsing geometry, running a renderer, or generating previews offline.

**`SkpScene.bounds` / `InstancedScene.bounds`** give the model's axis-aligned extent, with `size` and `center` alongside `min`/`max` — answering "how big is this block?" and "where do I point the camera?", which previously meant sweeping every position buffer by hand.

## Type
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] New platform implementation

## Changes

### Thumbnails

```ts
const thumb = extractThumbnail(buffer);   // or SkpFile#thumbnail()
// { data: Uint8Array, mimeType, width, height, source: 'model' | 'preview' }
```

Reads container metadata only — no geometry parsing.

**Which stored image is returned is not arbitrary.** SketchUp writes two, and they are visibly different:

| Entry | Content |
|---|---|
| `meta/model_thumbnail.png` | The model on a clean background — **preferred** |
| `meta/preview_thumbnail.png` | The same view **with the red/green/blue axis lines drawn in** |

The axes read as clutter on a product card, so the model image wins and `preview` is only a fallback for a file that lacks it. `source` reports which was used. Both are 256×256 PNGs in the fixtures here.

### Returning `null` instead of guessing

`extractThumbnail()` returns `null` rather than throwing when there is no usable preview. That covers two real cases, and the second is a deliberate limitation worth calling out:

- **Modern files with no thumbnail entry** (e.g. written by a tool other than SketchUp).
- **Legacy (pre-2021 MFC) files.** These *do* embed PNGs — `gondola_v20.skp` carries three 256×256 ones, `capilla_quiroz_v17.skp` likewise — but the container stores images **without entry names**, so a thumbnail cannot be distinguished from a material's texture image without heuristics. I'd rather return `null` than hand back a texture labelled as a preview. (`Untitled.skp`, a VFF file, has exactly this trap: a `materials/_/thumbnail.jpg` sitting alongside the real ones.)

A malformed container still throws `SkpParseError`, matching the rest of the library.

### Bounds

```ts
const scene = buildScene(buffer);
if (scene.bounds) {
  const [w, h, d] = scene.bounds.size;   // metres, glTF Y-up
  scene.bounds.center;                    // e.g. to frame a camera
}
```

`null` when the scene has no geometry, so an empty model stays distinguishable from one sitting at the origin.

Two implementation details that are load-bearing rather than incidental:

**The baked path reads values back out of the `Float32Array`** rather than using the float64 intermediates it just computed. Bounds must describe the vertex data *as stored*, so that a consumer sweeping `positions` itself gets the identical answer. Using the float64 values is arguably *more* accurate but disagrees by a float32 ulp — which the test caught (1.4e-6 m on a 46 m model).

**The instanced path can't do the same**, since its geometry stays in local space. It walks the node tree and transforms each resource's local box by the accumulated matrix — only the **8 corners**, since an affine transform maps a box's corners to the corners of the transformed box, so the axis-aligned result is exact at a fraction of the cost of transforming every vertex. Reporting the union of local boxes instead would be meaningless as a model size; a test asserts both builders agree per fixture.

Accumulated during the bake, so it costs no extra pass over the vertex data.

## Testing

`npm test` → **303 passed, 35 files** (282 pre-existing, all unchanged + 21 new). Rebased onto `main` after #205 and #206 merged.

`tests/thumbnail-bounds.test.ts` covers:

- thumbnails extracted from both VFF fixtures, verified as real PNGs by signature (not just "something parsed"), 256×256;
- the `model`-over-`preview` preference, which is observable because both entries exist in those files;
- `null` for all four legacy fixtures;
- throwing on a non-SketchUp file;
- that extraction is cheaper than a full parse (deliberately loose — an order-of-magnitude property, not a benchmark, so it can't turn flaky in CI);
- reachability via `SkpFile`;
- bounds matching a manual sweep of the baked positions, per fixture, to 6 decimal places;
- baked and instanced bounds agreeing per fixture (1e-5 m, the same float32 tolerance the existing parity tests use);
- `null` bounds on `blank_v17.skp`, which has no geometry.

```
$ npm run typecheck   # clean
$ npm run build       # ESM/CJS/DTS success
$ npm test            # 303 passed (35 files)
$ npm run lint        # clean
```

Also verified against the **built** package (`dist/index.js`): `extractThumbnail`, `SkpFile#thumbnail`, and `scene.bounds` all resolve, and the extracted PNG opens as a clean 256×256 cover image with no axis lines.

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (303/303)
- [x] Documentation updated (new "Cataloguing models" README section)
- [x] No breaking changes to the public API

## Notes

- `bounds` is a **new field** on the scene types, so existing consumers are unaffected; `parseSkp()`, `buildScene()`, `toGLB()` and `toInstancedGLB()` are otherwise untouched. No new dependencies.
- Scope is `packages/typescript`; the other four ports are untouched. If the thumbnail idea is welcome, the VFF entry names are the same across ports, so it would port straightforwardly — happy to leave that to whoever owns each.
- Rebased onto `main` now that #205 and #206 have merged; the README and one `instanced.ts` import needed manual resolution, and both prior sections are preserved intact.
- If you'd prefer the legacy case to make a best-effort guess rather than return `null`, say so and I'll add it behind an explicit opt-in — I just didn't want guessing to be the default behaviour.
