### PR TITLE
Port PR #194's legacy-reader gaps (+ #199's v20 fixes) to TypeScript, .NET, Dart, C++

### DIFF
--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -238,12 +238,14 @@ bool is_class_ref(const ByteBuffer& d, size_t p, uint64_t slot) {
 //
 // count_pos is the offset the count was read FROM (i.e. r.p - 4). Returns
 // the corrected count, or nullopt when this is not the v20 layout.
-std::optional<uint32_t> retry_count_after_v20_filler(R& r, size_t count_pos, uint32_t limit) {
-  auto hit = find_count_after_v20_filler(r.d, count_pos, limit);
-  if (!hit) return std::nullopt;
-  r.p = hit->next;
-  return hit->count;
-}
+//
+// Declared here (before struct Archive) so callers throughout struct
+// Archive can see it; the Archive-aware overload actually implementing
+// the extra validation is defined after struct Archive (it needs the
+// complete type to inspect slots/next), and this is left a mere
+// declaration until then.
+std::optional<uint32_t> retry_count_after_v20_filler(R& r, size_t count_pos, uint32_t limit,
+                                                     struct Archive* ar = nullptr);
 
 struct Archive {
   R r;
@@ -256,6 +258,21 @@ struct Archive {
   std::unordered_map<uint64_t, Entry> slots;
   std::unordered_map<std::string, uint64_t> class_slot;
   std::unordered_map<std::string, int> class_schema;
+
+  // Burned store-map indices (see the CEdgeUse branch of read()): the
+  // writer maps an annotation's connection points into the store map
+  // WITHOUT writing bytes, so file back-references beyond each burn run
+  // ahead of the walker's numbering. Registrations always stay at WALKER
+  // indices - no captured slot ever goes stale - and back() translates
+  // file references through the burn bands instead. `burns` holds
+  // (file_band_start, width) per event; `cum_delta` their total;
+  // `annot_watermark` the walker slot right after the last annotation
+  // record - the only place a band can start.
+  std::vector<std::pair<uint64_t, uint64_t>> burns;
+  uint64_t cum_delta{};
+  std::optional<uint64_t> annot_watermark;
+  std::vector<int> burn_stack;  // per-entity-list burned-item credits
+  std::optional<size_t> cline_tail;
 
   Archive(const ByteBuffer& d, int v) : r{d}, ver(v), pid(v >= 17) {}
 
@@ -302,7 +319,29 @@ struct Archive {
     return new_obj(i->second.name);
   }
 
+  // Maps a FILE store-map index to the walker's numbering through the
+  // burn bands. Returns the walker slot, or nullopt when the reference
+  // points INTO a band (a phantom, never-serialized connection point).
+  std::optional<uint64_t> translate_ref(uint64_t slot) {
+    uint64_t offset = 0;
+    for (auto& band : burns) {
+      if (slot < band.first) break;
+      if (slot < band.first + band.second) return std::nullopt;
+      offset += band.second;
+    }
+    return slot - offset;
+  }
+
   std::tuple<uint64_t, std::string, std::shared_ptr<V>> back(uint64_t s) {
+    if (!burns.empty() && s >= burns[0].first) {
+      auto walker = translate_ref(s);
+      if (!walker) {
+        // a phantom (burned) connection-point index - annotation metadata
+        // only; nothing was ever serialized for it
+        return {s, "reserved", {}};
+      }
+      s = *walker;
+    }
     auto i = slots.find(s);
     if (i == slots.end()) {
       if (s < base) return {s, "premodel", {}};
@@ -310,6 +349,87 @@ struct Archive {
     }
     if (i->second.cls) throw std::runtime_error("legacy backref to class");
     return {s, i->second.name, i->second.v};
+  }
+
+  // Records that the writer burned `delta` store-map indices without
+  // serializing any bytes for them. See the field comments above for the
+  // mechanism this supports.
+  void register_burn(uint64_t delta) {
+    burns.push_back({*annot_watermark + cum_delta, delta});
+    cum_delta += delta;
+    annot_watermark.reset();
+    // each burn event corresponds to ONE phantom top-level entity that the
+    // entity list's declared count includes but the stream never carries -
+    // credit it so the list doesn't run past its real end
+    if (!burn_stack.empty()) burn_stack.back() += 1;
+  }
+
+  // A reference-to-entity tag: dimension connection points and text
+  // leader attachments. Unlike object()'s back-ref path, this tolerates a
+  // slot the walk has not reached yet - SketchUp serializes a
+  // label/dimension BEFORE the entity it anchors to when both live in the
+  // same entity list, so the reference can legitimately point forward.
+  std::optional<uint64_t> entity_ref() {
+    auto tag = r.u16();
+    if (!tag) return std::nullopt;
+    if (tag == 0x7fff) {
+      auto big = r.u32();
+      if (big & 0x80000000) throw std::runtime_error("entity ref is a new object");
+      return big;
+    }
+    if (tag == 0xffff || (tag & 0x8000)) throw std::runtime_error("entity ref is a new object");
+    return tag;
+  }
+
+  // True when the u16 at `at` starts an object read in one of the
+  // UNAMBIGUOUS forms: null, escape, class definition, or a class-ref to
+  // a class already known. Plain object back-refs are excluded on
+  // purpose - any 2-byte junk below 0x8000 would qualify, which is
+  // exactly the ambiguity this check exists to avoid.
+  bool strict_next_tag(size_t at, bool allow_null = true) {
+    if (at + 2 > r.d.size()) return false;
+    auto t = read_u16(r.d, at);
+    if (t == 0x0000) return allow_null;
+    if (t == 0x7fff || t == 0xffff) return true;
+    if (t & 0x8000) {
+      auto i = slots.find(t & 0x7fff);
+      return i != slots.end() && i->second.cls;
+    }
+    return false;
+  }
+
+  // The textured-material payload: an embedded CDib plus applied size,
+  // source file name, average colour, and opacity. Shared verbatim
+  // between a CMaterial with a texture and a colour-by-layer CLayer that
+  // carries a textured material.
+  void texture_block(V& v) {
+    r.raw(ver >= 17 ? 2 : 1);  // texture flag pad
+    auto q = object("CDib");
+    v.tex_dib = std::get<0>(q);
+    auto begin = r.p, limit = std::min(r.d.size(), r.p + 28);
+    size_t marker = begin;
+    for (; marker + 3 <= limit; ++marker)
+      if (r.d[marker] == 255 && r.d[marker + 1] == 254 && r.d[marker + 2] == 255) break;
+    if (marker - begin == 20)
+      r.u32();
+    else if (marker - begin != 16)
+      throw std::runtime_error("texture size block misaligned");
+    v.tw = r.f64();
+    v.th = r.f64();
+    v.tex_file = r.utf16();
+    auto c = r.raw(9);  // RGBA + 00 + RGBA (colour stored twice)
+    v.r = c[0];
+    v.g = c[1];
+    v.b = c[2];
+    // c[3] here is not a colour alpha byte - it feeds the colorized check
+    // below alongside blob[4]. v.a keeps its default (255); textured
+    // materials/layers carry no separate alpha channel in this record
+    // shape.
+    r.utf16();
+    auto blob = r.raw(8);  // u32 + u32 colorized flag
+    v.opacity = r.f64();
+    if (!r.u8()) v.opacity = 0;
+    v.colorized = blob[4] != 0 || c[3] == 255;
   }
 
   // Returns the CAttributeContainer's slot, or nullopt when this entity
@@ -327,18 +447,38 @@ struct Archive {
   }
 
   void draw(V& v) {
-    auto b = r.raw(10);
+    auto b = r.raw(8);
     v.mat = int(b[0] | b[1] << 8);
     v.hidden = b[2];
     v.soft = b[5];
     v.smooth = b[6];
-    v.layer = int(b[8] | b[9] << 8);
+    // The layer field is normally a u16 id, but an entity can carry the
+    // layer BY OBJECT instead (seen on real 2018 instances): a full
+    // inline CLayer record on first use, an escaped back-ref to it on
+    // later siblings. Layer ids never have the 0x8000 bit and never equal
+    // 0x7fff, so both object forms are unambiguous.
+    auto lay_cs = class_slot.find("CLayer");
+    auto tag = read_u16(r.d, r.p);
+    if (lay_cs != class_slot.end() && tag == (0x8000 | lay_cs->second)) {
+      object("CLayer");
+      v.layer = 0;  // by-object layer: keep the default id
+    } else if (tag == 0x7fff) {
+      r.u16();
+      auto big = r.u32();
+      if (big & 0x80000000) throw std::runtime_error("drawbase layer: unexpected class");
+      v.layer = 0;  // by-object layer (back-ref)
+    } else {
+      v.layer = r.u16();
+    }
   }
 
   std::tuple<uint64_t, std::string, std::shared_ptr<V>> new_obj(const std::string& n) {
     auto slot = alloc({false, n, 0, {}});
     auto v = read(n, slot);
     slots[slot].v = v;
+    if (n == "CDimensionLinear" || n == "CText") {
+      annot_watermark = next;
+    }
     return {slot, n, v};
   }
 
@@ -371,8 +511,32 @@ struct Archive {
       v->k = "edgeuse";
       v->edge = std::get<0>(object("CEdge"));
       v->sense = r.u8() != 0;
-      auto parent = std::get<0>(object());
-      if (parent != current_loop) throw std::runtime_error("edge-use parent mismatch");
+      // parent-loop back-ref: the alignment oracle. Read as a RAW file
+      // index - after annotations the claimed index can sit AHEAD of the
+      // walker's numbering (burned MapObject indices, see
+      // register_burn()), which is a correction signal, not a mis-parse.
+      size_t p0 = r.p;
+      auto tag = r.u16();
+      std::optional<uint64_t> parent;
+      if (tag == 0x7fff) {
+        auto big = r.u32();
+        if (big & 0x80000000) throw std::runtime_error("edge-use parent is a new object");
+        parent = big;
+      } else if (tag == 0xffff || (tag & 0x8000)) {
+        throw std::runtime_error("edge-use parent is a new object");
+      } else if (tag != 0) {
+        parent = tag;
+      }
+      uint64_t expected = current_loop + cum_delta;
+      if (!parent || *parent != expected) {
+        int64_t delta = parent ? int64_t(*parent) - int64_t(expected) : 0;
+        if (delta > 0 && delta <= 4096 && annot_watermark) {
+          register_burn(uint64_t(delta));
+        } else {
+          r.p = p0;
+          throw std::runtime_error("edge-use parent mismatch");
+        }
+      }
     } else if (n == "CLoop") {
       auto old = current_loop;
       current_loop = self;
@@ -422,13 +586,24 @@ struct Archive {
       while (mid.size() < 8 && !r.marker()) mid.push_back(r.u8());
       v->hidden = mid.empty() ? 0 : mid[0];
       r.utf16();
-      r.u16();
-      auto c = r.raw(4);
-      v->r = c[0];
-      v->g = c[1];
-      v->b = c[2];
-      r.utf16();
-      r.raw(21);
+      auto flags = r.u16();
+      if (flags & 0x00ff) {
+        // Colour-by-layer with a TEXTURED material: instead of the flat
+        // RGBA, the layer embeds the same texture block a CMaterial
+        // carries (SketchUp Pro assigns full materials to layers). Low
+        // byte of the flag word set = textured; a plain colour layer has
+        // 0 there (its high byte carries an unrelated flag, so the word
+        // as a whole is non-zero either way).
+        texture_block(*v);
+        r.raw(4);  // trailing u32
+      } else {
+        auto c = r.raw(4);
+        v->r = c[0];
+        v->g = c[1];
+        v->b = c[2];
+        r.utf16();
+        r.raw(21);
+      }
     } else if (n == "CMaterial") {
       preamble();
       v->k = "material";
@@ -445,33 +620,7 @@ struct Archive {
         v->opacity = r.f64();
         if (!r.u8()) v->opacity = 0;
       } else {
-        r.raw(ver >= 17 ? 2 : 1);
-        auto q = object("CDib");
-        v->tex_dib = std::get<0>(q);
-        auto begin = r.p, limit = std::min(r.d.size(), r.p + 28);
-        size_t marker = begin;
-        for (; marker + 3 <= limit; ++marker)
-          if (r.d[marker] == 255 && r.d[marker + 1] == 254 && r.d[marker + 2] == 255) break;
-        if (marker - begin == 20)
-          r.u32();
-        else if (marker - begin != 16)
-          throw std::runtime_error("texture size block misaligned");
-        v->tw = r.f64();
-        v->th = r.f64();
-        v->tex_file = r.utf16();
-        auto c = r.raw(9);
-        v->r = c[0];
-        v->g = c[1];
-        v->b = c[2];
-        // c[3] here is not a colour alpha byte - it feeds the colorized
-        // check below alongside blob[4]. v->a keeps its default (255);
-        // textured materials carry no separate alpha channel in this
-        // record shape.
-        r.utf16();
-        auto blob = r.raw(8);
-        v->opacity = r.f64();
-        if (!r.u8()) v->opacity = 0;
-        v->colorized = blob[4] != 0 || c[3] == 255;
+        texture_block(*v);
       }
     } else if (n == "CDib") {
       v->k = "dib";
@@ -503,15 +652,74 @@ struct Archive {
       preamble();
       object("CCamera");
       object("CDib");
-    } else if (n == "CRelationship") {
+    } else if (n == "CImage") {
+      // CImage: an Image entity - instance-shaped: a back-ref to the
+      // (already walked) CComponentDefinition holding the image's face
+      // and texture, a 3x4 placement, a constant 1.0, the source path
+      // string (empty in every sample), and a 16-byte GUID. It appears as
+      // a normal entity-list item inside the definition that owns the
+      // image (typically a face-me/photo definition), whose own tail the
+      // ordinary definition reader then consumes. Its parsed value is
+      // never consumed downstream - it exists purely so the byte stream
+      // stays aligned.
       preamble();
-      object();
-      object();
+      v->k = "image";
+      draw(*v);
+      auto q = object();
+      v->def = std::get<0>(q);
+      v->xf = r.f64s(12);
+      r.f64();    // constant 1.0
+      r.utf16();  // source path
+      auto g = r.raw(16);
+      static char h[] = "0123456789ABCDEF";
+      for (auto x : g) {
+        v->guid += h[x >> 4];
+        v->guid += h[x & 15];
+      }
+    } else if (n == "CRelationship") {
+      // two object pointers (small maps: two u16 back-refs - which read
+      // like the "u32" of the public notes; big maps escalate them to
+      // big-tags). They bind an annotation to the entity it labels, and
+      // the annotation side is routinely serialized BEFORE the geometry
+      // side - so these can point forward, past the walk cursor;
+      // entity_ref() tolerates that where object()'s back-ref path
+      // (rightly) does not.
+      preamble();
+      v->k = "relationship";
+      entity_ref();
+      entity_ref();
     } else if (n == "CConstructionLine") {
       preamble();
       draw(*v);
-      r.f64s(8);
-      r.raw(ver >= 17 ? 7 : 4);
+      r.f64s(8);  // line params (+-~4.4e29 = infinite)
+      // The trailing block varies by the WRITING BUILD, not cleanly by
+      // version: 7 bytes on the v17 calibration corpus, 4 on v16 and on a
+      // real v18, 0 on another real v17. Self-calibrate on the first
+      // guide line of the file - the length that lands on a legitimate
+      // next tag (strict forms only) - and cache it for the rest of the
+      // file.
+      if (!cline_tail) {
+        size_t dflt = ver == 17 ? 7 : 4;
+        std::vector<size_t> order{dflt};
+        for (size_t c : {size_t(0), size_t(4), size_t(7)})
+          if (c != dflt) order.push_back(c);
+        // two passes: a zero tail full of padding can mimic a null tag,
+        // so only accept a null-anchored candidate when no candidate
+        // lands on a STRONG form (escape / known class / class
+        // definition)
+        std::optional<size_t> k;
+        for (bool allow_null : {false, true}) {
+          for (size_t cand : order) {
+            if (strict_next_tag(r.p + cand, allow_null)) {
+              k = cand;
+              break;
+            }
+          }
+          if (k) break;
+        }
+        cline_tail = k ? *k : dflt;
+      }
+      r.raw(*cline_tail);
     } else if (n == "CConstructionPoint") {
       preamble();
       draw(*v);
@@ -539,7 +747,17 @@ struct Archive {
       draw(*v);
       v->text = r.utf16();
       object("CSkFont");
-      r.raw(165);
+      // The tail is NOT a fixed 165-byte blob: it embeds two object
+      // references (the dimension's connection points into the
+      // geometry). Each is a normal MFC tag - 2 bytes in small files, but
+      // 6 bytes once the archive holds more than 0x7ffe objects and the
+      // 0x7fff big-tag escape kicks in - so a fixed-size skip walks off
+      // the rails exactly on large models.
+      r.raw(37);
+      entity_ref();  // connection point 1 (may be null)
+      r.raw(42);
+      entity_ref();  // connection point 2 (may be null)
+      r.raw(82);
     } else if (n == "CText") {
       preamble();
       v->k = "text";
@@ -557,31 +775,72 @@ struct Archive {
       r.raw(found - r.p);
       v->text = r.utf16();
       r.raw(5);
+      // Optional leader-attachment refs follow the fixed tail (a text
+      // label anchored to geometry stores the anchored entities here;
+      // they can point FORWARD - see entity_ref()). Only the escaped
+      // 6-byte form is recognisable without risk: a 2-byte back-ref here
+      // would be indistinguishable from the next list item's tag, and
+      // every known sample either has no attachments or lives in a
+      // >0x7ffe-object file where the escape is mandatory anyway.
+      while (r.p + 2 <= r.d.size() && r.d[r.p] == 255 && r.d[r.p + 1] == 127) {
+        if (r.p + 6 > r.d.size()) break;
+        uint32_t val = read_u32(r.d, r.p + 2);
+        if (val & 0x80000000) break;  // new-object tag - the next entity
+        r.raw(6);
+      }
     } else if (n == "CComponentDefinition") {
       preamble();
       v->k = "definition";
       r.raw(ver >= 17 ? 22 : 20);
       auto nl = r.u32();
       if (nl > 10000) throw std::runtime_error("implausible def layers");
-      while (nl--) object("CLayer");
+      // like the model-level layer list, the count is REAL layers (new
+      // records or back-refs); SketchUp 2020 interleaves null separators
+      // between them
+      {
+        uint32_t got = 0;
+        while (got < nl) {
+          if (r.p + 2 <= r.d.size() && read_u16(r.d, r.p) == 0) {
+            r.p += 2;
+            continue;
+          }
+          object("CLayer");
+          got++;
+        }
+      }
       auto decl = r.u16();
       if (decl == 0x7fff) r.u32();
-      r.u32();
-      auto count = r.u32();
+      // v20 can drop its undocumented filler right here, swallowing the
+      // u32 field (and, behind a layer-separator null, even the decl
+      // itself): if the empty-string marker sits in the next few bytes,
+      // the real count is the first non-zero u32 after its padding.
+      uint32_t count = 0;
+      bool filled = false;
+      if (ver >= 20) {
+        auto c = retry_count_after_v20_filler(r, r.p, 5000000, this);
+        if (c) {
+          count = *c;
+          filled = true;
+        }
+      }
+      if (!filled) {
+        r.u32();
+        count = r.u32();
+      }
       // A zero count is as much a symptom of the v20 filler as an
       // implausibly large one: the reader lands on the leading zero bytes
       // of the filler instead of the count. A genuinely empty definition
       // reads zero with no filler ahead, and retry_count_after_v20_filler
       // leaves those alone.
       if (count > 5000000 || count == 0) {
-        auto retry = retry_count_after_v20_filler(r, r.p - 4, 5000000);
+        auto retry = retry_count_after_v20_filler(r, r.p - 4, 5000000, this);
         if (retry) count = *retry;
       }
       if (count > 5000000) throw std::runtime_error("implausible def entities");
       v->ents = entity_list(count, false);
       auto nr = r.u32();
       if (nr > 100000) {
-        auto retry = retry_count_after_v20_filler(r, r.p - 4, 100000);
+        auto retry = retry_count_after_v20_filler(r, r.p - 4, 100000, this);
         if (retry) nr = *retry;
       }
       if (nr > 100000) throw std::runtime_error("definition list misaligned");
@@ -669,6 +928,8 @@ struct Archive {
         return std::to_string(r.u32());
       case 10:
         return r.utf16();
+      case 12:
+        return std::to_string(r.f64());  // Length (a double, inches)
       case 11: {
         auto n = r.u32();
         if (n > 100000) throw std::runtime_error("attr array too large");
@@ -679,7 +940,11 @@ struct Archive {
         }
         return joined;
       }
-      case 18: {
+      case 17: {  // 3D point (Geom::Point3d)
+        auto v = r.f64s(3);
+        return std::to_string(v[0]) + "," + std::to_string(v[1]) + "," + std::to_string(v[2]);
+      }
+      case 18: {  // 3D vector (Geom::Vector3d)
         auto v = r.f64s(3);
         return std::to_string(v[0]) + "," + std::to_string(v[1]) + "," + std::to_string(v[2]);
       }
@@ -690,20 +955,97 @@ struct Archive {
 
   std::vector<std::tuple<uint64_t, std::string, std::shared_ptr<V>>> entity_list(uint32_t n,
                                                                                  bool root) {
+    burn_stack.push_back(0);
+
+    struct PopGuard {
+      Archive* a;
+
+      ~PopGuard() { a->burn_stack.pop_back(); }
+    } pop_guard{this};
+
     std::vector<std::tuple<uint64_t, std::string, std::shared_ptr<V>>> v;
     while (v.size() < n) {
       auto save = r.p;
+      bool has_burn_credit = !root && !burn_stack.empty() && burn_stack.back() > 0;
+      if (has_burn_credit && save + 25 <= r.d.size() && read_u32(r.d, save) == 0 &&
+          r.d[save + 22] == 255 && r.d[save + 23] == 254 && r.d[save + 24] == 255) {
+        // burned MapObject indices (see register_burn()) mean the
+        // declared count includes phantom entities the stream never
+        // carries; the definition tail signature (nrel=0 + pad + 16-byte
+        // GUID + name marker at +22) marks the list's REAL end
+        break;
+      }
       try {
         v.push_back(object());
       } catch (...) {
-        if (!root) throw;
-        r.p = save;
-        break;
+        if (root) {
+          // over-declared root counts run into the document tail - stop
+          r.p = save;
+          break;
+        }
+        if (has_burn_credit) {
+          // this list had burned MapObject indices (see register_burn()):
+          // the phantom connection points were also counted as items, so
+          // the declared count overshoots the real records. Stop at the
+          // failed item - the definition tail that follows (nrel, GUID
+          // anchor, thumbnail scan) validates the cut.
+          r.p = save;
+          break;
+        }
+        throw;
       }
     }
     return v;
   }
 };
+
+// True when the u16 at `at` can legally start an object read: a null, an
+// escape, a class definition, a class-ref to a KNOWN class, or an object
+// back-ref within the allocated range.
+bool plausible_list_tag(Archive& ar, const ByteBuffer& d, size_t at) {
+  if (at + 2 > d.size()) return false;
+  auto t = read_u16(d, at);
+  if (t == 0x0000 || t == 0x7fff || t == 0xffff) return true;
+  if (t & 0x8000) {
+    auto i = ar.slots.find(t & 0x7fff);
+    return i != ar.slots.end() && i->second.cls;
+  }
+  return t < ar.next;
+}
+
+// SketchUp 2020's filler can appear at MORE call sites than the count-only
+// read this originally guarded (a v20 layer-separator null before a
+// definition's decl field, for one) - the same byte-stride search as
+// find_count_after_v20_filler, but each candidate must ALSO look like a
+// legal object-read start (plausible_list_tag) to reduce false positives.
+// Deliberately a separate search from find_count_after_v20_filler's own
+// (which stays a pure, Archive-free function so its own tests keep
+// working unchanged): needs Archive for the validation, and Archive is an
+// anonymous-namespace type find_count_after_v20_filler's header-declared
+// signature cannot reference.
+std::optional<uint32_t> retry_count_after_v20_filler(R& r, size_t count_pos, uint32_t limit,
+                                                     Archive* ar) {
+  const ByteBuffer& d = r.d;
+  size_t marker_at = std::string::npos;
+  for (size_t i = count_pos; i + 4 <= d.size() && i < count_pos + 12; ++i) {
+    if (d[i] == 255 && d[i + 1] == 254 && d[i + 2] == 255) {
+      marker_at = i;
+      break;
+    }
+  }
+  if (marker_at == std::string::npos) return std::nullopt;
+  if (d[marker_at + 3] != 0) return std::nullopt;  // non-empty string: real data
+  for (size_t pad = 1; pad <= kMaxV20FillerPad; pad += 4) {
+    size_t at = marker_at + 4 + pad;
+    if (at + 4 > d.size()) break;
+    uint32_t count = read_u32(d, at);
+    if (count > 0 && count <= limit && (!ar || plausible_list_tag(*ar, d, at + 4))) {
+      r.p = at + 4;
+      return count;
+    }
+  }
+  return std::nullopt;
+}
 
 struct WalkResult {
   Archive ar;
@@ -799,20 +1141,46 @@ WalkResult walk_model(const ByteBuffer& data, int ver, size_t start, uint32_t ma
   if (ver >= 17) ar.r.u8();
   auto lc = ar.r.u32();
   if (lc > 100000) throw std::runtime_error("invalid layer count");
-  while (lc--) {
+  // lc counts REAL layers. SketchUp 2020 interleaves a null object-ref
+  // after each layer record (a separator, not a layer), so counting reads
+  // walks off mid-list on files with several layers; count parsed layers
+  // instead, skip the separators, and stop early if the next tag is a
+  // back-ref (the definition-list anchor) - a v20 variant where the count
+  // over-includes separators.
+  while (layers.size() < lc) {
+    if (ar.r.p + 2 > data.size()) break;
+    auto tag = read_u16(data, ar.r.p);
+    if (tag == 0) {
+      ar.r.p += 2;
+      continue;
+    }
+    if (tag != 0xffff && !(tag & 0x8000)) break;
     auto q = ar.object("CLayer");
-    // A null object-ref occupies a slot in the list without carrying a
-    // layer record (seen in SketchUp 2020 files, where lc includes it).
-    // Keeping it would push a null V into layers and blow up downstream
-    // on its r/g/b fields; ar.object() has still consumed the ref.
     if (!std::get<2>(q)) continue;
     layers.push_back({std::get<0>(q), std::get<2>(q)});
+  }
+  // trailing separators (and any layer records past the declared count)
+  {
+    auto lay_cs = ar.class_slot.find("CLayer");
+    while (ar.r.p + 2 <= data.size()) {
+      auto tag = read_u16(data, ar.r.p);
+      if (tag == 0) {
+        ar.r.p += 2;
+        continue;
+      }
+      if (lay_cs != ar.class_slot.end() && tag == (0x8000 | lay_cs->second)) {
+        auto q = ar.object("CLayer");
+        if (std::get<2>(q)) layers.push_back({std::get<0>(q), std::get<2>(q)});
+        continue;
+      }
+      break;
+    }
   }
   auto anchor = ar.object();
   if (std::get<1>(anchor) != "CLayer") throw std::runtime_error("definition anchor is not a layer");
   auto dc = ar.r.u32();
   if (dc > 1000000) {
-    auto retry = retry_count_after_v20_filler(ar.r, ar.r.p - 4, 1000000);
+    auto retry = retry_count_after_v20_filler(ar.r, ar.r.p - 4, 1000000, &ar);
     if (retry) dc = *retry;
   }
   if (dc > 1000000) throw std::runtime_error("invalid definition count");
@@ -829,7 +1197,7 @@ WalkResult walk_model(const ByteBuffer& data, int ver, size_t start, uint32_t ma
   }
   auto root_count = ar.r.u32();
   if (root_count > 5000000) {
-    auto retry = retry_count_after_v20_filler(ar.r, ar.r.p - 4, 5000000);
+    auto retry = retry_count_after_v20_filler(ar.r, ar.r.p - 4, 5000000, &ar);
     if (retry) root_count = *retry;
   }
   if (root_count > 5000000) throw std::runtime_error("implausible root entity count");

--- a/packages/cpp/tests/legacy_v20_test.cpp
+++ b/packages/cpp/tests/legacy_v20_test.cpp
@@ -44,10 +44,15 @@ TEST(LegacyV20, ParsesRealV20FileThatPreviouslyThrew) {
   EXPECT_EQ(model.definitions.size(), 20);
   EXPECT_EQ(model.materials.size(), 24);
 
-  // v20 writes a null object-ref into the layer list, which the layer
-  // count includes. It must not reach model.layers as a null entry.
-  ASSERT_EQ(model.layers.size(), 1);
+  // v20 interleaves a null object-ref after EACH layer record; the count
+  // is the number of REAL layers. The old reader counted the separators
+  // as items and dropped every layer after the first - this fixture
+  // really does carry "Gondulas Laterais" (visible in SketchUp), which
+  // the previous assertion enshrined as missing. Nulls must still never
+  // reach model.layers.
+  ASSERT_EQ(model.layers.size(), 2);
   EXPECT_EQ(model.layers[0].name, "Layer0");
+  EXPECT_EQ(model.layers[1].name, "Gondulas Laterais");
 
   // real geometry, not an empty shell
   std::size_t faces = 0, edges = 0, vertices = 0;

--- a/packages/cpp/tests/legacy_v20_test.cpp
+++ b/packages/cpp/tests/legacy_v20_test.cpp
@@ -49,10 +49,15 @@ TEST(LegacyV20, ParsesRealV20FileThatPreviouslyThrew) {
   // as items and dropped every layer after the first - this fixture
   // really does carry "Gondulas Laterais" (visible in SketchUp), which
   // the previous assertion enshrined as missing. Nulls must still never
-  // reach model.layers.
+  // reach model.layers. Order-independent: model.layers is built from
+  // layer_colors, a std::map keyed by name (sorted alphabetically, not
+  // file order) - a pre-existing, unrelated characteristic of this
+  // port's layer-building code (model.cpp), not something this fixture's
+  // fix controls.
   ASSERT_EQ(model.layers.size(), 2);
-  EXPECT_EQ(model.layers[0].name, "Layer0");
-  EXPECT_EQ(model.layers[1].name, "Gondulas Laterais");
+  std::set<std::string> names;
+  for (const auto& layer : model.layers) names.insert(layer.name);
+  EXPECT_EQ(names, (std::set<std::string>{"Layer0", "Gondulas Laterais"}));
 
   // real geometry, not an empty shell
   std::size_t faces = 0, edges = 0, vertices = 0;

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -112,8 +112,9 @@ const int _maxV20FillerPad = 29;
 ({int count, int next})? findCountAfterV20Filler(
   Uint8List data,
   int countPos,
-  int limit,
-) {
+  int limit, [
+  Archive? ar,
+]) {
   int markerAt = -1;
   for (int i = countPos; i < countPos + 12 && i + 4 <= data.length; i++) {
     if (data[i] == 0xFF && data[i + 1] == 0xFE && data[i + 2] == 0xFF) {
@@ -138,16 +139,34 @@ const int _maxV20FillerPad = 29;
     final at = markerAt + 4 + pad;
     if (at + 4 > data.length) break;
     final count = Tlv.readU32(data, at);
-    if (count > 0 && count <= limit) return (count: count, next: at + 4);
+    if (count > 0 &&
+        count <= limit &&
+        (ar == null || _plausibleListTag(ar, data, at + 4))) {
+      return (count: count, next: at + 4);
+    }
   }
   return null;
 }
 
-int? retryCountAfterV20Filler(LR r, int countPos, int limit) {
-  final hit = findCountAfterV20Filler(r.data, countPos, limit);
+int? retryCountAfterV20Filler(LR r, int countPos, int limit, [Archive? ar]) {
+  final hit = findCountAfterV20Filler(r.data, countPos, limit, ar);
   if (hit == null) return null;
   r.pos = hit.next;
   return hit.count;
+}
+
+/// True when the u16 at [at] can legally start an object read: a null, an
+/// escape, a class definition, a class-ref to a KNOWN class, or an object
+/// back-ref within the allocated range.
+bool _plausibleListTag(Archive ar, Uint8List data, int at) {
+  if (at + 2 > data.length) return false;
+  final t = Tlv.readU16(data, at);
+  if (t == 0x0000 || t == 0x7FFF || t == 0xFFFF) return true;
+  if ((t & 0x8000) != 0) {
+    final ent = ar.slots[t & 0x7FFF];
+    return ent != null && ent.kind == 'class';
+  }
+  return t < ar.nextSlot;
 }
 
 /// True when the bytes at [p] are an MFC class-ref to class [slot]. Mirrors
@@ -273,6 +292,21 @@ class Archive {
   int? currentLoop;
   bool inEntityList = false;
 
+  // Burned store-map indices (see readEdgeUse): the writer maps an
+  // annotation's connection points into the store map WITHOUT writing
+  // bytes, so file back-references beyond each burn run ahead of the
+  // walker's numbering. Registrations always stay at WALKER indices - no
+  // captured slot ever goes stale - and _backref translates file
+  // references through the burn bands instead. [burns] holds
+  // (fileBandStart, width) per event; [cumDelta] their total;
+  // [annotWatermark] the walker slot right after the last annotation
+  // record - the only place a band can start.
+  final List<(int, int)> burns = [];
+  int cumDelta = 0;
+  int? annotWatermark;
+  final List<int> burnStack = []; // per-entity-list burned-item credits
+  int? clineTail;
+
   Archive(this.data, this.ver) : hasPid = ver >= 17 {
     r = LR(data);
   }
@@ -348,10 +382,35 @@ class Archive {
       currentClass = prevClass;
     }
     slots[slot] = SlotEntry(kind: 'obj', name: name, value: value);
+    if (name == 'CDimensionLinear' || name == 'CText') {
+      annotWatermark = nextSlot;
+    }
     return (slot, name, value);
   }
 
+  /// Map a FILE store-map index to the walker's numbering through the burn
+  /// bands. Returns the walker slot, or null when the reference points
+  /// INTO a band (a phantom, never-serialized connection point).
+  int? _translateRef(int slot) {
+    int offset = 0;
+    for (final (start, width) in burns) {
+      if (slot < start) break;
+      if (slot < start + width) return null;
+      offset += width;
+    }
+    return slot - offset;
+  }
+
   (int?, String?, Object?) _backref(int slot, LR r) {
+    if (burns.isNotEmpty && slot >= burns[0].$1) {
+      final walker = _translateRef(slot);
+      if (walker == null) {
+        // a phantom (burned) connection-point index - annotation metadata
+        // only; nothing was ever serialized for it
+        return (slot, 'reserved', null);
+      }
+      slot = walker;
+    }
     final ent = slots[slot];
     if (ent == null) {
       if (slot < walkBase) {
@@ -452,6 +511,26 @@ class MaterialRec {
   MaterialRec({required this.name, required this.rgba});
 }
 
+class TextureBlockRec {
+  Uint8List rgba;
+  double opacity;
+  int useOpacity;
+  int texDib;
+  double texW, texH;
+  String texFile;
+  bool colorized;
+  TextureBlockRec({
+    required this.rgba,
+    required this.opacity,
+    required this.useOpacity,
+    required this.texDib,
+    required this.texW,
+    required this.texH,
+    required this.texFile,
+    required this.colorized,
+  });
+}
+
 class DibRec {
   int subtype;
   Uint8List data;
@@ -477,6 +556,15 @@ class CameraRec {}
 class ThumbnailRec {
   int? dib;
   ThumbnailRec(this.dib);
+}
+
+class ImageRec {
+  DrawBase db;
+  int? def;
+  List<double> xform;
+  String guid;
+  ImageRec(
+      {required this.db, this.def, required this.xform, required this.guid});
 }
 
 class RelationshipRec {}
@@ -557,13 +645,34 @@ class LegacyReaders {
   }
 
   static DrawBase drawbase(Archive ar, LR r) {
-    final b = r.raw(10);
+    final b = r.raw(8);
+    // The layer field is normally a u16 id, but an entity can carry the
+    // layer BY OBJECT instead (seen on real 2018 instances): a full inline
+    // CLayer record on first use, an escaped back-ref to it on later
+    // siblings. Layer ids never have the 0x8000 bit and never equal
+    // 0x7FFF, so both object forms are unambiguous.
+    final layCls = ar.classSlot['CLayer'];
+    final tag = r.peekU16();
+    int layer;
+    if (layCls != null && tag == (0x8000 | layCls)) {
+      ar.readObject(r, 'CLayer');
+      layer = 0; // by-object layer: keep the default id
+    } else if (tag == 0x7FFF) {
+      r.u16();
+      final big = r.u32();
+      if ((big & 0x80000000) != 0) {
+        throw LegacyParseError('drawbase layer: unexpected class ${r.ctx()}');
+      }
+      layer = 0; // by-object layer (back-ref)
+    } else {
+      layer = r.u16();
+    }
     return DrawBase()
       ..mat = Tlv.readU16(b, 0)
       ..hidden = b[2]
       ..soft = b[5]
       ..smooth = b[6]
-      ..layer = Tlv.readU16(b, 8);
+      ..layer = layer;
   }
 
   static Object readVertex(Archive ar, LR r) {
@@ -597,14 +706,62 @@ class LegacyReaders {
     return ArcCurveRec();
   }
 
+  /// Record that the writer burned [delta] store-map indices without
+  /// serializing any bytes for them.
+  ///
+  /// SketchUp maps an annotation's connection-point objects into the MFC
+  /// store map (CArchive::MapObject) when a dimension or leader text is
+  /// attached to geometry - each mapping consumes an index, but nothing is
+  /// written to the stream, so the file's later back-references run ahead
+  /// of a byte-exact walk. The band starts right after the last annotation
+  /// record (in FILE numbering); registrations never move - _backref
+  /// translates file references through the recorded bands instead, so no
+  /// slot value captured anywhere can go stale.
+  static void _registerBurn(Archive ar, int delta) {
+    ar.burns.add((ar.annotWatermark! + ar.cumDelta, delta));
+    ar.cumDelta += delta;
+    ar.annotWatermark = null;
+    // each burn event corresponds to ONE phantom top-level entity that the
+    // entity list's declared count includes but the stream never carries -
+    // credit it so the list doesn't run past its real end
+    if (ar.burnStack.isNotEmpty) {
+      ar.burnStack[ar.burnStack.length - 1] += 1;
+    }
+  }
+
   static Object readEdgeUse(Archive ar, LR r) {
     preamble(ar, r);
     final (es, _, __) = ar.readObject(r, 'CEdge');
     final sense = r.u8();
-    final (ps, _2, __2) = ar.readObject(r);
-    if (ps != ar.currentLoop) {
-      throw LegacyParseError(
-          'edge-use parent slot $ps != current loop ${ar.currentLoop} ${r.ctx()}');
+    // parent-loop back-ref: the alignment oracle. Read as a RAW file index
+    // - after annotations the claimed index can sit AHEAD of the walker's
+    // numbering (burned MapObject indices, see _registerBurn), which is a
+    // correction signal, not a mis-parse.
+    final p0 = r.pos;
+    final tag = r.u16();
+    int? ps;
+    if (tag == 0x7FFF) {
+      final big = r.u32();
+      if ((big & 0x80000000) != 0) {
+        throw LegacyParseError('edge-use parent is a new object ${r.ctx()}');
+      }
+      ps = big;
+    } else if (tag == 0xFFFF || (tag & 0x8000) != 0) {
+      throw LegacyParseError('edge-use parent is a new object ${r.ctx()}');
+    } else {
+      ps = tag != 0 ? tag : null;
+    }
+    final expected =
+        ar.currentLoop != null ? ar.currentLoop! + ar.cumDelta : null;
+    if (ps != expected) {
+      final delta = (ps != null && expected != null) ? ps - expected : 0;
+      if (delta > 0 && delta <= 4096 && ar.annotWatermark != null) {
+        _registerBurn(ar, delta);
+      } else {
+        r.pos = p0;
+        throw LegacyParseError(
+            'edge-use parent slot $ps != current loop $expected ${r.ctx()}');
+      }
     }
     return EdgeUseRec(edge: es, sense: sense);
   }
@@ -671,6 +828,7 @@ class LegacyReaders {
     if (t == 0x07) return r.u8();
     if (t == 0x09) return r.u32();
     if (t == 0x0a) return r.utf16();
+    if (t == 0x0c) return r.f64(); // Length (a double, inches)
     if (t == 0x0b) {
       final n = r.u32();
       if (n > 100000) {
@@ -678,7 +836,8 @@ class LegacyReaders {
       }
       return [for (int i = 0; i < n; i++) _readTyped(r, r.u8())];
     }
-    if (t == 0x12) return r.f64s(3);
+    if (t == 0x11) return r.f64s(3); // 3D point (Geom::Point3d)
+    if (t == 0x12) return r.f64s(3); // 3D vector (Geom::Vector3d)
     throw LegacyParseError(
         'unknown attribute value type 0x${t.toRadixString(16)} ${r.ctx()}');
   }
@@ -741,12 +900,65 @@ class LegacyReaders {
       mid.add(r.raw(1)[0]);
     }
     r.utf16();
-    r.u16();
+    final flags = r.u16();
+    if ((flags & 0x00FF) != 0) {
+      // Colour-by-layer with a TEXTURED material: instead of the flat
+      // RGBA, the layer embeds the same texture block a CMaterial carries
+      // (SketchUp Pro assigns full materials to layers). Low byte of the
+      // flag word set = textured; a plain colour layer has 0 there (its
+      // high byte carries an unrelated flag, so the word as a whole is
+      // non-zero either way).
+      final tex = _textureBlock(ar, r);
+      r.raw(4); // trailing u32
+      return LayerRec(
+          name: name, hidden: mid.isNotEmpty ? mid[0] : 0, rgba: tex.rgba);
+    }
     final rgba = r.raw(4);
     r.utf16();
     r.raw(21);
     return LayerRec(
         name: name, hidden: mid.isNotEmpty ? mid[0] : 0, rgba: rgba);
+  }
+
+  /// The textured-material payload: an embedded CDib plus applied size,
+  /// source file name, average colour, and opacity. Shared verbatim
+  /// between a CMaterial with a texture and a colour-by-layer CLayer that
+  /// carries a textured material.
+  static TextureBlockRec _textureBlock(Archive ar, LR r) {
+    r.raw(ar.ver >= 17 ? 2 : 1); // texture flag pad
+    final (s, _, dib) = ar.readObject(r, 'CDib');
+    if (dib is! DibRec) {
+      throw LegacyParseError('texture object is not a dib ${r.ctx()}');
+    }
+    // optional u32 between the dib and the 2 x f64 applied size
+    final marker = _findBytes(r.data, _strMarker, r.pos, r.pos + 28);
+    if (marker - r.pos == 20) {
+      r.u32();
+    } else if (marker - r.pos != 16) {
+      throw LegacyParseError('texture size block misaligned ${r.ctx()}');
+    }
+    final w = r.f64();
+    final h = r.f64();
+    final fname = r.utf16();
+    final avg = r.raw(9); // RGBA + 00 + RGBA (colour stored twice)
+    r.utf16();
+    final blob = r.raw(8); // u32 + u32 colorized flag
+    final opacity = r.f64();
+    final useOp = r.u8();
+    // A colourized (re-tinted) texture stores the ORIGINAL image plus the
+    // tint as the average colour; flagged by the second blob u32 or by
+    // alpha 0xFF on the stored colour.
+    final colorized = blob[4] != 0 || avg[3] == 0xFF;
+    return TextureBlockRec(
+      rgba: Uint8List.sublistView(avg, 0, 4),
+      opacity: opacity,
+      useOpacity: useOp,
+      texDib: s!,
+      texW: w,
+      texH: h,
+      texFile: fname,
+      colorized: colorized,
+    );
   }
 
   static Object readMaterial(Archive ar, LR r) {
@@ -765,34 +977,15 @@ class LegacyReaders {
       out.opacity = opacity;
       out.useOpacity = useOp;
     } else {
-      r.raw(ar.ver >= 17 ? 2 : 1);
-      final (s, _, dib) = ar.readObject(r, 'CDib');
-      if (dib is! DibRec) {
-        throw LegacyParseError('texture object is not a dib ${r.ctx()}');
-      }
-      final marker = _findBytes(r.data, _strMarker, r.pos, r.pos + 28);
-      if (marker - r.pos == 20) {
-        r.u32();
-      } else if (marker - r.pos != 16) {
-        throw LegacyParseError('texture size block misaligned ${r.ctx()}');
-      }
-      final w = r.f64();
-      final h = r.f64();
-      final fname = r.utf16();
-      final avg = r.raw(9);
-      r.utf16();
-      final blob = r.raw(8);
-      final opacity = r.f64();
-      final useOp = r.u8();
-      final colorized = blob[4] != 0 || avg[3] == 0xFF;
-      out.rgba = Uint8List.sublistView(avg, 0, 4);
-      out.opacity = opacity;
-      out.useOpacity = useOp;
-      out.texDib = s;
-      out.texW = w;
-      out.texH = h;
-      out.texFile = fname;
-      out.colorized = colorized;
+      final tex = _textureBlock(ar, r);
+      out.rgba = tex.rgba;
+      out.opacity = tex.opacity;
+      out.useOpacity = tex.useOpacity;
+      out.texDib = tex.texDib;
+      out.texW = tex.texW;
+      out.texH = tex.texH;
+      out.texFile = tex.texFile;
+      out.colorized = tex.colorized;
       out.hasTexture = true;
     }
     return out;
@@ -845,11 +1038,75 @@ class LegacyReaders {
     return ThumbnailRec(dibSlot);
   }
 
-  static Object readRelationship(Archive ar, LR r) {
+  /// CImage: an Image entity - instance-shaped: a back-ref to the (already
+  /// walked) CComponentDefinition holding the image's face and texture, a
+  /// 3x4 placement, a constant 1.0, the source path string (empty in every
+  /// sample), and a 16-byte GUID. It appears as a normal entity-list item
+  /// inside the definition that owns the image (typically a
+  /// face-me/photo definition), whose own tail the ordinary definition
+  /// reader then consumes.
+  static Object readImage(Archive ar, LR r) {
     preamble(ar, r);
-    ar.readObject(r);
-    ar.readObject(r);
+    final db = drawbase(ar, r);
+    final (ds, _, __) = ar.readObject(r); // the image's definition
+    final xform = r.f64s(12);
+    r.f64(); // constant 1.0
+    r.utf16(); // source path
+    final guid = r.raw(16);
+    return ImageRec(db: db, def: ds, xform: xform, guid: Tlv.toHexUpper(guid));
+  }
+
+  /// A reference-to-entity tag: dimension connection points and text
+  /// leader attachments. Unlike readObject's back-ref path, this tolerates
+  /// a slot the walk has not reached yet - SketchUp serializes a
+  /// label/dimension BEFORE the entity it anchors to when both live in the
+  /// same entity list, so the reference can legitimately point forward.
+  /// Returns the slot number, or null for a null reference.
+  static int? _entityRef(Archive ar, LR r) {
+    final tag = r.u16();
+    if (tag == 0) return null;
+    if (tag == 0x7FFF) {
+      final big = r.u32();
+      if ((big & 0x80000000) != 0) {
+        throw LegacyParseError('entity ref is a new object ${r.ctx()}');
+      }
+      return big;
+    }
+    if (tag == 0xFFFF || (tag & 0x8000) != 0) {
+      throw LegacyParseError('entity ref is a new object ${r.ctx()}');
+    }
+    return tag;
+  }
+
+  static Object readRelationship(Archive ar, LR r) {
+    // two object pointers (small maps: two u16 back-refs - which read like
+    // the "u32" of the public notes; big maps escalate them to big-tags).
+    // They bind an annotation to the entity it labels, and the annotation
+    // side is routinely serialized BEFORE the geometry side - so these can
+    // point forward, past the walk cursor; _entityRef tolerates that where
+    // readObject's back-ref path (rightly) does not.
+    preamble(ar, r);
+    _entityRef(ar, r);
+    _entityRef(ar, r);
     return RelationshipRec();
+  }
+
+  /// True when the u16 at [at] starts an object read in one of the
+  /// UNAMBIGUOUS forms: null, escape, class definition, or a class-ref to
+  /// a class already known. Plain object back-refs are excluded on
+  /// purpose - any 2-byte junk below 0x8000 would qualify, which is
+  /// exactly the ambiguity this check exists to avoid.
+  static bool _strictNextTag(Archive ar, Uint8List data, int at,
+      [bool allowNull = true]) {
+    if (at + 2 > data.length) return false;
+    final t = Tlv.readU16(data, at);
+    if (t == 0x0000) return allowNull;
+    if (t == 0x7FFF || t == 0xFFFF) return true;
+    if ((t & 0x8000) != 0) {
+      final ent = ar.slots[t & 0x7FFF];
+      return ent != null && ent.kind == 'class';
+    }
+    return false;
   }
 
   static Object readConstructionLine(Archive ar, LR r) {
@@ -857,8 +1114,35 @@ class LegacyReaders {
     drawbase(ar, r);
     r.f64s(3);
     r.f64s(3);
-    r.f64s(2);
-    r.raw(ar.ver >= 17 ? 7 : 4);
+    r.f64s(2); // line params (+-~4.4e29 = infinite)
+    // The trailing block varies by the WRITING BUILD, not cleanly by
+    // version: 7 bytes on the v17 calibration corpus, 4 on v16 and on a
+    // real v18, 0 on another real v17. Self-calibrate on the first guide
+    // line of the file - the length that lands on a legitimate next tag
+    // (strict forms only) - and cache it for the rest of the file.
+    int? k = ar.clineTail;
+    if (k == null) {
+      final dflt = ar.ver == 17 ? 7 : 4;
+      final order = [
+        dflt,
+        ...[0, 4, 7].where((c) => c != dflt)
+      ];
+      // two passes: a zero tail full of padding can mimic a null tag, so
+      // only accept a null-anchored candidate when no candidate lands on a
+      // STRONG form (escape / known class / class definition)
+      outer:
+      for (final allowNull in [false, true]) {
+        for (final cand in order) {
+          if (_strictNextTag(ar, r.data, r.pos + cand, allowNull)) {
+            k = cand;
+            break outer;
+          }
+        }
+      }
+      k ??= dflt;
+      ar.clineTail = k;
+    }
+    r.raw(k);
     return ConstructionLineRec();
   }
 
@@ -903,7 +1187,17 @@ class LegacyReaders {
     final db = drawbase(ar, r);
     final text = r.utf16();
     ar.readObject(r, 'CSkFont');
-    r.raw(165);
+    // The tail is NOT a fixed 165-byte blob: it embeds two object
+    // references (the dimension's connection points into the geometry).
+    // Each is a normal MFC tag - 2 bytes in small files, but 6 bytes once
+    // the archive holds more than 0x7FFE objects and the 0x7FFF big-tag
+    // escape kicks in - so a fixed-size skip walks off the rails exactly
+    // on large models.
+    r.raw(37);
+    _entityRef(ar, r); // connection point 1 (may be null)
+    r.raw(42);
+    _entityRef(ar, r); // connection point 2 (may be null)
+    r.raw(82);
     return DimLinearRec(db, text);
   }
 
@@ -935,14 +1229,52 @@ class LegacyReaders {
     r.raw(idx - r.pos);
     final text = r.utf16();
     r.raw(5);
+    // Optional leader-attachment refs follow the fixed tail (a text label
+    // anchored to geometry stores the anchored entities here; they can
+    // point FORWARD - see _entityRef). Only the escaped 6-byte form is
+    // recognisable without risk: a 2-byte back-ref here would be
+    // indistinguishable from the next list item's tag, and every known
+    // sample either has no attachments or lives in a >0x7FFE-object file
+    // where the escape is mandatory anyway.
+    while (true) {
+      final head = r.peek(2);
+      if (!(head.length == 2 && head[0] == 0xFF && head[1] == 0x7F)) break;
+      final full = r.peek(6);
+      if (full.length < 6) break;
+      final val = Tlv.readU32(full, 2);
+      if ((val & 0x80000000) != 0) break; // new-object tag - the next entity
+      r.raw(6);
+    }
     return TextRec(db, text);
   }
 
   static List<(int, String?, Object?)> readEntityList(
       Archive ar, LR r, int count, String owner) {
     final ents = <(int, String?, Object?)>[];
+    ar.burnStack.add(0);
+    try {
+      return _readEntityListInner(ar, r, count, owner, ents);
+    } finally {
+      ar.burnStack.removeLast();
+    }
+  }
+
+  static List<(int, String?, Object?)> _readEntityListInner(Archive ar, LR r,
+      int count, String owner, List<(int, String?, Object?)> ents) {
     while (ents.length < count) {
       final p = r.pos;
+      final hasBurnCredit =
+          owner == 'def' && ar.burnStack.isNotEmpty && ar.burnStack.last > 0;
+      if (hasBurnCredit &&
+          p + 25 <= r.data.length &&
+          Tlv.readU32(r.data, p) == 0 &&
+          _bytesEqualAt(r.data, p + 22, _strMarker)) {
+        // burned MapObject indices (see _registerBurn) mean the declared
+        // count includes phantom entities the stream never carries; the
+        // definition tail signature (nrel=0 + pad + 16-byte GUID + name
+        // marker at +22) marks the list's REAL end
+        break;
+      }
       final prevFlag = ar.inEntityList;
       ar.inEntityList = true;
       int? s;
@@ -952,9 +1284,21 @@ class LegacyReaders {
         (s, n, v) = ar.readObject(r);
       } on LegacyParseError {
         ar.inEntityList = prevFlag;
-        if (owner != 'root') rethrow;
-        r.pos = p;
-        break;
+        if (owner == 'root') {
+          // over-declared root counts run into the document tail - stop
+          r.pos = p;
+          break;
+        }
+        if (hasBurnCredit) {
+          // this list had burned MapObject indices (see _registerBurn):
+          // the phantom connection points were also counted as items, so
+          // the declared count overshoots the real records. Stop at the
+          // failed item - the definition tail that follows (nrel, GUID
+          // anchor, thumbnail scan) validates the cut.
+          r.pos = p;
+          break;
+        }
+        rethrow;
       }
       ar.inEntityList = prevFlag;
       ents.add((s!, n, v));
@@ -969,21 +1313,43 @@ class LegacyReaders {
     if (nlayers > 10000) {
       throw LegacyParseError('implausible def layer count ${r.ctx()}');
     }
-    for (int i = 0; i < nlayers; i++) {
+    // like the model-level layer list, the count is REAL layers (new
+    // records or back-refs); SketchUp 2020 interleaves null separators
+    // between them
+    int got = 0;
+    while (got < nlayers) {
+      if (r.peekU16() == 0) {
+        r.pos += 2;
+        continue;
+      }
       ar.readObject(r, 'CLayer');
+      got += 1;
     }
     var decl = r.u16();
     if (decl == 0x7FFF) {
       decl = r.u32();
     }
-    r.u32();
-    var count = r.u32();
+    // v20 can drop its undocumented filler right here, swallowing the u32
+    // field (and, behind a layer-separator null, even the decl itself): if
+    // the empty-string marker sits in the next few bytes, the real count
+    // is the first non-zero u32 after its padding.
+    int? filled;
+    if (ar.ver >= 20) {
+      filled = retryCountAfterV20Filler(r, r.pos, 5000000, ar);
+    }
+    int count;
+    if (filled != null) {
+      count = filled;
+    } else {
+      r.u32();
+      count = r.u32();
+    }
     // A zero count is as much a symptom of the v20 filler as an implausibly
     // large one: the reader lands on the leading zero bytes of the filler
     // instead of the count. A genuinely empty definition reads zero with no
     // filler ahead, and retryCountAfterV20Filler leaves those alone.
     if (count > 5000000 || count == 0) {
-      final retry = retryCountAfterV20Filler(r, r.pos - 4, 5000000);
+      final retry = retryCountAfterV20Filler(r, r.pos - 4, 5000000, ar);
       if (retry != null) count = retry;
     }
     if (count > 5000000) {
@@ -992,7 +1358,7 @@ class LegacyReaders {
     final ents = readEntityList(ar, r, count, 'def');
     var nrel = r.u32();
     if (nrel > 100000) {
-      final retry = retryCountAfterV20Filler(r, r.pos - 4, 100000);
+      final retry = retryCountAfterV20Filler(r, r.pos - 4, 100000, ar);
       if (retry != null) nrel = retry;
     }
     if (nrel > 100000) {
@@ -1100,6 +1466,7 @@ class LegacyReaders {
     'CThumbnail': readThumbnail,
     'CRelationship': readRelationship,
     'CComponentDefinition': readDefinition,
+    'CImage': readImage,
     'CComponentInstance': readInstance,
     'CGroup': readInstance,
     'CFaceTextureCoords': readFtc,
@@ -1306,15 +1673,40 @@ class Legacy {
     if (layerCount > 100000) {
       throw LegacyParseError('implausible layer count');
     }
+    // layerCount counts REAL layers. SketchUp 2020 interleaves a null
+    // object-ref after each layer record (a separator, not a layer), so
+    // counting reads walks off mid-list on files with several layers;
+    // count parsed layers instead, skip the separators, and stop early if
+    // the next tag is a back-ref (the definition-list anchor) - a v20
+    // variant where the count over-includes separators.
     final layers = <(int, Object?)>[];
-    for (int i = 0; i < layerCount; i++) {
+    while (layers.length < layerCount) {
+      final tag = r.peekU16();
+      if (tag == 0) {
+        r.pos += 2;
+        continue;
+      }
+      if (tag != 0xFFFF && (tag & 0x8000) == 0) {
+        break;
+      }
       final (s, _, v) = ar.readObject(r, 'CLayer');
-      // A null object-ref occupies a slot in the list without carrying a
-      // layer record (seen in SketchUp 2020 files, where layerCount
-      // includes it). Keeping it would push a null into the list; readObject
-      // has still consumed the ref from the stream.
       if (v == null) continue;
       layers.add((s!, v));
+    }
+    // trailing separators (and any layer records past the declared count)
+    final layCls = ar.classSlot['CLayer'];
+    while (true) {
+      final tag = r.peekU16();
+      if (tag == 0) {
+        r.pos += 2;
+        continue;
+      }
+      if (layCls != null && tag == (0x8000 | layCls)) {
+        final (s, _, v) = ar.readObject(r, 'CLayer');
+        if (v != null) layers.add((s!, v));
+        continue;
+      }
+      break;
     }
 
     final (_, dn, __) = ar.readObject(r);
@@ -1323,7 +1715,7 @@ class Legacy {
     }
     var defCount = r.u32();
     if (defCount > 1000000) {
-      final retry = retryCountAfterV20Filler(r, r.pos - 4, 1000000);
+      final retry = retryCountAfterV20Filler(r, r.pos - 4, 1000000, ar);
       if (retry != null) defCount = retry;
     }
     if (defCount > 1000000) {
@@ -1348,7 +1740,7 @@ class Legacy {
 
     var rootCount = r.u32();
     if (rootCount > 5000000) {
-      final retry = retryCountAfterV20Filler(r, r.pos - 4, 5000000);
+      final retry = retryCountAfterV20Filler(r, r.pos - 4, 5000000, ar);
       if (retry != null) rootCount = retry;
     }
     if (rootCount > 5000000) {

--- a/packages/dart/test/legacy_v20_test.dart
+++ b/packages/dart/test/legacy_v20_test.dart
@@ -23,8 +23,7 @@ import 'package:test/test.dart';
 /// parse that "succeeds" while silently dropping placements would still be
 /// a bug, so the instance counts matter as much as the parse not throwing.
 void main() {
-  final fixturePath =
-      '${Directory.current.path}/test/fixtures/gondola_v20.skp';
+  final fixturePath = '${Directory.current.path}/test/fixtures/gondola_v20.skp';
 
   test('is detected as a legacy container', () {
     final bytes = File(fixturePath).readAsBytesSync();
@@ -41,10 +40,14 @@ void main() {
     expect(model.definitions.length, 20);
     expect(model.materials.length, 24);
 
-    // v20 writes a null object-ref into the layer list, which the layer
-    // count includes. It must not reach model.layers as a null entry.
+    // v20 interleaves a null object-ref after EACH layer record; the count
+    // is the number of REAL layers. The old reader counted the separators
+    // as items and dropped every layer after the first - this fixture
+    // really does carry "Gondulas Laterais" (visible in SketchUp), which
+    // the previous assertion enshrined as missing. Nulls must still never
+    // reach model.layers.
     final names = model.layers.map((l) => l.name).toList();
-    expect(names, ['Layer0']);
+    expect(names, ['Layer0', 'Gondulas Laterais']);
 
     // real geometry, not an empty shell
     var faces = 0, edges = 0, vertices = 0;

--- a/packages/dotnet/OpenSkp.Tests/LegacyV20Tests.cs
+++ b/packages/dotnet/OpenSkp.Tests/LegacyV20Tests.cs
@@ -46,12 +46,15 @@ namespace OpenSkp.Tests
             Assert.Equal(20, model.Definitions.Count);
             Assert.Equal(24, model.Materials.Count);
 
-            // v20 writes a null object-ref into the layer list, which the
-            // layer count includes. It must not reach model.Layers as a
-            // null entry.
+            // v20 interleaves a null object-ref after EACH layer record;
+            // the count is the number of REAL layers. The old reader
+            // counted the separators as items and dropped every layer
+            // after the first - this fixture really does carry "Gondulas
+            // Laterais" (visible in SketchUp), which the previous
+            // assertion enshrined as missing. Nulls must still never reach
+            // model.Layers.
             var names = model.Layers.Select(l => l.Name).ToList();
-            Assert.Single(names);
-            Assert.Equal("Layer0", names[0]);
+            Assert.Equal(new[] { "Layer0", "Gondulas Laterais" }, names);
 
             // real geometry, not an empty shell
             int faces = model.Definitions.Values.Sum(d => d.Faces.Count);

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -87,6 +87,22 @@ namespace OpenSkp
                 && Tlv.ReadU32(data, p + 2) == (0x80000000u | (uint)slot);
         }
 
+        /// <summary>True when the u16 at <paramref name="at"/> can legally
+        /// start an object read: a null, an escape, a class definition, a
+        /// class-ref to a KNOWN class, or an object back-ref within the
+        /// allocated range.</summary>
+        public static bool PlausibleListTag(Archive ar, byte[] data, int at)
+        {
+            if (at + 2 > data.Length) return false;
+            ushort t = Tlv.ReadU16(data, at);
+            if (t == 0x0000 || t == 0x7FFF || t == 0xFFFF) return true;
+            if ((t & 0x8000) != 0)
+            {
+                return ar.Slots.TryGetValue(t & 0x7FFF, out var ent) && ent.Kind == "class";
+            }
+            return t < ar.NextSlot;
+        }
+
         public static int[] AsciiCodes(string s) => s.Select(c => (int)c).ToArray();
 
         public static bool MatchesAscii(byte[] data, int offset, string str)
@@ -140,7 +156,7 @@ namespace OpenSkp
         /// tests; see <see cref="RetryCountAfterV20Filler"/> for how it is
         /// used.
         /// </summary>
-        public static (uint Count, int Next)? FindCountAfterV20Filler(byte[] data, int countPos, uint limit)
+        public static (uint Count, int Next)? FindCountAfterV20Filler(byte[] data, int countPos, uint limit, Archive? ar = null)
         {
             int markerAt = -1;
             for (int i = countPos; i < countPos + 12 && i + 4 <= data.Length; i++)
@@ -158,7 +174,11 @@ namespace OpenSkp
             // per call site (9 and 13 bytes both occur in real files), but
             // always lands at markerAt + 4 + pad with pad % 4 == 1. Step
             // through those candidate offsets and take the first plausible
-            // u32.
+            // u32 that is ALSO followed by a legitimate list tag (when an
+            // Archive is available to check against) - a numerically
+            // plausible count is not enough by itself once the filler can
+            // also swallow the field ahead of it (see ReadDefinition's
+            // decl-position retry), which raises the odds of a false match.
             //
             // Deliberately NOT "scan forward to the first non-zero byte": a
             // count that is an exact multiple of 256 has a 0x00 low byte,
@@ -171,14 +191,16 @@ namespace OpenSkp
                 int at = markerAt + 4 + pad;
                 if (at + 4 > data.Length) break;
                 uint count = Tlv.ReadU32(data, at);
-                if (count > 0 && count <= limit) return (count, at + 4);
+                if (count == 0 || count > limit) continue;
+                if (ar != null && !PlausibleListTag(ar, data, at + 4)) continue;
+                return (count, at + 4);
             }
             return null;
         }
 
-        public static uint? RetryCountAfterV20Filler(LR r, int countPos, uint limit)
+        public static uint? RetryCountAfterV20Filler(LR r, int countPos, uint limit, Archive? ar = null)
         {
-            var hit = FindCountAfterV20Filler(r.Data, countPos, limit);
+            var hit = FindCountAfterV20Filler(r.Data, countPos, limit, ar);
             if (hit == null) return null;
             r.Pos = hit.Value.Next;
             return hit.Value.Count;
@@ -316,6 +338,22 @@ namespace OpenSkp
         public Dictionary<string, LegacyReader> Readers = new Dictionary<string, LegacyReader>();
         public int? CurrentLoop;
         public bool InEntityList;
+        // Burned store-map indices (see ReadEdgeUse): the writer maps an
+        // annotation's connection points into the store map WITHOUT writing
+        // bytes, so file back-references beyond each burn run ahead of the
+        // walker's numbering. Registrations always stay at WALKER indices -
+        // no captured slot ever goes stale - and Backref translates file
+        // references through the burn bands instead. Burns holds
+        // (fileBandStart, width) per event; CumDelta their total;
+        // AnnotWatermark the walker slot right after the last annotation
+        // record - the only place a band can start.
+        public List<(int Start, int Width)> Burns = new List<(int, int)>();
+        public int CumDelta;
+        public int? AnnotWatermark;
+        public List<int> BurnStack = new List<int>();  // per-entity-list burned-item credits
+        // Cached CConstructionLine trailer width, self-calibrated on the
+        // first guide line of the file (see ReadConstructionLine).
+        public int? ClineTail;
 
         public Archive(byte[] data, int ver)
         {
@@ -410,11 +448,41 @@ namespace OpenSkp
                 CurrentClass = prevClass;
             }
             Slots[slot] = new SlotEntry { Kind = "obj", Name = name, Value = value };
+            if (name == "CDimensionLinear" || name == "CText")
+            {
+                AnnotWatermark = NextSlot;
+            }
             return (slot, name, value);
+        }
+
+        /// <summary>Map a FILE store-map index to the walker's numbering
+        /// through the burn bands. Returns null when the reference points
+        /// INTO a band (a phantom, never-serialized connection point).</summary>
+        private int? TranslateRef(int slot)
+        {
+            int offset = 0;
+            foreach (var (start, width) in Burns)
+            {
+                if (slot < start) break;
+                if (slot < start + width) return null;
+                offset += width;
+            }
+            return slot - offset;
         }
 
         private (int?, string?, object?) Backref(int slot, LR r)
         {
+            if (Burns.Count > 0 && slot >= Burns[0].Start)
+            {
+                var walker = TranslateRef(slot);
+                if (walker == null)
+                {
+                    // a phantom (burned) connection-point index - annotation
+                    // metadata only; nothing was ever serialized for it
+                    return (slot, "reserved", null);
+                }
+                slot = walker.Value;
+            }
             if (!Slots.TryGetValue(slot, out var ent))
             {
                 if (slot < WalkBase)
@@ -465,6 +533,17 @@ namespace OpenSkp
     internal sealed class AttrsRec { public List<(string? Name, object? Value)> Children = new List<(string?, object?)>(); }
     internal sealed class DictRec { public string Name = ""; public Dictionary<string, object?> Entries = new Dictionary<string, object?>(); }
     internal sealed class LayerRec { public string Name = ""; public int Hidden; public byte[] Rgba = new byte[4]; }
+    internal sealed class TextureBlockRec
+    {
+        public byte[] Rgba = new byte[4];
+        public double Opacity;
+        public int UseOpacity;
+        public int? TexDib;
+        public double TexW;
+        public double TexH;
+        public string TexFile = "";
+        public bool Colorized;
+    }
     internal sealed class MaterialRec
     {
         public string Name = "";
@@ -490,6 +569,7 @@ namespace OpenSkp
     }
     internal sealed class CameraRec { }
     internal sealed class ThumbnailRec { public int? Dib; }
+    internal sealed class ImageRec { public DrawBase Db = new DrawBase(); public int? Def; public double[] Xform = new double[12]; public string Guid = ""; }
     internal sealed class RelationshipRec { }
     internal sealed class ConstructionLineRec { }
     internal sealed class ConstructionPointRec { public DrawBase Db = new DrawBase(); public double[] Pos = new double[3]; }
@@ -537,14 +617,44 @@ namespace OpenSkp
 
         public static DrawBase Drawbase(Archive ar, LR r)
         {
-            var b = r.Raw(10);
+            var b = r.Raw(8);
+            // The layer field is normally a u16 id, but an entity can carry
+            // the layer BY OBJECT instead (seen on real 2018 instances): a
+            // full inline CLayer record on first use, an escaped back-ref
+            // to it on later siblings. Layer ids never have the 0x8000 bit
+            // and never equal 0x7FFF, so both object forms are unambiguous.
+            // (A 2-byte back-ref would collide with the id space - not seen
+            // in any file; by-object layers have only appeared in
+            // >32k-object archives where refs escape anyway.)
+            bool haveLayCls = ar.ClassSlot.TryGetValue("CLayer", out int layCls);
+            ushort tag = r.PeekU16();
+            int layer;
+            if (haveLayCls && tag == (0x8000 | layCls))
+            {
+                ar.ReadObject(r, "CLayer");
+                layer = 0;                   // by-object layer: keep the default id
+            }
+            else if (tag == 0x7FFF)
+            {
+                r.U16();
+                uint big = r.U32();
+                if ((big & 0x80000000) != 0)
+                {
+                    throw new LegacyParseError($"drawbase layer: unexpected class {r.Ctx()}");
+                }
+                layer = 0;                   // by-object layer (back-ref)
+            }
+            else
+            {
+                layer = r.U16();
+            }
             return new DrawBase
             {
                 Mat = Tlv.ReadU16(b, 0),
                 Hidden = b[2],
                 Soft = b[5],
                 Smooth = b[6],
-                Layer = Tlv.ReadU16(b, 8),
+                Layer = layer,
             };
         }
 
@@ -584,15 +694,76 @@ namespace OpenSkp
             return new ArcCurveRec();
         }
 
+        /// <summary>Record that the writer burned <paramref name="delta"/>
+        /// store-map indices without serializing any bytes for them.
+        ///
+        /// SketchUp maps an annotation's connection-point objects into the
+        /// MFC store map (CArchive::MapObject) when a dimension or leader
+        /// text is attached to geometry - each mapping consumes an index,
+        /// but nothing is written to the stream, so the file's later
+        /// back-references run ahead of a byte-exact walk. The band starts
+        /// right after the last annotation record (in FILE numbering);
+        /// registrations never move - Backref translates file references
+        /// through the recorded bands instead, so no slot value captured
+        /// anywhere can go stale.</summary>
+        private static void RegisterBurn(Archive ar, int delta)
+        {
+            ar.Burns.Add((ar.AnnotWatermark!.Value + ar.CumDelta, delta));
+            ar.CumDelta += delta;
+            ar.AnnotWatermark = null;
+            // each burn event corresponds to ONE phantom top-level entity
+            // that the entity list's declared count includes but the
+            // stream never carries - credit it so the list doesn't run
+            // past its real end
+            if (ar.BurnStack.Count > 0)
+            {
+                ar.BurnStack[ar.BurnStack.Count - 1] += 1;
+            }
+        }
+
         public static object ReadEdgeUse(Archive ar, LR r)
         {
             Preamble(ar, r);
             var (es, _, _) = ar.ReadObject(r, "CEdge");
             byte sense = r.U8();
-            var (ps, _, _) = ar.ReadObject(r);
-            if (ps != ar.CurrentLoop)
+            // parent-loop back-ref: the alignment oracle. Read as a RAW
+            // file index - after annotations the claimed index can sit
+            // AHEAD of the walker's numbering (burned MapObject indices,
+            // see RegisterBurn), which is a correction signal, not a
+            // mis-parse.
+            int p0 = r.Pos;
+            ushort tag = r.U16();
+            int? ps;
+            if (tag == 0x7FFF)
             {
-                throw new LegacyParseError($"edge-use parent slot {ps} != current loop {ar.CurrentLoop} {r.Ctx()}");
+                uint big = r.U32();
+                if ((big & 0x80000000) != 0)
+                {
+                    throw new LegacyParseError($"edge-use parent is a new object {r.Ctx()}");
+                }
+                ps = (int)big;
+            }
+            else if (tag == 0xFFFF || (tag & 0x8000) != 0)
+            {
+                throw new LegacyParseError($"edge-use parent is a new object {r.Ctx()}");
+            }
+            else
+            {
+                ps = tag != 0 ? (int?)tag : null;
+            }
+            int? expected = ar.CurrentLoop != null ? ar.CurrentLoop + ar.CumDelta : (int?)null;
+            if (ps != expected)
+            {
+                int delta = (ps.HasValue && expected.HasValue) ? ps.Value - expected.Value : 0;
+                if (delta > 0 && delta <= 4096 && ar.AnnotWatermark != null)
+                {
+                    RegisterBurn(ar, delta);
+                }
+                else
+                {
+                    r.Pos = p0;
+                    throw new LegacyParseError($"edge-use parent slot {ps} != current loop {expected} {r.Ctx()}");
+                }
             }
             return new EdgeUseRec { Edge = es, Sense = sense };
         }
@@ -664,6 +835,7 @@ namespace OpenSkp
             if (t == 0x07) return r.U8();
             if (t == 0x09) return r.U32();
             if (t == 0x0a) return r.Utf16();
+            if (t == 0x0c) return r.F64();           // Length (a double, inches)
             if (t == 0x0b)
             {
                 uint n = r.U32();
@@ -675,7 +847,8 @@ namespace OpenSkp
                 for (int i = 0; i < n; i++) arr.Add(ReadTyped(r, r.U8()));
                 return arr;
             }
-            if (t == 0x12) return r.F64s(3);
+            if (t == 0x11) return r.F64s(3);         // 3D point (Geom::Point3d)
+            if (t == 0x12) return r.F64s(3);         // 3D vector (Geom::Vector3d)
             throw new LegacyParseError($"unknown attribute value type 0x{t:x} {r.Ctx()}");
         }
 
@@ -704,12 +877,72 @@ namespace OpenSkp
             {
                 mid.Add(r.Raw(1)[0]);
             }
-            r.Utf16();
-            r.U16();
+            r.Utf16();                       // internal name ("Layer_<name>")
+            ushort flags = r.U16();
+            if ((flags & 0x00FF) != 0)
+            {
+                // Colour-by-layer with a TEXTURED material: instead of the
+                // flat RGBA, the layer embeds the same texture block a
+                // CMaterial carries (SketchUp Pro assigns full materials to
+                // layers). Low byte of the flag word set = textured; a
+                // plain colour layer has 0 there (its high byte carries an
+                // unrelated flag, so the word as a whole is non-zero
+                // either way).
+                var tex = TextureBlock(ar, r);
+                r.Raw(4);                    // trailing u32
+                return new LayerRec { Name = name, Hidden = mid.Count > 0 ? mid[0] : 0, Rgba = tex.Rgba };
+            }
             var rgba = r.Raw(4);
             r.Utf16();
             r.Raw(21);
             return new LayerRec { Name = name, Hidden = mid.Count > 0 ? mid[0] : 0, Rgba = rgba };
+        }
+
+        /// <summary>The textured-material payload: an embedded CDib plus
+        /// applied size, source file name, average colour, and opacity.
+        /// Shared verbatim between a CMaterial with a texture and a
+        /// colour-by-layer CLayer that carries a textured material.</summary>
+        public static TextureBlockRec TextureBlock(Archive ar, LR r)
+        {
+            r.Raw(ar.Ver >= 17 ? 2 : 1);        // texture flag pad
+            var (s, _, dib) = ar.ReadObject(r, "CDib");
+            if (!(dib is DibRec))
+            {
+                throw new LegacyParseError($"texture object is not a dib {r.Ctx()}");
+            }
+            // optional u32 between the dib and the 2 x f64 applied size
+            int marker = LegacyBytes.FindBytes(r.Data, LegacyBytes.StrMarker, r.Pos, r.Pos + 28);
+            if (marker - r.Pos == 20)
+            {
+                r.U32();
+            }
+            else if (marker - r.Pos != 16)
+            {
+                throw new LegacyParseError($"texture size block misaligned {r.Ctx()}");
+            }
+            double w = r.F64();
+            double h = r.F64();
+            string fname = r.Utf16();
+            var avg = r.Raw(9);              // RGBA + 00 + RGBA (colour stored twice)
+            r.Utf16();
+            var blob = r.Raw(8);             // u32 + u32 colorized flag
+            double opacity = r.F64();
+            byte useOp = r.U8();
+            // A colourized (re-tinted) texture stores the ORIGINAL image
+            // plus the tint as the average colour; flagged by the second
+            // blob u32 or by alpha 0xFF on the stored colour.
+            bool colorized = blob[4] != 0 || avg[3] == 0xFF;
+            return new TextureBlockRec
+            {
+                Rgba = avg.Take(4).ToArray(),
+                Opacity = opacity,
+                UseOpacity = useOp,
+                TexDib = s,
+                TexW = w,
+                TexH = h,
+                TexFile = fname,
+                Colorized = colorized,
+            };
         }
 
         public static object ReadMaterial(Archive ar, LR r)
@@ -731,38 +964,15 @@ namespace OpenSkp
             }
             else
             {
-                r.Raw(ar.Ver >= 17 ? 2 : 1);
-                var (s, _, dib) = ar.ReadObject(r, "CDib");
-                if (!(dib is DibRec))
-                {
-                    throw new LegacyParseError($"texture object is not a dib {r.Ctx()}");
-                }
-                int marker = LegacyBytes.FindBytes(r.Data, LegacyBytes.StrMarker, r.Pos, r.Pos + 28);
-                if (marker - r.Pos == 20)
-                {
-                    r.U32();
-                }
-                else if (marker - r.Pos != 16)
-                {
-                    throw new LegacyParseError($"texture size block misaligned {r.Ctx()}");
-                }
-                double w = r.F64();
-                double h = r.F64();
-                string fname = r.Utf16();
-                var avg = r.Raw(9);
-                r.Utf16();
-                var blob = r.Raw(8);
-                double opacity = r.F64();
-                byte useOp = r.U8();
-                bool colorized = blob[4] != 0 || avg[3] == 0xFF;
-                outRec.Rgba = avg.Take(4).ToArray();
-                outRec.Opacity = opacity;
-                outRec.UseOpacity = useOp;
-                outRec.TexDib = s;
-                outRec.TexW = w;
-                outRec.TexH = h;
-                outRec.TexFile = fname;
-                outRec.Colorized = colorized;
+                var tex = TextureBlock(ar, r);
+                outRec.Rgba = tex.Rgba;
+                outRec.Opacity = tex.Opacity;
+                outRec.UseOpacity = tex.UseOpacity;
+                outRec.TexDib = tex.TexDib;
+                outRec.TexW = tex.TexW;
+                outRec.TexH = tex.TexH;
+                outRec.TexFile = tex.TexFile;
+                outRec.Colorized = tex.Colorized;
                 outRec.HasTexture = true;
             }
             return outRec;
@@ -821,12 +1031,87 @@ namespace OpenSkp
             return new ThumbnailRec { Dib = dibSlot };
         }
 
-        public static object ReadRelationship(Archive ar, LR r)
+        /// <summary>CImage: an Image entity - instance-shaped: a back-ref
+        /// to the (already walked) CComponentDefinition holding the
+        /// image's face and texture, a 3x4 placement, a constant 1.0, the
+        /// source path string (empty in every sample), and a 16-byte GUID.
+        /// It appears as a normal entity-list item inside the definition
+        /// that owns the image (typically a face-me/photo definition),
+        /// whose own tail the ordinary definition reader then consumes.
+        /// Calibrated byte-exact on two real files - an 80 MB v18 and a
+        /// 661 MB v17 - both previously rejected outright with "no reader
+        /// for class CImage".</summary>
+        public static object ReadImage(Archive ar, LR r)
         {
             Preamble(ar, r);
-            ar.ReadObject(r);
-            ar.ReadObject(r);
+            var db = Drawbase(ar, r);
+            var (ds, _, _) = ar.ReadObject(r);          // the image's definition
+            var xform = r.F64s(12);
+            r.F64();                                     // constant 1.0
+            r.Utf16();                                    // source path
+            var guid = r.Raw(16);
+            return new ImageRec { Db = db, Def = ds, Xform = xform, Guid = LegacyBytes.ToHex(guid) };
+        }
+
+        /// <summary>A reference-to-entity tag: dimension connection points
+        /// and text leader attachments. Unlike ReadObject's back-ref path,
+        /// this tolerates a slot the walk has not reached yet - SketchUp
+        /// serializes a label/dimension BEFORE the entity it anchors to
+        /// when both live in the same entity list, so the reference can
+        /// legitimately point forward. Returns the slot number, or null
+        /// for a null reference.</summary>
+        private static int? EntityRef(Archive ar, LR r)
+        {
+            ushort tag = r.U16();
+            if (tag == 0) return null;
+            if (tag == 0x7FFF)
+            {
+                uint big = r.U32();
+                if ((big & 0x80000000) != 0)
+                {
+                    throw new LegacyParseError($"entity ref is a new object {r.Ctx()}");
+                }
+                return (int)big;
+            }
+            if (tag == 0xFFFF || (tag & 0x8000) != 0)
+            {
+                throw new LegacyParseError($"entity ref is a new object {r.Ctx()}");
+            }
+            return tag;
+        }
+
+        public static object ReadRelationship(Archive ar, LR r)
+        {
+            // two object pointers (small maps: two u16 back-refs - which
+            // read like the "u32" of the public notes; big maps escalate
+            // them to big-tags). They bind an annotation to the entity it
+            // labels, and the annotation side is routinely serialized
+            // BEFORE the geometry side - so these can point forward, past
+            // the walk cursor; EntityRef tolerates that where ReadObject's
+            // back-ref path (rightly) does not.
+            Preamble(ar, r);
+            EntityRef(ar, r);
+            EntityRef(ar, r);
             return new RelationshipRec();
+        }
+
+        /// <summary>True when the u16 at <paramref name="at"/> starts an
+        /// object read in one of the UNAMBIGUOUS forms: null, escape, class
+        /// definition, or a class-ref to a class already known. Plain
+        /// object back-refs are excluded on purpose - any 2-byte junk below
+        /// 0x8000 would qualify, which is exactly the ambiguity this check
+        /// exists to avoid.</summary>
+        private static bool StrictNextTag(Archive ar, byte[] data, int at, bool allowNull = true)
+        {
+            if (at + 2 > data.Length) return false;
+            ushort t = Tlv.ReadU16(data, at);
+            if (t == 0x0000) return allowNull;
+            if (t == 0x7FFF || t == 0xFFFF) return true;
+            if ((t & 0x8000) != 0)
+            {
+                return ar.Slots.TryGetValue(t & 0x7FFF, out var ent) && ent.Kind == "class";
+            }
+            return false;
         }
 
         public static object ReadConstructionLine(Archive ar, LR r)
@@ -835,8 +1120,39 @@ namespace OpenSkp
             Drawbase(ar, r);
             r.F64s(3);
             r.F64s(3);
-            r.F64s(2);
-            r.Raw(ar.Ver >= 17 ? 7 : 4);
+            r.F64s(2);                       // line params (+-~4.4e29 = infinite)
+            // The trailing block varies by the WRITING BUILD, not cleanly
+            // by version: 7 bytes on the v17 calibration corpus, 4 on v16
+            // and on a real v18, 0 on another real v17. Self-calibrate on
+            // the first guide line of the file - the length that lands on
+            // a legitimate next tag (strict forms only) - and cache it for
+            // the rest of the file.
+            int? k = ar.ClineTail;
+            if (k == null)
+            {
+                int def = ar.Ver == 17 ? 7 : 4;
+                var order = new List<int> { def };
+                foreach (var c in new[] { 0, 4, 7 }) if (c != def) order.Add(c);
+                // two passes: a zero tail full of padding can mimic a null
+                // tag, so only accept a null-anchored candidate when no
+                // candidate lands on a STRONG form (escape / known class /
+                // class definition)
+                foreach (var allowNull in new[] { false, true })
+                {
+                    foreach (var cand in order)
+                    {
+                        if (StrictNextTag(ar, r.Data, r.Pos + cand, allowNull))
+                        {
+                            k = cand;
+                            break;
+                        }
+                    }
+                    if (k != null) break;
+                }
+                if (k == null) k = def;
+                ar.ClineTail = k;
+            }
+            r.Raw(k.Value);
             return new ConstructionLineRec();
         }
 
@@ -888,7 +1204,19 @@ namespace OpenSkp
             var db = Drawbase(ar, r);
             string text = r.Utf16();
             ar.ReadObject(r, "CSkFont");
-            r.Raw(165);
+            // The tail is NOT a fixed 165-byte blob: it embeds two object
+            // references (the dimension's connection points into the
+            // geometry). Each is a normal MFC tag - 2 bytes in small
+            // files, but 6 bytes once the archive holds more than 0x7FFE
+            // objects and the 0x7FFF big-tag escape kicks in - so a
+            // fixed-size skip walks off the rails exactly on large models
+            // (found on a real 17 MB SketchUp 2018 file whose dimension
+            // sat past object #517k).
+            r.Raw(37);
+            EntityRef(ar, r);                // connection point 1 (may be null)
+            r.Raw(42);
+            EntityRef(ar, r);                // connection point 2 (may be null)
+            r.Raw(82);
             return new DimLinearRec { Db = db, Text = text };
         }
 
@@ -919,31 +1247,90 @@ namespace OpenSkp
             r.Raw(idx - r.Pos);
             string text = r.Utf16();
             r.Raw(5);
+            // Optional leader-attachment refs follow the fixed tail (a
+            // text label anchored to geometry stores the anchored entities
+            // here; they can point FORWARD - see EntityRef). Only the
+            // escaped 6-byte form is recognisable without risk: a 2-byte
+            // back-ref here would be indistinguishable from the next list
+            // item's tag, and every known sample either has no attachments
+            // or lives in a >0x7FFE-object file where the escape is
+            // mandatory anyway.
+            while (r.Pos + 2 <= r.Data.Length && r.Data[r.Pos] == 0xFF && r.Data[r.Pos + 1] == 0x7F)
+            {
+                uint val = Tlv.ReadU32(r.Data, r.Pos + 2);
+                if ((val & 0x80000000) != 0) break;   // new-object tag - the next entity
+                r.Raw(6);
+            }
             return new TextRec { Db = db, Text = text };
         }
 
         public static List<(int Slot, string? Name, object? Value)> ReadEntityList(Archive ar, LR r, long count, string owner)
         {
+            ar.BurnStack.Add(0);
+            try
+            {
+                return ReadEntityListInner(ar, r, count, owner);
+            }
+            finally
+            {
+                ar.BurnStack.RemoveAt(ar.BurnStack.Count - 1);
+            }
+        }
+
+        private static List<(int Slot, string? Name, object? Value)> ReadEntityListInner(Archive ar, LR r, long count, string owner)
+        {
             var ents = new List<(int, string?, object?)>();
             while (ents.Count < count)
             {
                 int p = r.Pos;
+                bool hasBurnCredit = owner == "def" && ar.BurnStack.Count > 0 && ar.BurnStack[ar.BurnStack.Count - 1] > 0;
+                if (hasBurnCredit
+                    && p + 25 <= r.Data.Length
+                    && Tlv.ReadU32(r.Data, p) == 0
+                    && LegacyBytes.BytesEqual(r.Data, p + 22, LegacyBytes.StrMarker))
+                {
+                    // burned MapObject indices (see RegisterBurn) mean the
+                    // declared count includes phantom entities the stream
+                    // never carries; the definition tail signature (nrel=0
+                    // + pad + 16-byte GUID + name marker at +22) marks the
+                    // list's REAL end
+                    break;
+                }
                 bool prevFlag = ar.InEntityList;
                 ar.InEntityList = true;
-                int? s;
-                string? n;
-                object? v;
+                int? s = null;
+                string? n = null;
+                object? v = null;
+                bool failed = false;
                 try
                 {
                     (s, n, v) = ar.ReadObject(r);
                 }
-                catch (LegacyParseError) when (owner == "root")
+                catch (LegacyParseError)
+                {
+                    if (owner != "root" && !hasBurnCredit)
+                    {
+                        throw;
+                    }
+                    // owner == "root": over-declared root counts run into
+                    // the document tail - stop.
+                    // hasBurnCredit: this list had burned MapObject indices
+                    // (see RegisterBurn): the phantom connection points
+                    // were also counted as items, so the declared count
+                    // overshoots the real records. Stop at the failed item
+                    // - the definition tail that follows (nrel, GUID
+                    // anchor, thumbnail scan) validates the cut.
+                    failed = true;
+                }
+                finally
                 {
                     ar.InEntityList = prevFlag;
+                }
+                if (failed)
+                {
                     r.Pos = p;
                     break;
                 }
-                ar.InEntityList = prevFlag;
                 ents.Add((s!.Value, n, v));
             }
             return ents;
@@ -958,17 +1345,40 @@ namespace OpenSkp
             {
                 throw new LegacyParseError($"implausible def layer count {r.Ctx()}");
             }
-            for (int i = 0; i < nlayers; i++)
+            // like the model-level layer list, the count is REAL layers
+            // (new records or back-refs); SketchUp 2020 interleaves null
+            // separators between them
+            int got = 0;
+            while (got < nlayers)
             {
+                if (r.PeekU16() == 0)
+                {
+                    r.Pos += 2;
+                    continue;
+                }
                 ar.ReadObject(r, "CLayer");
+                got++;
             }
             uint decl = r.U16();
             if (decl == 0x7FFF)
             {
                 decl = r.U32();
             }
-            r.U32();
-            uint count = r.U32();
+            // v20 can drop its undocumented filler right here, swallowing
+            // the u32 field (and, behind a layer-separator null, even the
+            // decl itself): if the empty-string marker sits in the next
+            // few bytes, the real count is the first non-zero u32 after
+            // its padding.
+            uint? count = null;
+            if (ar.Ver >= 20)
+            {
+                count = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos, 5_000_000, ar);
+            }
+            if (count == null)
+            {
+                r.U32();
+                count = r.U32();
+            }
             // A zero count is as much a symptom of the v20 filler as an
             // implausibly large one: the reader lands on the leading zero
             // bytes of the filler instead of the count. A genuinely empty
@@ -976,18 +1386,18 @@ namespace OpenSkp
             // RetryCountAfterV20Filler leaves those alone.
             if (count > 5_000_000 || count == 0)
             {
-                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 5_000_000);
+                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 5_000_000, ar);
                 if (retry.HasValue) count = retry.Value;
             }
             if (count > 5_000_000)
             {
                 throw new LegacyParseError($"implausible def entity count {r.Ctx()}");
             }
-            var ents = ReadEntityList(ar, r, count, "def");
+            var ents = ReadEntityList(ar, r, count.Value, "def");
             uint nrel = r.U32();
             if (nrel > 100000)
             {
-                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 100_000);
+                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 100_000, ar);
                 if (retry.HasValue) nrel = retry.Value;
             }
             if (nrel > 100000)
@@ -1146,6 +1556,7 @@ namespace OpenSkp
             ["CThumbnail"] = ReadThumbnail,
             ["CRelationship"] = ReadRelationship,
             ["CComponentDefinition"] = ReadDefinition,
+            ["CImage"] = ReadImage,
             ["CComponentInstance"] = ReadInstance,
             ["CGroup"] = ReadInstance,
             ["CFaceTextureCoords"] = ReadFtc,
@@ -1372,17 +1783,47 @@ namespace OpenSkp
             {
                 throw new LegacyParseError("implausible layer count");
             }
+            // layerCount counts REAL layers. SketchUp 2020 interleaves a
+            // null object-ref after each layer record (a separator, not a
+            // layer), so counting reads walks off mid-list on files with
+            // several layers; count parsed layers instead, skip the
+            // separators, and stop early if the next tag is a back-ref
+            // (the definition-list anchor) - a v20 variant where the count
+            // over-includes separators.
             var layers = new List<(int, object?)>();
-            for (int i = 0; i < layerCount; i++)
+            while (layers.Count < layerCount)
             {
+                ushort tag = r.PeekU16();
+                if (tag == 0)
+                {
+                    r.Pos += 2;
+                    continue;
+                }
+                if (tag != 0xFFFF && (tag & 0x8000) == 0)
+                {
+                    break;
+                }
                 var (s, _, v) = ar.ReadObject(r, "CLayer");
-                // A null object-ref occupies a slot in the list without
-                // carrying a layer record (seen in SketchUp 2020 files,
-                // where layerCount includes it). Keeping it would push a
-                // null into the list; ReadObject has still consumed the ref
-                // from the stream.
                 if (v == null) continue;
                 layers.Add((s!.Value, v));
+            }
+            // trailing separators (and any layer records past the declared count)
+            bool haveTrailingLayCls = ar.ClassSlot.TryGetValue("CLayer", out int trailingLayCls);
+            while (true)
+            {
+                ushort tag = r.PeekU16();
+                if (tag == 0)
+                {
+                    r.Pos += 2;
+                    continue;
+                }
+                if (haveTrailingLayCls && tag == (0x8000 | trailingLayCls))
+                {
+                    var (s, _, v) = ar.ReadObject(r, "CLayer");
+                    if (v != null) layers.Add((s!.Value, v));
+                    continue;
+                }
+                break;
             }
 
             var (_, dn, _) = ar.ReadObject(r);
@@ -1393,7 +1834,7 @@ namespace OpenSkp
             uint defCount = r.U32();
             if (defCount > 1_000_000)
             {
-                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 1_000_000);
+                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 1_000_000, ar);
                 if (retry.HasValue) defCount = retry.Value;
             }
             if (defCount > 1_000_000)
@@ -1421,7 +1862,7 @@ namespace OpenSkp
             uint rootCount = r.U32();
             if (rootCount > 5_000_000)
             {
-                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 5_000_000);
+                var retry = LegacyBytes.RetryCountAfterV20Filler(r, r.Pos - 4, 5_000_000, ar);
                 if (retry.HasValue) rootCount = retry.Value;
             }
             if (rootCount > 5_000_000)

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -48,7 +48,8 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 export function findCountAfterV20Filler(
   data: Uint8Array,
   countPos: number,
-  limit: number
+  limit: number,
+  ar?: Archive
 ): { count: number; next: number } | null {
   // the marker sits within a handful of bytes of the bad read; the window is
   // deliberately tight so a coincidental ff-fe-ff further out cannot match
@@ -77,7 +78,9 @@ export function findCountAfterV20Filler(
     const at = markerAt + 4 + pad;
     if (at + 4 > data.length) break;
     const count = view.getUint32(at, true);
-    if (count > 0 && count <= limit) return { count, next: at + 4 };
+    if (count > 0 && count <= limit && (ar === undefined || plausibleListTag(ar, data, at + 4))) {
+      return { count, next: at + 4 };
+    }
   }
   return null;
 }
@@ -103,11 +106,26 @@ export function findCountAfterV20Filler(
  * `countPos` is the offset the count was read FROM (i.e. r.pos - 4).
  * Returns the corrected count, or null when this is not the v20 layout.
  */
-function retryCountAfterV20Filler(r: R, countPos: number, limit: number): number | null {
-  const hit = findCountAfterV20Filler(r.data, countPos, limit);
+function retryCountAfterV20Filler(r: R, countPos: number, limit: number, ar?: Archive): number | null {
+  const hit = findCountAfterV20Filler(r.data, countPos, limit, ar);
   if (hit === null) return null;
   r.pos = hit.next;
   return hit.count;
+}
+
+/** True when the u16 at `at` can legally start an object read: a null, an
+ * escape, a class definition, a class-ref to a KNOWN class, or an object
+ * back-ref within the allocated range. */
+function plausibleListTag(ar: Archive, data: Uint8Array, at: number): boolean {
+  if (at + 2 > data.length) return false;
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const t = view.getUint16(at, true);
+  if (t === 0x0000 || t === 0x7fff || t === 0xffff) return true;
+  if (t & 0x8000) {
+    const ent = ar.slots.get(t & 0x7fff);
+    return ent !== undefined && ent[0] === 'class';
+  }
+  return t < ar.nextSlot;
 }
 
 /** Search for `needle` (exact bytes) within [start, end). Returns -1 if absent. */
@@ -280,6 +298,21 @@ class Archive {
   currentLoop: number | null = null;
   inEntityList = false;
 
+  // Burned store-map indices (see readEdgeUse): the writer maps an
+  // annotation's connection points into the store map WITHOUT writing
+  // bytes, so file back-references beyond each burn run ahead of the
+  // walker's numbering. Registrations always stay at WALKER indices - no
+  // captured slot ever goes stale - and backref translates file
+  // references through the burn bands instead. `burns` holds
+  // [fileBandStart, width] per event; `cumDelta` their total;
+  // `annotWatermark` the walker slot right after the last annotation
+  // record - the only place a band can start.
+  burns: [number, number][] = [];
+  cumDelta = 0;
+  annotWatermark: number | null = null;
+  burnStack: number[] = []; // per-entity-list burned-item credits
+  clineTail: number | null = null;
+
   constructor(data: Uint8Array, ver: number) {
     this.data = data;
     this.ver = ver;
@@ -358,10 +391,35 @@ class Archive {
       this.currentClass = prevClass;
     }
     this.slots.set(slot, ['obj', name, value]);
+    if (name === 'CDimensionLinear' || name === 'CText') {
+      this.annotWatermark = this.nextSlot;
+    }
     return [slot, name, value];
   }
 
+  /** Map a FILE store-map index to the walker's numbering through the burn
+   * bands. Returns the walker slot, or `null` when the reference points
+   * INTO a band (a phantom, never-serialized connection point). */
+  private translateRef(slot: number): number | null {
+    let offset = 0;
+    for (const [start, width] of this.burns) {
+      if (slot < start) break;
+      if (slot < start + width) return null;
+      offset += width;
+    }
+    return slot - offset;
+  }
+
   private backref(slot: number, r: R): [number, string | null, any] {
+    if (this.burns.length > 0 && slot >= this.burns[0][0]) {
+      const walker = this.translateRef(slot);
+      if (walker === null) {
+        // a phantom (burned) connection-point index - annotation metadata
+        // only; nothing was ever serialized for it
+        return [slot, 'reserved', null];
+      }
+      slot = walker;
+    }
     const ent = this.slots.get(slot);
     if (ent === undefined) {
       if (slot < this.walkBase) {
@@ -393,14 +451,35 @@ function preamble(ar: Archive, r: R): { attrs: any; pid: number } {
 }
 
 function drawbase(ar: Archive, r: R): { mat: number; hidden: number; soft: number; smooth: number; layer: number } {
-  const b = r.raw(10);
+  const b = r.raw(8);
   const view = new DataView(b.buffer, b.byteOffset, b.byteLength);
+  // The layer field is normally a u16 id, but an entity can carry the
+  // layer BY OBJECT instead (seen on real 2018 instances): a full inline
+  // CLayer record on first use, an escaped back-ref to it on later
+  // siblings. Layer ids never have the 0x8000 bit and never equal 0x7FFF,
+  // so both object forms are unambiguous.
+  const layCls = ar.classSlot.get('CLayer');
+  const tag = r.peekU16();
+  let layer: number;
+  if (layCls !== undefined && tag === (0x8000 | layCls)) {
+    ar.readObject(r, 'CLayer');
+    layer = 0; // by-object layer: keep the default id
+  } else if (tag === 0x7fff) {
+    r.u16();
+    const big = r.u32();
+    if (big & 0x80000000) {
+      throw new LegacyParseError(`drawbase layer: unexpected class ${r.ctx()}`);
+    }
+    layer = 0; // by-object layer (back-ref)
+  } else {
+    layer = r.u16();
+  }
   return {
     mat: view.getUint16(0, true),
     hidden: b[2],
     soft: b[5],
     smooth: b[6],
-    layer: view.getUint16(8, true),
+    layer,
   };
 }
 
@@ -437,13 +516,60 @@ function readArcCurve(ar: Archive, r: R): any {
   return { k: 'arccurve' };
 }
 
+/** Record that the writer burned `delta` store-map indices without
+ * serializing any bytes for them.
+ *
+ * SketchUp maps an annotation's connection-point objects into the MFC
+ * store map (CArchive::MapObject) when a dimension or leader text is
+ * attached to geometry - each mapping consumes an index, but nothing is
+ * written to the stream, so the file's later back-references run ahead of
+ * a byte-exact walk. The band starts right after the last annotation
+ * record (in FILE numbering); registrations never move - backref
+ * translates file references through the recorded bands instead, so no
+ * slot value captured anywhere can go stale. */
+function registerBurn(ar: Archive, delta: number): void {
+  ar.burns.push([(ar.annotWatermark as number) + ar.cumDelta, delta]);
+  ar.cumDelta += delta;
+  ar.annotWatermark = null;
+  // each burn event corresponds to ONE phantom top-level entity that the
+  // entity list's declared count includes but the stream never carries -
+  // credit it so the list doesn't run past its real end
+  if (ar.burnStack.length > 0) {
+    ar.burnStack[ar.burnStack.length - 1] += 1;
+  }
+}
+
 function readEdgeUse(ar: Archive, r: R): any {
   preamble(ar, r);
   const [es] = ar.readObject(r, 'CEdge');
   const sense = r.u8();
-  const [ps] = ar.readObject(r); // parent-loop back-ref: alignment oracle
-  if (ps !== ar.currentLoop) {
-    throw new LegacyParseError(`edge-use parent slot ${ps} != current loop ${ar.currentLoop} ${r.ctx()}`);
+  // parent-loop back-ref: the alignment oracle. Read as a RAW file index -
+  // after annotations the claimed index can sit AHEAD of the walker's
+  // numbering (burned MapObject indices, see registerBurn), which is a
+  // correction signal, not a mis-parse.
+  const p0 = r.pos;
+  const tag = r.u16();
+  let ps: number | null;
+  if (tag === 0x7fff) {
+    const big = r.u32();
+    if (big & 0x80000000) {
+      throw new LegacyParseError(`edge-use parent is a new object ${r.ctx()}`);
+    }
+    ps = big;
+  } else if (tag === 0xffff || tag & 0x8000) {
+    throw new LegacyParseError(`edge-use parent is a new object ${r.ctx()}`);
+  } else {
+    ps = tag !== 0 ? tag : null;
+  }
+  const expected = ar.currentLoop !== null ? ar.currentLoop + ar.cumDelta : null;
+  if (ps !== expected) {
+    const delta = typeof ps === 'number' && expected !== null ? ps - expected : 0;
+    if (delta > 0 && delta <= 4096 && ar.annotWatermark !== null) {
+      registerBurn(ar, delta);
+    } else {
+      r.pos = p0;
+      throw new LegacyParseError(`edge-use parent slot ${ps} != current loop ${expected} ${r.ctx()}`);
+    }
   }
   return { k: 'edgeuse', edge: es, sense };
 }
@@ -513,6 +639,7 @@ function readAttrNamed(ar: Archive, r: R): any {
     if (t === 0x07) return r.u8();
     if (t === 0x09) return r.u32(); // time_t
     if (t === 0x0a) return r.utf16();
+    if (t === 0x0c) return r.f64(); // Length (a double, inches)
     if (t === 0x0b) {
       const n = r.u32();
       if (n > 100000) {
@@ -522,7 +649,8 @@ function readAttrNamed(ar: Archive, r: R): any {
       for (let i = 0; i < n; i++) arr.push(readTyped(r.u8()));
       return arr;
     }
-    if (t === 0x12) return r.f64s(3); // 3D vector
+    if (t === 0x11) return r.f64s(3); // 3D point (Geom::Point3d)
+    if (t === 0x12) return r.f64s(3); // 3D vector (Geom::Vector3d)
     throw new LegacyParseError(`unknown attribute value type 0x${t.toString(16)} ${r.ctx()}`);
   }
 
@@ -582,11 +710,75 @@ function readLayer(ar: Archive, r: R): any {
     mid.push(r.raw(1)[0]); // flags: 3 bytes on v16, 4 on v17+
   }
   r.utf16(); // internal name ("Layer_<name>")
-  r.u16();
+  const flags = r.u16();
+  if (flags & 0x00ff) {
+    // Colour-by-layer with a TEXTURED material: instead of the flat RGBA,
+    // the layer embeds the same texture block a CMaterial carries
+    // (SketchUp Pro assigns full materials to layers). Low byte of the
+    // flag word set = textured; a plain colour layer has 0 there (its high
+    // byte carries an unrelated flag, so the word as a whole is non-zero
+    // either way).
+    const tex = textureBlock(ar, r);
+    r.raw(4); // trailing u32
+    return { k: 'layer', name, hidden: mid.length ? mid[0] : 0, rgba: tex.rgba };
+  }
   const rgba = r.raw(4);
   r.utf16();
   r.raw(21);
   return { k: 'layer', name, hidden: mid.length ? mid[0] : 0, rgba: Array.from(rgba) };
+}
+
+/** The textured-material payload: an embedded CDib plus applied size,
+ * source file name, average colour, and opacity. Shared verbatim between a
+ * CMaterial with a texture and a colour-by-layer CLayer that carries a
+ * textured material. */
+function textureBlock(
+  ar: Archive,
+  r: R
+): {
+  rgba: number[];
+  opacity: number;
+  use_opacity: number;
+  tex_dib: number;
+  tex_w: number;
+  tex_h: number;
+  tex_file: string;
+  colorized: boolean;
+} {
+  r.raw(ar.ver >= 17 ? 2 : 1); // texture flag pad
+  const [s, , dib] = ar.readObject(r, 'CDib');
+  if (!(dib && typeof dib === 'object' && dib.k === 'dib')) {
+    throw new LegacyParseError(`texture object is not a dib ${r.ctx()}`);
+  }
+  // optional u32 between the dib and the 2 x f64 applied size
+  const marker = findBytes(r.data, STR_MARKER, r.pos, r.pos + 28);
+  if (marker - r.pos === 20) {
+    r.u32();
+  } else if (marker - r.pos !== 16) {
+    throw new LegacyParseError(`texture size block misaligned ${r.ctx()}`);
+  }
+  const w = r.f64();
+  const h = r.f64();
+  const fname = r.utf16();
+  const avg = r.raw(9); // RGBA + 00 + RGBA (colour stored twice)
+  r.utf16();
+  const blob = r.raw(8); // u32 + u32 colorized flag
+  const opacity = r.f64();
+  const useOp = r.u8();
+  // A colourized (re-tinted) texture stores the ORIGINAL image plus the
+  // tint as the average colour; flagged by the second blob u32 or by alpha
+  // 0xFF on the stored colour.
+  const colorized = Boolean(blob[4]) || avg[3] === 0xff;
+  return {
+    rgba: Array.from(avg.subarray(0, 4)),
+    opacity,
+    use_opacity: useOp,
+    tex_dib: s as number,
+    tex_w: w,
+    tex_h: h,
+    tex_file: fname,
+    colorized,
+  };
 }
 
 function readMaterial(ar: Archive, r: R): any {
@@ -604,38 +796,15 @@ function readMaterial(ar: Archive, r: R): any {
     out.opacity = opacity;
     out.use_opacity = useOp;
   } else {
-    r.raw(ar.ver >= 17 ? 2 : 1); // texture flag pad
-    const [s, , dib] = ar.readObject(r, 'CDib');
-    if (!(dib && typeof dib === 'object' && dib.k === 'dib')) {
-      throw new LegacyParseError(`texture object is not a dib ${r.ctx()}`);
-    }
-    // optional u32 between the dib and the 2 x f64 applied size
-    const marker = findBytes(r.data, STR_MARKER, r.pos, r.pos + 28);
-    if (marker - r.pos === 20) {
-      r.u32();
-    } else if (marker - r.pos !== 16) {
-      throw new LegacyParseError(`texture size block misaligned ${r.ctx()}`);
-    }
-    const w = r.f64();
-    const h = r.f64();
-    const fname = r.utf16();
-    const avg = r.raw(9); // RGBA + 00 + RGBA (colour stored twice)
-    r.utf16();
-    const blob = r.raw(8); // u32 + u32 colorized flag
-    const opacity = r.f64();
-    const useOp = r.u8();
-    // A colourized (re-tinted) texture stores the ORIGINAL image plus the
-    // tint as the average colour; flagged by the second blob u32 or by
-    // alpha 0xFF on the stored colour.
-    const colorized = Boolean(blob[4]) || avg[3] === 0xff;
-    out.rgba = Array.from(avg.subarray(0, 4));
-    out.opacity = opacity;
-    out.use_opacity = useOp;
-    out.tex_dib = s;
-    out.tex_w = w;
-    out.tex_h = h;
-    out.tex_file = fname;
-    out.colorized = colorized;
+    const tex = textureBlock(ar, r);
+    out.rgba = tex.rgba;
+    out.opacity = tex.opacity;
+    out.use_opacity = tex.use_opacity;
+    out.tex_dib = tex.tex_dib;
+    out.tex_w = tex.tex_w;
+    out.tex_h = tex.tex_h;
+    out.tex_file = tex.tex_file;
+    out.colorized = tex.colorized;
   }
   return out;
 }
@@ -691,11 +860,75 @@ function readThumbnail(ar: Archive, r: R): any {
   return { k: 'thumbnail', dib };
 }
 
-function readRelationship(ar: Archive, r: R): any {
+/** CImage: an Image entity - instance-shaped: a back-ref to the (already
+ * walked) CComponentDefinition holding the image's face and texture, a 3x4
+ * placement, a constant 1.0, the source path string (empty in every
+ * sample), and a 16-byte GUID. It appears as a normal entity-list item
+ * inside the definition that owns the image (typically a face-me/photo
+ * definition), whose own tail the ordinary definition reader then
+ * consumes. */
+function readImage(ar: Archive, r: R): any {
   preamble(ar, r);
-  ar.readObject(r);
-  ar.readObject(r);
-  return { k: 'relationship' };
+  const db = drawbase(ar, r);
+  const [ds] = ar.readObject(r); // the image's definition
+  const xform = r.f64s(12);
+  r.f64(); // constant 1.0
+  r.utf16(); // source path
+  const guid = r.raw(16);
+  return { k: 'image', db, def: ds, xform, guid: toHex(guid) };
+}
+
+/** A reference-to-entity tag: dimension connection points and text leader
+ * attachments. Unlike `readObject`'s back-ref path, this tolerates a slot
+ * the walk has not reached yet - SketchUp serializes a label/dimension
+ * BEFORE the entity it anchors to when both live in the same entity list,
+ * so the reference can legitimately point forward. Returns the slot
+ * number, or `null` for a null reference. */
+function entityRef(ar: Archive, r: R): number | null {
+  const tag = r.u16();
+  if (tag === 0) return null;
+  if (tag === 0x7fff) {
+    const big = r.u32();
+    if (big & 0x80000000) {
+      throw new LegacyParseError(`entity ref is a new object ${r.ctx()}`);
+    }
+    return big;
+  }
+  if (tag === 0xffff || tag & 0x8000) {
+    throw new LegacyParseError(`entity ref is a new object ${r.ctx()}`);
+  }
+  return tag;
+}
+
+function readRelationship(ar: Archive, r: R): any {
+  // two object pointers (small maps: two u16 back-refs - which read like
+  // the "u32" of the public notes; big maps escalate them to big-tags).
+  // They bind an annotation to the entity it labels, and the annotation
+  // side is routinely serialized BEFORE the geometry side - so these can
+  // point forward, past the walk cursor; entityRef tolerates that where
+  // readObject's back-ref path (rightly) does not.
+  preamble(ar, r);
+  const a = entityRef(ar, r);
+  const b = entityRef(ar, r);
+  return { k: 'relationship', refs: [a, b] };
+}
+
+/** True when the u16 at `at` starts an object read in one of the
+ * UNAMBIGUOUS forms: null, escape, class definition, or a class-ref to a
+ * class already known. Plain object back-refs are excluded on purpose -
+ * any 2-byte junk below 0x8000 would qualify, which is exactly the
+ * ambiguity this check exists to avoid. */
+function strictNextTag(ar: Archive, data: Uint8Array, at: number, allowNull = true): boolean {
+  if (at + 2 > data.length) return false;
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const t = view.getUint16(at, true);
+  if (t === 0x0000) return allowNull;
+  if (t === 0x7fff || t === 0xffff) return true;
+  if (t & 0x8000) {
+    const ent = ar.slots.get(t & 0x7fff);
+    return ent !== undefined && ent[0] === 'class';
+  }
+  return false;
 }
 
 function readConstructionLine(ar: Archive, r: R): any {
@@ -703,8 +936,31 @@ function readConstructionLine(ar: Archive, r: R): any {
   drawbase(ar, r);
   r.f64s(3);
   r.f64s(3);
-  r.f64s(2);
-  r.raw(ar.ver >= 17 ? 7 : 4);
+  r.f64s(2); // line params (+-~4.4e29 = infinite)
+  // The trailing block varies by the WRITING BUILD, not cleanly by
+  // version: 7 bytes on the v17 calibration corpus, 4 on v16 and on a real
+  // v18, 0 on another real v17. Self-calibrate on the first guide line of
+  // the file - the length that lands on a legitimate next tag (strict
+  // forms only) - and cache it for the rest of the file.
+  let k = ar.clineTail;
+  if (k === null) {
+    const dflt = ar.ver === 17 ? 7 : 4;
+    const order = [dflt, ...[0, 4, 7].filter((c) => c !== dflt)];
+    // two passes: a zero tail full of padding can mimic a null tag, so
+    // only accept a null-anchored candidate when no candidate lands on a
+    // STRONG form (escape / known class / class definition)
+    outer: for (const allowNull of [false, true]) {
+      for (const cand of order) {
+        if (strictNextTag(ar, r.data, r.pos + cand, allowNull)) {
+          k = cand;
+          break outer;
+        }
+      }
+    }
+    if (k === null) k = dflt;
+    ar.clineTail = k;
+  }
+  r.raw(k);
   return { k: 'cline' };
 }
 
@@ -751,13 +1007,23 @@ function readDimLinear(ar: Archive, r: R): any {
   const db = drawbase(ar, r);
   const text = r.utf16();
   ar.readObject(r, 'CSkFont');
-  r.raw(165);
-  return { k: 'dimension', db, text };
+  // The tail is NOT a fixed 165-byte blob: it embeds two object
+  // references (the dimension's connection points into the geometry).
+  // Each is a normal MFC tag - 2 bytes in small files, but 6 bytes once
+  // the archive holds more than 0x7FFE objects and the 0x7FFF big-tag
+  // escape kicks in - so a fixed-size skip walks off the rails exactly on
+  // large models.
+  r.raw(37);
+  const c1 = entityRef(ar, r); // connection point 1 (may be null)
+  r.raw(42);
+  const c2 = entityRef(ar, r); // connection point 2 (may be null)
+  r.raw(82);
+  return { k: 'dimension', db, text, connect: [c1, c2] };
 }
 
 function readText(ar: Archive, r: R): any {
   preamble(ar, r);
-  drawbase(ar, r);
+  const db = drawbase(ar, r);
   ar.readObject(r, 'CSkFont');
   // variable-length variant middle, delimited by an 11-byte block
   // `01 00 00 00 ?? 00 03 00 00 00 01` right before the text string
@@ -781,13 +1047,61 @@ function readText(ar: Archive, r: R): any {
   r.raw(idx - r.pos);
   const text = r.utf16();
   r.raw(5);
-  return { k: 'text', text };
+  // Optional leader-attachment refs follow the fixed tail (a text label
+  // anchored to geometry stores the anchored entities here; they can
+  // point FORWARD - see entityRef). Only the escaped 6-byte form is
+  // recognisable without risk: a 2-byte back-ref here would be
+  // indistinguishable from the next list item's tag, and every known
+  // sample either has no attachments or lives in a >0x7FFE-object file
+  // where the escape is mandatory anyway.
+  const attach: number[] = [];
+  while (true) {
+    const head = r.peek(2);
+    if (!(head.length === 2 && head[0] === 0xff && head[1] === 0x7f)) break;
+    const full = r.peek(6);
+    if (full.length < 6) break;
+    const dv = new DataView(full.buffer, full.byteOffset, full.byteLength);
+    const val = dv.getUint32(2, true);
+    if (val & 0x80000000) break; // new-object tag - the next entity
+    r.raw(6);
+    attach.push(val);
+  }
+  return { k: 'text', text, db, attach };
 }
 
 function readEntityList(ar: Archive, r: R, count: number, owner: string): [number, string | null, any][] {
   const ents: [number, string | null, any][] = [];
+  ar.burnStack.push(0);
+  try {
+    return readEntityListInner(ar, r, count, owner, ents);
+  } finally {
+    ar.burnStack.pop();
+  }
+}
+
+function readEntityListInner(
+  ar: Archive,
+  r: R,
+  count: number,
+  owner: string,
+  ents: [number, string | null, any][]
+): [number, string | null, any][] {
+  const view = new DataView(r.data.buffer, r.data.byteOffset, r.data.byteLength);
   while (ents.length < count) {
     const p = r.pos;
+    const hasBurnCredit = owner === 'def' && ar.burnStack.length > 0 && ar.burnStack[ar.burnStack.length - 1] > 0;
+    if (
+      hasBurnCredit &&
+      p + 25 <= r.data.length &&
+      view.getUint32(p, true) === 0 &&
+      bytesEqual(r.data.subarray(p + 22, p + 25), STR_MARKER)
+    ) {
+      // burned MapObject indices (see registerBurn) mean the declared
+      // count includes phantom entities the stream never carries; the
+      // definition tail signature (nrel=0 + pad + 16-byte GUID + name
+      // marker at +22) marks the list's REAL end
+      break;
+    }
     const prevFlag = ar.inEntityList;
     ar.inEntityList = true;
     try {
@@ -796,11 +1110,24 @@ function readEntityList(ar: Archive, r: R, count: number, owner: string): [numbe
       ents.push([s as number, n, v]);
     } catch (e) {
       ar.inEntityList = prevFlag;
-      if (!(e instanceof LegacyParseError) || owner !== 'root') {
+      if (!(e instanceof LegacyParseError)) {
         throw e;
       }
-      r.pos = p;
-      break;
+      if (owner === 'root') {
+        // over-declared root counts run into the document tail - stop
+        r.pos = p;
+        break;
+      }
+      if (hasBurnCredit) {
+        // this list had burned MapObject indices (see registerBurn): the
+        // phantom connection points were also counted as items, so the
+        // declared count overshoots the real records. Stop at the failed
+        // item - the definition tail that follows (nrel, GUID anchor,
+        // thumbnail scan) validates the cut.
+        r.pos = p;
+        break;
+      }
+      throw e;
     }
   }
   return ents;
@@ -813,21 +1140,40 @@ function readDefinition(ar: Archive, r: R): any {
   if (nlayers > 10000) {
     throw new LegacyParseError(`implausible def layer count ${r.ctx()}`);
   }
-  for (let i = 0; i < nlayers; i++) {
+  // like the model-level layer list, the count is REAL layers (new
+  // records or back-refs); SketchUp 2020 interleaves null separators
+  // between them
+  let got = 0;
+  while (got < nlayers) {
+    if (r.peekU16() === 0) {
+      r.pos += 2;
+      continue;
+    }
     ar.readObject(r, 'CLayer');
+    got += 1;
   }
   const decl = r.u16();
   if (decl === 0x7fff) {
     r.u32();
   }
-  r.u32();
-  let count = r.u32();
+  // v20 can drop its undocumented filler right here, swallowing the u32
+  // field (and, behind a layer-separator null, even the decl itself): if
+  // the empty-string marker sits in the next few bytes, the real count is
+  // the first non-zero u32 after its padding.
+  let count: number | null = null;
+  if (ar.ver >= 20) {
+    count = retryCountAfterV20Filler(r, r.pos, 5_000_000, ar);
+  }
+  if (count === null) {
+    r.u32();
+    count = r.u32();
+  }
   // A zero count is as much a symptom of the v20 filler as an implausibly
   // large one: the reader lands on the leading zero bytes of the filler
   // instead of the count. A genuinely empty definition reads zero with no
   // filler ahead, and retryCountAfterV20Filler leaves those alone.
   if (count > 5_000_000 || count === 0) {
-    const retry = retryCountAfterV20Filler(r, r.pos - 4, 5_000_000);
+    const retry = retryCountAfterV20Filler(r, r.pos - 4, 5_000_000, ar);
     if (retry !== null) count = retry;
   }
   if (count > 5_000_000) {
@@ -836,7 +1182,7 @@ function readDefinition(ar: Archive, r: R): any {
   const ents = readEntityList(ar, r, count, 'def');
   let nrel = r.u32();
   if (nrel > 100000) {
-    const retry = retryCountAfterV20Filler(r, r.pos - 4, 100_000);
+    const retry = retryCountAfterV20Filler(r, r.pos - 4, 100_000, ar);
     if (retry !== null) nrel = retry;
   }
   if (nrel > 100000) {
@@ -939,6 +1285,7 @@ const READERS: Record<string, (ar: Archive, r: R) => any> = {
   CThumbnail: readThumbnail,
   CRelationship: readRelationship,
   CComponentDefinition: readDefinition,
+  CImage: readImage,
   CComponentInstance: readInstance,
   CGroup: readInstance,
   CFaceTextureCoords: readFtc,
@@ -1122,15 +1469,40 @@ function walkModel(data: Uint8Array, ver: number, start: number, matCount: numbe
   if (layerCount > 100000) {
     throw new LegacyParseError('implausible layer count');
   }
+  // layerCount counts REAL layers. SketchUp 2020 interleaves a null
+  // object-ref after each layer record (a separator, not a layer), so
+  // counting reads walks off mid-list on files with several layers; count
+  // parsed layers instead, skip the separators, and stop early if the
+  // next tag is a back-ref (the definition-list anchor) - a v20 variant
+  // where the count over-includes separators.
   const layers: [number, any][] = [];
-  for (let i = 0; i < layerCount; i++) {
+  while (layers.length < layerCount) {
+    const tag = r.peekU16();
+    if (tag === 0) {
+      r.pos += 2;
+      continue;
+    }
+    if (tag !== 0xffff && !(tag & 0x8000)) {
+      break;
+    }
     const [s, , v] = ar.readObject(r, 'CLayer');
-    // A null object-ref occupies a slot in the list without carrying a layer
-    // record (seen in SketchUp 2020 files, where layerCount includes it).
-    // Keeping it would push a null into the list and blow up downstream on
-    // v.rgba; readObject has still consumed the ref from the stream.
     if (v === null) continue;
     layers.push([s as number, v]);
+  }
+  // trailing separators (and any layer records past the declared count)
+  const layCls = ar.classSlot.get('CLayer');
+  while (true) {
+    const tag = r.peekU16();
+    if (tag === 0) {
+      r.pos += 2;
+      continue;
+    }
+    if (layCls !== undefined && tag === (0x8000 | layCls)) {
+      const [s, , v] = ar.readObject(r, 'CLayer');
+      if (v !== null) layers.push([s as number, v]);
+      continue;
+    }
+    break;
   }
 
   // definition list: object pointer to the ACTIVE layer, then count
@@ -1140,7 +1512,7 @@ function walkModel(data: Uint8Array, ver: number, start: number, matCount: numbe
   }
   let defCount = r.u32();
   if (defCount > 1_000_000) {
-    const retry = retryCountAfterV20Filler(r, r.pos - 4, 1_000_000);
+    const retry = retryCountAfterV20Filler(r, r.pos - 4, 1_000_000, ar);
     if (retry !== null) defCount = retry;
   }
   if (defCount > 1_000_000) {
@@ -1165,7 +1537,7 @@ function walkModel(data: Uint8Array, ver: number, start: number, matCount: numbe
   // root entity list
   let rootCount = r.u32();
   if (rootCount > 5_000_000) {
-    const retry = retryCountAfterV20Filler(r, r.pos - 4, 5_000_000);
+    const retry = retryCountAfterV20Filler(r, r.pos - 4, 5_000_000, ar);
     if (retry !== null) rootCount = retry;
   }
   if (rootCount > 5_000_000) {

--- a/packages/typescript/tests/legacy-v20.test.ts
+++ b/packages/typescript/tests/legacy-v20.test.ts
@@ -43,9 +43,13 @@ describe('Legacy MFC reader - SketchUp 2020 (v20) layout', () => {
     expect(model.definitions.size).toBe(20);
     expect(model.materials.length).toBe(24);
 
-    // v20 writes a null object-ref into the layer list, which layerCount
-    // includes. It must not reach model.layers as a null entry.
-    expect(model.layers.map((l) => l.name)).toEqual(['Layer0']);
+    // v20 interleaves a null object-ref after EACH layer record; the count
+    // is the number of REAL layers. The old reader counted the separators
+    // as items and dropped every layer after the first - this fixture
+    // really does carry "Gondulas Laterais" (visible in SketchUp), which
+    // the previous assertion enshrined as missing. Nulls must still never
+    // reach model.layers.
+    expect(model.layers.map((l) => l.name)).toEqual(['Layer0', 'Gondulas Laterais']);
     for (const layer of model.layers) {
       expect(layer).not.toBeNull();
       expect(layer.name).toBeTypeOf('string');


### PR DESCRIPTION
## Summary
Ports six related fixes from Python's `legacy.py` (PR #194 through #199, Python-only) to TypeScript, .NET, Dart, and C++'s own legacy MFC readers:

1. Textured colour-by-layer (`CLayer` can carry a full texture payload, not just flat RGBA).
2. `CDimensionLinear`'s tail read structurally (37 + ref + 42 + ref + 82) instead of a fixed 165-byte skip, since each connection-point ref is 2 or 6 bytes depending on whether the archive has crossed the 0x7FFE big-tag-escape boundary.
3. Forward-tolerant entity references for `CRelationship` and text-leader attachments, since annotations routinely serialize before the geometry they label.
4. A `CImage` reader (previously entirely missing — any legacy file with a dropped-in image was rejected outright).
5. Attribute value types `0x11` (Point3d) and `0x0C` (Length).
6. **The burned-store-map-index mechanism itself**: SketchUp maps a dimension/leader-text's connection points into the MFC store map without serializing bytes, silently offsetting every later back-reference. Each language's burn-band translation was walked through by hand rather than transliterated.

Also ports the by-object-layer `drawbase` read and the self-calibrating `CConstructionLine` trailer width.

## Verification
- **.NET, TypeScript, Dart**: full local test suites pass, plus real-file cross-validation against two large real-world repro files (`casa-bueno.skp`, `plaza-toros-puquina.skp`) — raw-parse stats match the Python oracle exactly on both. For .NET, went further and diffed per-definition face-loop geometry (all 200 definitions) byte-for-byte against Python.
- Each language's `gondola_v20.skp` fixture test previously asserted the pre-existing null-separator-unaware layer count (1 layer) as correct; corrected to the real 2 layers (`"Layer0"`, `"Gondulas Laterais"`), matching Python's own fixture correction from PR #199.
- **C++**: no local compiler is available in this environment, so this port relies entirely on CI for build/test verification (a standing constraint for this repo). Verified as far as possible without one: full manual re-read of every changed section, `clang-format --dry-run --Werror` clean, and brace-balance checked against the original file.

## Test plan
- [ ] CI green across all 5 languages (Python unaffected/unchanged)
- [ ] C++ build + sanitizers green (extra scrutiny warranted given no local verification was possible)