### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v7

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -8,14 +8,13 @@ version = "1.1.0"
 description = "Open-source SketchUp (.skp) binary file parser, writer, and converter — extract geometry, metadata, layers, and materials; create and edit .skp files; convert to GLB, OBJ, STL, PLY, DXF, and IFC4"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{name = "Ahsan Mehmood"}]
 keywords = ["sketchup", "skp", "3d", "parser", "writer", "converter", "conversion", "glb", "gltf", "bim", "cad", "dxf", "autocad", "ifc", "obj", "stl", "ply"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
Python 3.9 reached its own upstream end-of-life in October 2025.

Bumps \`requires-python\` to \`>=3.10\`, drops the matching trove
classifier, and removes 3.9 from the CI matrix.

**No existing user is affected.** pip's own resolver caps a 3.9
install at the last version that declared 3.9 support (1.1.0) - this
only changes what *future* releases require, not what already-installed
copies do.

Unblocks 4 previously-closed Dependabot PRs that all needed
\`>=3.10\` and were blocked on exactly this: #210 (pytest), #213
(trimesh), #215 (setuptools), #216 (shapely). None were tied to a
flagged vulnerability, so this isn't urgent - just clearing a
recurring blocker.