### PR TITLE
perf(typescript): store vertex coordinates in a flat Float64Array (1.6x, benchmarked both mappings)

### DIFF
--- a/packages/typescript/package.json
+++ b/packages/typescript/package.json
@@ -20,6 +20,7 @@
     "copy-dist": "node copy-dist.js",
     "test": "vitest run",
     "bench:instanced": "vite-node tests/bench/instanced-bench.ts",
+    "bench:vertex-store": "node --expose-gc ./node_modules/vite-node/vite-node.mjs tests/bench/vertex-store-bench.ts",
     "lint": "eslint src/",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -1,6 +1,7 @@
 import { TlvNode, readF64, readU32, parseVarInt, parseTlvRecursive } from './parser';
 import { ParseOptions, emitLog } from './observability';
 import { EdgeFlagStore } from './edge-flags';
+import { DefaultVertexStore, type VertexStore } from './vertex-store';
 
 export interface GeometryBuilderInstance {
   offset: number;
@@ -34,7 +35,9 @@ export interface GeometryBuilderFace {
 }
 
 export class GeometryBuilder {
-  vertices = new Map<number, [number, number, number]>(); // id -> [x, y, z]
+  /** id -> [x, y, z]. Backed by a flat Float64Array rather than a Map of
+   * boxed arrays: see vertex-store.ts for the memory rationale. */
+  vertices: VertexStore = new DefaultVertexStore();
   edges = new Map<number, [number | null, number | null]>(); // id -> [v1, v2]
   /** Edge id -> display flag byte (D307). Backed by a Uint8Array rather
    * than a Map: the value is one byte, and a Map entry costs ~30. */

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -17,6 +17,7 @@
 
 import { GeometryBuilderFace, GeometryBuilderInstance, ParsedDefinition } from './geometry';
 import { EdgeFlagStore } from './edge-flags';
+import { DefaultVertexStore, type VertexStore } from './vertex-store';
 import { Material, Texture, ParsedRawData } from './model';
 import { SkpParseError } from './errors';
 import { ParseOptions, PROGRESS_INTERVAL, emitLog, emitProgress } from './observability';
@@ -1180,7 +1181,7 @@ function walkModel(data: Uint8Array, ver: number, start: number, matCount: numbe
 /** Mirror of geometry.ts's GeometryBuilder (structurally compatible, kept
  * dependency-free from the VFF-specific TLV machinery). */
 class LegacyBuilder {
-  vertices = new Map<number, [number, number, number]>();
+  vertices: VertexStore = new DefaultVertexStore();
   edges = new Map<number, [number | null, number | null]>();
   edgeFlags = new EdgeFlagStore();
   faces = new Map<number, GeometryBuilderFace>();

--- a/packages/typescript/src/triangulator.ts
+++ b/packages/typescript/src/triangulator.ts
@@ -44,7 +44,9 @@ export function computeFaceNormal(
 export function triangulateFace3D(
   vertices3D:
     | Map<number, { x: number; y: number; z: number } | [number, number, number] | number[]>
-    | Record<number, { x: number; y: number; z: number } | [number, number, number] | number[]>,
+    | Record<number, { x: number; y: number; z: number } | [number, number, number] | number[]>
+    // Any id-keyed lookup with a Map-shaped `get`, e.g. VertexStore.
+    | { get(id: number): { x: number; y: number; z: number } | [number, number, number] | number[] | undefined },
   loops: number[][],
   normal: [number, number, number]
 ): number[][] {
@@ -106,10 +108,14 @@ export function triangulateFace3D(
 
   const getVertex = (id: number): { x: number; y: number; z: number } | null => {
     let pt: any;
-    if (vertices3D instanceof Map) {
-      pt = vertices3D.get(id);
+    // Anything exposing a Map-shaped `get` is queried through it; only a
+    // plain Record falls back to index access. Checking for the method
+    // rather than `instanceof Map` is what lets a VertexStore be passed
+    // here without the Record branch silently returning undefined.
+    if (typeof (vertices3D as any).get === 'function') {
+      pt = (vertices3D as any).get(id);
     } else {
-      pt = vertices3D[id];
+      pt = (vertices3D as any)[id];
     }
     if (!pt) return null;
     if (Array.isArray(pt)) {

--- a/packages/typescript/src/vertex-store.ts
+++ b/packages/typescript/src/vertex-store.ts
@@ -1,0 +1,213 @@
+/**
+ * Vertex coordinate storage.
+ *
+ * A `Map<number, [x, y, z]>` costs ~92 MB per million vertices: every
+ * `[x, y, z]` is a separate JS array with its own object header, and every
+ * Map entry adds hash-bucket overhead on top. The coordinates themselves
+ * are 24 bytes. That overhead is the dominant term in this package's
+ * memory use on large files.
+ *
+ * Coordinates move into one flat `Float64Array` (f64, not f32: the file
+ * stores doubles and narrowing would silently change parsed geometry).
+ * Ids are NOT dense in real files - measured across this repository's
+ * fixtures, vertex ids are ~33% dense on aggregate and as low as 7.6%
+ * within a single definition - so indexing the array by raw id would waste
+ * more than it saves. An id -> index mapping is therefore mandatory, and
+ * this module provides two implementations of it behind one interface so
+ * they can be benchmarked against real files rather than chosen blind:
+ *
+ * - {@link MapVertexStore}: `Map<id, index>`. O(1) lookup, but the Map is
+ *   then the dominant remaining cost (~57 MB/1M measured).
+ * - {@link SortedVertexStore}: a sorted `Uint32Array` of ids plus binary
+ *   search. O(log n) lookup, denser (~42 MB/1M measured).
+ *
+ * Both preserve insertion order for iteration, which the parsers and
+ * `buildDefinition()` rely on.
+ */
+
+/** Read/write access to a definition's vertex coordinates, keyed by id. */
+export interface VertexStore {
+  /** Number of stored vertices. */
+  readonly size: number;
+  /** Store (or overwrite) a vertex's coordinates. */
+  set(id: number, xyz: [number, number, number]): void;
+  /** Coordinates for `id`, or `undefined` when absent - matching
+   * `Map.prototype.get`, so existing `!`/`?? ` handling is unchanged. */
+  get(id: number): [number, number, number] | undefined;
+  has(id: number): boolean;
+  /** Ids and coordinates in insertion order. */
+  entries(): IterableIterator<[number, [number, number, number]]>;
+  /** Ids in insertion order. */
+  ids(): IterableIterator<number>;
+}
+
+/** Initial capacity in vertices; grown geometrically. */
+const INITIAL_CAPACITY = 256;
+
+/**
+ * Shared coordinate storage: a flat `Float64Array` holding
+ * `[x, y, z, x, y, z, ...]` in insertion order, plus the insertion-ordered
+ * id list. Subclasses differ only in how they map an id to its slot.
+ */
+abstract class BaseVertexStore implements VertexStore {
+  protected coords = new Float64Array(INITIAL_CAPACITY * 3);
+  /** Ids in insertion order; `idList[i]` owns slot `i`. */
+  protected idList = new Uint32Array(INITIAL_CAPACITY);
+  protected count = 0;
+
+  get size(): number {
+    return this.count;
+  }
+
+  protected grow(): void {
+    if (this.count < this.idList.length) return;
+    const nextCapacity = this.idList.length * 2;
+    const nextCoords = new Float64Array(nextCapacity * 3);
+    nextCoords.set(this.coords);
+    this.coords = nextCoords;
+    const nextIds = new Uint32Array(nextCapacity);
+    nextIds.set(this.idList);
+    this.idList = nextIds;
+  }
+
+  /** Slot for `id`, or -1. */
+  protected abstract slotOf(id: number): number;
+  /** Record that `id` now owns `slot`. */
+  protected abstract remember(id: number, slot: number): void;
+
+  set(id: number, xyz: [number, number, number]): void {
+    const existing = this.slotOf(id);
+    const slot = existing >= 0 ? existing : this.count;
+    if (existing < 0) {
+      this.grow();
+      this.idList[slot] = id;
+      this.count++;
+      this.remember(id, slot);
+    }
+    this.coords[slot * 3] = xyz[0];
+    this.coords[slot * 3 + 1] = xyz[1];
+    this.coords[slot * 3 + 2] = xyz[2];
+  }
+
+  get(id: number): [number, number, number] | undefined {
+    const slot = this.slotOf(id);
+    if (slot < 0) return undefined;
+    return [this.coords[slot * 3], this.coords[slot * 3 + 1], this.coords[slot * 3 + 2]];
+  }
+
+  has(id: number): boolean {
+    return this.slotOf(id) >= 0;
+  }
+
+  *entries(): IterableIterator<[number, [number, number, number]]> {
+    for (let i = 0; i < this.count; i++) {
+      yield [
+        this.idList[i],
+        [this.coords[i * 3], this.coords[i * 3 + 1], this.coords[i * 3 + 2]],
+      ];
+    }
+  }
+
+  *ids(): IterableIterator<number> {
+    for (let i = 0; i < this.count; i++) yield this.idList[i];
+  }
+}
+
+/** id -> slot via a `Map`. O(1) lookup; the Map dominates memory. */
+export class MapVertexStore extends BaseVertexStore {
+  private index = new Map<number, number>();
+
+  protected slotOf(id: number): number {
+    const slot = this.index.get(id);
+    return slot === undefined ? -1 : slot;
+  }
+
+  protected remember(id: number, slot: number): void {
+    this.index.set(id, slot);
+  }
+}
+
+/**
+ * id -> slot via binary search over a sorted id array.
+ *
+ * Ids arrive in essentially ascending order in real files, so the sorted
+ * array is usually built by appending; the out-of-order case is handled by
+ * inserting in place, which keeps lookups correct at the cost of a memmove
+ * on the rare unsorted write.
+ */
+export class SortedVertexStore extends BaseVertexStore {
+  /** Ids in ASCENDING order (unlike `idList`, which is insertion order). */
+  private sortedIds = new Uint32Array(INITIAL_CAPACITY);
+  /** `slots[i]` is the storage slot for `sortedIds[i]`. */
+  private slots = new Uint32Array(INITIAL_CAPACITY);
+  private sortedCount = 0;
+
+  /** Index into `sortedIds` where `id` is, or `-(insertionPoint) - 1`. */
+  private search(id: number): number {
+    let lo = 0;
+    let hi = this.sortedCount - 1;
+    while (lo <= hi) {
+      const mid = (lo + hi) >>> 1;
+      const v = this.sortedIds[mid];
+      if (v === id) return mid;
+      if (v < id) lo = mid + 1;
+      else hi = mid - 1;
+    }
+    return -lo - 1;
+  }
+
+  protected slotOf(id: number): number {
+    const at = this.search(id);
+    return at >= 0 ? this.slots[at] : -1;
+  }
+
+  protected remember(id: number, slot: number): void {
+    if (this.sortedCount >= this.sortedIds.length) {
+      const nextCapacity = this.sortedIds.length * 2;
+      const nextIds = new Uint32Array(nextCapacity);
+      nextIds.set(this.sortedIds);
+      this.sortedIds = nextIds;
+      const nextSlots = new Uint32Array(nextCapacity);
+      nextSlots.set(this.slots);
+      this.slots = nextSlots;
+    }
+
+    const at = this.search(id);
+    // `remember` is only called for ids not already present, so `at` is
+    // always negative here; the insertion point is its complement.
+    const pos = -at - 1;
+    if (pos < this.sortedCount) {
+      // Out-of-order id: shift to keep the array sorted. Rare in practice.
+      this.sortedIds.copyWithin(pos + 1, pos, this.sortedCount);
+      this.slots.copyWithin(pos + 1, pos, this.sortedCount);
+    }
+    this.sortedIds[pos] = id;
+    this.slots[pos] = slot;
+    this.sortedCount++;
+  }
+}
+
+/**
+ * The implementation the parsers use.
+ *
+ * Chosen by measurement, not preference - see
+ * `tests/bench/vertex-store-bench.ts`. At 1M vertices and the ~33% id
+ * density real files show:
+ *
+ * | storage                      | memory | vs today | lookup    |
+ * |------------------------------|--------|----------|-----------|
+ * | today: `Map<id,[x,y,z]>`     | 92 MB  | 1.0x     | 1068 ns   |
+ * | `Map<id,index>`              | 57 MB  | **1.6x** | 1088 ns   |
+ * | sorted `Uint32Array`         | 42 MB  | 2.2x     | 1445 ns   |
+ *
+ * The sorted array saves more memory but costs ~35% on lookup, and lookup
+ * is the hot path: `face-groups.ts` calls `get()` once per triangle corner,
+ * so gets vastly outnumber writes. `MapVertexStore` takes the larger share
+ * of the memory win at parity on speed, which is the better trade for a
+ * library whose scene building is already the expensive half.
+ *
+ * {@link SortedVertexStore} is kept, tested and benchmarked rather than
+ * deleted: it is the right choice if lookups ever stop dominating, and
+ * keeping it makes the decision re-checkable instead of folklore.
+ */
+export const DefaultVertexStore = MapVertexStore;

--- a/packages/typescript/tests/bench/vertex-store-bench.ts
+++ b/packages/typescript/tests/bench/vertex-store-bench.ts
@@ -1,0 +1,163 @@
+/**
+ * Vertex storage: memory and lookup cost, Map-index vs sorted-array.
+ *
+ * Run with:  npm run bench:vertex-store
+ *
+ * Deliberately not a vitest test - these are timings and RSS readings,
+ * which vary by machine and would be flaky as assertions. The stores'
+ * correctness is asserted in tests/vertex-store.test.ts instead.
+ *
+ * Memory is read from RSS, not heapUsed: a typed array's backing store
+ * lives outside the V8 heap that heapUsed reports, which makes the typed
+ * cases look like literally 0 MB. Values are retained in `keep` so nothing
+ * is optimised away.
+ *
+ * Run node with --expose-gc for stable memory numbers.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { MapVertexStore, SortedVertexStore, type VertexStore } from '../../src/vertex-store';
+import { parseSkp, buildScene } from '../../src/index';
+
+const keep: unknown[] = [];
+const gc = (globalThis as any).gc as (() => void) | undefined;
+
+function rssMb(): number {
+  if (gc) gc();
+  return process.memoryUsage().rss / 1048576;
+}
+
+function median(values: number[]): number {
+  const sorted = values.slice().sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+const IMPLS: [string, new () => VertexStore][] = [
+  ['Map<id,index>', MapVertexStore],
+  ['sorted Uint32Array', SortedVertexStore],
+];
+
+// ---------------------------------------------------------------- memory
+
+const N = 1_000_000;
+/** Ids at ~33% density, matching what the fixtures actually contain. */
+const idFor = (i: number) => i * 3;
+
+console.log(`\nMemory, ${N.toLocaleString()} vertices at ~33% id density (RSS delta)\n`);
+console.log('| storage | MB | vs Map-of-arrays |');
+console.log('|---|---:|---:|');
+
+let baselineMb = 0;
+{
+  const before = rssMb();
+  const m = new Map<number, [number, number, number]>();
+  for (let i = 0; i < N; i++) m.set(idFor(i), [i * 1.1, i * 2.2, i * 3.3]);
+  keep.push(m);
+  baselineMb = rssMb() - before;
+  console.log(`| today: \`Map<number,[x,y,z]>\` | ${baselineMb.toFixed(1)} | 1.0x |`);
+}
+
+const memory: Record<string, number> = {};
+for (const [name, Impl] of IMPLS) {
+  const before = rssMb();
+  const store = new Impl();
+  for (let i = 0; i < N; i++) store.set(idFor(i), [i * 1.1, i * 2.2, i * 3.3]);
+  keep.push(store);
+  const mb = rssMb() - before;
+  memory[name] = mb;
+  console.log(`| \`${name}\` | ${mb.toFixed(1)} | ${(baselineMb / mb).toFixed(1)}x |`);
+}
+
+// ---------------------------------------------------------------- lookup
+
+/**
+ * The hot path this choice actually matters for: face-groups.ts calls
+ * `builder.vertices.get(vId)` once per triangle corner, so lookups vastly
+ * outnumber writes.
+ */
+const LOOKUPS = 2_000_000;
+const REPEATS = 5;
+
+console.log(`\nLookup, ${LOOKUPS.toLocaleString()} random gets over ${N.toLocaleString()} vertices (median of ${REPEATS})\n`);
+console.log('| storage | ms | ns/lookup |');
+console.log('|---|---:|---:|');
+
+{
+  const m = new Map<number, [number, number, number]>();
+  for (let i = 0; i < N; i++) m.set(idFor(i), [i * 1.1, i * 2.2, i * 3.3]);
+  const samples: number[] = [];
+  for (let r = 0; r < REPEATS; r++) {
+    let seed = 13579;
+    let sink = 0;
+    const t0 = performance.now();
+    for (let i = 0; i < LOOKUPS; i++) {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      const v = m.get(idFor(seed % N));
+      if (v) sink += v[0];
+    }
+    samples.push(performance.now() - t0);
+    keep.push(sink);
+  }
+  const ms = median(samples);
+  console.log(`| today: \`Map<number,[x,y,z]>\` | ${ms.toFixed(0)} | ${((ms * 1e6) / LOOKUPS).toFixed(1)} |`);
+}
+
+for (const [name, Impl] of IMPLS) {
+  const store = new Impl();
+  for (let i = 0; i < N; i++) store.set(idFor(i), [i * 1.1, i * 2.2, i * 3.3]);
+  const samples: number[] = [];
+  for (let r = 0; r < REPEATS; r++) {
+    let seed = 13579;
+    let sink = 0;
+    const t0 = performance.now();
+    for (let i = 0; i < LOOKUPS; i++) {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      const v = store.get(idFor(seed % N));
+      if (v) sink += v[0];
+    }
+    samples.push(performance.now() - t0);
+    keep.push(sink);
+  }
+  const ms = median(samples);
+  console.log(`| \`${name}\` | ${ms.toFixed(0)} | ${((ms * 1e6) / LOOKUPS).toFixed(1)} |`);
+}
+
+// ------------------------------------------------------------ real files
+
+const FIXTURES = ['SU_File.skp', 'Untitled.skp', 'capilla_quiroz_v17.skp', 'gondola_v20.skp'];
+
+console.log('\nEnd-to-end on real fixtures, with the store actually wired in (median of 3)\n');
+console.log('| fixture | vertices | parseSkp ms | buildScene ms |');
+console.log('|---|---:|---:|---:|');
+
+for (const name of FIXTURES) {
+  const file = path.join(__dirname, '..', 'fixtures', name);
+  const buf = fs.readFileSync(file);
+  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+
+  const model = parseSkp(ab);
+  let verts = model.root.vertices.length;
+  for (const [, d] of model.definitions) verts += d.vertices.length;
+
+  const parseSamples: number[] = [];
+  const sceneSamples: number[] = [];
+  for (let r = 0; r < 3; r++) {
+    let t = performance.now();
+    keep.push(parseSkp(ab));
+    parseSamples.push(performance.now() - t);
+    t = performance.now();
+    keep.push(buildScene(ab));
+    sceneSamples.push(performance.now() - t);
+  }
+
+  console.log(
+    `| ${name} | ${verts.toLocaleString()} | ${median(parseSamples).toFixed(0)} | ${median(sceneSamples).toFixed(0)} |`
+  );
+}
+
+console.log(
+  `\nStores agree on results; correctness is covered by tests/vertex-store.test.ts` +
+    ` and the existing fixture-parity suite.\n`
+);

--- a/packages/typescript/tests/vertex-store.test.ts
+++ b/packages/typescript/tests/vertex-store.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from 'vitest';
+import { MapVertexStore, SortedVertexStore, type VertexStore } from '../src/vertex-store';
+
+/**
+ * Both stores replace a `Map<number, [x, y, z]>` and must be
+ * observationally identical to it for every access pattern the parsers
+ * produce - including ids arriving out of order, which the sorted store
+ * handles by inserting in place and is the easiest thing to get subtly
+ * wrong.
+ */
+
+const IMPLS: [string, new () => VertexStore][] = [
+  ['MapVertexStore', MapVertexStore],
+  ['SortedVertexStore', SortedVertexStore],
+];
+
+for (const [name, Impl] of IMPLS) {
+  describe(name, () => {
+    it('stores and returns coordinates', () => {
+      const s = new Impl();
+      s.set(1, [1.5, -2.5, 3.25]);
+      expect(s.get(1)).toEqual([1.5, -2.5, 3.25]);
+      expect(s.has(1)).toBe(true);
+      expect(s.size).toBe(1);
+    });
+
+    it('returns undefined for an absent id, like Map.get', () => {
+      const s = new Impl();
+      expect(s.get(42)).toBeUndefined();
+      expect(s.has(42)).toBe(false);
+      s.set(1, [0, 0, 0]);
+      expect(s.get(999)).toBeUndefined();
+      expect(s.get(0)).toBeUndefined();
+    });
+
+    it('overwrites in place without growing size', () => {
+      const s = new Impl();
+      s.set(7, [1, 2, 3]);
+      s.set(7, [9, 8, 7]);
+      expect(s.get(7)).toEqual([9, 8, 7]);
+      expect(s.size).toBe(1);
+    });
+
+    it('preserves f64 precision', () => {
+      // The file stores doubles; narrowing to f32 would change geometry.
+      const s = new Impl();
+      const precise = 1234.5678901234567;
+      s.set(1, [precise, -precise, precise / 3]);
+      expect(s.get(1)![0]).toBe(precise);
+      expect(s.get(1)![1]).toBe(-precise);
+      expect(s.get(1)![2]).toBe(precise / 3);
+    });
+
+    it('handles sparse ids', () => {
+      // Real files are ~33% dense, as low as 7.6% within one definition.
+      const s = new Impl();
+      s.set(5, [1, 1, 1]);
+      s.set(100_000, [2, 2, 2]);
+      s.set(37, [3, 3, 3]);
+      expect(s.get(5)).toEqual([1, 1, 1]);
+      expect(s.get(100_000)).toEqual([2, 2, 2]);
+      expect(s.get(37)).toEqual([3, 3, 3]);
+      expect(s.get(50_000)).toBeUndefined();
+      expect(s.size).toBe(3);
+    });
+
+    it('handles ids arriving OUT OF ORDER', () => {
+      // The sorted store inserts in place here; nothing guarantees the
+      // parser emits ascending ids.
+      const s = new Impl();
+      const ids = [500, 5, 2000, 1, 1500, 700, 3, 9999, 250];
+      ids.forEach((id, i) => s.set(id, [i, i * 2, i * 3]));
+      ids.forEach((id, i) => expect(s.get(id)).toEqual([i, i * 2, i * 3]));
+      expect(s.size).toBe(ids.length);
+    });
+
+    it('grows past its initial capacity', () => {
+      const s = new Impl();
+      const N = 5000; // well past INITIAL_CAPACITY
+      for (let i = 0; i < N; i++) s.set(i * 3, [i, i + 0.5, -i]);
+      expect(s.size).toBe(N);
+      for (let i = 0; i < N; i += 137) {
+        expect(s.get(i * 3)).toEqual([i, i + 0.5, -i]);
+      }
+      expect(s.get(1)).toBeUndefined();
+    });
+
+    it('iterates entries in INSERTION order', () => {
+      // buildDefinition() and the JSON export depend on this ordering.
+      const s = new Impl();
+      const ids = [900, 10, 500, 1];
+      ids.forEach((id, i) => s.set(id, [i, 0, 0]));
+      expect([...s.entries()].map(([id]) => id)).toEqual(ids);
+      expect([...s.ids()]).toEqual(ids);
+    });
+
+    it('matches a reference Map on a randomised pattern', () => {
+      // Deterministic LCG - a failure is reproducible.
+      const s = new Impl();
+      const ref = new Map<number, [number, number, number]>();
+      let seed = 987654321;
+      const next = () => {
+        seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+        return seed;
+      };
+      for (let i = 0; i < 3000; i++) {
+        const id = next() % 40_000;
+        const xyz: [number, number, number] = [next() % 1000, next() % 1000, next() % 1000];
+        s.set(id, xyz);
+        ref.set(id, xyz);
+      }
+      expect(s.size).toBe(ref.size);
+      for (let id = 0; id < 40_000; id += 11) {
+        expect(s.get(id)).toEqual(ref.get(id));
+        expect(s.has(id)).toBe(ref.has(id));
+      }
+      // insertion order must match the Map's too
+      expect([...s.ids()]).toEqual([...ref.keys()]);
+    });
+  });
+}
+
+describe('the two stores agree with each other', () => {
+  it('produces identical results for the same write sequence', () => {
+    const a = new MapVertexStore();
+    const b = new SortedVertexStore();
+    let seed = 24680;
+    const next = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed;
+    };
+    for (let i = 0; i < 2000; i++) {
+      const id = next() % 20_000;
+      const xyz: [number, number, number] = [next() % 100, next() % 100, next() % 100];
+      a.set(id, xyz);
+      b.set(id, xyz);
+    }
+    expect(a.size).toBe(b.size);
+    expect([...a.ids()]).toEqual([...b.ids()]);
+    for (const id of a.ids()) {
+      expect(a.get(id)).toEqual(b.get(id));
+    }
+  });
+});


### PR DESCRIPTION
Implements item 1 of #201, on the terms you set: both mapping strategies implemented behind one interface, benchmarked against the real hot path, and the winner shipped.

## Summary

`GeometryBuilder.vertices` moves from `Map<number, [x, y, z]>` to a flat `Float64Array` plus an id→index mapping.

Every `[x, y, z]` was a separate JS array with its own object header, and every Map entry added hash-bucket overhead — so a million vertices cost **~92 MB to carry 24 MB of coordinates**. That overhead is the dominant term in this package's memory use on large files, and the reason it needs 8–16 GB of heap where the other ports need far less.

`f64`, not `f32` — the file stores doubles and narrowing at parse time would silently change parsed geometry. Holding that as the hard requirement you called it.

## The measurement

Ids are sparse, as you predicted: ~33% dense on aggregate across the fixtures, as low as **7.6%** within a single definition. Raw `Float64Array[id]` would waste more than it saves, so the id→index mapping is mandatory.

Both candidates, at 1M vertices and the ~33% density real files show (RSS after forced GC, values retained, medians of 5):

| storage | memory | vs today | lookup |
|---|---:|---:|---:|
| today: `Map<id,[x,y,z]>` | 92 MB | 1.0x | 1068 ns |
| **`Map<id,index>`** | **57 MB** | **1.6x** | **1088 ns** |
| sorted `Uint32Array` + binary search | 42 MB | 2.2x | 1445 ns |

**`MapVertexStore` ships.** The sorted array saves more memory but costs **~35% on lookup**, and lookup is the hot path — `face-groups.ts` calls `get()` once per triangle corner, so gets vastly outnumber writes. Taking the larger share of the memory win at parity on speed is the better trade for a library whose scene building is already the expensive half.

You said to weight toward maintainability if they were close. They aren't close on lookup, so the measurement decided it — and the simpler implementation happens to be the one that won.

`SortedVertexStore` is **kept, tested and benchmarked** rather than deleted: it wins if lookups ever stop dominating, and keeping it makes the decision re-checkable instead of folklore. `npm run bench:vertex-store` reruns the comparison.

### Honest scope note

This is **1.6x on vertex storage**, not 1.6x on a file's total footprint. The repository's fixtures are too small to show it end-to-end — at 11k vertices the residual `Vertex[]` objects that `buildDefinition()` materialises dominate, and that was item 3, which we agreed to close. So the number above is from the microbenchmark at a realistic scale and density, not from a large real file I don't have. If you have a large `.skp` to hand, I'd genuinely like the before/after RSS on it before this merges.

## Two things worth flagging in review

**`triangulateFace3D` branched on `vertices3D instanceof Map`.** A `VertexStore` is not a `Map`, so it would have silently fallen through to the `Record` path and returned `undefined` for every vertex — no error, just empty geometry. It now checks for a callable `get`, which keeps both existing call shapes working. This is exactly the dual-mode you spotted in your first reply; it needed one more case.

**`get()` returns a fresh array per call, deliberately.** Returning a reused buffer would be the obvious optimization and would be a bug: `face-groups.ts` *retains* the returned array (`group.localVerts.push(p)`), so a shared buffer would corrupt geometry. Left as-is with a comment.

## Testing

`npm test` → **322 passed, 36 files** (303 pre-existing, all unchanged + 19 new).

The existing fixture-parity suite is the real guard here — both scene builders read `builder.vertices` through `face-groups.ts`, and #200's flatten-and-compare test covers both paths on real files. It passed unchanged.

`tests/vertex-store.test.ts` runs the same suite against **both** implementations: sparse ids, ids arriving **out of order** (the sorted store inserts in place — the easiest thing to get subtly wrong), growth past initial capacity, overwrite-without-double-counting, f64 precision preservation, insertion-order iteration (which `buildDefinition()` and the JSON export depend on), and a deterministic 3,000-write randomised pattern asserted key-by-key against a reference `Map`. Plus a test that the two implementations agree with each other on an identical write sequence.

```
$ npm run typecheck        # clean
$ npm run build            # ESM/CJS/DTS success
$ npm test                 # 322 passed (36 files)
$ npm run lint             # clean
$ npm run bench:vertex-store   # table above
```

## Checklist
- [x] Code follows the project's style guidelines
- [x] Tests pass locally (322/322)
- [x] Documentation updated (module-level rationale in `vertex-store.ts`; no user-facing API change to document)
- [x] No breaking changes to the public API

## Notes

- **No public API change.** `GeometryBuilder` is internal and never re-exported, as you confirmed earlier; `Definition.vertices` is still the same `Vertex[]`, built the same way. No new dependencies.
- Benchmark added as `npm run bench:vertex-store`, following the existing `bench:instanced` convention — needs `--expose-gc` for stable RSS, which the script sets.
- Scope is `packages/typescript`; the other four ports are untouched.
- With this, #201 is: item 2 merged (#202), item 3 closed as not worth pursuing, item 4 no action, item 1 here.
