### PR TITLE
Port #193 GLB texture embedding + material-dedup fix to Python, .NET, Dart, C++

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e packages/python[dev]
+          pip install -e packages/python[dev,textures]
 
       - name: Run tests
         run: |

--- a/packages/cpp/include/openskp/glb.hpp
+++ b/packages/cpp/include/openskp/glb.hpp
@@ -8,10 +8,20 @@
 
 namespace openskp {
 
+/// Options for to_glb()/export_glb().
+struct GlbOptions {
+  /// Embed the scene's texture images in the GLB and point each textured
+  /// material's baseColorTexture at them. Off by default, matching every
+  /// other language's exporter: photographic textures can multiply the
+  /// file size, and the geometry alone is what most callers are after.
+  bool textures{false};
+};
+
 /// Serialize a baked scene as a binary glTF 2.0 (GLB) asset.
-OPENSKP_EXPORT ByteBuffer to_glb(const Scene& scene);
+OPENSKP_EXPORT ByteBuffer to_glb(const Scene& scene, const GlbOptions& options = {});
 
 /// Serialize a baked scene and write the resulting bytes to a file.
-OPENSKP_EXPORT void export_glb(const Scene& scene, const std::filesystem::path& output_path);
+OPENSKP_EXPORT void export_glb(const Scene& scene, const std::filesystem::path& output_path,
+                               const GlbOptions& options = {});
 
 }  // namespace openskp

--- a/packages/cpp/include/openskp/scene.hpp
+++ b/packages/cpp/include/openskp/scene.hpp
@@ -3,10 +3,12 @@
 #include <array>
 #include <cstdint>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
 #include <openskp/export.hpp>
+#include <openskp/model.hpp>
 
 namespace openskp {
 
@@ -51,6 +53,11 @@ struct PbrMetallicRoughness {
   std::array<double, 4> base_color_factor{1, 1, 1, 1};
   double metallic_factor{};
   double roughness_factor{0.8};
+  // Index into Scene::textures, or nullopt for an untextured material.
+  // baseColorFactor stays the resolved color even with a texture set:
+  // glTF multiplies the two, and SketchUp's own colorized materials rely
+  // on exactly that tint.
+  std::optional<std::size_t> base_color_texture;
 };
 
 struct GltfMaterial {
@@ -60,10 +67,24 @@ struct GltfMaterial {
   bool double_sided{};
 };
 
+/// One texture image referenced by Scene::gltf_materials.
+struct SceneTexture {
+  /// The image file's raw bytes, exactly as stored in the .skp.
+  ByteBuffer data;
+  /// Sniffed from the bytes, not from filename: SketchUp records the
+  /// authoring machine's path, whose extension can disagree with the
+  /// content.
+  std::string mime_type;
+  std::string filename;
+};
+
 struct OPENSKP_EXPORT Scene {
   InstanceNode scene_hierarchy;
   std::map<std::string, MeshMetadata> mesh_index;
   std::vector<GlbPrimitive> glb_primitives;
   std::vector<GltfMaterial> gltf_materials;
+  // Distinct texture images the placed materials use, deduplicated by
+  // source bytes. Empty when nothing placed in the scene is textured.
+  std::vector<SceneTexture> textures;
 };
 }  // namespace openskp

--- a/packages/cpp/src/glb.cpp
+++ b/packages/cpp/src/glb.cpp
@@ -162,7 +162,7 @@ void validate_scene(const Scene& scene) {
   }
 }
 
-gltf::Model make_model(const Scene& scene) {
+gltf::Model make_model(const Scene& scene, bool embed_textures) {
   validate_scene(scene);
 
   gltf::Model model;
@@ -181,6 +181,14 @@ gltf::Model make_model(const Scene& scene) {
     material.pbrMetallicRoughness.roughnessFactor = source_pbr.roughness_factor;
     material.doubleSided = source.double_sided;
     if (source_pbr.base_color_factor[3] < 1.0) material.alphaMode = "BLEND";
+    // baseColorTexture.index defaults to -1 (unset); TinyGLTF omits the
+    // key from the serialized JSON in that case, so leaving it untouched
+    // when not embedding is the strip - no separate pass needed, unlike
+    // the hand-rolled writers in the other languages.
+    if (embed_textures && source_pbr.base_color_texture) {
+      material.pbrMetallicRoughness.baseColorTexture.index =
+          static_cast<int>(*source_pbr.base_color_texture);
+    }
     model.materials.push_back(std::move(material));
   }
 
@@ -243,6 +251,38 @@ gltf::Model make_model(const Scene& scene) {
     mesh.primitives.push_back(std::move(primitive));
   }
 
+  if (embed_textures && !scene.textures.empty()) {
+    model.samplers.emplace_back();
+    model.samplers[0].wrapS = TINYGLTF_TEXTURE_WRAP_REPEAT;
+    model.samplers[0].wrapT = TINYGLTF_TEXTURE_WRAP_REPEAT;
+
+    for (const auto& tex : scene.textures) {
+      const auto image_offset = append_values(
+          binary, tex.data, [](ByteBuffer& bytes, std::uint8_t value) { bytes.push_back(value); });
+
+      // Not add_view(): that helper always sets BufferView::target, but an
+      // image bufferView must leave target unset (glTF's target enum only
+      // covers vertex/index buffers - 0 is not a valid value, and TinyGLTF
+      // only omits the key from the output when target is its -1 default).
+      gltf::BufferView view;
+      view.buffer = 0;
+      view.byteOffset = image_offset;
+      view.byteLength = tex.data.size();
+      model.bufferViews.push_back(std::move(view));
+      const auto image_view = static_cast<int>(model.bufferViews.size() - 1);
+
+      gltf::Image image;
+      image.mimeType = tex.mime_type;
+      image.bufferView = image_view;
+      model.images.push_back(std::move(image));
+
+      gltf::Texture texture;
+      texture.sampler = 0;
+      texture.source = static_cast<int>(model.images.size() - 1);
+      model.textures.push_back(std::move(texture));
+    }
+  }
+
   model.meshes.push_back(std::move(mesh));
   model.nodes.emplace_back();
   model.nodes[0].name = "OpenSKP Scene";
@@ -253,8 +293,8 @@ gltf::Model make_model(const Scene& scene) {
 
 }  // namespace
 
-ByteBuffer to_glb(const Scene& scene) {
-  auto model = make_model(scene);
+ByteBuffer to_glb(const Scene& scene, const GlbOptions& options) {
+  auto model = make_model(scene, options.textures);
   std::ostringstream stream(std::ios::binary | std::ios::out);
   try {
     gltf::TinyGLTF writer;
@@ -274,8 +314,9 @@ ByteBuffer to_glb(const Scene& scene) {
   return ByteBuffer(serialized.begin(), serialized.end());
 }
 
-void export_glb(const Scene& scene, const std::filesystem::path& output_path) {
-  const auto bytes = to_glb(scene);
+void export_glb(const Scene& scene, const std::filesystem::path& output_path,
+                const GlbOptions& options) {
+  const auto bytes = to_glb(scene, options);
   std::ofstream stream(output_path, std::ios::binary | std::ios::trunc);
   if (!stream) throw std::runtime_error("failed to open GLB output file");
   stream.write(reinterpret_cast<const char*>(bytes.data()),

--- a/packages/cpp/src/scene.cpp
+++ b/packages/cpp/src/scene.cpp
@@ -14,9 +14,15 @@ using Key = std::array<int, 4>;
 struct GroupKey {
   Key color;
   bool double_sided{};
+  // The texture is part of the identity, not just the color: two
+  // different images can average to the same RGB (real files do this),
+  // and keying on color alone would merge them into one material and
+  // lose one of the images.
+  std::optional<std::size_t> texture_index;
 
   bool operator<(const GroupKey& other) const {
-    return std::tie(color, double_sided) < std::tie(other.color, other.double_sided);
+    return std::tie(color, double_sided, texture_index) <
+           std::tie(other.color, other.double_sided, other.texture_index);
   }
 };
 
@@ -49,6 +55,20 @@ std::optional<Key> material_color(const std::shared_ptr<RawMaterial>& material) 
   if (!material) return {};
   return Key{material->r, material->g, material->b,
              static_cast<int>(std::lround(std::clamp(material->transparency, 0.0, 1.0) * 255.0))};
+}
+
+// Identifies an image's MIME type from its magic bytes. Returns nullopt
+// for anything glTF cannot carry (glTF only allows PNG and JPEG).
+std::optional<std::string> sniff_image_mime(const ByteBuffer& data) {
+  if (data.size() >= 3 && data[0] == 0xff && data[1] == 0xd8 && data[2] == 0xff) {
+    return "image/jpeg";
+  }
+  if (data.size() >= 8 && data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4e &&
+      data[3] == 0x47 && data[4] == 0x0d && data[5] == 0x0a && data[6] == 0x1a &&
+      data[7] == 0x0a) {
+    return "image/png";
+  }
+  return std::nullopt;
 }
 
 std::pair<double, double> tile_size(const std::shared_ptr<RawMaterial>& material) {
@@ -138,6 +158,34 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
   std::map<GroupKey, size_t> materials;
   size_t mesh_counter = 0, instance_counter = 0;
   std::set<EntityId> active;
+
+  // Textures deduplicated by bytes: the same image routinely backs
+  // several materials, and re-embedding it per material would multiply
+  // the export size for nothing.
+  std::map<std::string, std::size_t> texture_index_by_key;
+  auto texture_index_for =
+      [&](const std::shared_ptr<RawMaterial>& mat) -> std::optional<std::size_t> {
+    if (!mat || !mat->texture || !mat->texture->data || mat->texture->data->empty()) {
+      return std::nullopt;
+    }
+    const auto& data = *mat->texture->data;
+    auto mime_type = sniff_image_mime(data);
+    if (!mime_type) return std::nullopt;  // a format glTF cannot carry
+    // length plus a short byte prefix is enough to tell real images apart
+    // without hashing megabytes on every face
+    std::ostringstream key_stream;
+    key_stream << data.size() << ':';
+    for (std::size_t i = 0; i < data.size() && i < 16; ++i) {
+      key_stream << std::hex << static_cast<int>(data[i]);
+    }
+    const auto key = key_stream.str();
+    auto found = texture_index_by_key.find(key);
+    if (found != texture_index_by_key.end()) return found->second;
+    const auto idx = scene.textures.size();
+    scene.textures.push_back(SceneTexture{data, *mime_type, mat->texture->filename});
+    texture_index_by_key.emplace(key, idx);
+    return idx;
+  };
   std::function<std::vector<InstanceNode>(
       const GeometryBuilder&, const std::string&, std::optional<EntityId>,
       const std::vector<double>&, const std::string&, const std::string&, std::optional<Key>)>
@@ -195,12 +243,12 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
       };
       if (front == back) {
         const auto [tw, th] = tile_size(front_mat);
-        add_side({front, true}, false, f.uv_transform, tw, th);
+        add_side({front, true, texture_index_for(front_mat)}, false, f.uv_transform, tw, th);
       } else {
         const auto [ftw, fth] = tile_size(front_mat);
-        add_side({front, false}, false, f.uv_transform, ftw, fth);
+        add_side({front, false, texture_index_for(front_mat)}, false, f.uv_transform, ftw, fth);
         const auto [btw, bth] = tile_size(back_mat);
-        add_side({back, false}, true, f.uv_transform_back, btw, bth);
+        add_side({back, false, texture_index_for(back_mat)}, true, f.uv_transform_back, btw, bth);
       }
     }
     for (auto& kv : groups) {
@@ -265,6 +313,7 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
         gm.pbr_metallic_roughness.base_color_factor = {
             kv.first.color[0] / 255., kv.first.color[1] / 255., kv.first.color[2] / 255.,
             kv.first.color[3] / 255.};
+        gm.pbr_metallic_roughness.base_color_texture = kv.first.texture_index;
         gm.double_sided = kv.first.double_sided;
         scene.gltf_materials.push_back(gm);
         mi = materials.emplace(kv.first, idx).first;

--- a/packages/cpp/src/scene.cpp
+++ b/packages/cpp/src/scene.cpp
@@ -64,8 +64,7 @@ std::optional<std::string> sniff_image_mime(const ByteBuffer& data) {
     return "image/jpeg";
   }
   if (data.size() >= 8 && data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4e &&
-      data[3] == 0x47 && data[4] == 0x0d && data[5] == 0x0a && data[6] == 0x1a &&
-      data[7] == 0x0a) {
+      data[3] == 0x47 && data[4] == 0x0d && data[5] == 0x0a && data[6] == 0x1a && data[7] == 0x0a) {
     return "image/png";
   }
   return std::nullopt;

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(
   face_instance_hidden_test.cpp
   geometry_test.cpp
   glb_test.cpp
+  glb_textures_test.cpp
   ifc_export_test.cpp
   json_export_test.cpp
   layer_hidden_test.cpp

--- a/packages/cpp/tests/glb_textures_test.cpp
+++ b/packages/cpp/tests/glb_textures_test.cpp
@@ -29,9 +29,19 @@
 namespace openskp {
 namespace {
 
+// TinyGLTF is built with TINYGLTF_NO_STB_IMAGE, so it has no default pixel
+// decoder and refuses to load a GLB with embedded images unless the caller
+// supplies one. These tests only check structure (bufferView, mimeType,
+// indices), never pixel data, so a no-op stand-in is enough.
+bool skip_image_decode(tinygltf::Image*, const int, std::string*, std::string*, int, int,
+                       const unsigned char*, int, void*) {
+  return true;
+}
+
 tinygltf::Model load_glb(const ByteBuffer& bytes) {
   tinygltf::Model model;
   tinygltf::TinyGLTF loader;
+  loader.SetImageLoader(skip_image_decode, nullptr);
   std::string error;
   std::string warning;
   EXPECT_TRUE(loader.LoadBinaryFromMemory(&model, &error, &warning, bytes.data(), bytes.size()))

--- a/packages/cpp/tests/glb_textures_test.cpp
+++ b/packages/cpp/tests/glb_textures_test.cpp
@@ -5,9 +5,12 @@
 #include <gtest/gtest.h>
 #include <initializer_list>
 #include <string>
-#include <tiny_gltf.h>
 
 #include <openskp/openskp.hpp>
+
+#define TINYGLTF_NO_STB_IMAGE
+#define TINYGLTF_NO_STB_IMAGE_WRITE
+#include <tiny_gltf.h>
 
 #include "test_helpers.hpp"
 

--- a/packages/cpp/tests/glb_textures_test.cpp
+++ b/packages/cpp/tests/glb_textures_test.cpp
@@ -1,0 +1,128 @@
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <initializer_list>
+#include <string>
+
+#include <openskp/openskp.hpp>
+
+#include <tiny_gltf.h>
+
+#include "test_helpers.hpp"
+
+// GLB texture embedding and the material-identity fix it depends on
+// (openskp#193, ported from TypeScript).
+//
+// Before this, gltf_materials was keyed on (color, double_sided) alone, so
+// two different textures that happened to average to the same RGB would
+// silently collapse into one material and lose an image. Fixed by keying on
+// (color, double_sided, texture_index) instead, at both the face-grouping
+// and material-dedup layers.
+//
+// Fixture: capilla_quiroz_v17.skp, which carries 3 real, distinct JPEG
+// textures - real coverage, not a synthetic mock.
+
+namespace openskp {
+namespace {
+
+tinygltf::Model load_glb(const ByteBuffer& bytes) {
+  tinygltf::Model model;
+  tinygltf::TinyGLTF loader;
+  std::string error;
+  std::string warning;
+  EXPECT_TRUE(loader.LoadBinaryFromMemory(&model, &error, &warning, bytes.data(), bytes.size()))
+      << error << warning;
+  EXPECT_TRUE(error.empty()) << error;
+  return model;
+}
+
+bool contains_bytes(const ByteBuffer& haystack, std::initializer_list<std::uint8_t> needle) {
+  return std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end()) !=
+         haystack.end();
+}
+
+const ByteBuffer kJpegMagic{0xff, 0xd8, 0xff};
+
+TEST(GlbTextures, SceneDeduplicatesTexturesAndKeysMaterialsByThem) {
+  const auto scene = SkpFile::open(test::fixture("capilla_quiroz_v17.skp")).build_scene();
+
+  ASSERT_EQ(scene.textures.size(), 3);
+  for (const auto& tex : scene.textures) {
+    EXPECT_TRUE(tex.mime_type == "image/jpeg" || tex.mime_type == "image/png");
+    EXPECT_FALSE(tex.data.empty());
+  }
+
+  std::size_t textured = 0;
+  for (const auto& mat : scene.gltf_materials) {
+    if (mat.pbr_metallic_roughness.base_color_texture.has_value()) {
+      ++textured;
+      EXPECT_LT(*mat.pbr_metallic_roughness.base_color_texture, scene.textures.size());
+    }
+  }
+  EXPECT_EQ(textured, 4);
+}
+
+TEST(GlbTextures, ExportOmitsImagesByDefault) {
+  const auto scene = SkpFile::open(test::fixture("capilla_quiroz_v17.skp")).build_scene();
+  const auto bytes = to_glb(scene);
+
+  const std::string text(bytes.begin(), bytes.end());
+  EXPECT_EQ(text.find("\"images\""), std::string::npos);
+  EXPECT_FALSE(contains_bytes(bytes, {0xff, 0xd8, 0xff}));
+
+  const auto model = load_glb(bytes);
+  EXPECT_TRUE(model.images.empty());
+}
+
+TEST(GlbTextures, ExportEmbedsTexturesWhenAsked) {
+  const auto scene = SkpFile::open(test::fixture("capilla_quiroz_v17.skp")).build_scene();
+  const auto without_textures = to_glb(scene);
+  const auto with_textures = to_glb(scene, GlbOptions{true});
+
+  EXPECT_GT(with_textures.size(), without_textures.size());
+  EXPECT_TRUE(contains_bytes(with_textures, {0xff, 0xd8, 0xff}));
+
+  const auto model = load_glb(with_textures);
+  ASSERT_EQ(model.images.size(), 3);
+  for (const auto& image : model.images) {
+    EXPECT_GE(image.bufferView, 0);
+    ASSERT_GE(image.mimeType.size(), 6);
+    EXPECT_EQ(image.mimeType.substr(0, 6), "image/");
+  }
+  ASSERT_EQ(model.textures.size(), 3);
+  for (const auto& texture : model.textures) {
+    EXPECT_GE(texture.source, 0);
+  }
+
+  bool found_textured_material = false;
+  for (const auto& material : model.materials) {
+    if (material.pbrMetallicRoughness.baseColorTexture.index >= 0) {
+      found_textured_material = true;
+      EXPECT_LT(material.pbrMetallicRoughness.baseColorTexture.index,
+                static_cast<int>(model.textures.size()));
+    }
+  }
+  EXPECT_TRUE(found_textured_material);
+}
+
+TEST(GlbTextures, ExportGlbFileWritesEmbeddedTextures) {
+  const auto scene = SkpFile::open(test::fixture("capilla_quiroz_v17.skp")).build_scene();
+  const auto output = std::filesystem::temp_directory_path() / "openskp-cpp-textures-test.glb";
+  export_glb(scene, output, GlbOptions{true});
+
+  std::ifstream stream(output, std::ios::binary | std::ios::ate);
+  ASSERT_TRUE(stream);
+  const auto size = stream.tellg();
+  ByteBuffer actual(static_cast<std::size_t>(size));
+  stream.seekg(0);
+  stream.read(reinterpret_cast<char*>(actual.data()), size);
+  stream.close();
+
+  EXPECT_TRUE(contains_bytes(actual, {0xff, 0xd8, 0xff}));
+  std::filesystem::remove(output);
+}
+
+}  // namespace
+}  // namespace openskp

--- a/packages/cpp/tests/glb_textures_test.cpp
+++ b/packages/cpp/tests/glb_textures_test.cpp
@@ -5,10 +5,9 @@
 #include <gtest/gtest.h>
 #include <initializer_list>
 #include <string>
+#include <tiny_gltf.h>
 
 #include <openskp/openskp.hpp>
-
-#include <tiny_gltf.h>
 
 #include "test_helpers.hpp"
 

--- a/packages/dart/lib/src/glb.dart
+++ b/packages/dart/lib/src/glb.dart
@@ -17,9 +17,23 @@ const int _glbSizeLimit = 0xFFFFFFFF;
 /// chunk directly, no custom serializer needed. Structurally ported from
 /// the TypeScript reference implementation's `toGLB()`, with full
 /// TEXCOORD_0 UV support.
-Uint8List toGlb(Scene scene) {
+///
+/// [textures]: embed the scene's texture images in the GLB and point each
+/// textured material's `baseColorTexture` at them. Off by default,
+/// matching every other language's exporter: photographic textures can
+/// multiply the file size, and the geometry alone is what most callers
+/// are after.
+Uint8List toGlb(Scene scene, {bool textures = false}) {
   final prims = scene.glbPrimitives;
-  final materials = scene.gltfMaterials;
+  final rawMaterials = scene.gltfMaterials;
+  final sceneTextures = textures ? scene.textures : <SceneTexture>[];
+
+  // Materials always reference textures by index (buildScene() sets that
+  // up unconditionally); embedding the actual image bytes is the opt-in
+  // part. When not embedding, strip the reference so a strict glTF reader
+  // never sees a baseColorTexture pointing at a textures[] array that was
+  // never written - a copy, never mutating the Scene the caller owns.
+  final materials = textures ? rawMaterials : _stripTextureRefs(rawMaterials);
 
   _validateScene(prims, materials);
 
@@ -30,6 +44,16 @@ Uint8List toGlb(Scene scene) {
     totalBinaryLength += prim.uvs.length * 4;
     totalBinaryLength += prim.indices.length * 4;
   }
+
+  // Each image is placed on its own 4-byte-aligned offset, as glTF
+  // requires for bufferView data.
+  final imagePlacements = <(int offset, int length)>[];
+  for (final tex in sceneTextures) {
+    totalBinaryLength += (4 - (totalBinaryLength % 4)) % 4;
+    imagePlacements.add((totalBinaryLength, tex.data.length));
+    totalBinaryLength += tex.data.length;
+  }
+
   if (totalBinaryLength > _glbSizeLimit) {
     throw StateError("scene geometry exceeds GLB's 32-bit binary-buffer limit");
   }
@@ -166,6 +190,26 @@ Uint8List toGlb(Scene scene) {
     });
   }
 
+  final gltfImages = <Map<String, dynamic>>[];
+  final gltfTextures = <Map<String, dynamic>>[];
+  final bufferBytes = binaryBuffer.buffer.asUint8List();
+  for (var i = 0; i < sceneTextures.length; i++) {
+    final tex = sceneTextures[i];
+    final (offset, length) = imagePlacements[i];
+    bufferBytes.setRange(offset, offset + length, tex.data);
+
+    final imgBufferViewIdx = bufferViews.length;
+    bufferViews.add({
+      'buffer': 0,
+      'byteOffset': offset,
+      'byteLength': length,
+    });
+
+    final imageIdx = gltfImages.length;
+    gltfImages.add({'bufferView': imgBufferViewIdx, 'mimeType': tex.mimeType});
+    gltfTextures.add({'sampler': 0, 'source': imageIdx});
+  }
+
   final gltfMeshes = <Map<String, dynamic>>[];
   if (gltfPrimitives.isNotEmpty) {
     gltfMeshes.add({'primitives': gltfPrimitives});
@@ -187,16 +231,41 @@ Uint8List toGlb(Scene scene) {
     ],
     'bufferViews': bufferViews,
     'accessors': accessors,
+    if (gltfImages.isNotEmpty) 'images': gltfImages,
+    if (gltfImages.isNotEmpty) 'textures': gltfTextures,
+    if (gltfImages.isNotEmpty)
+      'samplers': [
+        {'wrapS': 10497, 'wrapT': 10497}, // REPEAT / REPEAT
+      ],
   };
 
-  return _createGlb(gltfJson, binaryBuffer.buffer.asUint8List());
+  return _createGlb(gltfJson, bufferBytes);
+}
+
+/// Materials with every `baseColorTexture` reference removed - a copy,
+/// never mutating the input. Used when not embedding images, so a strict
+/// glTF reader never sees a reference into a textures[] array that was
+/// never written.
+List<Map<String, dynamic>> _stripTextureRefs(List<Map<String, dynamic>> materials) {
+  final needsCopy = materials.any((m) {
+    final pbr = m['pbrMetallicRoughness'] as Map<String, dynamic>?;
+    return pbr != null && pbr.containsKey('baseColorTexture');
+  });
+  if (!needsCopy) return materials;
+
+  return materials.map((m) {
+    final pbr = m['pbrMetallicRoughness'] as Map<String, dynamic>?;
+    if (pbr == null || !pbr.containsKey('baseColorTexture')) return m;
+    final newPbr = Map<String, dynamic>.from(pbr)..remove('baseColorTexture');
+    return Map<String, dynamic>.from(m)..['pbrMetallicRoughness'] = newPbr;
+  }).toList();
 }
 
 /// Serializes a baked [Scene] to GLB and writes it to [path]. Does not
 /// create missing parent directories - matching the C++ and .NET ports'
 /// export_glb/ExportGlb.
-void exportGlb(Scene scene, String path) {
-  File(path).writeAsBytesSync(toGlb(scene));
+void exportGlb(Scene scene, String path, {bool textures = false}) {
+  File(path).writeAsBytesSync(toGlb(scene, textures: textures));
 }
 
 void _validateScene(List<GlbPrimitive> prims, List<Map<String, dynamic>> materials) {

--- a/packages/dart/lib/src/scene.dart
+++ b/packages/dart/lib/src/scene.dart
@@ -88,6 +88,21 @@ class GlbPrimitive {
   });
 }
 
+/// One texture image referenced by Scene.gltfMaterials.
+class SceneTexture {
+  /// The image file's raw bytes, exactly as stored in the .skp.
+  final List<int> data;
+
+  /// Sniffed from the bytes, not from [filename]: SketchUp records the
+  /// authoring machine's path, whose extension can disagree with the
+  /// content.
+  final String mimeType;
+
+  final String filename;
+
+  SceneTexture({required this.data, required this.mimeType, this.filename = ''});
+}
+
 /// The result of baking a parsed file's placed instances into a flat,
 /// world-space 3D scene.
 class Scene {
@@ -96,12 +111,31 @@ class Scene {
   List<GlbPrimitive> glbPrimitives;
   List<Map<String, dynamic>> gltfMaterials;
 
+  /// Distinct texture images the placed materials use, deduplicated by
+  /// source bytes. Empty when nothing placed in the scene is textured.
+  List<SceneTexture> textures;
+
   Scene({
     required this.sceneHierarchy,
     required this.meshIndex,
     required this.glbPrimitives,
     required this.gltfMaterials,
-  });
+    List<SceneTexture>? textures,
+  }) : textures = textures ?? [];
+}
+
+/// Identifies an image's MIME type from its magic bytes. Returns null for
+/// anything glTF cannot carry (glTF only allows PNG and JPEG).
+String? sniffImageMime(List<int> data) {
+  if (data.length >= 3 && data[0] == 0xff && data[1] == 0xd8 && data[2] == 0xff) {
+    return 'image/jpeg';
+  }
+  if (data.length >= 8 &&
+      data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4e && data[3] == 0x47 &&
+      data[4] == 0x0d && data[5] == 0x0a && data[6] == 0x1a && data[7] == 0x0a) {
+    return 'image/png';
+  }
+  return null;
 }
 
 class _FaceGroup {
@@ -196,7 +230,31 @@ class SceneBuilder {
     final meshIndex = <String, MeshMetadata>{};
     final glbPrimitives = <GlbPrimitive>[];
 
-    final colorToMaterialIndex = <((int, int, int), bool), int>{};
+    // Textures deduplicated by bytes: the same image routinely backs
+    // several materials, and re-embedding it per material would multiply
+    // the export size for nothing.
+    final textures = <SceneTexture>[];
+    final textureIndexByKey = <String, int>{};
+
+    int? textureIndexFor(RawTexture? tex) {
+      if (tex == null || tex.data == null || tex.data!.isEmpty) return null;
+      final data = tex.data!;
+      final mimeType = sniffImageMime(data);
+      if (mimeType == null) return null; // a format glTF cannot carry
+      // length plus a short byte prefix is enough to tell real images
+      // apart without hashing megabytes on every face
+      final headLen = data.length < 16 ? data.length : 16;
+      final head = data.sublist(0, headLen).join(',');
+      final key = '${data.length}:$head';
+      final hit = textureIndexByKey[key];
+      if (hit != null) return hit;
+      final idx = textures.length;
+      textures.add(SceneTexture(data: data, mimeType: mimeType, filename: tex.filename));
+      textureIndexByKey[key] = idx;
+      return idx;
+    }
+
+    final colorToMaterialIndex = <((int, int, int), bool, int?), int>{};
     final gltfMaterials = <Map<String, dynamic>>[];
 
     // Definitions currently being instantiated on the active recursion path
@@ -208,19 +266,28 @@ class SceneBuilder {
 
     (int, int, int) getLayerColor(String name) => layerColors[name] ?? (136, 136, 136);
 
-    int getMaterialIndex((int, int, int) color, bool doubleSided) {
-      final key = (color, doubleSided);
+    int getMaterialIndex((int, int, int) color, bool doubleSided, int? textureIndex) {
+      // The texture is part of the identity, not just the color: two
+      // different images can average to the same RGB (real files do
+      // this), and keying on color alone would merge them into one
+      // material and lose one of the images.
+      final key = (color, doubleSided, textureIndex);
       final existing = colorToMaterialIndex[key];
       if (existing != null) return existing;
       final idx = gltfMaterials.length;
       final (r, g, b) = color;
-      final material = <String, dynamic>{
-        'pbrMetallicRoughness': {
-          'baseColorFactor': [r / 255, g / 255, b / 255, 1.0],
-          'metallicFactor': 0.0,
-          'roughnessFactor': 0.8,
-        },
+      final pbr = <String, dynamic>{
+        'baseColorFactor': [r / 255, g / 255, b / 255, 1.0],
+        'metallicFactor': 0.0,
+        'roughnessFactor': 0.8,
       };
+      // baseColorFactor stays as the resolved color even with a texture
+      // attached: glTF multiplies the two, and SketchUp's own colorized
+      // materials rely on exactly that tint.
+      if (textureIndex != null) {
+        pbr['baseColorTexture'] = {'index': textureIndex};
+      }
+      final material = <String, dynamic>{'pbrMetallicRoughness': pbr};
       if (doubleSided) material['doubleSided'] = true;
       gltfMaterials.add(material);
       colorToMaterialIndex[key] = idx;
@@ -265,7 +332,7 @@ class SceneBuilder {
         // the back material - so each side renders its own correct color
         // instead of the front material leaking onto (or the back
         // vanishing from) the far side.
-        final faceGroups = <((int, int, int), bool), _FaceGroup>{};
+        final faceGroups = <((int, int, int), bool, int?), _FaceGroup>{};
 
         RawMaterial? resolveMaterial(int? matId) =>
             _resolveMaterial(matId, materialIdToName, materials, materialsByFolder);
@@ -281,7 +348,12 @@ class SceneBuilder {
           (double, double, double) xr,
           (double, double, double) yr,
         ) {
-          final key = (color, doubleSided);
+          // faces are batched per emitted material, so the texture has to
+          // be part of the key too - otherwise two differently-textured
+          // faces with the same average color end up in one group with
+          // one image
+          final texIndex = textureIndexFor(mat?.texture);
+          final key = (color, doubleSided, texIndex);
           final group = faceGroups.putIfAbsent(key, () => _FaceGroup(color, doubleSided));
 
           final tex = mat?.texture;
@@ -370,7 +442,9 @@ class SceneBuilder {
         final isRootPath = pathName == 'ROOT';
         final multiGroup = faceGroups.length > 1;
 
-        for (final group in faceGroups.values) {
+        for (final groupEntry in faceGroups.entries) {
+          final (_, _, texIndex) = groupEntry.key;
+          final group = groupEntry.value;
           final color = group.color;
           if (group.localFaces.isEmpty) continue;
 
@@ -455,7 +529,7 @@ class SceneBuilder {
             indices.add(tri[2]);
           }
 
-          final materialIndex = getMaterialIndex(color, group.doubleSided);
+          final materialIndex = getMaterialIndex(color, group.doubleSided, texIndex);
           glbPrimitives.add(GlbPrimitive(
             positions: positions,
             normals: normals,
@@ -593,6 +667,7 @@ class SceneBuilder {
       meshIndex: meshIndex,
       glbPrimitives: glbPrimitives,
       gltfMaterials: gltfMaterials,
+      textures: textures,
     );
   }
 

--- a/packages/dart/test/glb_textures_test.dart
+++ b/packages/dart/test/glb_textures_test.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:openskp/openskp.dart';
+import 'package:test/test.dart';
+
+/// GLB texture embedding and the material-identity fix it depends on
+/// (openskp#193, ported from TypeScript).
+///
+/// Before this, gltfMaterials was keyed on (color, doubleSided) alone, so
+/// two different textures that happened to average to the same RGB would
+/// silently collapse into one material and lose an image. Fixed by keying
+/// on (color, doubleSided, textureIndex) instead, at both the
+/// face-grouping and material-dedup layers.
+///
+/// Fixture: capilla_quiroz_v17.skp, which carries 3 real, distinct JPEG
+/// textures - real coverage, not a synthetic mock.
+
+({Map<String, dynamic> json, Uint8List binary}) _parseGlb(Uint8List bytes) {
+  final bd = ByteData.sublistView(bytes);
+  final jsonChunkLen = bd.getUint32(12, Endian.little);
+  final jsonStr = utf8.decode(bytes.sublist(20, 20 + jsonChunkLen));
+  final json = jsonDecode(jsonStr) as Map<String, dynamic>;
+
+  final binHeaderOffset = 20 + jsonChunkLen;
+  var binary = Uint8List(0);
+  if (binHeaderOffset < bytes.length) {
+    final binChunkLen = bd.getUint32(binHeaderOffset, Endian.little);
+    binary = bytes.sublist(binHeaderOffset + 8, binHeaderOffset + 8 + binChunkLen);
+  }
+  return (json: json, binary: binary);
+}
+
+bool _containsBytes(List<int> haystack, List<int> needle) {
+  for (var i = 0; i <= haystack.length - needle.length; i++) {
+    var match = true;
+    for (var j = 0; j < needle.length; j++) {
+      if (haystack[i + j] != needle[j]) { match = false; break; }
+    }
+    if (match) return true;
+  }
+  return false;
+}
+
+const _jpegMagic = [0xFF, 0xD8, 0xFF];
+
+void main() {
+  final fixturePath = 'test/fixtures/capilla_quiroz_v17.skp';
+
+  group('GLB texture embedding', () {
+    test('scene deduplicates textures and keys materials by them', () {
+      final skp = SkpFile.open(fixturePath);
+      final scene = skp.buildScene();
+
+      expect(scene.textures.length, equals(3));
+      for (final tex in scene.textures) {
+        expect(tex.mimeType, anyOf('image/jpeg', 'image/png'));
+        expect(tex.data, isNotEmpty);
+      }
+
+      var textured = 0;
+      for (final m in scene.gltfMaterials) {
+        final pbr = m['pbrMetallicRoughness'] as Map<String, dynamic>;
+        if (pbr.containsKey('baseColorTexture')) {
+          textured++;
+          final idx = (pbr['baseColorTexture'] as Map<String, dynamic>)['index'] as int;
+          expect(idx, inInclusiveRange(0, scene.textures.length - 1));
+        }
+      }
+      expect(textured, equals(4));
+    });
+
+    test('export omits images by default', () {
+      final skp = SkpFile.open(fixturePath);
+      final scene = skp.buildScene();
+      final bytes = toGlb(scene);
+
+      final str = latin1.decode(bytes, allowInvalid: true);
+      expect(str.contains('"images"'), isFalse);
+      expect(_containsBytes(bytes, _jpegMagic), isFalse);
+    });
+
+    test('export embeds textures when asked', () {
+      final skp = SkpFile.open(fixturePath);
+      final scene = skp.buildScene();
+      final noTex = toGlb(scene);
+      final withTex = toGlb(scene, textures: true);
+
+      expect(withTex.length, greaterThan(noTex.length));
+      final str = latin1.decode(withTex, allowInvalid: true);
+      expect(str.contains('"images"'), isTrue);
+      expect(_containsBytes(withTex, _jpegMagic), isTrue);
+
+      final parsed = _parseGlb(withTex);
+      final images = parsed.json['images'] as List;
+      expect(images.length, equals(3));
+      for (final img in images) {
+        expect(img['bufferView'], isNotNull);
+        expect((img['mimeType'] as String).startsWith('image/'), isTrue);
+      }
+    });
+
+    test('exportGlb file writes embedded textures', () {
+      final skp = SkpFile.open(fixturePath);
+      final scene = skp.buildScene();
+      final tmp = File('${Directory.systemTemp.path}/openskp_glbtex_test.glb');
+      try {
+        exportGlb(scene, tmp.path, textures: true);
+        final bytes = tmp.readAsBytesSync();
+        expect(_containsBytes(bytes, _jpegMagic), isTrue);
+      } finally {
+        if (tmp.existsSync()) tmp.deleteSync();
+      }
+    });
+  });
+}

--- a/packages/dotnet/OpenSkp.Tests/GlbTexturesTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/GlbTexturesTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// GLB texture embedding and the material-identity fix it depends on
+    /// (openskp#193, ported from TypeScript).
+    ///
+    /// Before this, GltfMaterials was keyed on (color, doubleSided) alone,
+    /// so two different textures that happened to average to the same RGB
+    /// would silently collapse into one material and lose an image. Fixed
+    /// by keying on (color, doubleSided, textureIndex) instead, at both the
+    /// face-grouping and material-dedup layers.
+    ///
+    /// Fixture: capilla_quiroz_v17.skp, which carries 3 real, distinct JPEG
+    /// textures - real coverage, not a synthetic mock.
+    /// </summary>
+    public class GlbTexturesTests
+    {
+        private static readonly string FixturePath =
+            Path.Combine(AppContext.BaseDirectory, "fixtures", "capilla_quiroz_v17.skp");
+
+        private static (JsonElement Json, byte[] Binary) ParseGlb(byte[] bytes)
+        {
+            var jsonChunkLen = BitConverter.ToUInt32(bytes, 12);
+            var jsonStr = Encoding.UTF8.GetString(bytes, 20, (int)jsonChunkLen);
+            var json = JsonDocument.Parse(jsonStr).RootElement;
+
+            var binHeaderOffset = 20 + (int)jsonChunkLen;
+            byte[] binary = Array.Empty<byte>();
+            if (binHeaderOffset < bytes.Length)
+            {
+                var binChunkLen = BitConverter.ToUInt32(bytes, binHeaderOffset);
+                binary = new byte[binChunkLen];
+                Array.Copy(bytes, binHeaderOffset + 8, binary, 0, (int)binChunkLen);
+            }
+            return (json, binary);
+        }
+
+        private static bool ContainsBytes(byte[] haystack, byte[] needle)
+        {
+            for (int i = 0; i <= haystack.Length - needle.Length; i++)
+            {
+                bool match = true;
+                for (int j = 0; j < needle.Length; j++)
+                {
+                    if (haystack[i + j] != needle[j]) { match = false; break; }
+                }
+                if (match) return true;
+            }
+            return false;
+        }
+
+        [Fact]
+        public void SceneDeduplicatesTexturesAndKeysMaterialsByThem()
+        {
+            var scene = SkpFile.BuildScene(FixturePath);
+
+            Assert.Equal(3, scene.Textures.Count);
+            foreach (var tex in scene.Textures)
+            {
+                Assert.True(tex.MimeType == "image/jpeg" || tex.MimeType == "image/png");
+                Assert.True(tex.Data.Length > 0);
+            }
+
+            int textured = 0;
+            foreach (var m in scene.GltfMaterials)
+            {
+                var dict = (IDictionary<string, object>)m;
+                var pbr = (IDictionary<string, object>)dict["pbrMetallicRoughness"];
+                if (pbr.TryGetValue("baseColorTexture", out var texRef))
+                {
+                    textured++;
+                    var texDict = (IDictionary<string, object>)texRef;
+                    int idx = (int)texDict["index"];
+                    Assert.InRange(idx, 0, scene.Textures.Count - 1);
+                }
+            }
+            Assert.Equal(4, textured);
+        }
+
+        [Fact]
+        public void ExportOmitsImagesByDefault()
+        {
+            var scene = SkpFile.BuildScene(FixturePath);
+            var bytes = GlbExport.ToGlb(scene);
+
+            Assert.DoesNotContain("\"images\"", Encoding.ASCII.GetString(bytes));
+            Assert.False(ContainsBytes(bytes, new byte[] { 0xFF, 0xD8, 0xFF })); // JPEG magic
+        }
+
+        [Fact]
+        public void ExportEmbedsTexturesWhenAsked()
+        {
+            var scene = SkpFile.BuildScene(FixturePath);
+            var noTex = GlbExport.ToGlb(scene);
+            var withTex = GlbExport.ToGlb(scene, new GlbOptions { Textures = true });
+
+            Assert.True(withTex.Length > noTex.Length);
+            Assert.Contains("\"images\"", Encoding.ASCII.GetString(withTex));
+            Assert.True(ContainsBytes(withTex, new byte[] { 0xFF, 0xD8, 0xFF })); // real JPEG bytes
+
+            var (json, _) = ParseGlb(withTex);
+            var images = json.GetProperty("images");
+            Assert.Equal(3, images.GetArrayLength());
+            foreach (var img in images.EnumerateArray())
+            {
+                Assert.True(img.TryGetProperty("bufferView", out _));
+                Assert.True(img.TryGetProperty("mimeType", out var mt));
+                Assert.StartsWith("image/", mt.GetString());
+            }
+        }
+
+        [Fact]
+        public void ExportGlbFileWritesEmbeddedTextures()
+        {
+            var scene = SkpFile.BuildScene(FixturePath);
+            var tmp = Path.Combine(Path.GetTempPath(), $"openskp_glbtex_{Guid.NewGuid():N}.glb");
+            try
+            {
+                GlbExport.ExportGlb(scene, tmp, new GlbOptions { Textures = true });
+                var bytes = File.ReadAllBytes(tmp);
+                Assert.True(ContainsBytes(bytes, new byte[] { 0xFF, 0xD8, 0xFF }));
+            }
+            finally
+            {
+                if (File.Exists(tmp)) File.Delete(tmp);
+            }
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp.Tests/SceneTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/SceneTests.cs
@@ -81,8 +81,8 @@ namespace OpenSkp.Tests
             bool HasColor(int r, int g, int b) => scene.GltfMaterials.Any(m =>
             {
                 var dict = (System.Collections.Generic.IDictionary<string, object>)m;
-                dynamic pbr = dict["pbrMetallicRoughness"];
-                double[] c = pbr.baseColorFactor;
+                var pbr = (System.Collections.Generic.IDictionary<string, object>)dict["pbrMetallicRoughness"];
+                double[] c = (double[])pbr["baseColorFactor"];
                 return (int)Math.Round(c[0] * 255) == r &&
                     (int)Math.Round(c[1] * 255) == g &&
                     (int)Math.Round(c[2] * 255) == b;

--- a/packages/dotnet/OpenSkp/Glb.cs
+++ b/packages/dotnet/OpenSkp/Glb.cs
@@ -138,6 +138,17 @@ namespace OpenSkp
     /// bundled TinyGLTF. Ported from the TypeScript reference
     /// implementation's toGLB(), with full TEXCOORD_0 UV support and the
     /// same validation rigor as the C++ port's glb.cpp.</summary>
+    /// <summary>Options for <see cref="GlbExport.ToGlb"/>/<see cref="GlbExport.ExportGlb"/>.</summary>
+    public sealed class GlbOptions
+    {
+        /// <summary>Embed the scene's texture images in the GLB and point
+        /// each textured material's baseColorTexture at them. Off by
+        /// default, matching every other language's exporter: photographic
+        /// textures can multiply the file size, and the geometry alone is
+        /// what most callers are after.</summary>
+        public bool Textures { get; set; }
+    }
+
     public static class GlbExport
     {
         // glTF's chunk-length fields are uint32 - a GLB file's total size
@@ -146,11 +157,21 @@ namespace OpenSkp
         private const long GlbSizeLimit = uint.MaxValue;
 
         /// <summary>Serializes a baked Scene to binary glTF 2.0 (GLB) bytes.</summary>
-        public static byte[] ToGlb(Scene scene)
+        public static byte[] ToGlb(Scene scene, GlbOptions? options = null)
         {
             if (scene == null) throw new ArgumentNullException(nameof(scene));
             var prims = scene.GlbPrimitives ?? new List<GlbPrimitive>();
-            var materials = scene.GltfMaterials ?? new List<object>();
+            var rawMaterials = scene.GltfMaterials ?? new List<object>();
+            bool embedTextures = options?.Textures == true;
+            var sceneTextures = embedTextures ? (scene.Textures ?? new List<SceneTexture>()) : new List<SceneTexture>();
+
+            // Materials always reference textures by index (Scene.Build sets
+            // that up unconditionally); embedding the actual image bytes is
+            // the opt-in part. When not embedding, strip the reference so a
+            // strict glTF reader never sees a baseColorTexture pointing at a
+            // textures[] array that was never written - a copy, so the
+            // Scene the caller owns is never mutated.
+            var materials = embedTextures ? rawMaterials : StripTextureRefs(rawMaterials);
 
             ValidateScene(prims, materials);
 
@@ -162,6 +183,17 @@ namespace OpenSkp
                 totalBinaryLength += (long)prim.Uvs.Length * 4;
                 totalBinaryLength += (long)prim.Indices.Length * 4;
             }
+
+            // Each image is placed on its own 4-byte-aligned offset, as
+            // glTF requires for bufferView data.
+            var imagePlacements = new List<(long Offset, int Length)>();
+            foreach (var tex in sceneTextures)
+            {
+                totalBinaryLength += (4 - (totalBinaryLength % 4)) % 4;
+                imagePlacements.Add((totalBinaryLength, tex.Data.Length));
+                totalBinaryLength += tex.Data.Length;
+            }
+
             if (totalBinaryLength > GlbSizeLimit)
                 throw new InvalidOperationException("scene geometry exceeds GLB's 32-bit binary-buffer limit");
 
@@ -295,6 +327,31 @@ namespace OpenSkp
                 });
             }
 
+            var gltfImages = new List<object>();
+            var gltfTextures = new List<object>();
+            for (var i = 0; i < sceneTextures.Count; i++)
+            {
+                var tex = sceneTextures[i];
+                var (offset, length) = imagePlacements[i];
+                Buffer.BlockCopy(tex.Data, 0, binaryBuffer, (int)offset, length);
+
+                var imgBufferViewIdx = bufferViews.Count;
+                bufferViews.Add(new Dictionary<string, object>
+                {
+                    ["buffer"] = 0,
+                    ["byteOffset"] = offset,
+                    ["byteLength"] = length,
+                });
+
+                var imageIdx = gltfImages.Count;
+                gltfImages.Add(new Dictionary<string, object>
+                {
+                    ["bufferView"] = imgBufferViewIdx,
+                    ["mimeType"] = tex.MimeType,
+                });
+                gltfTextures.Add(new Dictionary<string, object> { ["sampler"] = 0, ["source"] = imageIdx });
+            }
+
             var gltfMeshes = new List<object>();
             if (gltfPrimitives.Count > 0)
             {
@@ -316,17 +373,74 @@ namespace OpenSkp
                 ["bufferViews"] = bufferViews,
                 ["accessors"] = accessors,
             };
+            if (gltfImages.Count > 0)
+            {
+                gltfJson["images"] = gltfImages;
+                gltfJson["textures"] = gltfTextures;
+                gltfJson["samplers"] = new object[]
+                {
+                    new Dictionary<string, object> { ["wrapS"] = 10497, ["wrapT"] = 10497 }, // REPEAT / REPEAT
+                };
+            }
 
             return CreateGlb(gltfJson, binaryBuffer);
+        }
+
+        /// <summary>Materials with every baseColorTexture reference removed -
+        /// a copy, never mutating the input. Used when not embedding images,
+        /// so a strict glTF reader never sees a reference into a textures[]
+        /// array that was never written.
+        ///
+        /// Only Dictionary-shaped materials (what SceneBuilder.Build
+        /// produces) are inspected; anything else - e.g. the anonymous
+        /// types a hand-built Scene can still use, since GltfMaterials is
+        /// publicly just List&lt;object&gt; - passes through unchanged.
+        /// Stripping is a courtesy for the auto-generated shape, not a
+        /// contract on every possible material representation.</summary>
+        private static List<object> StripTextureRefs(List<object> materials)
+        {
+            var needsCopy = false;
+            foreach (var m in materials)
+            {
+                if (m is IDictionary<string, object> dict &&
+                    dict.TryGetValue("pbrMetallicRoughness", out var pbrObj) &&
+                    pbrObj is IDictionary<string, object> pbr &&
+                    pbr.ContainsKey("baseColorTexture"))
+                {
+                    needsCopy = true;
+                    break;
+                }
+            }
+            if (!needsCopy) return materials;
+
+            var result = new List<object>(materials.Count);
+            foreach (var m in materials)
+            {
+                if (m is IDictionary<string, object> dict &&
+                    dict.TryGetValue("pbrMetallicRoughness", out var pbrObj) &&
+                    pbrObj is IDictionary<string, object> pbr &&
+                    pbr.ContainsKey("baseColorTexture"))
+                {
+                    var newPbr = new Dictionary<string, object>(pbr);
+                    newPbr.Remove("baseColorTexture");
+                    var newMat = new Dictionary<string, object>(dict) { ["pbrMetallicRoughness"] = newPbr };
+                    result.Add(newMat);
+                }
+                else
+                {
+                    result.Add(m);
+                }
+            }
+            return result;
         }
 
         /// <summary>Serializes a baked Scene to GLB and writes it to
         /// <paramref name="path"/>. Does not create missing parent
         /// directories - matching the C++ port's export_glb, the other
         /// language with this same in-memory-bytes/file-write pair.</summary>
-        public static void ExportGlb(Scene scene, string path)
+        public static void ExportGlb(Scene scene, string path, GlbOptions? options = null)
         {
-            var bytes = ToGlb(scene);
+            var bytes = ToGlb(scene, options);
             File.WriteAllBytes(path, bytes);
         }
 

--- a/packages/dotnet/OpenSkp/Scene.cs
+++ b/packages/dotnet/OpenSkp/Scene.cs
@@ -65,6 +65,20 @@ namespace OpenSkp
         public string GeomName { get; set; } = "";
     }
 
+    /// <summary>One texture image referenced by Scene.GltfMaterials.</summary>
+    public sealed class SceneTexture
+    {
+        /// <summary>The image file's raw bytes, exactly as stored in the .skp.</summary>
+        public byte[] Data { get; set; } = Array.Empty<byte>();
+
+        /// <summary>Sniffed from the bytes, not from Filename: SketchUp
+        /// records the authoring machine's path, whose extension can
+        /// disagree with the content.</summary>
+        public string MimeType { get; set; } = "";
+
+        public string Filename { get; set; } = "";
+    }
+
     /// <summary>The result of baking a parsed file's placed instances into
     /// a flat, world-space 3D scene.</summary>
     public sealed class Scene
@@ -73,6 +87,11 @@ namespace OpenSkp
         public Dictionary<string, MeshMetadata> MeshIndex { get; set; } = new Dictionary<string, MeshMetadata>();
         public List<GlbPrimitive> GlbPrimitives { get; set; } = new List<GlbPrimitive>();
         public List<object> GltfMaterials { get; set; } = new List<object>();
+
+        /// <summary>Distinct texture images the placed materials use,
+        /// deduplicated by source bytes. Empty when nothing placed in the
+        /// scene is textured.</summary>
+        public List<SceneTexture> Textures { get; set; } = new List<SceneTexture>();
     }
 
     /// <summary>Bakes every instance actually placed in a parsed model into
@@ -196,7 +215,29 @@ namespace OpenSkp
             // models with tens or hundreds of thousands of placed instances.
             var pathUpdates = new Dictionary<string, (Dictionary<string, string> Props, string Name)>();
 
-            var colorToMaterialIndex = new Dictionary<((int, int, int) Color, bool DoubleSided), int>();
+            // Textures deduplicated by bytes: the same image routinely backs
+            // several materials, and re-embedding it per material would
+            // multiply the export size for nothing.
+            var textures = new List<SceneTexture>();
+            var textureIndexByKey = new Dictionary<string, int>();
+
+            int? TextureIndexFor(Geometry.RawTexture? tex)
+            {
+                if (tex?.Data == null || tex.Data.Length == 0) return null;
+                var mimeType = SniffImageMime(tex.Data);
+                if (mimeType == null) return null; // a format glTF cannot carry
+                // length plus a short byte prefix is enough to tell real
+                // images apart without hashing megabytes on every face
+                var head = BitConverter.ToString(tex.Data, 0, Math.Min(16, tex.Data.Length));
+                var key = $"{tex.Data.Length}:{head}";
+                if (textureIndexByKey.TryGetValue(key, out var hit)) return hit;
+                var idx = textures.Count;
+                textures.Add(new SceneTexture { Data = tex.Data, MimeType = mimeType, Filename = tex.Filename });
+                textureIndexByKey[key] = idx;
+                return idx;
+            }
+
+            var colorToMaterialIndex = new Dictionary<((int, int, int) Color, bool DoubleSided, int? TextureIndex), int>();
             var gltfMaterials = new List<object>();
 
             // Definitions currently being instantiated on the active
@@ -212,20 +253,30 @@ namespace OpenSkp
                 return layerColors.TryGetValue(name, out var c) ? c : (136, 136, 136);
             }
 
-            int GetMaterialIndex((int R, int G, int B) color, bool doubleSided)
+            int GetMaterialIndex((int R, int G, int B) color, bool doubleSided, int? textureIndex)
             {
-                var key = (color, doubleSided);
+                // The texture is part of the identity, not just the color:
+                // two different images can average to the same RGB (real
+                // files do this), and keying on color alone would merge
+                // them into one material and lose one of the images.
+                var key = (color, doubleSided, textureIndex);
                 if (colorToMaterialIndex.TryGetValue(key, out var existing)) return existing;
                 int idx = gltfMaterials.Count;
-                var material = new Dictionary<string, object>
+                var pbr = new Dictionary<string, object>
                 {
-                    ["pbrMetallicRoughness"] = new
-                    {
-                        baseColorFactor = new[] { color.R / 255.0, color.G / 255.0, color.B / 255.0, 1.0 },
-                        metallicFactor = 0.0,
-                        roughnessFactor = 0.8,
-                    },
+                    ["baseColorFactor"] = new[] { color.R / 255.0, color.G / 255.0, color.B / 255.0, 1.0 },
+                    ["metallicFactor"] = 0.0,
+                    ["roughnessFactor"] = 0.8,
                 };
+                // baseColorFactor stays as the resolved color even with a
+                // texture attached: glTF multiplies the two, and
+                // SketchUp's own colorized materials rely on exactly that
+                // tint.
+                if (textureIndex.HasValue)
+                {
+                    pbr["baseColorTexture"] = new Dictionary<string, object> { ["index"] = textureIndex.Value };
+                }
+                var material = new Dictionary<string, object> { ["pbrMetallicRoughness"] = pbr };
                 if (doubleSided) material["doubleSided"] = true;
                 gltfMaterials.Add(material);
                 colorToMaterialIndex[key] = idx;
@@ -270,7 +321,7 @@ namespace OpenSkp
             {
                 if (builder.Faces.Count > 0)
                 {
-                    var faceGroups = new Dictionary<((int R, int G, int B) Color, bool DoubleSided), FaceGroup>();
+                    var faceGroups = new Dictionary<((int R, int G, int B) Color, bool DoubleSided, int? TextureIndex), FaceGroup>();
 
                     void AddSide(
                         List<long[]> triangles, (double X, double Y, double Z) fn,
@@ -278,7 +329,13 @@ namespace OpenSkp
                         Geometry.RawMaterial? mat, double[]? uvTransform,
                         (double X, double Y, double Z) xr, (double X, double Y, double Z) yr)
                     {
-                        var key = (color, doubleSided);
+                        // faces are batched per emitted material, so the
+                        // texture has to be part of the key too -
+                        // otherwise two differently-textured faces with
+                        // the same average color end up in one group with
+                        // one image
+                        int? texIndex = TextureIndexFor(mat?.Texture);
+                        var key = (color, doubleSided, texIndex);
                         if (!faceGroups.TryGetValue(key, out var group))
                         {
                             group = new FaceGroup { Color = color, DoubleSided = doubleSided };
@@ -388,6 +445,7 @@ namespace OpenSkp
                     foreach (var groupKv in faceGroups)
                     {
                         var color = groupKv.Key.Color;
+                        var texIndex = groupKv.Key.TextureIndex;
                         var group = groupKv.Value;
                         if (group.LocalFaces.Count == 0) continue;
 
@@ -468,7 +526,7 @@ namespace OpenSkp
                             indices[i * 3 + 2] = (uint)group.LocalFaces[i][2];
                         }
 
-                        int materialIndex = GetMaterialIndex(color, group.DoubleSided);
+                        int materialIndex = GetMaterialIndex(color, group.DoubleSided, texIndex);
                         glbPrimitives.Add(new GlbPrimitive
                         {
                             Positions = positions,
@@ -647,7 +705,26 @@ namespace OpenSkp
                 MeshIndex = meshIndex,
                 GlbPrimitives = glbPrimitives,
                 GltfMaterials = gltfMaterials,
+                Textures = textures,
             };
+        }
+
+        /// <summary>Identifies an image's MIME type from its magic bytes.
+        /// Returns null for anything glTF cannot carry (glTF only allows
+        /// PNG and JPEG).</summary>
+        private static string? SniffImageMime(byte[] data)
+        {
+            if (data.Length >= 3 && data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF)
+            {
+                return "image/jpeg";
+            }
+            if (data.Length >= 8 &&
+                data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47 &&
+                data[4] == 0x0D && data[5] == 0x0A && data[6] == 0x1A && data[7] == 0x0A)
+            {
+                return "image/png";
+            }
+            return null;
         }
 
         /// <summary>Internal (not private) so Edit.cs can reuse this same

--- a/packages/python/pyproject.toml
+++ b/packages/python/pyproject.toml
@@ -33,6 +33,9 @@ dev = [
     "pytest>=7.0",
     "pytest-cov>=7.1.0",
 ]
+textures = [
+    "pillow>=9.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/iamahsanmehmood/openskp"

--- a/packages/python/src/openskp/__init__.py
+++ b/packages/python/src/openskp/__init__.py
@@ -23,7 +23,7 @@ from .create import ComponentDefinitionBuilder, SkpBuilder, SkpWriteError, creat
 from .edit import open_existing
 from .errors import SkpParseError
 from .model import SkpFile, SkpModel
-from .scene import Scene, InstanceNode, MeshMetadata, GlbPrimitive
+from .scene import Scene, InstanceNode, MeshMetadata, GlbPrimitive, SceneTexture
 
 try:
     __version__: str = _version("openskp")
@@ -36,6 +36,7 @@ __all__: list[str] = [
     "InstanceNode",
     "MeshMetadata",
     "GlbPrimitive",
+    "SceneTexture",
     "SkpParseError",
     "create",
     "SkpBuilder",

--- a/packages/python/src/openskp/export/glb.py
+++ b/packages/python/src/openskp/export/glb.py
@@ -42,7 +42,25 @@ from typing import Any, Dict, List
 _M_TO_MM = 1000.0
 
 
-def _primitive_to_trimesh(prim, materials: List[Dict[str, Any]]):
+def _decode_texture_image(data: bytes):
+    """Decode raw image bytes into a PIL Image for trimesh's
+    ``baseColorTexture``. Imported lazily so callers who never pass
+    ``textures=True`` never pay for (or need) Pillow."""
+    try:
+        from PIL import Image
+    except ImportError as e:
+        raise ImportError(
+            "export(..., textures=True) requires Pillow to decode texture "
+            "images. Install it with `pip install pillow`."
+        ) from e
+    import io
+
+    return Image.open(io.BytesIO(data))
+
+
+def _primitive_to_trimesh(
+    prim, materials: List[Dict[str, Any]], scene_textures: List[Any], embed_textures: bool,
+):
     import trimesh
 
     n_verts = len(prim.positions) // 3
@@ -74,10 +92,16 @@ def _primitive_to_trimesh(prim, materials: List[Dict[str, Any]]):
 
     mat = materials[prim.material_index]
     pbr = mat["pbrMetallicRoughness"]
+    base_color_texture = None
+    tex_ref = pbr.get("baseColorTexture") if embed_textures else None
+    if tex_ref is not None:
+        tex = scene_textures[tex_ref["index"]]
+        base_color_texture = _decode_texture_image(tex.data)
     mesh.visual = trimesh.visual.TextureVisuals(
         uv=uvs,
         material=trimesh.visual.material.PBRMaterial(
             baseColorFactor=pbr["baseColorFactor"],
+            baseColorTexture=base_color_texture,
             metallicFactor=pbr["metallicFactor"],
             roughnessFactor=pbr["roughnessFactor"],
             doubleSided=mat.get("doubleSided", False),
@@ -116,6 +140,7 @@ def export(
     *,
     coordinate_system: str = "y-up",
     units: str = "mm",
+    textures: bool = False,
 ) -> str:
     """Export a parsed SkpFile to GLB (binary glTF 2.0) format.
 
@@ -130,6 +155,13 @@ def export(
         coordinate_system: Target coordinate system. Currently only
             ``"y-up"`` (glTF standard) is supported.
         units: Target unit system. Currently only ``"mm"`` is supported.
+        textures: Embed the scene's texture images in the GLB, so each
+            textured material's ``baseColorTexture`` points at real image
+            data instead of just a resolved color. Off by default:
+            photographic textures can multiply the file size, and the
+            geometry alone is what most callers are after. Requires
+            Pillow (``pip install pillow``) - imported lazily, so callers
+            who leave this off never need it installed.
 
     Returns:
         Absolute path to the written GLB file.
@@ -168,7 +200,7 @@ def export(
 
     trimesh_scene = trimesh.Scene()
     for prim in scene_obj.glb_primitives:
-        mesh = _primitive_to_trimesh(prim, scene_obj.gltf_materials)
+        mesh = _primitive_to_trimesh(prim, scene_obj.gltf_materials, scene_obj.textures, textures)
         trimesh_scene.add_geometry(mesh, geom_name=prim.geom_name)
 
     output_dir = os.path.dirname(os.path.abspath(output_path))

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -103,6 +103,23 @@ class GlbPrimitive:
 
 
 @dataclass
+class SceneTexture:
+    """One texture image referenced by :attr:`Scene.gltf_materials`.
+
+    Attributes:
+        data: The image file's raw bytes, exactly as stored in the .skp.
+        mime_type: Sniffed from the bytes, not from ``filename`` -
+            SketchUp records the authoring machine's path, whose
+            extension can disagree with the content.
+        filename: Best-effort original filename, for diagnostics only.
+    """
+
+    data: bytes
+    mime_type: str
+    filename: str = ""
+
+
+@dataclass
 class Scene:
     """The result of baking a parsed file's placed instances into a flat,
     world-space 3D scene."""
@@ -111,6 +128,22 @@ class Scene:
     mesh_index: Dict[str, MeshMetadata] = field(default_factory=dict)
     glb_primitives: List[GlbPrimitive] = field(default_factory=list)
     gltf_materials: List[Dict[str, Any]] = field(default_factory=list)
+    # Distinct texture images the placed materials use, deduplicated by
+    # source bytes. Empty when nothing placed in the scene is textured.
+    # GLB export only embeds these when explicitly asked (export(...,
+    # textures=True)) - most callers just want geometry, and photographic
+    # textures can multiply file size.
+    textures: List[SceneTexture] = field(default_factory=list)
+
+
+def _sniff_image_mime(data: bytes) -> Optional[str]:
+    """Identify an image's MIME type from its magic bytes. Returns ``None``
+    for anything glTF cannot carry (glTF only allows PNG and JPEG)."""
+    if len(data) >= 3 and data[0] == 0xff and data[1] == 0xd8 and data[2] == 0xff:
+        return "image/jpeg"
+    if len(data) >= 8 and data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    return None
 
 
 def _invert_3x3(m: Tuple[float, ...]) -> Tuple[float, ...]:
@@ -215,7 +248,33 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
     mesh_index: Dict[str, MeshMetadata] = {}
     glb_primitives: List[GlbPrimitive] = []
 
-    color_to_material_index: Dict[Tuple[Tuple[int, int, int], bool], int] = {}
+    # Textures deduplicated by bytes: the same image routinely backs
+    # several materials, and re-embedding it per material would multiply
+    # the export size for nothing.
+    textures: List[SceneTexture] = []
+    texture_index_by_key: Dict[str, int] = {}
+
+    def texture_index_for(tex: Optional[Dict[str, Any]]) -> Optional[int]:
+        if not tex:
+            return None
+        data = tex.get("data")
+        if not data:
+            return None
+        mime_type = _sniff_image_mime(data)
+        if mime_type is None:
+            return None  # a format glTF cannot carry
+        # length plus a short byte prefix is enough to tell real images
+        # apart without hashing megabytes on every face
+        key = f"{len(data)}:{data[:16].hex()}"
+        hit = texture_index_by_key.get(key)
+        if hit is not None:
+            return hit
+        idx = len(textures)
+        textures.append(SceneTexture(data=data, mime_type=mime_type, filename=tex.get("filename", "")))
+        texture_index_by_key[key] = idx
+        return idx
+
+    color_to_material_index: Dict[Tuple[Tuple[int, int, int], bool, Optional[int]], int] = {}
     gltf_materials: List[Dict[str, Any]] = []
 
     # Definitions currently being instantiated on the active recursion
@@ -228,19 +287,29 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
     def get_layer_color(name: str) -> Tuple[int, int, int]:
         return layer_colors.get(name, (136, 136, 136))
 
-    def get_material_index(color: Tuple[int, int, int], double_sided: bool) -> int:
-        key = (color, double_sided)
+    def get_material_index(
+        color: Tuple[int, int, int], double_sided: bool, texture_index: Optional[int]
+    ) -> int:
+        # The texture is part of the identity, not just the color: two
+        # different images can average to the same RGB (real files do
+        # this), and keying on color alone would merge them into one
+        # material and lose one of the images.
+        key = (color, double_sided, texture_index)
         if key in color_to_material_index:
             return color_to_material_index[key]
         idx = len(gltf_materials)
         r, g, b = color
-        mat_dict: Dict[str, Any] = {
-            "pbrMetallicRoughness": {
-                "baseColorFactor": [r / 255, g / 255, b / 255, 1.0],
-                "metallicFactor": 0.0,
-                "roughnessFactor": 0.8,
-            }
+        pbr: Dict[str, Any] = {
+            "baseColorFactor": [r / 255, g / 255, b / 255, 1.0],
+            "metallicFactor": 0.0,
+            "roughnessFactor": 0.8,
         }
+        # baseColorFactor stays as the resolved color even with a texture
+        # attached: glTF multiplies the two, and SketchUp's own colorized
+        # materials rely on exactly that tint.
+        if texture_index is not None:
+            pbr["baseColorTexture"] = {"index": texture_index}
+        mat_dict: Dict[str, Any] = {"pbrMetallicRoughness": pbr}
         if double_sided:
             mat_dict["doubleSided"] = True
         gltf_materials.append(mat_dict)
@@ -271,7 +340,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             # reverse-wound using the back material - so each side renders
             # its own correct color instead of the front material leaking
             # onto (or the back vanishing from) the far side.
-            face_groups: Dict[Tuple[Tuple[int, int, int], bool], Dict[str, Any]] = {}
+            face_groups: Dict[Tuple[Tuple[int, int, int], bool, Optional[int]], Dict[str, Any]] = {}
 
             for f_id, f_data in builder.faces.items():
                 fallback_color = inherited_color if inherited_color is not None else get_layer_color(parent_layer)
@@ -302,14 +371,14 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
 
                 if front_color == back_color:
                     _add_face_side(face_groups, builder, triangles, fn, front_color, True, False, front_mat,
-                                   f_data.get("uv_transform"), xr, yr)
+                                   f_data.get("uv_transform"), xr, yr, texture_index_for)
                 else:
                     _add_face_side(face_groups, builder, triangles, fn, front_color, False, False, front_mat,
-                                   f_data.get("uv_transform"), xr, yr)
+                                   f_data.get("uv_transform"), xr, yr, texture_index_for)
                     _add_face_side(face_groups, builder, triangles, fn, back_color, False, True, back_mat,
-                                   f_data.get("uv_transform_back"), xr, yr)
+                                   f_data.get("uv_transform_back"), xr, yr, texture_index_for)
 
-            for (face_color, double_sided), group in face_groups.items():
+            for (face_color, double_sided, tex_index), group in face_groups.items():
                 local_faces = group["local_faces"]
                 if not local_faces:
                     continue
@@ -378,7 +447,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
                     indices[i * 3 + 1] = tri[1]
                     indices[i * 3 + 2] = tri[2]
 
-                material_index = get_material_index(face_color, double_sided)
+                material_index = get_material_index(face_color, double_sided, tex_index)
                 glb_primitives.append(
                     GlbPrimitive(
                         positions=positions,
@@ -498,6 +567,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
         mesh_index=mesh_index,
         glb_primitives=glb_primitives,
         gltf_materials=gltf_materials,
+        textures=textures,
     )
 
 
@@ -521,7 +591,7 @@ def _resolve_color(mat: Optional[Dict[str, Any]]) -> Optional[Tuple[int, int, in
 
 
 def _add_face_side(
-    face_groups: Dict[Tuple[Tuple[int, int, int], bool], Dict[str, Any]],
+    face_groups: Dict[Tuple[Tuple[int, int, int], bool, Optional[int]], Dict[str, Any]],
     builder: Any,
     triangles: List[List[int]],
     fn: Tuple[float, float, float],
@@ -532,8 +602,14 @@ def _add_face_side(
     uv_transform: Optional[Tuple[float, ...]],
     xr: Tuple[float, float, float],
     yr: Tuple[float, float, float],
+    texture_index_for,
 ) -> None:
-    key = (color, double_sided)
+    tex = mat.get("texture") if mat else None
+    # faces are batched per emitted material, so the texture has to be
+    # part of the key too - otherwise two differently-textured faces with
+    # the same average color end up in one group with one image
+    tex_index = texture_index_for(tex)
+    key = (color, double_sided, tex_index)
     group = face_groups.get(key)
     if group is None:
         group = {
@@ -547,7 +623,6 @@ def _add_face_side(
         }
         face_groups[key] = group
 
-    tex = mat.get("texture") if mat else None
     tile_w = tex.get("x_scale") if tex else None
     tile_h = tex.get("y_scale") if tex else None
     tile_w = tile_w if tile_w and tile_w > 1e-9 else 1.0

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2310,6 +2310,66 @@ class TestGlbExport:
         with pytest.raises(NotImplementedError, match="units"):
             glb_export.export(skp, str(tmp_path / "out.glb"), units="inches")
 
+    def test_scene_deduplicates_textures_and_keys_materials_by_them(self, tmp_path) -> None:
+        # openskp#193 (ported from TypeScript): color-to-material dedup used
+        # to key on (color, double_sided) alone, so two different textures
+        # averaging to the same color would silently collapse into one
+        # material and lose an image. Real fixture, not a mock: 3 distinct
+        # JPEGs, correctly deduplicated and correctly referenced.
+        from openskp import scene as scene_mod
+        from openskp.model import SkpFile
+
+        skp = SkpFile.open(str(self.FIXTURE))
+        skp.parse()
+        scene_obj = scene_mod.build_scene(skp._parsed)
+
+        assert len(scene_obj.textures) == 3
+        for tex in scene_obj.textures:
+            assert tex.mime_type in ("image/jpeg", "image/png")
+            assert len(tex.data) > 0
+
+        textured_materials = [
+            m for m in scene_obj.gltf_materials if "baseColorTexture" in m["pbrMetallicRoughness"]
+        ]
+        assert len(textured_materials) == 4
+        # every referenced index is a real, in-range texture
+        for mat in textured_materials:
+            idx = mat["pbrMetallicRoughness"]["baseColorTexture"]["index"]
+            assert 0 <= idx < len(scene_obj.textures)
+
+    def test_export_omits_images_by_default(self, tmp_path) -> None:
+        skp, glb_path = self._export(tmp_path)
+        with open(glb_path, "rb") as f:
+            data = f.read()
+        assert b'"images"' not in data
+        assert b"\xff\xd8\xff" not in data  # no JPEG magic bytes embedded
+
+    def test_export_embeds_textures_when_asked(self, tmp_path) -> None:
+        from openskp.export import glb as glb_export
+        from openskp.model import SkpFile
+
+        skp = SkpFile.open(str(self.FIXTURE))
+        skp.parse()
+        out_path = tmp_path / "with_textures.glb"
+        glb_export.export(skp, str(out_path), textures=True)
+
+        with open(out_path, "rb") as f:
+            data = f.read()
+        assert b'"images"' in data
+        assert b"\xff\xd8\xff" in data  # real JPEG bytes, not a reference
+
+        import trimesh
+        loaded = trimesh.load(out_path, file_type="glb")
+        # the embedded images must actually be usable as textures, not just
+        # bytes sitting in the file
+        found_texture = False
+        for geom in loaded.geometry.values():
+            mat = getattr(geom.visual, "material", None)
+            if mat is not None and getattr(mat, "baseColorTexture", None) is not None:
+                found_texture = True
+                break
+        assert found_texture
+
     def test_export_rejects_self_referencing_definition(self, tmp_path) -> None:
         # export() now bakes via scene.build_scene() instead of its own
         # separate trimesh pass, so the recursion guard covered by


### PR DESCRIPTION
## Summary

Checklist item: port #193's fix (originally TypeScript-only) to the
other four languages. Confirmed by direct code reading (not the
checklist note) that all four ports carried both parts of the bug:

1. **Material dedup keyed by color alone** — `(color, doubleSided)`,
   no texture identity. Two different textures that happen to average
   to the same RGB silently collapse into one material and lose an
   image. In Python this went one layer deeper: even *face-grouping*
   was keyed the same way, so two differently-textured faces sharing
   a color merged into one mesh group, not just one material.
2. **No texture/image embedding at all** — none of the four GLB
   writers had a `SceneTexture`-equivalent type or wrote `images`/
   `textures` into the GLB JSON.

## Changes, per language

Widened the dedup key to `(color, doubleSided, textureIndex)` at
every layer that groups by color, and added opt-in image embedding
mirroring TypeScript's `toGLB(scene, { textures: true })`. Material/
texture *identity* is always computed at scene-build time; embedding
the actual image *bytes* is opt-in at export time — when off, a
textured material still gets a stripped `baseColorTexture` reference
removed (or never set) rather than pointing at an image that was
never written.

- **Python** — `textures: bool = False` param on `export()`. Pillow is
  a new lazy, optional import (`[project.optional-dependencies]
  textures = ["pillow>=9.0"]`), only touched on the embed path, with a
  friendly `ImportError` if missing. CI updated to install `[dev,textures]`
  so the path is actually exercised.
- **.NET** — new `GlbOptions.Textures` on `ToGlb`/`ExportGlb`.
- **Dart** — `textures` named param on `toGlb()`/`exportGlb()`.
- **C++** — new `GlbOptions.textures` on `to_glb()`/`export_glb()`,
  against TinyGLTF (fetched via CMake `FetchContent`, not vendored).

MIME sniffing (magic bytes: JPEG `FF D8 FF`, PNG's 8-byte signature)
and content-based texture dedup (`byte_length:first_16_bytes`) are
ported identically to TypeScript's `sniffImageMime` in all four.

## Verification

Real-fixture check (`capilla_quiroz_v17.skp`, 3 real distinct JPEGs)
gives identical numbers across Python, .NET, and Dart: **3 textures,
4 textured materials, 13 total materials**. Each language's full test
suite passes locally with the widened dedup key (no regressions) plus
new tests covering dedup, opt-in embedding on/off, and file export:

- Python: 358/358, ruff clean
- .NET: 136/136
- Dart: 168/168, `dart analyze --fatal-infos` clean

C++ has no local compiler in this environment, so it's unverified
beyond careful by-hand review — this is the first real check of the
TinyGLTF integration written here. Added `glb_textures_test.cpp`
mirroring the other three languages' coverage, round-tripping through
TinyGLTF's own loader.

## Test plan

- [x] Python/.NET/Dart test suites pass locally
- [ ] CI green on all 5 workflows, especially C++ build/format/sanitizers