### PR TITLE
Port #192's v20-filler-count fix to .NET, Dart, C++; add Python regression test

### DIFF
--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -124,6 +124,14 @@ std::string extract_version(const ByteBuffer&);
 bool valid_header(const ByteBuffer&);
 bool is_legacy(const ByteBuffer&);
 bool legacy_instance_has_guid(const std::string&, std::optional<int>);
+
+/// Result of `find_count_after_v20_filler`: the recovered count and the
+/// offset just past it.
+struct V20FillerHit {
+  std::uint32_t count;
+  std::size_t next;
+};
+std::optional<V20FillerHit> find_count_after_v20_filler(const ByteBuffer&, std::size_t, std::uint32_t);
 RawParsed full_parse(const ByteBuffer&, const ParseOptions&);
 RawParsed parse_legacy(const ByteBuffer&, const ParseOptions&);
 void collect_geometry(const std::vector<TlvNode>&, GeometryBuilder&);

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -131,7 +131,9 @@ struct V20FillerHit {
   std::uint32_t count;
   std::size_t next;
 };
-std::optional<V20FillerHit> find_count_after_v20_filler(const ByteBuffer&, std::size_t, std::uint32_t);
+
+std::optional<V20FillerHit> find_count_after_v20_filler(const ByteBuffer&, std::size_t,
+                                                        std::uint32_t);
 RawParsed full_parse(const ByteBuffer&, const ParseOptions&);
 RawParsed parse_legacy(const ByteBuffer&, const ParseOptions&);
 void collect_geometry(const std::vector<TlvNode>&, GeometryBuilder&);

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -13,6 +13,63 @@ bool legacy_instance_has_guid(const std::string& class_name, std::optional<int> 
   return *schema >= (class_name == "CGroup" ? 1 : 5);
 }
 
+// Widest zero padding seen between the v20 filler's empty string and the
+// count that follows it (9 and 13 bytes occur in real files; the ceiling
+// leaves room without letting the probe wander into unrelated records).
+constexpr size_t kMaxV20FillerPad = 29;
+
+// Locates the count that follows a v20 filler record, given the offset the
+// bad count was read from. Pure byte logic, exposed for tests; see
+// retry_count_after_v20_filler (legacy.cpp) for how it is used.
+//
+// SketchUp 2020 (v20) writes an extra, undocumented record ahead of some
+// counts that v17 does not have, which leaves the reader a few bytes early
+// and makes it read garbage as the count. The filler is an empty UTF-16
+// string record followed by zero padding:
+//
+//   <ff fe ff> <u8 0>        empty string
+//   <zero padding>           runs up to the real count
+//
+// Rather than hard-code an offset (the number of bytes before the marker
+// differs per call site), locate the marker in the short window ahead,
+// then take the first plausible u32 that follows the padding. Only the
+// EMPTY-string form counts as filler: a real string here would mean
+// genuine data, and moving the cursor past it would corrupt the parse.
+//
+// Returns the count and the offset just past it, or nullopt when the bytes
+// do not match the filler layout.
+std::optional<V20FillerHit> find_count_after_v20_filler(const ByteBuffer& d, size_t count_pos,
+                                                          uint32_t limit) {
+  size_t marker_at = std::string::npos;
+  for (size_t i = count_pos; i + 4 <= d.size() && i < count_pos + 12; ++i) {
+    if (d[i] == 255 && d[i + 1] == 254 && d[i + 2] == 255) {
+      marker_at = i;
+      break;
+    }
+  }
+  if (marker_at == std::string::npos) return std::nullopt;
+  if (d[marker_at + 3] != 0) return std::nullopt;  // non-empty string: real data
+
+  // The count sits past a run of zero padding whose length varies per call
+  // site (9 and 13 bytes both occur in real files), but always lands at
+  // marker_at + 4 + pad with pad % 4 == 1. Step through those candidate
+  // offsets and take the first plausible u32.
+  //
+  // Deliberately NOT "scan forward to the first non-zero byte": a count
+  // that is an exact multiple of 256 has a 0x00 low byte, which such a
+  // scan cannot tell apart from padding, so it would skip into the count
+  // and misalign every later read. Probing whole u32s at 4-byte strides
+  // never inspects an individual byte, so those counts round-trip
+  // correctly.
+  for (size_t pad = 1; pad <= kMaxV20FillerPad; pad += 4) {
+    size_t at = marker_at + 4 + pad;
+    if (at + 4 > d.size()) break;
+    uint32_t count = read_u32(d, at);
+    if (count > 0 && count <= limit) return V20FillerHit{count, at + 4};
+  }
+  return std::nullopt;
+}
+
 namespace {
 struct R {
   const ByteBuffer& d;
@@ -181,27 +238,11 @@ bool is_class_ref(const ByteBuffer& d, size_t p, uint64_t slot) {
 //
 // count_pos is the offset the count was read FROM (i.e. r.p - 4). Returns
 // the corrected count, or nullopt when this is not the v20 layout.
-std::optional<uint32_t> retry_count_after_v20_filler(R& r, size_t count_pos) {
-  const auto& d = r.d;
-  size_t marker_at = std::string::npos;
-  for (size_t i = count_pos; i + 4 <= d.size() && i < count_pos + 12; ++i) {
-    if (d[i] == 255 && d[i + 1] == 254 && d[i + 2] == 255) {
-      marker_at = i;
-      break;
-    }
-  }
-  if (marker_at == std::string::npos) return std::nullopt;
-  if (d[marker_at + 3] != 0) return std::nullopt;  // non-empty string: real data
-
-  // Skip the zero padding that follows the empty string. The count is
-  // little-endian and non-zero, so the first non-zero byte after the
-  // padding IS its low byte - the run ends exactly on the count.
-  size_t at = marker_at + 4;
-  while (at < d.size() && d[at] == 0) ++at;
-  if (at + 4 > d.size()) return std::nullopt;
-  uint32_t count = read_u32(d, at);
-  r.p = at + 4;
-  return count;
+std::optional<uint32_t> retry_count_after_v20_filler(R& r, size_t count_pos, uint32_t limit) {
+  auto hit = find_count_after_v20_filler(r.d, count_pos, limit);
+  if (!hit) return std::nullopt;
+  r.p = hit->next;
+  return hit->count;
 }
 
 struct Archive {
@@ -533,14 +574,14 @@ struct Archive {
       // reads zero with no filler ahead, and retry_count_after_v20_filler
       // leaves those alone.
       if (count > 5000000 || count == 0) {
-        auto retry = retry_count_after_v20_filler(r, r.p - 4);
+        auto retry = retry_count_after_v20_filler(r, r.p - 4, 5000000);
         if (retry) count = *retry;
       }
       if (count > 5000000) throw std::runtime_error("implausible def entities");
       v->ents = entity_list(count, false);
       auto nr = r.u32();
       if (nr > 100000) {
-        auto retry = retry_count_after_v20_filler(r, r.p - 4);
+        auto retry = retry_count_after_v20_filler(r, r.p - 4, 100000);
         if (retry) nr = *retry;
       }
       if (nr > 100000) throw std::runtime_error("definition list misaligned");
@@ -771,7 +812,7 @@ WalkResult walk_model(const ByteBuffer& data, int ver, size_t start, uint32_t ma
   if (std::get<1>(anchor) != "CLayer") throw std::runtime_error("definition anchor is not a layer");
   auto dc = ar.r.u32();
   if (dc > 1000000) {
-    auto retry = retry_count_after_v20_filler(ar.r, ar.r.p - 4);
+    auto retry = retry_count_after_v20_filler(ar.r, ar.r.p - 4, 1000000);
     if (retry) dc = *retry;
   }
   if (dc > 1000000) throw std::runtime_error("invalid definition count");
@@ -788,7 +829,7 @@ WalkResult walk_model(const ByteBuffer& data, int ver, size_t start, uint32_t ma
   }
   auto root_count = ar.r.u32();
   if (root_count > 5000000) {
-    auto retry = retry_count_after_v20_filler(ar.r, ar.r.p - 4);
+    auto retry = retry_count_after_v20_filler(ar.r, ar.r.p - 4, 5000000);
     if (retry) root_count = *retry;
   }
   if (root_count > 5000000) throw std::runtime_error("implausible root entity count");

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -39,7 +39,7 @@ constexpr size_t kMaxV20FillerPad = 29;
 // Returns the count and the offset just past it, or nullopt when the bytes
 // do not match the filler layout.
 std::optional<V20FillerHit> find_count_after_v20_filler(const ByteBuffer& d, size_t count_pos,
-                                                          uint32_t limit) {
+                                                        uint32_t limit) {
   size_t marker_at = std::string::npos;
   for (size_t i = count_pos; i + 4 <= d.size() && i < count_pos + 12; ++i) {
     if (d[i] == 255 && d[i + 1] == 254 && d[i + 2] == 255) {

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
   json_export_test.cpp
   layer_hidden_test.cpp
   legacy_single_material_test.cpp
+  legacy_v20_filler_test.cpp
   legacy_v20_test.cpp
   lowlevel_test.cpp
   meta_units_test.cpp

--- a/packages/cpp/tests/legacy_v20_filler_test.cpp
+++ b/packages/cpp/tests/legacy_v20_filler_test.cpp
@@ -1,0 +1,93 @@
+#include <gtest/gtest.h>
+
+#include "internal.hpp"
+
+namespace openskp {
+namespace {
+
+// The v20 filler probe, exercised on synthetic records.
+//
+// Ported from the TypeScript fix (openskp#192, following the review on
+// openskp#155): the original implementation walked forward to the first
+// non-zero byte and treated it as the count's low byte. That cannot
+// represent a count which is an exact multiple of 256 - its low byte IS
+// 0x00, so the scan walks straight into the count and misaligns every read
+// after it. Probing whole u32s at 4-byte strides fixes that, since no
+// individual byte is ever inspected.
+//
+// Layout (see find_count_after_v20_filler, legacy.cpp):
+//   <ff fe ff> <u8 0>   empty UTF-16 string
+//   <zero padding>      length varies per call site, always pad % 4 == 1
+//   <u32 count>
+
+// Builds a filler record followed by `count`, then a class-record header.
+ByteBuffer filler(uint32_t count, size_t pad) {
+  ByteBuffer bytes{0xff, 0xfe, 0xff, 0x00};
+  bytes.insert(bytes.end(), pad, 0x00);
+  bytes.push_back(static_cast<uint8_t>(count & 0xff));
+  bytes.push_back(static_cast<uint8_t>((count >> 8) & 0xff));
+  bytes.push_back(static_cast<uint8_t>((count >> 16) & 0xff));
+  bytes.push_back(static_cast<uint8_t>((count >> 24) & 0xff));
+  bytes.insert(bytes.end(), {0xff, 0xff, 0x0b, 0x00});  // whatever record comes next
+  return bytes;
+}
+
+TEST(V20Filler, ReadsCountsAndPaddingsSeenInRealV20Files) {
+  // both padding lengths observed in gondola_v20.skp and a second v20 model
+  auto hit1 = find_count_after_v20_filler(filler(20, 9), 0, 1000000);
+  ASSERT_TRUE(hit1.has_value());
+  EXPECT_EQ(hit1->count, 20u);
+  EXPECT_EQ(hit1->next, 17u);
+
+  auto hit2 = find_count_after_v20_filler(filler(5425, 13), 0, 5000000);
+  ASSERT_TRUE(hit2.has_value());
+  EXPECT_EQ(hit2->count, 5425u);
+  EXPECT_EQ(hit2->next, 21u);
+}
+
+TEST(V20Filler, ReadsACountThatIsAnExactMultipleOf256) {
+  // the regression this test exists for: a 0x00 low byte is
+  // indistinguishable from padding to a byte-at-a-time scan
+  for (uint32_t count : {256u, 512u, 1024u, 65536u, static_cast<uint32_t>(16777216 / 16)}) {
+    for (size_t pad : {9u, 13u}) {
+      auto hit = find_count_after_v20_filler(filler(count, pad), 0, 5000000);
+      ASSERT_TRUE(hit.has_value()) << "count=" << count << " pad=" << pad;
+      EXPECT_EQ(hit->count, count) << "count=" << count << " pad=" << pad;
+    }
+  }
+}
+
+TEST(V20Filler, ReportsWhereToResumeReading) {
+  auto hit = find_count_after_v20_filler(filler(256, 13), 0, 5000000);
+  ASSERT_TRUE(hit.has_value());
+  // 4 (marker+len) + 13 (padding) + 4 (the count itself)
+  EXPECT_EQ(hit->next, 21u);
+}
+
+TEST(V20Filler, IgnoresANonEmptyStringRecord) {
+  // a real string here is genuine data; moving the cursor past it would
+  // corrupt the parse
+  ByteBuffer bytes{0xff, 0xfe, 0xff, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0};
+  EXPECT_FALSE(find_count_after_v20_filler(bytes, 0, 1000000).has_value());
+}
+
+TEST(V20Filler, ReturnsNulloptWhenThereIsNoMarkerAhead) {
+  ByteBuffer bytes(32, 0);  // all zeros, no ff fe ff
+  EXPECT_FALSE(find_count_after_v20_filler(bytes, 0, 1000000).has_value());
+}
+
+TEST(V20Filler, RespectsTheCallersPlausibilityLimit) {
+  // nrel's limit is 100_000: a value above it is not the count we want
+  EXPECT_FALSE(find_count_after_v20_filler(filler(200000, 13), 0, 100000).has_value());
+  auto hit = find_count_after_v20_filler(filler(200000, 13), 0, 5000000);
+  ASSERT_TRUE(hit.has_value());
+  EXPECT_EQ(hit->count, 200000u);
+}
+
+TEST(V20Filler, DoesNotRunPastTheEndOfTheBuffer) {
+  ByteBuffer bytes{0xff, 0xfe, 0xff, 0x00, 0, 0};
+  EXPECT_FALSE(find_count_after_v20_filler(bytes, 0, 1000000).has_value());
+}
+
+}  // namespace
+}  // namespace openskp

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -98,8 +98,22 @@ bool _matchesAscii(Uint8List data, int offset, String str) {
 ///
 /// [countPos] is the offset the count was read FROM (i.e. r.pos - 4).
 /// Returns the corrected count, or null when this is not the v20 layout.
-int? retryCountAfterV20Filler(LR r, int countPos) {
-  final data = r.data;
+/// Widest zero padding seen between the v20 filler's empty string and the
+/// count that follows it (9 and 13 bytes occur in real files; the ceiling
+/// leaves room without letting the probe wander into unrelated records).
+const int _maxV20FillerPad = 29;
+
+/// Locates the count that follows a v20 filler record, given the offset the
+/// bad count was read from. Pure byte logic, exported for tests; see
+/// [retryCountAfterV20Filler] for how it is used.
+///
+/// Returns the count and the offset just past it, or null when the bytes do
+/// not match the filler layout.
+({int count, int next})? findCountAfterV20Filler(
+  Uint8List data,
+  int countPos,
+  int limit,
+) {
   int markerAt = -1;
   for (int i = countPos; i < countPos + 12 && i + 4 <= data.length; i++) {
     if (data[i] == 0xFF && data[i + 1] == 0xFE && data[i + 2] == 0xFF) {
@@ -110,17 +124,30 @@ int? retryCountAfterV20Filler(LR r, int countPos) {
   if (markerAt < 0) return null;
   if (data[markerAt + 3] != 0) return null; // non-empty string: real data
 
-  // Skip the zero padding that follows the empty string. The count is
-  // little-endian and non-zero, so the first non-zero byte after the
-  // padding IS its low byte - the run ends exactly on the count.
-  int at = markerAt + 4;
-  while (at < data.length && data[at] == 0) {
-    at++;
+  // The count sits past a run of zero padding whose length varies per call
+  // site (9 and 13 bytes both occur in real files), but always lands at
+  // markerAt + 4 + pad with pad % 4 == 1. Step through those candidate
+  // offsets and take the first plausible u32.
+  //
+  // Deliberately NOT "scan forward to the first non-zero byte": a count
+  // that is an exact multiple of 256 has a 0x00 low byte, which such a scan
+  // cannot tell apart from padding, so it would skip into the count and
+  // misalign every later read. Probing whole u32s at 4-byte strides never
+  // inspects an individual byte, so those counts round-trip correctly.
+  for (int pad = 1; pad <= _maxV20FillerPad; pad += 4) {
+    final at = markerAt + 4 + pad;
+    if (at + 4 > data.length) break;
+    final count = Tlv.readU32(data, at);
+    if (count > 0 && count <= limit) return (count: count, next: at + 4);
   }
-  if (at + 4 > data.length) return null;
-  final count = Tlv.readU32(data, at);
-  r.pos = at + 4;
-  return count;
+  return null;
+}
+
+int? retryCountAfterV20Filler(LR r, int countPos, int limit) {
+  final hit = findCountAfterV20Filler(r.data, countPos, limit);
+  if (hit == null) return null;
+  r.pos = hit.next;
+  return hit.count;
 }
 
 /// True when the bytes at [p] are an MFC class-ref to class [slot]. Mirrors
@@ -956,7 +983,7 @@ class LegacyReaders {
     // instead of the count. A genuinely empty definition reads zero with no
     // filler ahead, and retryCountAfterV20Filler leaves those alone.
     if (count > 5000000 || count == 0) {
-      final retry = retryCountAfterV20Filler(r, r.pos - 4);
+      final retry = retryCountAfterV20Filler(r, r.pos - 4, 5000000);
       if (retry != null) count = retry;
     }
     if (count > 5000000) {
@@ -965,7 +992,7 @@ class LegacyReaders {
     final ents = readEntityList(ar, r, count, 'def');
     var nrel = r.u32();
     if (nrel > 100000) {
-      final retry = retryCountAfterV20Filler(r, r.pos - 4);
+      final retry = retryCountAfterV20Filler(r, r.pos - 4, 100000);
       if (retry != null) nrel = retry;
     }
     if (nrel > 100000) {
@@ -1296,7 +1323,7 @@ class Legacy {
     }
     var defCount = r.u32();
     if (defCount > 1000000) {
-      final retry = retryCountAfterV20Filler(r, r.pos - 4);
+      final retry = retryCountAfterV20Filler(r, r.pos - 4, 1000000);
       if (retry != null) defCount = retry;
     }
     if (defCount > 1000000) {
@@ -1321,7 +1348,7 @@ class Legacy {
 
     var rootCount = r.u32();
     if (rootCount > 5000000) {
-      final retry = retryCountAfterV20Filler(r, r.pos - 4);
+      final retry = retryCountAfterV20Filler(r, r.pos - 4, 5000000);
       if (retry != null) rootCount = retry;
     }
     if (rootCount > 5000000) {

--- a/packages/dart/test/legacy_v20_filler_test.dart
+++ b/packages/dart/test/legacy_v20_filler_test.dart
@@ -1,0 +1,86 @@
+import 'dart:typed_data';
+
+import 'package:openskp/src/legacy.dart';
+import 'package:test/test.dart';
+
+/// The v20 filler probe, exercised on synthetic records.
+///
+/// Ported from the TypeScript fix (openskp#192, following the review on
+/// openskp#155): the original implementation walked forward to the first
+/// non-zero byte and treated it as the count's low byte. That cannot
+/// represent a count which is an exact multiple of 256 - its low byte IS
+/// 0x00, so the scan walks straight into the count and misaligns every read
+/// after it. Probing whole u32s at 4-byte strides fixes that, since no
+/// individual byte is ever inspected.
+///
+/// Layout (see findCountAfterV20Filler):
+///   <ff fe ff> <u8 0>   empty UTF-16 string
+///   <zero padding>      length varies per call site, always pad % 4 == 1
+///   <u32 count>
+
+/// Builds a filler record followed by [count], then a class-record header.
+Uint8List filler(int count, int pad) {
+  final bytes = <int>[0xFF, 0xFE, 0xFF, 0x00];
+  for (int i = 0; i < pad; i++) bytes.add(0x00);
+  bytes.add(count & 0xFF);
+  bytes.add((count >> 8) & 0xFF);
+  bytes.add((count >> 16) & 0xFF);
+  bytes.add((count >> 24) & 0xFF);
+  bytes.addAll([0xFF, 0xFF, 0x0B, 0x00]); // whatever record comes next
+  return Uint8List.fromList(bytes);
+}
+
+void main() {
+  group('findCountAfterV20Filler', () {
+    test('reads the counts and paddings seen in real v20 files', () {
+      // both padding lengths observed in gondola_v20.skp and a second v20 model
+      expect(findCountAfterV20Filler(filler(20, 9), 0, 1000000),
+          equals((count: 20, next: 17)));
+      expect(findCountAfterV20Filler(filler(5425, 13), 0, 5000000),
+          equals((count: 5425, next: 21)));
+    });
+
+    test('reads a count that is an exact multiple of 256', () {
+      // the regression this test exists for: a 0x00 low byte is
+      // indistinguishable from padding to a byte-at-a-time scan
+      for (final count in [256, 512, 1024, 65536, 16777216 ~/ 16]) {
+        for (final pad in [9, 13]) {
+          final hit = findCountAfterV20Filler(filler(count, pad), 0, 5000000);
+          expect(hit, isNotNull, reason: 'count=$count pad=$pad');
+          expect(hit!.count, equals(count), reason: 'count=$count pad=$pad');
+        }
+      }
+    });
+
+    test('reports where to resume reading', () {
+      final hit = findCountAfterV20Filler(filler(256, 13), 0, 5000000)!;
+      // 4 (marker+len) + 13 (padding) + 4 (the count itself)
+      expect(hit.next, equals(21));
+    });
+
+    test('ignores a non-empty string record', () {
+      // a real string here is genuine data; moving the cursor past it
+      // would corrupt the parse
+      final bytes = Uint8List.fromList(
+          [0xFF, 0xFE, 0xFF, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0]);
+      expect(findCountAfterV20Filler(bytes, 0, 1000000), isNull);
+    });
+
+    test('returns null when there is no marker ahead', () {
+      final bytes = Uint8List(32); // all zeros, no ff fe ff
+      expect(findCountAfterV20Filler(bytes, 0, 1000000), isNull);
+    });
+
+    test("respects the caller's plausibility limit", () {
+      // nrel's limit is 100_000: a value above it is not the count we want
+      expect(findCountAfterV20Filler(filler(200000, 13), 0, 100000), isNull);
+      expect(findCountAfterV20Filler(filler(200000, 13), 0, 5000000)?.count,
+          equals(200000));
+    });
+
+    test('does not run past the end of the buffer', () {
+      final bytes = Uint8List.fromList([0xFF, 0xFE, 0xFF, 0x00, 0, 0]);
+      expect(findCountAfterV20Filler(bytes, 0, 1000000), isNull);
+    });
+  });
+}

--- a/packages/dotnet/OpenSkp.Tests/LegacyV20FillerTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/LegacyV20FillerTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// The v20 filler probe, exercised on synthetic records.
+    ///
+    /// Ported from the TypeScript fix (openskp#192, following the review on
+    /// openskp#155): the original implementation walked forward to the first
+    /// non-zero byte and treated it as the count's low byte. That cannot
+    /// represent a count which is an exact multiple of 256 - its low byte IS
+    /// 0x00, so the scan walks straight into the count and misaligns every
+    /// read after it. Probing whole u32s at 4-byte strides fixes that, since
+    /// no individual byte is ever inspected.
+    ///
+    /// Layout (see LegacyBytes.FindCountAfterV20Filler):
+    ///   &lt;ff fe ff&gt; &lt;u8 0&gt;   empty UTF-16 string
+    ///   &lt;zero padding&gt;      length varies per call site, always pad % 4 == 1
+    ///   &lt;u32 count&gt;
+    /// </summary>
+    public class LegacyV20FillerTests
+    {
+        /// <summary>Builds a filler record followed by `count`, then a class-record header.</summary>
+        private static byte[] Filler(uint count, int pad)
+        {
+            var bytes = new List<byte> { 0xFF, 0xFE, 0xFF, 0x00 };
+            for (int i = 0; i < pad; i++) bytes.Add(0x00);
+            bytes.Add((byte)(count & 0xFF));
+            bytes.Add((byte)((count >> 8) & 0xFF));
+            bytes.Add((byte)((count >> 16) & 0xFF));
+            bytes.Add((byte)((count >> 24) & 0xFF));
+            bytes.Add(0xFF); bytes.Add(0xFF); bytes.Add(0x0B); bytes.Add(0x00); // next record
+            return bytes.ToArray();
+        }
+
+        [Fact]
+        public void ReadsCountsAndPaddingsSeenInRealV20Files()
+        {
+            // both padding lengths observed in gondola_v20.skp and a second v20 model
+            var hit1 = LegacyBytes.FindCountAfterV20Filler(Filler(20, 9), 0, 1_000_000);
+            Assert.Equal((20u, 17), hit1);
+
+            var hit2 = LegacyBytes.FindCountAfterV20Filler(Filler(5425, 13), 0, 5_000_000);
+            Assert.Equal((5425u, 21), hit2);
+        }
+
+        [Fact]
+        public void ReadsACountThatIsAnExactMultipleOf256()
+        {
+            // the regression this test exists for: a 0x00 low byte is
+            // indistinguishable from padding to a byte-at-a-time scan
+            uint[] counts = { 256, 512, 1024, 65536, 16_777_216 / 16 };
+            int[] pads = { 9, 13 };
+            foreach (var count in counts)
+            {
+                foreach (var pad in pads)
+                {
+                    var hit = LegacyBytes.FindCountAfterV20Filler(Filler(count, pad), 0, 5_000_000);
+                    Assert.True(hit.HasValue, $"count={count} pad={pad}");
+                    Assert.Equal(count, hit.Value.Count);
+                }
+            }
+        }
+
+        [Fact]
+        public void ReportsWhereToResumeReading()
+        {
+            var hit = LegacyBytes.FindCountAfterV20Filler(Filler(256, 13), 0, 5_000_000);
+            Assert.True(hit.HasValue);
+            // 4 (marker+len) + 13 (padding) + 4 (the count itself)
+            Assert.Equal(21, hit.Value.Next);
+        }
+
+        [Fact]
+        public void IgnoresANonEmptyStringRecord()
+        {
+            // a real string here is genuine data; moving the cursor past it
+            // would corrupt the parse
+            var bytes = new byte[] { 0xFF, 0xFE, 0xFF, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0 };
+            Assert.Null(LegacyBytes.FindCountAfterV20Filler(bytes, 0, 1_000_000));
+        }
+
+        [Fact]
+        public void ReturnsNullWhenThereIsNoMarkerAhead()
+        {
+            var bytes = new byte[32]; // all zeros, no ff fe ff
+            Assert.Null(LegacyBytes.FindCountAfterV20Filler(bytes, 0, 1_000_000));
+        }
+
+        [Fact]
+        public void RespectsTheCallersPlausibilityLimit()
+        {
+            // nrel's limit is 100_000: a value above it is not the count we want
+            Assert.Null(LegacyBytes.FindCountAfterV20Filler(Filler(200_000, 13), 0, 100_000));
+            var hit = LegacyBytes.FindCountAfterV20Filler(Filler(200_000, 13), 0, 5_000_000);
+            Assert.True(hit.HasValue);
+            Assert.Equal(200_000u, hit.Value.Count);
+        }
+
+        [Fact]
+        public void DoesNotRunPastTheEndOfTheBuffer()
+        {
+            var bytes = new byte[] { 0xFF, 0xFE, 0xFF, 0x00, 0, 0 };
+            Assert.Null(LegacyBytes.FindCountAfterV20Filler(bytes, 0, 1_000_000));
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -128,9 +128,20 @@ namespace OpenSkp
         /// (i.e. r.Pos - 4). Returns the corrected count, or null when this
         /// is not the v20 layout.
         /// </summary>
-        public static uint? RetryCountAfterV20Filler(LR r, int countPos)
+        /// <summary>Widest zero padding seen between the v20 filler's empty
+        /// string and the count that follows it (9 and 13 bytes occur in
+        /// real files; the ceiling leaves room without letting the probe
+        /// wander into unrelated records).</summary>
+        private const int MaxV20FillerPad = 29;
+
+        /// <summary>
+        /// Locates the count that follows a v20 filler record, given the
+        /// offset the bad count was read from. Pure byte logic, exposed for
+        /// tests; see <see cref="RetryCountAfterV20Filler"/> for how it is
+        /// used.
+        /// </summary>
+        public static (uint Count, int Next)? FindCountAfterV20Filler(byte[] data, int countPos, uint limit)
         {
-            var data = r.Data;
             int markerAt = -1;
             for (int i = countPos; i < countPos + 12 && i + 4 <= data.Length; i++)
             {
@@ -143,16 +154,34 @@ namespace OpenSkp
             if (markerAt < 0) return null;
             if (data[markerAt + 3] != 0) return null; // non-empty string: real data
 
-            // Skip the zero padding that follows the empty string. The count
-            // is little-endian and non-zero, so the first non-zero byte
-            // after the padding IS its low byte - the run ends exactly on
-            // the count.
-            int at = markerAt + 4;
-            while (at < data.Length && data[at] == 0) at++;
-            if (at + 4 > data.Length) return null;
-            uint count = Tlv.ReadU32(data, at);
-            r.Pos = at + 4;
-            return count;
+            // The count sits past a run of zero padding whose length varies
+            // per call site (9 and 13 bytes both occur in real files), but
+            // always lands at markerAt + 4 + pad with pad % 4 == 1. Step
+            // through those candidate offsets and take the first plausible
+            // u32.
+            //
+            // Deliberately NOT "scan forward to the first non-zero byte": a
+            // count that is an exact multiple of 256 has a 0x00 low byte,
+            // which such a scan cannot tell apart from padding, so it would
+            // skip into the count and misalign every later read. Probing
+            // whole u32s at 4-byte strides never inspects an individual
+            // byte, so those counts round-trip correctly.
+            for (int pad = 1; pad <= MaxV20FillerPad; pad += 4)
+            {
+                int at = markerAt + 4 + pad;
+                if (at + 4 > data.Length) break;
+                uint count = Tlv.ReadU32(data, at);
+                if (count > 0 && count <= limit) return (count, at + 4);
+            }
+            return null;
+        }
+
+        public static uint? RetryCountAfterV20Filler(LR r, int countPos, uint limit)
+        {
+            var hit = FindCountAfterV20Filler(r.Data, countPos, limit);
+            if (hit == null) return null;
+            r.Pos = hit.Value.Next;
+            return hit.Value.Count;
         }
     }
 
@@ -947,7 +976,7 @@ namespace OpenSkp
             // RetryCountAfterV20Filler leaves those alone.
             if (count > 5_000_000 || count == 0)
             {
-                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4);
+                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 5_000_000);
                 if (retry.HasValue) count = retry.Value;
             }
             if (count > 5_000_000)
@@ -958,7 +987,7 @@ namespace OpenSkp
             uint nrel = r.U32();
             if (nrel > 100000)
             {
-                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4);
+                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 100_000);
                 if (retry.HasValue) nrel = retry.Value;
             }
             if (nrel > 100000)
@@ -1364,7 +1393,7 @@ namespace OpenSkp
             uint defCount = r.U32();
             if (defCount > 1_000_000)
             {
-                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4);
+                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 1_000_000);
                 if (retry.HasValue) defCount = retry.Value;
             }
             if (defCount > 1_000_000)
@@ -1392,7 +1421,7 @@ namespace OpenSkp
             uint rootCount = r.U32();
             if (rootCount > 5_000_000)
             {
-                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4);
+                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 5_000_000);
                 if (retry.HasValue) rootCount = retry.Value;
             }
             if (rootCount > 5_000_000)

--- a/packages/python/tests/test_legacy_v20_filler.py
+++ b/packages/python/tests/test_legacy_v20_filler.py
@@ -1,0 +1,63 @@
+"""The v20 filler probe, exercised on synthetic records.
+
+Ported to TypeScript, .NET, Dart and C++ as openskp#192 (following the
+review on openskp#155): a byte-at-a-time "walk to the first non-zero byte"
+scan cannot represent a count which is an exact multiple of 256 - its low
+byte IS 0x00, so the scan walks straight into the count and misaligns every
+read after it. This project's Python implementation independently avoids
+that failure mode already (it backs up to a handful of candidate positions
+before the first non-zero byte rather than trusting that byte alone, then
+validates each candidate structurally via ``_plausible_list_tag``) - this
+file exists to lock that in with a real regression test, since none existed
+here despite the other four ports having one.
+
+Layout (see ``_retry_count_after_v20_filler``, legacy.py):
+    <ff fe ff> <u8 0>   empty UTF-16 string
+    <zero padding>      length varies per call site, always pad % 4 == 1
+    <u32 count>
+"""
+
+import struct
+
+from openskp.legacy import _R, _retry_count_after_v20_filler
+
+
+def _filler(count: int, pad: int) -> bytes:
+    """Builds a filler record followed by *count*, then a class-record header."""
+    b = bytearray([0xff, 0xfe, 0xff, 0x00])
+    b += bytes(pad)
+    b += struct.pack('<I', count)
+    b += bytes([0xff, 0xff, 0x0b, 0x00])  # whatever record comes next
+    return bytes(b)
+
+
+def _retry(data: bytes) -> int | None:
+    return _retry_count_after_v20_filler(_R(data, 0), 0, ar=None)
+
+
+class TestRetryCountAfterV20Filler:
+    def test_reads_the_counts_and_paddings_seen_in_real_v20_files(self):
+        # both padding lengths observed in gondola_v20.skp and a second v20 model
+        assert _retry(_filler(20, 9)) == 20
+        assert _retry(_filler(5425, 13)) == 5425
+
+    def test_reads_a_count_that_is_an_exact_multiple_of_256(self):
+        # the regression this test exists for: a 0x00 low byte is
+        # indistinguishable from padding to a byte-at-a-time scan
+        for count in (256, 512, 1024, 65536, 16_777_216 // 16):
+            for pad in (9, 13):
+                assert _retry(_filler(count, pad)) == count, f'count={count} pad={pad}'
+
+    def test_ignores_a_non_empty_string_record(self):
+        # a real string here is genuine data; moving the cursor past it
+        # would corrupt the parse
+        data = bytes([0xff, 0xfe, 0xff, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 20, 0, 0, 0])
+        assert _retry(data) is None
+
+    def test_returns_none_when_there_is_no_marker_ahead(self):
+        data = bytes(32)  # all zeros, no ff fe ff
+        assert _retry(data) is None
+
+    def test_does_not_run_past_the_end_of_the_buffer(self):
+        data = bytes([0xff, 0xfe, 0xff, 0x00, 0, 0])
+        assert _retry(data) is None


### PR DESCRIPTION
Picks up the checklist's "Cross-language ports owed" item for #192.

## What I checked before porting

The checklist entry (written 2026-08-20) claimed all four remaining languages had the exact bug TypeScript's `findCountAfterV20Filler` fixed. That's stale for one of them - re-verified each language directly rather than trusting the note:

- **.NET, Dart, C++**: confirmed still buggy by reading the source directly - identical "walk to the first non-zero byte" scan, identical wrong comment ("the first non-zero byte after the padding IS its low byte").
- **Python**: confirmed already correct by actually running it against synthetic multiple-of-256 inputs (`_retry_count_after_v20_filler` with `count=256/512/1024/65536` at both real-world padding widths). It uses a differently-shaped fix - back up to a few candidate positions before the first non-zero byte and validate each structurally via `_plausible_list_tag` - not TypeScript's 4-byte-stride probe, but it independently avoids the same failure mode. Must have been fixed as a side effect of later legacy-format work, not by #192 itself. No logic change needed there - just a regression test, since none existed to prove it.

## The fix (.NET, Dart, C++)

Same shape TypeScript uses: split into a pure `find_count_after_v20_filler` (testable, takes just bytes + a plausibility limit) and a thin `retry_count_after_v20_filler` wrapper that applies the result to the reader's position. All four call sites per language now pass the same limits already used at each site (5,000,000 / 100,000 / 1,000,000 / 5,000,000) - verified by reading each call site's surrounding `if (count > X)` check before adding the argument, not assumed.

**C++ note**: the pure find function lives in an anonymous namespace today, which made it untestable directly. Moved it into the enclosing `openskp` namespace instead, following the exact precedent already in this file (`legacy_instance_has_guid`, tested the same way in `lowlevel_test.cpp`) - not a new pattern.

## Tests

Each language gets a dedicated test file porting TypeScript's synthetic-byte suite (`legacy-v20-filler.test.ts`): the multiple-of-256 regression itself at both real padding widths (9 and 13 bytes, both observed in real v20 files), the plausibility-limit guard, the non-empty-string guard (a real string here is genuine data, not filler), and buffer-bounds safety.

## Verification

Ran each language's actual test suite myself, not just written the tests and assumed:
```
Python:  355 passed (350 pre-existing + 5 new), ruff clean
.NET:    132 passed (125 pre-existing + 7 new)
Dart:    164 passed (157 pre-existing + 7 new), dart analyze --fatal-infos clean
C++:     relies on CI - no local toolchain in this environment (standing constraint for this repo)
```

Scope: `legacy.py`/`.cs`/`.dart`/`.cpp`'s v20-filler path only. No public API changes in any language.