### PR TITLE
Port PR #190's VFF scenes/dimensions to TypeScript, .NET, Dart, C++

### DIFF
--- a/packages/cpp/CMakeLists.txt
+++ b/packages/cpp/CMakeLists.txt
@@ -122,6 +122,7 @@ set(
   src/model.cpp
   src/obj_export.cpp
   src/observability.cpp
+  src/pages_dimensions.cpp
   src/parser.cpp
   src/ply_export.cpp
   src/scene.cpp

--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -181,10 +181,49 @@ struct TextEntity {
   bool hidden{false};
 };
 
-/// Dimension entity.
+/// A linear dimension (SketchUp's Dimension tool).
+///
+/// The legacy (pre-2021) reader recovers only `text`/`hidden`. The VFF
+/// reader (2021+) recovers the full geometry - see `SkpModel::dimensions`
+/// for the model-level, world-space list.
 struct Dimension {
+  /// The displayed text. Empty when the dimension shows its auto-computed
+  /// measured value (the caller formats |b - a|).
   std::string text;
   bool hidden{false};
+  /// First measured point (x, y, z) in inches (world space), or unset when
+  /// only the text was recovered.
+  std::optional<Vec3> a;
+  /// Second measured point.
+  std::optional<Vec3> b;
+  /// Offset distance (inches) - how far the dimension line sits from the
+  /// a-b segment, along the in-plane perpendicular.
+  double offset{};
+  /// The dimension plane's x-axis, or unset.
+  std::optional<Vec3> plane_x;
+  /// The dimension plane's normal, or unset.
+  std::optional<Vec3> normal;
+};
+
+/// A saved scene (SketchUp's "Scenes" tabs; "pages" in the SDK).
+struct Page {
+  /// Scene name as shown on its tab.
+  std::string name;
+  /// Camera position (x, y, z) in inches, or unset.
+  std::optional<Vec3> eye;
+  /// Point the camera looks at, in inches.
+  std::optional<Vec3> target;
+  /// Camera up vector.
+  std::optional<Vec3> up;
+  /// Field of view in degrees (SketchUp default 35).
+  double fov{35.0};
+  /// True when the scene uses parallel (orthographic) projection; `fov`
+  /// still holds the stored perspective angle.
+  bool parallel{};
+  /// Visible height in inches when `parallel`.
+  double ortho_height{};
+  /// Names of the layers this scene hides.
+  std::vector<std::string> hidden_layers;
 };
 
 /// Reusable geometry container (component definition or group).
@@ -231,6 +270,13 @@ class OPENSKP_EXPORT SkpModel {
   std::map<EntityId, Definition> definitions;
   /// Model layers.
   std::vector<Layer> layers;
+  /// The file's saved scenes (VFF files; classic pre-2021 files import
+  /// with none).
+  std::vector<Page> pages;
+  /// Model-level linear dimensions with world-space endpoints (VFF
+  /// files). Legacy files surface text-only dimensions per definition
+  /// instead (`Definition::dimensions`).
+  std::vector<Dimension> dimensions;
   /// Model materials sequence.
   std::deque<Material> materials;
   /// Model rendering styles.

--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -251,6 +251,10 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
   auto hs = headers(*model, 0, model->size());
   if (hs.size() == 1 && model->at(hs[0].offset) == 0xf4 && model->at(hs[0].offset + 1) == 1)
     hs = headers(*model, hs[0].offset + 6, hs[0].offset + 6 + hs[0].size);
+  std::map<std::string, Vec3> vertex_positions;
+  std::map<std::string, std::vector<double>> instance_world;
+  const TlvNode* page_node = nullptr;
+  std::vector<TlvNode> page_node_owner;  // keeps page_node's subtree alive past the loop
   auto total = hs.size();
   for (std::size_t i = 0; i < total; ++i) {
     std::string tag;
@@ -261,6 +265,14 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
       collect_layers(one, p.layer_id_to_name);
       collect_material_ids(one, p.material_id_to_name);
       collect_definitions(one, p.definitions);
+      scan_vertex_positions(one[0], vertex_positions);
+      scan_instance_transforms(one[0], instance_world);
+      if (!page_node) {
+        if (auto* found = find_page_node(one[0])) {
+          page_node_owner.push_back(*found);
+          page_node = &page_node_owner.back();
+        }
+      }
       if (one[0].tag == "F601") collect_geometry(one[0].children, p.root.builder);
     } catch (const SkpParseError&) {
       throw;
@@ -279,6 +291,8 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
     p.units = std::nullopt;
     emit_log(o, LogLevel::debug, "Failed to read units from meta/meta.dat");
   }
+  p.pages = parse_pages(page_node);
+  p.dimensions = parse_dimensions(*model, vertex_positions, instance_world);
   if (!p.layer_id_to_name.count(1)) p.layer_id_to_name[1] = "Layer0";
   if (!p.layer_colors.count("Layer0")) p.layer_colors["Layer0"] = {136, 136, 136};
   if (!p.layer_hidden.count("Layer0")) p.layer_hidden["Layer0"] = false;

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -92,6 +92,26 @@ struct RawStyle {
   std::optional<Color3> back_color;
 };
 
+struct RawPage {
+  std::string name;
+  std::optional<Vec3> eye;
+  std::optional<Vec3> target;
+  std::optional<Vec3> up;
+  double fov{35.0};
+  bool parallel{};
+  double ortho_height{};
+  std::vector<EntityId> hidden_layer_ids;
+};
+
+struct RawDimension {
+  Vec3 a{};
+  Vec3 b{};
+  double offset{};
+  std::optional<Vec3> plane_x;
+  std::optional<Vec3> normal;
+  std::string text;
+};
+
 struct RawParsed {
   std::string version{"unknown"};
   // The model's unit-system string (e.g. "Millimeter"), read from
@@ -104,6 +124,8 @@ struct RawParsed {
   // so every VFF layer defaults to visible.
   std::map<std::string, bool> layer_hidden;
   std::map<EntityId, std::string> layer_id_to_name;
+  std::vector<RawPage> pages;
+  std::vector<RawDimension> dimensions;
   std::map<EntityId, std::string> material_id_to_name;
   std::map<std::string, std::shared_ptr<RawMaterial>> materials;
   std::map<std::string, std::shared_ptr<RawMaterial>> materials_by_folder;
@@ -147,6 +169,12 @@ std::array<double, 3> transform_point(const std::vector<double>&, const std::arr
 std::array<double, 3> transform_normal(const std::vector<double>&, const std::array<double, 3>&);
 double transform_determinant(const std::vector<double>&);
 std::vector<double> multiply_matrices(const std::vector<double>&, const std::vector<double>&);
+void scan_vertex_positions(const TlvNode&, std::map<std::string, Vec3>&);
+void scan_instance_transforms(const TlvNode&, std::map<std::string, std::vector<double>>&);
+std::vector<RawDimension> parse_dimensions(const ByteBuffer&, const std::map<std::string, Vec3>&,
+                                           const std::map<std::string, std::vector<double>>&);
+const TlvNode* find_page_node(const TlvNode&);
+std::vector<RawPage> parse_pages(const TlvNode*);
 
 struct EarPoint {
   double x{};

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -104,6 +104,34 @@ SkpModel build_model(RawParsed&& p, const ParseOptions& o) {
     bool hidden = hidden_it != p.layer_hidden.end() && hidden_it->second;
     m.layers.push_back({l.first, l.second, hidden});
   }
+  // Convert pages (saved scenes) - hidden layer ids resolve to names;
+  // unknown ids (stale refs) are dropped.
+  for (auto& pg : p.pages) {
+    Page page;
+    page.name = pg.name;
+    page.eye = pg.eye;
+    page.target = pg.target;
+    page.up = pg.up;
+    page.fov = pg.fov;
+    page.parallel = pg.parallel;
+    page.ortho_height = pg.ortho_height;
+    for (auto id : pg.hidden_layer_ids) {
+      auto it = p.layer_id_to_name.find(id);
+      if (it != p.layer_id_to_name.end()) page.hidden_layers.push_back(it->second);
+    }
+    m.pages.push_back(std::move(page));
+  }
+  // Convert model-level linear dimensions (VFF; world space).
+  for (auto& dm : p.dimensions) {
+    Dimension dim;
+    dim.a = dm.a;
+    dim.b = dm.b;
+    dim.offset = dm.offset;
+    dim.plane_x = dm.plane_x;
+    dim.normal = dm.normal;
+    dim.text = dm.text;
+    m.dimensions.push_back(std::move(dim));
+  }
   std::map<const RawMaterial*, std::size_t> raw_index;
   for (auto& v : p.materials) {
     auto& r = *v.second;

--- a/packages/cpp/src/pages_dimensions.cpp
+++ b/packages/cpp/src/pages_dimensions.cpp
@@ -1,0 +1,345 @@
+#include <algorithm>
+#include <functional>
+
+#include "internal.hpp"
+
+// VFF (2021+) scenes ("pages") and linear dimensions. Ported from Python's
+// _core.py (PR #190) - see that module's _scan_vertex_positions /
+// _scan_instance_transforms / _parse_dimensions / _find_page_node /
+// _parse_pages for the byte-format details this file mirrors.
+
+namespace openskp {
+namespace {
+
+// ── flat TLV, integer tags ──────────────────────────────────────────────
+// A second, deliberately separate flat-TLV reader from parse_flat/flat_find
+// (geometry.cpp): those use the STRING byte-order tag convention the main
+// tree already relies on (e.g. "C409"), while the sub-records this feature
+// reads (5208, 520A, 53FC, 5BCD, ...) are most directly and safely ported
+// from Python's own _tlv_items/_tlv_find (which read the tag as a
+// little-endian uint16) by keeping the SAME integer convention here,
+// copying Python's numeric constants byte-for-byte rather than
+// hand-converting each one to the swapped string form. Every payload is
+// copied (ByteBuffer by value) rather than referenced by view: C++17 has
+// no std::span, and a pointer into a temporary vector's element would
+// dangle the moment that vector goes out of scope - the payloads involved
+// here (leaf tags, floats, small ids) are small enough that copying costs
+// nothing that matters.
+
+struct FlatTlvItem {
+  std::uint16_t tag;
+  ByteBuffer payload;
+};
+
+std::vector<FlatTlvItem> tlv_items_int(const ByteBuffer& buf) {
+  std::vector<FlatTlvItem> items;
+  std::size_t off = 0;
+  std::size_t n = buf.size();
+  while (off < n) {
+    if (off + 6 > n) return {};
+    std::uint16_t tag = static_cast<std::uint16_t>(buf[off] | (buf[off + 1] << 8));
+    auto ln = read_u32(buf, off + 2);
+    if (tag == 0 || off + 6 + ln > n) return {};
+    items.push_back({tag, ByteBuffer(buf.begin() + off + 6, buf.begin() + off + 6 + ln)});
+    off += 6 + ln;
+  }
+  return items;
+}
+
+std::optional<ByteBuffer> tlv_find_int(const std::vector<FlatTlvItem>& items, std::uint16_t tag) {
+  for (auto& it : items) {
+    if (it.tag == tag) return it.payload;
+  }
+  return std::nullopt;
+}
+
+std::string hex_upper(const ByteBuffer& p) {
+  static char h[] = "0123456789ABCDEF";
+  std::string s;
+  s.reserve(p.size() * 2);
+  for (auto b : p) {
+    s += h[b >> 4];
+    s += h[b & 15];
+  }
+  return s;
+}
+
+ByteBuffer strip_de05(const ByteBuffer& p) {
+  if (p.size() >= 6 && p[0] == 0xde && p[1] == 0x05) {
+    auto idlen = read_u32(p, 2);
+    if (idlen <= p.size() - 6) return ByteBuffer(p.begin() + 6, p.begin() + 6 + idlen);
+  }
+  return p;
+}
+
+const TlvNode* find_child_tag(const std::vector<TlvNode>& nodes, const std::string& target) {
+  for (auto& n : nodes) {
+    if (n.tag == target) return &n;
+    if (auto* r = find_child_tag(n.children, target)) return r;
+  }
+  return nullptr;
+}
+
+std::optional<Vec3> vec3_of(const std::optional<ByteBuffer>& p) {
+  if (p && p->size() == 24) return Vec3{read_f64(*p, 0), read_f64(*p, 8), read_f64(*p, 16)};
+  return std::nullopt;
+}
+
+}  // namespace
+
+// Accumulate every vertex's persistent id (hex) -> (x, y, z) inches. A
+// vertex is a "C409" record: "DC05" holds its persistent id (the "DE05"
+// var-int payload), "C509" its 3xf64 position. Dimension connection points
+// reference geometry by this id. Called once per top-level record -
+// full_parse streams the TLV tree and never holds it whole.
+void scan_vertex_positions(const TlvNode& top, std::map<std::string, Vec3>& id2pos) {
+  // Operates on `top` (and el.children, all real members) by reference the
+  // whole way down - never wraps a node in a synthetic {node} vector,
+  // which would construct a TEMPORARY vector (a value-type TlvNode copies
+  // its whole subtree) whose lifetime ends at that expression, dangling
+  // any pointer taken into it.
+  std::function<void(const TlvNode&)> visit = [&](const TlvNode& el) {
+    if (el.tag == "C409") {
+      auto* dc05 = find_child_tag(el.children, "DC05");
+      auto* c509 = find_child_tag(el.children, "C509");
+      if (dc05 && c509 && c509->payload.size() == 24) {
+        auto idb = strip_de05(dc05->payload);
+        id2pos[hex_upper(idb)] = {read_f64(c509->payload, 0), read_f64(c509->payload, 8),
+                                  read_f64(c509->payload, 16)};
+      }
+    }
+    for (auto& c : el.children) visit(c);
+  };
+  visit(top);
+}
+
+// Accumulate each instance's persistent id (hex) -> its WORLD transform (a
+// 13-double matrix, or an empty vector for the identity/no-transform
+// case), walking the instance tree and composing parent x local at every
+// "6419". Per top-level record, like scan_vertex_positions - an instance
+// chain never crosses top-level records.
+//
+// A dimension connects to geometry INSIDE a placed component; its
+// connection reference names the vertex AND the instance holding it. The
+// vertex position is definition-local, so it must be lifted to world by
+// the instance's transform for the dimension to land where the author
+// drew it.
+void scan_instance_transforms(const TlvNode& top,
+                              std::map<std::string, std::vector<double>>& world) {
+  // Same reference-only traversal discipline as scan_vertex_positions -
+  // no synthetic {node} vector wrapping.
+  std::function<void(const TlvNode&, const std::vector<double>&)> visit =
+      [&](const TlvNode& el, const std::vector<double>& parent) {
+        if (el.tag == "6419") {
+          auto* d007 = find_child_tag(el.children, "D007");
+          auto* dc05 = d007 ? find_child_tag(d007->children, "DC05") : nullptr;
+          std::optional<std::string> iid;
+          if (dc05) iid = hex_upper(strip_de05(dc05->payload));
+
+          auto* m = find_child_tag(el.children, "6619");
+          std::optional<std::vector<double>> mat;
+          if (m && m->payload.size() == 104) {
+            std::vector<double> v(13);
+            for (int i = 0; i < 13; ++i) v[i] = read_f64(m->payload, i * 8);
+            mat = std::move(v);
+          }
+          std::vector<double> here = mat ? multiply_matrices(parent, *mat) : parent;
+          if (iid) world[*iid] = here;
+          for (auto& c : el.children) visit(c, here);
+        } else {
+          for (auto& c : el.children) visit(c, parent);
+        }
+      };
+  visit(top, {});
+}
+
+// Linear dimensions (SketchUp's Dimension tool).
+//
+// A dimension entity is a "5BCC" record (raw bytes cc 5b) holding:
+//
+// * 5BCD / 5BCE - the two connection points. Each wraps a 5208 whose 5209
+//   is the connection TYPE (1 = a free explicit point in 520A, already
+//   world space; 2 = connected to geometry, 520A is zero and 520B -> 53FC
+//   names the target: 53FD = the vertex by persistent id, 53FE = a
+//   length-prefixed persistent id of the INSTANCE holding it - the vertex
+//   position is definition-local, so it is lifted to world by that
+//   instance's transform).
+// * 5BCF - the dimension plane's x-axis; 5BD0 - its normal.
+// * 5BD2 - the offset distance (inches): how far the dimension line sits
+//   from the measured segment, along the in-plane perpendicular.
+//
+// The measured value is auto-computed from the two points (no cached text
+// on the samples seen), so callers format it themselves. Endpoints come
+// out in WORLD space (inches). A connection point that cannot be resolved
+// drops the whole dimension (fail-safe).
+std::vector<RawDimension> parse_dimensions(
+    const ByteBuffer& model_dat, const std::map<std::string, Vec3>& id2pos,
+    const std::map<std::string, std::vector<double>>& inst_world) {
+  std::vector<RawDimension> dims;
+  const ByteBuffer needle{0xcc, 0x5b};
+  std::size_t i = 0;
+  std::size_t n = model_dat.size();
+
+  auto point = [&](const std::optional<ByteBuffer>& block_payload) -> std::optional<Vec3> {
+    if (!block_payload) return std::nullopt;
+    auto blk_items = tlv_items_int(*block_payload);
+    auto blk = tlv_find_int(blk_items, 0x5208);
+    if (!blk) return std::nullopt;
+    auto sub = tlv_items_int(*blk);
+    auto typ_b = tlv_find_int(sub, 0x5209);
+    std::optional<std::uint32_t> typ;
+    if (typ_b && typ_b->size() == 4) typ = read_u32(*typ_b, 0);
+    if (typ == 1u) {
+      auto pos = tlv_find_int(sub, 0x520a);
+      return vec3_of(pos);
+    }
+    // type 2: resolve the geometry reference (vertex + instance).
+    auto ref_b = tlv_find_int(sub, 0x520b);
+    std::optional<ByteBuffer> f53fc;
+    if (ref_b) {
+      auto ref_items = tlv_items_int(*ref_b);
+      f53fc = tlv_find_int(ref_items, 0x53fc);
+    }
+    std::vector<FlatTlvItem> fi;
+    if (f53fc) fi = tlv_items_int(*f53fc);
+    auto vid = tlv_find_int(fi, 0x53fd);
+    auto iid = tlv_find_int(fi, 0x53fe);
+    if (!vid) return std::nullopt;
+    auto local_it = id2pos.find(hex_upper(*vid));
+    if (local_it == id2pos.end()) return std::nullopt;
+    if (iid && !iid->empty() && (*iid)[0] > 0 && std::size_t(1 + (*iid)[0]) <= iid->size()) {
+      ByteBuffer id_bytes(iid->begin() + 1, iid->begin() + 1 + (*iid)[0]);
+      auto w_it = inst_world.find(hex_upper(id_bytes));
+      if (w_it != inst_world.end() && !w_it->second.empty()) {
+        return transform_point(w_it->second, local_it->second);
+      }
+    }
+    return local_it->second;  // model-root vertex - already world
+  };
+
+  while (true) {
+    auto found = std::search(model_dat.begin() + i, model_dat.end(), needle.begin(), needle.end());
+    if (found == model_dat.end()) break;
+    std::size_t j = static_cast<std::size_t>(found - model_dat.begin());
+    i = j + 1;
+    if (j + 6 > n) continue;
+    auto ln = read_u32(model_dat, j + 2);
+    if (ln < 40 || j + 6 + ln > n) continue;
+    ByteBuffer body_bytes(model_dat.begin() + j + 6, model_dat.begin() + j + 6 + ln);
+    auto body = tlv_items_int(body_bytes);
+    if (body.empty()) continue;
+    bool has_5bcd = false, has_5bce = false;
+    for (auto& it : body) {
+      if (it.tag == 0x5bcd) has_5bcd = true;
+      if (it.tag == 0x5bce) has_5bce = true;
+    }
+    if (!has_5bcd || !has_5bce) continue;
+
+    auto a = point(tlv_find_int(body, 0x5bcd));
+    auto b = point(tlv_find_int(body, 0x5bce));
+    if (!a || !b) continue;
+
+    auto xaxis_b = tlv_find_int(body, 0x5bcf);
+    auto normal_b = tlv_find_int(body, 0x5bd0);
+    auto off_b = tlv_find_int(body, 0x5bd2);
+
+    RawDimension d;
+    d.a = *a;
+    d.b = *b;
+    d.plane_x = vec3_of(xaxis_b);
+    d.normal = vec3_of(normal_b);
+    d.offset = (off_b && off_b->size() == 8) ? read_f64(*off_b, 0) : 0.0;
+    dims.push_back(std::move(d));
+  }
+  return dims;
+}
+
+// Return the "0702" scenes node inside top's subtree, or nullptr. Called
+// per top-level record; retaining the (small) 0702 subtree is the only
+// thing kept alive past the streaming loop.
+const TlvNode* find_page_node(const TlvNode& top) {
+  // Checks `top` itself first, then delegates to find_child_tag on
+  // top.children (a real member) - never wraps `top` in a synthetic
+  // {top} vector (see scan_vertex_positions's comment on why that
+  // dangles).
+  if (top.tag == "0702") return &top;
+  return find_child_tag(top.children, "0702");
+}
+
+// Scenes ("pages"). The 0702 node's payload nests 6D60 > 6D61 > one 7148
+// record per page:
+//
+// * 6F54 > 6F55 - page name (UTF-8)
+// * 714A > 34BC - camera: 34BD eye, 34BE target, 34BF up (3xf64, inches),
+//   34C4 field of view (degrees), 34C2 u8 = PERSPECTIVE flag (00 =
+//   parallel projection - calibrated against the bundled scene
+//   thumbnails: parallel plans/elevations carry 00 and their 34C3 visible
+//   height matches the thumbnail framing exactly, while perspective
+//   scenes carry 01 with a stale 34C3), 34C3 f64 = visible height when
+//   parallel (inches)
+// * 7150 - layers hidden in this page: (u8 length, var-int layer id) runs
+std::vector<RawPage> parse_pages(const TlvNode* node) {
+  std::vector<RawPage> pages;
+  if (!node) return pages;
+
+  auto t60_items = tlv_items_int(node->payload);
+  for (auto& it60 : t60_items) {
+    if (it60.tag != 0x6d60) continue;
+    auto t61_items = tlv_items_int(it60.payload);
+    for (auto& it61 : t61_items) {
+      if (it61.tag != 0x6d61) continue;
+      auto t48_items = tlv_items_int(it61.payload);
+      for (auto& it48 : t48_items) {
+        if (it48.tag != 0x7148) continue;
+        auto items = tlv_items_int(it48.payload);
+        if (items.empty()) continue;
+
+        RawPage page;
+
+        auto head_payload = tlv_find_int(items, 0x6f54);
+        std::vector<FlatTlvItem> head;
+        if (head_payload) head = tlv_items_int(*head_payload);
+        auto name = tlv_find_int(head, 0x6f55);
+        if (name && !name->empty()) {
+          page.name.assign(reinterpret_cast<const char*>(name->data()), name->size());
+        }
+
+        auto cam_wrap_payload = tlv_find_int(items, 0x714a);
+        std::vector<FlatTlvItem> cam_wrap;
+        if (cam_wrap_payload) cam_wrap = tlv_items_int(*cam_wrap_payload);
+        auto cam_payload = tlv_find_int(cam_wrap, 0x34bc);
+        std::vector<FlatTlvItem> cam;
+        bool has_cam = false;
+        if (cam_payload) {
+          cam = tlv_items_int(*cam_payload);
+          has_cam = true;
+        }
+        if (has_cam) {
+          page.eye = vec3_of(tlv_find_int(cam, 0x34bd));
+          page.target = vec3_of(tlv_find_int(cam, 0x34be));
+          page.up = vec3_of(tlv_find_int(cam, 0x34bf));
+          auto fov = tlv_find_int(cam, 0x34c4);
+          if (fov && fov->size() == 8) page.fov = read_f64(*fov, 0);
+          auto flag = tlv_find_int(cam, 0x34c2);
+          page.parallel = flag && !flag->empty() && (*flag)[0] == 0;
+          auto height = tlv_find_int(cam, 0x34c3);
+          if (height && height->size() == 8) page.ortho_height = read_f64(*height, 0);
+        }
+
+        auto hidden = tlv_find_int(items, 0x7150);
+        std::size_t off = 0;
+        while (hidden && off + 1 <= hidden->size()) {
+          std::uint8_t ln = (*hidden)[off];
+          if (ln == 0 || off + 1 + ln > hidden->size()) break;
+          page.hidden_layer_ids.push_back(
+              static_cast<EntityId>(parse_varint(*hidden, off + 1, ln)));
+          off += 1 + ln;
+        }
+
+        if (page.eye && page.target) pages.push_back(std::move(page));
+      }
+    }
+  }
+  return pages;
+}
+}  // namespace openskp

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   meta_units_test.cpp
   obj_export_test.cpp
   observability_test.cpp
+  pages_dimensions_test.cpp
   parser_test.cpp
   ply_export_test.cpp
   scene_test.cpp

--- a/packages/cpp/tests/pages_dimensions_test.cpp
+++ b/packages/cpp/tests/pages_dimensions_test.cpp
@@ -1,0 +1,189 @@
+#include <cstring>
+#include <gtest/gtest.h>
+
+#include "internal.hpp"
+#include "test_helpers.hpp"
+
+// VFF scenes ("pages") and linear dimensions - ported from Python's
+// test_pages_dimensions.py (PR #190).
+//
+// Dimensions are exercised against the repository's own Untitled.skp
+// fixture (drawn in SketchUp 2025, it carries 13 linear dimensions); scenes
+// have no fixture yet, so their parser is exercised on a synthetic "0702"
+// record byte-for-byte shaped like the real ones (the layout was decoded
+// from production survey files and calibrated against the scene thumbnails
+// SketchUp embeds in the .skp itself).
+
+namespace openskp {
+namespace {
+
+// ── helpers: build TLV runs in the flat (u16-LE tag, u32 len) form ────────
+// Deliberately NOT test_helpers.hpp's tlv() - that one takes a hex-digit
+// STRING and writes it in the main tree's byte-order convention (tag[0..1]
+// as the first byte), whereas this feature's sub-records use Python's own
+// _tlv_items/_tlv_find INTEGER convention (a true little-endian uint16).
+// Passing e.g. "5208" through the string helper would write the byte-order
+// bytes for tag 0x0852, not 0x5208 - so this local helper takes the
+// numeric tag directly and packs it little-endian, matching Python's own
+// test helper (`def tlv(tag: int, payload: bytes)`) exactly.
+
+ByteBuffer tlv(std::uint16_t tag, ByteBuffer payload = {}) {
+  ByteBuffer result{static_cast<std::uint8_t>(tag & 0xff),
+                    static_cast<std::uint8_t>((tag >> 8) & 0xff)};
+  const auto size = static_cast<std::uint32_t>(payload.size());
+  for (int i = 0; i < 4; ++i) result.push_back(static_cast<std::uint8_t>(size >> (i * 8)));
+  result.insert(result.end(), payload.begin(), payload.end());
+  return result;
+}
+
+ByteBuffer vec3(double x, double y, double z) { return test::f64s({x, y, z}); }
+
+std::string hex_upper(const ByteBuffer& p) {
+  static char h[] = "0123456789ABCDEF";
+  std::string s;
+  for (auto b : p) {
+    s += h[b >> 4];
+    s += h[b & 15];
+  }
+  return s;
+}
+
+}  // namespace
+
+// ── linear dimensions ────────────────────────────────────────────────────
+
+TEST(PagesDimensions, UntitledFixtureHas13Dimensions) {
+  auto model = SkpFile::open(test::fixture("Untitled.skp")).parse();
+  EXPECT_EQ(model.dimensions.size(), 13u);
+  for (auto& d : model.dimensions) {
+    ASSERT_TRUE(d.a.has_value());
+    ASSERT_TRUE(d.b.has_value());
+    double dx = (*d.a)[0] - (*d.b)[0];
+    double dy = (*d.a)[1] - (*d.b)[1];
+    double dz = (*d.a)[2] - (*d.b)[2];
+    EXPECT_GT(dx * dx + dy * dy + dz * dz, 0.0);  // a real measured segment
+    EXPECT_TRUE(d.normal.has_value());
+    EXPECT_TRUE(d.plane_x.has_value());
+  }
+}
+
+TEST(PagesDimensions, DimensionFreePointsSynthetic) {
+  // A 5BCC record with two type-1 (free, world-space) connection points.
+  auto point_block = [](std::uint16_t wrap_tag, double x, double y, double z) {
+    auto inner = test::concat({tlv(0x5209, ByteBuffer{1, 0, 0, 0}), tlv(0x520a, vec3(x, y, z))});
+    return tlv(wrap_tag, tlv(0x5208, inner));
+  };
+
+  auto body = test::concat({
+      point_block(0x5bcd, 0.0, 0.0, 0.0), point_block(0x5bce, 100.0, 0.0, 0.0),
+      tlv(0x5bcf, vec3(1.0, 0.0, 0.0)),  // plane x-axis
+      tlv(0x5bd0, vec3(0.0, 0.0, 1.0)),  // plane normal
+      tlv(0x5bd2, test::f64s({15.5})),   // offset
+  });
+  auto blob = test::concat({ByteBuffer(8, 0), tlv(0x5bcc, body), ByteBuffer(8, 0)});
+
+  auto dims = parse_dimensions(blob, {}, {});
+  ASSERT_EQ(dims.size(), 1u);
+  auto& d = dims[0];
+  EXPECT_EQ(d.a, (Vec3{0.0, 0.0, 0.0}));
+  EXPECT_EQ(d.b, (Vec3{100.0, 0.0, 0.0}));
+  EXPECT_EQ(d.offset, 15.5);
+  ASSERT_TRUE(d.plane_x.has_value());
+  EXPECT_EQ(*d.plane_x, (Vec3{1.0, 0.0, 0.0}));
+  ASSERT_TRUE(d.normal.has_value());
+  EXPECT_EQ(*d.normal, (Vec3{0.0, 0.0, 1.0}));
+}
+
+TEST(PagesDimensions, DimensionConnectedPointResolvesThroughInstance) {
+  // A type-2 connection (vertex id + instance id): the vertex position is
+  // definition-local and must be lifted to world by the instance's
+  // transform. An unresolvable reference drops the dimension (fail-safe).
+  const ByteBuffer vid{0xaa, 0xbb, 0x01};
+  const ByteBuffer iid{0xcc, 0xdd, 0x02};
+
+  auto connected = [&](std::uint16_t wrap_tag) {
+    ByteBuffer id_len_prefixed{static_cast<std::uint8_t>(iid.size())};
+    id_len_prefixed.insert(id_len_prefixed.end(), iid.begin(), iid.end());
+    auto ref_tlv = tlv(0x53fc, test::concat({tlv(0x53fd, vid), tlv(0x53fe, id_len_prefixed)}));
+    auto inner = test::concat({tlv(0x5209, ByteBuffer{2, 0, 0, 0}), tlv(0x520b, ref_tlv)});
+    return tlv(wrap_tag, tlv(0x5208, inner));
+  };
+
+  auto free = [&](std::uint16_t wrap_tag) {
+    auto inner =
+        test::concat({tlv(0x5209, ByteBuffer{1, 0, 0, 0}), tlv(0x520a, vec3(0.0, 0.0, 0.0))});
+    return tlv(wrap_tag, tlv(0x5208, inner));
+  };
+
+  auto body = test::concat({connected(0x5bcd), free(0x5bce), tlv(0x5bd2, test::f64s({0.0}))});
+  auto blob = tlv(0x5bcc, body);
+
+  // Identity-ish transform that translates by (10, 20, 30).
+  std::vector<double> world{1, 0, 0, 0, 1, 0, 0, 0, 1, 10.0, 20.0, 30.0, 1.0};
+  std::map<std::string, Vec3> id2pos{{hex_upper(vid), Vec3{1.0, 2.0, 3.0}}};
+  std::map<std::string, std::vector<double>> inst_world{{hex_upper(iid), world}};
+
+  auto dims = parse_dimensions(blob, id2pos, inst_world);
+  ASSERT_EQ(dims.size(), 1u);
+  EXPECT_EQ(dims[0].a, (Vec3{11.0, 22.0, 33.0}));  // local + translation
+
+  // Same record, but the vertex id is unknown: the dimension is dropped.
+  auto empty_dims = parse_dimensions(blob, {}, {});
+  EXPECT_TRUE(empty_dims.empty());
+}
+
+// ── scenes (pages) ──────────────────────────────────────────────────────
+
+ByteBuffer page_record(const std::string& name, bool parallel, std::vector<int> hidden_ids = {}) {
+  auto cam = test::concat({
+      tlv(0x34bd, vec3(100.0, -200.0, 50.0)),  // eye
+      tlv(0x34be, vec3(0.0, 0.0, 0.0)),        // target
+      tlv(0x34bf, vec3(0.0, 0.0, 1.0)),        // up
+      tlv(0x34c4, test::f64s({35.0})),         // fov
+      tlv(0x34c2, ByteBuffer{static_cast<std::uint8_t>(parallel ? 0 : 1)}),
+      tlv(0x34c3, test::f64s({240.0})),  // ortho height
+  });
+  ByteBuffer hidden;
+  for (auto id : hidden_ids) {
+    hidden.push_back(1);
+    hidden.push_back(static_cast<std::uint8_t>(id));
+  }
+  auto body = test::concat({
+      tlv(0x6f54, tlv(0x6f55, test::bytes(name))),
+      tlv(0x714a, tlv(0x34bc, cam)),
+      tlv(0x7150, hidden),
+  });
+  return tlv(0x7148, body);
+}
+
+TEST(PagesDimensions, ParsePagesSynthetic) {
+  auto payload = tlv(0x6d60, tlv(0x6d61, test::concat({page_record("Planta", true, {2}),
+                                                       page_record("Vista 3D", false)})));
+  TlvNode node;
+  node.tag = "0702";
+  node.payload = payload;
+  auto pages = parse_pages(&node);
+
+  ASSERT_EQ(pages.size(), 2u);
+  EXPECT_EQ(pages[0].name, "Planta");
+  EXPECT_EQ(pages[1].name, "Vista 3D");
+  auto& planta = pages[0];
+  EXPECT_TRUE(planta.parallel);
+  EXPECT_EQ(planta.ortho_height, 240.0);
+  ASSERT_TRUE(planta.eye.has_value());
+  EXPECT_EQ(*planta.eye, (Vec3{100.0, -200.0, 50.0}));
+  ASSERT_TRUE(planta.up.has_value());
+  EXPECT_EQ(*planta.up, (Vec3{0.0, 0.0, 1.0}));
+  ASSERT_EQ(planta.hidden_layer_ids.size(), 1u);
+  EXPECT_EQ(planta.hidden_layer_ids[0], 2);
+  EXPECT_FALSE(pages[1].parallel);
+  EXPECT_EQ(pages[1].fov, 35.0);
+}
+
+TEST(PagesDimensions, PagesAbsentIsEmpty) { EXPECT_TRUE(parse_pages(nullptr).empty()); }
+
+TEST(PagesDimensions, FileWithNoPagesParsesWithEmptyPagesList) {
+  auto model = SkpFile::open(test::fixture("SU_File.skp")).parse();
+  EXPECT_TRUE(model.pages.empty());
+}
+}  // namespace openskp

--- a/packages/dart/lib/src/core.dart
+++ b/packages/dart/lib/src/core.dart
@@ -4,6 +4,7 @@ import 'errors.dart';
 import 'geometry.dart';
 import 'legacy.dart';
 import 'observability.dart';
+import 'pages_dimensions.dart';
 import 'tlv.dart';
 import 'vff.dart';
 
@@ -23,6 +24,8 @@ class RawParsed {
   // so every VFF layer defaults to visible.
   final Map<String, bool> layerHidden = {};
   final Map<int, String> layerIdToName = {};
+  final List<RawPage> pages = [];
+  final List<RawDimension> dimensions = [];
   final Map<int, String> materialIdToName = {};
   final Map<String, RawMaterial> materials = {};
   final Map<String, RawMaterial> materialsByFolder = {};
@@ -43,16 +46,19 @@ class Core {
     final header = Uint8List.sublistView(data, 0, headerLen);
 
     if (!Vff.hasValidHeader(header)) {
-      throw SkpParseException('Not a valid SketchUp file (bad header magic)', stage: 'header');
+      throw SkpParseException('Not a valid SketchUp file (bad header magic)',
+          stage: 'header');
     }
 
     if (Legacy.isLegacy(data)) {
-      emitLog(options, SkpLogLevel.debug, 'Detected legacy MFC container; routing to legacy walker');
+      emitLog(options, SkpLogLevel.debug,
+          'Detected legacy MFC container; routing to legacy walker');
       return Legacy.fullParseLegacy(data, options);
     }
 
     final version = Vff.extractVersion(header);
-    emitLog(options, SkpLogLevel.debug, 'Detected version $version (VFF/ZIP container)');
+    emitLog(options, SkpLogLevel.debug,
+        'Detected version $version (VFF/ZIP container)');
 
     final pkPos = Vff.findZipOffset(data);
     if (pkPos < 0) {
@@ -75,7 +81,8 @@ class Core {
           mat = Geometry.parseMaterialXml(zip, name, entry.content, options);
         } catch (e) {
           mat = null;
-          emitLog(options, SkpLogLevel.debug, 'Failed to parse material.xml $name: $e');
+          emitLog(options, SkpLogLevel.debug,
+              'Failed to parse material.xml $name: $e');
         }
         if (mat != null) {
           final parts = name.split('/');
@@ -105,15 +112,18 @@ class Core {
       }
     }
 
-    emitLog(options, SkpLogLevel.debug, 'Parsed ${materials.length} materials, ${styles.length} styles');
+    emitLog(options, SkpLogLevel.debug,
+        'Parsed ${materials.length} materials, ${styles.length} styles');
 
     final modelDatEntry = zip.findFile('model.dat');
     if (modelDatEntry == null) {
-      throw SkpParseException('model.dat not found in ZIP container', stage: 'zip_extract');
+      throw SkpParseException('model.dat not found in ZIP container',
+          stage: 'zip_extract');
     }
     Vff.validateEntrySize(modelDatEntry);
     final modelDat = modelDatEntry.content;
-    emitLog(options, SkpLogLevel.debug, 'Read model.dat: ${modelDat.length} bytes');
+    emitLog(
+        options, SkpLogLevel.debug, 'Read model.dat: ${modelDat.length} bytes');
 
     // Walk the TLV tree one top-level record at a time (instead of building
     // the whole file's tree at once) so peak memory is bounded by the
@@ -127,19 +137,29 @@ class Core {
     final materialIdToName = <int, String>{};
     final defsDictRaw = <int, RawDefinition>{};
     final rootBuilder = GeometryBuilder();
+    final vertexPositions = <String, (double, double, double)>{};
+    final instanceWorld = <String, List<double>>{};
+    TlvNode? pageNode;
 
-    for (final (index, total, el) in Tlv.iterTopLevelLazy(modelDat, 0, modelDat.length, Tlv.containerTags)) {
+    for (final (index, total, el) in Tlv.iterTopLevelLazy(
+        modelDat, 0, modelDat.length, Tlv.containerTags)) {
       try {
         Geometry.collectLayers([el], layerIdToName);
         Geometry.collectMaterialIds([el], materialIdToName);
         Geometry.collectDefs([el], defsDictRaw);
+        scanVertexPositions(el, vertexPositions);
+        scanInstanceTransforms(el, instanceWorld);
+        pageNode ??= findPageNode(el);
         if (el.tag == 'F601') {
           Geometry.extractGeometryFromNodes(el.children, rootBuilder);
         }
       } catch (e) {
         throw SkpParseException(
           'Failed while processing top-level record: $e',
-          stage: 'tlv_walk', recordIndex: index, totalRecords: total, tag: el.tag,
+          stage: 'tlv_walk',
+          recordIndex: index,
+          totalRecords: total,
+          tag: el.tag,
           cause: e,
         );
       }
@@ -147,12 +167,14 @@ class Core {
       // garbage collection before the next top-level record is built.
       if (index % progressInterval == 0 || index == total - 1) {
         emitProgress(options, 'tlv_walk', index + 1, total);
-        emitLog(options, SkpLogLevel.debug, 'Processed ${index + 1}/$total top-level records');
+        emitLog(options, SkpLogLevel.debug,
+            'Processed ${index + 1}/$total top-level records');
       }
     }
 
     emitLog(
-      options, SkpLogLevel.info,
+      options,
+      SkpLogLevel.info,
       'Parse complete: ${defsDictRaw.length} defs (${(sw.elapsedMilliseconds / 1000).toStringAsFixed(2)}s)',
     );
 
@@ -185,6 +207,9 @@ class Core {
       ..layerColors.addAll(layerColors)
       ..layerHidden.addAll(layerHidden)
       ..layerIdToName.addAll(layerIdToName)
+      ..pages.addAll(parsePages(pageNode))
+      ..dimensions
+          .addAll(parseDimensions(modelDat, vertexPositions, instanceWorld))
       ..materialIdToName.addAll(materialIdToName)
       ..materials.addAll(materials)
       ..materialsByFolder.addAll(materialsByFolder)

--- a/packages/dart/lib/src/model.dart
+++ b/packages/dart/lib/src/model.dart
@@ -195,13 +195,81 @@ class TextEntity {
   });
 }
 
+/// A linear dimension (SketchUp's Dimension tool).
+///
+/// The legacy (pre-2021) reader recovers only [text]/[hidden]. The VFF
+/// reader (2021+) recovers the full geometry - see [SkpModel.dimensions]
+/// for the model-level, world-space list.
 class Dimension {
+  /// The displayed text. Empty when the dimension shows its auto-computed
+  /// measured value (the caller formats `|b - a|`).
   final String text;
   final bool hidden;
+
+  /// First measured point (x, y, z) in inches (world space), or null when
+  /// only the text was recovered.
+  final (double, double, double)? a;
+
+  /// Second measured point.
+  final (double, double, double)? b;
+
+  /// Offset distance (inches) - how far the dimension line sits from the
+  /// a-b segment, along the in-plane perpendicular.
+  final double offset;
+
+  /// The dimension plane's x-axis, or null.
+  final (double, double, double)? planeX;
+
+  /// The dimension plane's normal, or null.
+  final (double, double, double)? normal;
 
   const Dimension({
     this.text = '',
     this.hidden = false,
+    this.a,
+    this.b,
+    this.offset = 0.0,
+    this.planeX,
+    this.normal,
+  });
+}
+
+/// A saved scene (SketchUp's "Scenes" tabs; "pages" in the SDK).
+class Page {
+  /// Scene name as shown on its tab.
+  final String name;
+
+  /// Camera position (x, y, z) in inches, or null.
+  final (double, double, double)? eye;
+
+  /// Point the camera looks at, in inches.
+  final (double, double, double)? target;
+
+  /// Camera up vector.
+  final (double, double, double)? up;
+
+  /// Field of view in degrees (SketchUp default 35).
+  final double fov;
+
+  /// True when the scene uses parallel (orthographic) projection; [fov]
+  /// still holds the stored perspective angle.
+  final bool parallel;
+
+  /// Visible height in inches when [parallel].
+  final double orthoHeight;
+
+  /// Names of the layers this scene hides.
+  final List<String> hiddenLayers;
+
+  const Page({
+    this.name = '',
+    this.eye,
+    this.target,
+    this.up,
+    this.fov = 35.0,
+    this.parallel = false,
+    this.orthoHeight = 0.0,
+    this.hiddenLayers = const [],
   });
 }
 
@@ -253,6 +321,16 @@ class SkpModel {
   Definition root = Definition(name: 'ROOT_MODEL');
 
   final List<Layer> layers = [];
+
+  /// The file's saved scenes (VFF files; classic pre-2021 files import
+  /// with none).
+  final List<Page> pages = [];
+
+  /// Model-level linear dimensions with world-space endpoints (VFF
+  /// files). Legacy files surface text-only dimensions per definition
+  /// instead ([Definition.dimensions]).
+  final List<Dimension> dimensions = [];
+
   final List<Material> materials = [];
 
   /// Join table for Face.materialId / Instance.materialId: TLV material ID

--- a/packages/dart/lib/src/pages_dimensions.dart
+++ b/packages/dart/lib/src/pages_dimensions.dart
@@ -1,0 +1,354 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'geometry.dart';
+import 'tlv.dart';
+import 'transforms.dart';
+
+/// VFF (2021+) scenes ("pages") and linear dimensions. Ported from Python's
+/// _core.py (PR #190) - see that module's _scan_vertex_positions /
+/// _scan_instance_transforms / _parse_dimensions / _find_page_node /
+/// _parse_pages for the byte-format details this file mirrors.
+
+class RawPage {
+  String name = '';
+  (double, double, double)? eye;
+  (double, double, double)? target;
+  (double, double, double)? up;
+  double fov = 35.0;
+  bool parallel = false;
+  double orthoHeight = 0.0;
+  final List<int> hiddenLayerIds = [];
+}
+
+class RawDimension {
+  (double, double, double) a;
+  (double, double, double) b;
+  double offset = 0.0;
+  (double, double, double)? planeX;
+  (double, double, double)? normal;
+  String text = '';
+
+  RawDimension({required this.a, required this.b});
+}
+
+// ── flat TLV, integer tags ────────────────────────────────────────────────
+// A second, deliberately separate flat-TLV reader from Tlv.parseFlat/
+// findFlat: those use the STRING byte-order tag convention the main tree
+// already relies on (e.g. "C409"), while the sub-records this feature reads
+// (5208, 520A, 53FC, 5BCD, ...) are most directly and safely ported from
+// Python's own _tlv_items/_tlv_find (which read the tag as a little-endian
+// uint16) by keeping the SAME integer convention here, copying Python's
+// numeric constants byte-for-byte rather than hand-converting each one to
+// the swapped string form.
+
+class _FlatTlvItem {
+  final int tag;
+  final Uint8List payload;
+  _FlatTlvItem(this.tag, this.payload);
+}
+
+List<_FlatTlvItem>? _tlvItemsInt(Uint8List? buf) {
+  if (buf == null) return null;
+  final items = <_FlatTlvItem>[];
+  int off = 0;
+  final n = buf.length;
+  while (off < n) {
+    if (off + 6 > n) return null;
+    final tag = buf[off] | (buf[off + 1] << 8);
+    final ln = Tlv.readU32(buf, off + 2);
+    if (tag == 0 || off + 6 + ln > n) return null;
+    items.add(
+        _FlatTlvItem(tag, Uint8List.sublistView(buf, off + 6, off + 6 + ln)));
+    off += 6 + ln;
+  }
+  return items;
+}
+
+Uint8List? _tlvFindInt(List<_FlatTlvItem>? items, int tag) {
+  if (items == null) return null;
+  for (final it in items) {
+    if (it.tag == tag) return it.payload;
+  }
+  return null;
+}
+
+Uint8List _stripDe05(Uint8List p) {
+  if (p.length >= 2 && p[0] == 0xDE && p[1] == 0x05) {
+    final idlen = Tlv.readU32(p, 2);
+    return Uint8List.sublistView(p, 6, 6 + idlen);
+  }
+  return p;
+}
+
+int _findBytes(Uint8List data, Uint8List needle, int start) {
+  final nlen = needle.length;
+  final limit = data.length - nlen;
+  outer:
+  for (int i = start; i <= limit; i++) {
+    for (int j = 0; j < nlen; j++) {
+      if (data[i + j] != needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+/// Accumulate every vertex's persistent id (hex) -> (x, y, z) inches. A
+/// vertex is a "C409" record: "DC05" holds its persistent id (the "DE05"
+/// var-int payload), "C509" its 3xf64 position. Dimension connection points
+/// reference geometry by this id. Called once per top-level record -
+/// [Core.fullParse] streams the TLV tree and never holds it whole.
+void scanVertexPositions(
+    TlvNode top, Map<String, (double, double, double)> id2pos) {
+  void walk(List<TlvNode> nodes) {
+    for (final el in nodes) {
+      if (el.tag == 'C409') {
+        final dc05 = Geometry.findChildTag(el.children, 'DC05');
+        final c509 = Geometry.findChildTag(el.children, 'C509');
+        if (dc05 != null && c509 != null && c509.payload.length == 24) {
+          final idb = _stripDe05(dc05.payload);
+          id2pos[Tlv.toHexUpper(idb)] = (
+            Tlv.readF64(c509.payload, 0),
+            Tlv.readF64(c509.payload, 8),
+            Tlv.readF64(c509.payload, 16),
+          );
+        }
+      }
+      if (el.children.isNotEmpty) walk(el.children);
+    }
+  }
+
+  walk([top]);
+}
+
+/// Accumulate each instance's persistent id (hex) -> its WORLD transform (a
+/// 13-double matrix, or an empty list for the identity/no-transform case),
+/// walking the instance tree and composing parent x local at every "6419".
+/// Per top-level record, like [scanVertexPositions] - an instance chain
+/// never crosses top-level records.
+///
+/// A dimension connects to geometry INSIDE a placed component; its
+/// connection reference names the vertex AND the instance holding it. The
+/// vertex position is definition-local, so it must be lifted to world by
+/// the instance's transform for the dimension to land where the author
+/// drew it.
+void scanInstanceTransforms(TlvNode top, Map<String, List<double>> world) {
+  void walk(List<TlvNode> nodes, List<double> parent) {
+    for (final el in nodes) {
+      if (el.tag == '6419') {
+        final d007 = Geometry.findChildTag(el.children, 'D007');
+        final dc05 =
+            d007 != null ? Geometry.findChildTag(d007.children, 'DC05') : null;
+        final iid =
+            dc05 != null ? Tlv.toHexUpper(_stripDe05(dc05.payload)) : null;
+
+        final m = Geometry.findChildTag(el.children, '6619');
+        List<double>? mat;
+        if (m != null && m.payload.length == 104) {
+          mat = [for (int i = 0; i < 13; i++) Tlv.readF64(m.payload, i * 8)];
+        }
+        final here =
+            mat != null ? Transforms.multiplyMatrices(parent, mat) : parent;
+        if (iid != null) world[iid] = here;
+        walk(el.children, here);
+      } else if (el.children.isNotEmpty) {
+        walk(el.children, parent);
+      }
+    }
+  }
+
+  walk([top], const []);
+}
+
+/// Linear dimensions (SketchUp's Dimension tool).
+///
+/// A dimension entity is a "5BCC" record (raw bytes cc 5b) holding:
+///
+/// * 5BCD / 5BCE - the two connection points. Each wraps a 5208 whose 5209
+///   is the connection TYPE (1 = a free explicit point in 520A, already
+///   world space; 2 = connected to geometry, 520A is zero and 520B -> 53FC
+///   names the target: 53FD = the vertex by persistent id, 53FE = a
+///   length-prefixed persistent id of the INSTANCE holding it - the vertex
+///   position is definition-local, so it is lifted to world by that
+///   instance's transform).
+/// * 5BCF - the dimension plane's x-axis; 5BD0 - its normal.
+/// * 5BD2 - the offset distance (inches): how far the dimension line sits
+///   from the measured segment, along the in-plane perpendicular.
+///
+/// The measured value is auto-computed from the two points (no cached text
+/// on the samples seen), so callers format it themselves. Endpoints come
+/// out in WORLD space (inches). A connection point that cannot be resolved
+/// drops the whole dimension (fail-safe).
+List<RawDimension> parseDimensions(
+  Uint8List modelDat,
+  Map<String, (double, double, double)> id2pos,
+  Map<String, List<double>> instWorld,
+) {
+  final dims = <RawDimension>[];
+  final needle = Uint8List.fromList([0xCC, 0x5B]);
+  int i = 0;
+  final n = modelDat.length;
+
+  (double, double, double)? point(Uint8List? blockPayload) {
+    if (blockPayload == null) return null;
+    final blk = _tlvFindInt(_tlvItemsInt(blockPayload), 0x5208);
+    if (blk == null) return null;
+    final sub = _tlvItemsInt(blk);
+    final typB = _tlvFindInt(sub, 0x5209);
+    final typ =
+        (typB != null && typB.length == 4) ? Tlv.readU32(typB, 0) : null;
+    if (typ == 1) {
+      final pos = _tlvFindInt(sub, 0x520A);
+      if (pos == null || pos.length != 24) return null;
+      return (Tlv.readF64(pos, 0), Tlv.readF64(pos, 8), Tlv.readF64(pos, 16));
+    }
+    // type 2: resolve the geometry reference (vertex + instance).
+    final refB = _tlvFindInt(sub, 0x520B);
+    final f53fc = refB != null ? _tlvFindInt(_tlvItemsInt(refB), 0x53FC) : null;
+    final fi = f53fc != null ? _tlvItemsInt(f53fc) : null;
+    final vid = _tlvFindInt(fi, 0x53FD);
+    final iid = _tlvFindInt(fi, 0x53FE);
+    if (vid == null) return null;
+    final local = id2pos[Tlv.toHexUpper(vid)];
+    if (local == null) return null;
+    if (iid != null &&
+        iid.isNotEmpty &&
+        iid[0] > 0 &&
+        1 + iid[0] <= iid.length) {
+      final idBytes = Uint8List.sublistView(iid, 1, 1 + iid[0]);
+      final w = instWorld[Tlv.toHexUpper(idBytes)];
+      if (w != null && w.isNotEmpty) {
+        return Transforms.transformPoint(w, local);
+      }
+    }
+    return local; // model-root vertex - already world
+  }
+
+  while (true) {
+    final j = _findBytes(modelDat, needle, i);
+    if (j < 0) break;
+    i = j + 1;
+    if (j + 6 > n) continue;
+    final ln = Tlv.readU32(modelDat, j + 2);
+    if (ln < 40 || j + 6 + ln > n) continue;
+    final bodyBytes = Uint8List.sublistView(modelDat, j + 6, j + 6 + ln);
+    final body = _tlvItemsInt(bodyBytes);
+    if (body == null) continue;
+    bool has5Bcd = false, has5Bce = false;
+    for (final it in body) {
+      if (it.tag == 0x5BCD) has5Bcd = true;
+      if (it.tag == 0x5BCE) has5Bce = true;
+    }
+    if (!has5Bcd || !has5Bce) continue;
+
+    final a = point(_tlvFindInt(body, 0x5BCD));
+    final b = point(_tlvFindInt(body, 0x5BCE));
+    if (a == null || b == null) continue;
+
+    final xaxisB = _tlvFindInt(body, 0x5BCF);
+    final normalB = _tlvFindInt(body, 0x5BD0);
+    final offB = _tlvFindInt(body, 0x5BD2);
+
+    dims.add(RawDimension(a: a, b: b)
+      ..planeX = (xaxisB != null && xaxisB.length == 24)
+          ? (
+              Tlv.readF64(xaxisB, 0),
+              Tlv.readF64(xaxisB, 8),
+              Tlv.readF64(xaxisB, 16)
+            )
+          : null
+      ..normal = (normalB != null && normalB.length == 24)
+          ? (
+              Tlv.readF64(normalB, 0),
+              Tlv.readF64(normalB, 8),
+              Tlv.readF64(normalB, 16)
+            )
+          : null
+      ..offset =
+          (offB != null && offB.length == 8) ? Tlv.readF64(offB, 0) : 0.0);
+  }
+  return dims;
+}
+
+/// Return the "0702" scenes node inside top's subtree, or null. Called per
+/// top-level record; retaining the (small) 0702 subtree is the only thing
+/// kept alive past the streaming loop.
+TlvNode? findPageNode(TlvNode top) {
+  return Geometry.findChildTag([top], '0702');
+}
+
+/// Scenes ("pages"). The 0702 node's payload nests 6D60 > 6D61 > one 7148
+/// record per page:
+///
+/// * 6F54 > 6F55 - page name (UTF-8)
+/// * 714A > 34BC - camera: 34BD eye, 34BE target, 34BF up (3xf64, inches),
+///   34C4 field of view (degrees), 34C2 u8 = PERSPECTIVE flag (00 =
+///   parallel projection - calibrated against the bundled scene
+///   thumbnails: parallel plans/elevations carry 00 and their 34C3 visible
+///   height matches the thumbnail framing exactly, while perspective
+///   scenes carry 01 with a stale 34C3), 34C3 f64 = visible height when
+///   parallel (inches)
+/// * 7150 - layers hidden in this page: (u8 length, var-int layer id) runs
+List<RawPage> parsePages(TlvNode? node) {
+  final pages = <RawPage>[];
+  if (node == null) return pages;
+
+  (double, double, double)? vec3(Uint8List? p) => (p != null && p.length == 24)
+      ? (Tlv.readF64(p, 0), Tlv.readF64(p, 8), Tlv.readF64(p, 16))
+      : null;
+
+  final t60Items = _tlvItemsInt(node.payload);
+  if (t60Items == null) return pages;
+  for (final it60 in t60Items) {
+    if (it60.tag != 0x6D60) continue;
+    final t61Items = _tlvItemsInt(it60.payload);
+    if (t61Items == null) continue;
+    for (final it61 in t61Items) {
+      if (it61.tag != 0x6D61) continue;
+      final t48Items = _tlvItemsInt(it61.payload);
+      if (t48Items == null) continue;
+      for (final it48 in t48Items) {
+        if (it48.tag != 0x7148) continue;
+        final items = _tlvItemsInt(it48.payload);
+        if (items == null) continue;
+
+        final page = RawPage();
+
+        final head = _tlvItemsInt(_tlvFindInt(items, 0x6F54));
+        final name = _tlvFindInt(head, 0x6F55);
+        if (name != null && name.isNotEmpty) {
+          page.name = utf8.decode(name, allowMalformed: true);
+        }
+
+        final camWrap = _tlvItemsInt(_tlvFindInt(items, 0x714A));
+        final cam =
+            camWrap != null ? _tlvItemsInt(_tlvFindInt(camWrap, 0x34BC)) : null;
+        if (cam != null) {
+          page.eye = vec3(_tlvFindInt(cam, 0x34BD));
+          page.target = vec3(_tlvFindInt(cam, 0x34BE));
+          page.up = vec3(_tlvFindInt(cam, 0x34BF));
+          final fov = _tlvFindInt(cam, 0x34C4);
+          if (fov != null && fov.length == 8) page.fov = Tlv.readF64(fov, 0);
+          final flag = _tlvFindInt(cam, 0x34C2);
+          page.parallel = flag != null && flag.isNotEmpty && flag[0] == 0;
+          final height = _tlvFindInt(cam, 0x34C3);
+          if (height != null && height.length == 8)
+            page.orthoHeight = Tlv.readF64(height, 0);
+        }
+
+        final hidden = _tlvFindInt(items, 0x7150);
+        int off = 0;
+        while (hidden != null && off + 1 <= hidden.length) {
+          final ln = hidden[off];
+          if (ln == 0 || off + 1 + ln > hidden.length) break;
+          page.hiddenLayerIds.add(Tlv.parseVarInt(hidden, off + 1, ln));
+          off += 1 + ln;
+        }
+
+        if (page.eye != null && page.target != null) pages.add(page);
+      }
+    }
+  }
+  return pages;
+}

--- a/packages/dart/lib/src/parser.dart
+++ b/packages/dart/lib/src/parser.dart
@@ -92,7 +92,38 @@ class SkpFile {
     for (final entry in parsed.layerColors.entries) {
       final (r, g, b) = entry.value;
       final hidden = parsed.layerHidden[entry.key] ?? false;
-      model.layers.add(Layer(name: entry.key, colorR: r, colorG: g, colorB: b, hidden: hidden));
+      model.layers.add(Layer(
+          name: entry.key, colorR: r, colorG: g, colorB: b, hidden: hidden));
+    }
+
+    // Convert pages (saved scenes) - hidden layer ids resolve to names;
+    // unknown ids (stale refs) are dropped.
+    for (final pg in parsed.pages) {
+      model.pages.add(Page(
+        name: pg.name,
+        eye: pg.eye,
+        target: pg.target,
+        up: pg.up,
+        fov: pg.fov,
+        parallel: pg.parallel,
+        orthoHeight: pg.orthoHeight,
+        hiddenLayers: [
+          for (final id in pg.hiddenLayerIds)
+            if (parsed.layerIdToName[id] != null) parsed.layerIdToName[id]!
+        ],
+      ));
+    }
+
+    // Convert model-level linear dimensions (VFF; world space).
+    for (final dm in parsed.dimensions) {
+      model.dimensions.add(Dimension(
+        a: dm.a,
+        b: dm.b,
+        offset: dm.offset,
+        planeX: dm.planeX,
+        normal: dm.normal,
+        text: dm.text,
+      ));
     }
 
     final matForData = <RawMaterial, Material>{};

--- a/packages/dart/test/pages_dimensions_test.dart
+++ b/packages/dart/test/pages_dimensions_test.dart
@@ -1,0 +1,224 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:openskp/openskp.dart';
+import 'package:openskp/src/pages_dimensions.dart';
+import 'package:openskp/src/tlv.dart';
+import 'package:test/test.dart';
+
+/// VFF scenes ("pages") and linear dimensions - ported from Python's
+/// test_pages_dimensions.py (PR #190).
+///
+/// Dimensions are exercised against the repository's own Untitled.skp
+/// fixture (drawn in SketchUp 2025, it carries 13 linear dimensions); scenes
+/// have no fixture yet, so their parser is exercised on a synthetic "0702"
+/// record byte-for-byte shaped like the real ones (the layout was decoded
+/// from production survey files and calibrated against the scene thumbnails
+/// SketchUp embeds in the .skp itself).
+
+// ── helpers: build TLV runs in the flat (u16-LE tag, u32 len) form ────────
+
+Uint8List tlv(int tag, Uint8List payload) {
+  final result = Uint8List(6 + payload.length);
+  result[0] = tag & 0xFF;
+  result[1] = (tag >> 8) & 0xFF;
+  final len = payload.length;
+  result[2] = len & 0xFF;
+  result[3] = (len >> 8) & 0xFF;
+  result[4] = (len >> 16) & 0xFF;
+  result[5] = (len >> 24) & 0xFF;
+  result.setRange(6, 6 + payload.length, payload);
+  return result;
+}
+
+Uint8List f64le(double v) {
+  final buf = Uint8List(8);
+  ByteData.sublistView(buf).setFloat64(0, v, Endian.little);
+  return buf;
+}
+
+Uint8List u32le(int v) {
+  final buf = Uint8List(4);
+  ByteData.sublistView(buf).setUint32(0, v, Endian.little);
+  return buf;
+}
+
+Uint8List vec3(double x, double y, double z) =>
+    concatBytes([f64le(x), f64le(y), f64le(z)]);
+
+Uint8List concatBytes(List<Uint8List> parts) {
+  final total = parts.fold<int>(0, (s, p) => s + p.length);
+  final result = Uint8List(total);
+  int off = 0;
+  for (final p in parts) {
+    result.setRange(off, off + p.length, p);
+    off += p.length;
+  }
+  return result;
+}
+
+void main() {
+  final fixturesDir = '${Directory.current.path}/test/fixtures';
+
+  group('linear dimensions', () {
+    test('the Untitled.skp fixture has 13 dimensions', () {
+      final model = SkpFile.open('$fixturesDir/Untitled.skp').parse();
+      expect(model.dimensions.length, 13);
+      for (final d in model.dimensions) {
+        expect(d.a, isNotNull);
+        expect(d.b, isNotNull);
+        final (ax, ay, az) = d.a!;
+        final (bx, by, bz) = d.b!;
+        final dx = ax - bx, dy = ay - by, dz = az - bz;
+        expect(dx * dx + dy * dy + dz * dz,
+            greaterThan(0.0)); // a real measured segment
+        expect(d.normal, isNotNull);
+        expect(d.planeX, isNotNull);
+      }
+    });
+
+    test('parses two free (world-space) connection points', () {
+      // A 5BCC record with two type-1 (free, world-space) connection points.
+      Uint8List pointBlock(int wrapTag, double x, double y, double z) {
+        final inner =
+            concatBytes([tlv(0x5209, u32le(1)), tlv(0x520A, vec3(x, y, z))]);
+        return tlv(wrapTag, tlv(0x5208, inner));
+      }
+
+      final body = concatBytes([
+        pointBlock(0x5BCD, 0.0, 0.0, 0.0),
+        pointBlock(0x5BCE, 100.0, 0.0, 0.0),
+        tlv(0x5BCF, vec3(1.0, 0.0, 0.0)), // plane x-axis
+        tlv(0x5BD0, vec3(0.0, 0.0, 1.0)), // plane normal
+        tlv(0x5BD2, f64le(15.5)), // offset
+      ]);
+      final blob = concatBytes([Uint8List(8), tlv(0x5BCC, body), Uint8List(8)]);
+
+      final dims = parseDimensions(blob, {}, {});
+      expect(dims.length, 1);
+      final d = dims[0];
+      expect(d.a, (0.0, 0.0, 0.0));
+      expect(d.b, (100.0, 0.0, 0.0));
+      expect(d.offset, 15.5);
+      expect(d.planeX, (1.0, 0.0, 0.0));
+      expect(d.normal, (0.0, 0.0, 1.0));
+    });
+
+    test(
+        'resolves a connected point through its instance transform, and drops an unresolvable one',
+        () {
+      // A type-2 connection (vertex id + instance id): the vertex position
+      // is definition-local and must be lifted to world by the instance's
+      // transform. An unresolvable reference drops the dimension
+      // (fail-safe).
+      final vid = Uint8List.fromList([0xAA, 0xBB, 0x01]);
+      final iid = Uint8List.fromList([0xCC, 0xDD, 0x02]);
+
+      Uint8List connected(int wrapTag) {
+        final idLenPrefixed = concatBytes([
+          Uint8List.fromList([iid.length]),
+          iid,
+        ]);
+        final refTlv = tlv(0x53FC,
+            concatBytes([tlv(0x53FD, vid), tlv(0x53FE, idLenPrefixed)]));
+        final inner = concatBytes([tlv(0x5209, u32le(2)), tlv(0x520B, refTlv)]);
+        return tlv(wrapTag, tlv(0x5208, inner));
+      }
+
+      Uint8List free(int wrapTag) {
+        final inner = concatBytes(
+            [tlv(0x5209, u32le(1)), tlv(0x520A, vec3(0.0, 0.0, 0.0))]);
+        return tlv(wrapTag, tlv(0x5208, inner));
+      }
+
+      final body = concatBytes(
+          [connected(0x5BCD), free(0x5BCE), tlv(0x5BD2, f64le(0.0))]);
+      final blob = tlv(0x5BCC, body);
+
+      // Identity-ish transform that translates by (10, 20, 30).
+      final world = <double>[
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        1.0,
+        10.0,
+        20.0,
+        30.0,
+        1.0
+      ];
+      final id2pos = {Tlv.toHexUpper(vid): (1.0, 2.0, 3.0)};
+      final instWorld = {Tlv.toHexUpper(iid): world};
+
+      final dims = parseDimensions(blob, id2pos, instWorld);
+      expect(dims.length, 1);
+      expect(dims[0].a, (11.0, 22.0, 33.0)); // local + translation
+
+      // Same record, but the vertex id is unknown: the dimension is dropped.
+      final emptyDims = parseDimensions(blob, {}, {});
+      expect(emptyDims, isEmpty);
+    });
+  });
+
+  group('scenes (pages)', () {
+    Uint8List pageRecord(String name, bool parallel,
+        [List<int> hiddenIds = const []]) {
+      final cam = concatBytes([
+        tlv(0x34BD, vec3(100.0, -200.0, 50.0)), // eye
+        tlv(0x34BE, vec3(0.0, 0.0, 0.0)), // target
+        tlv(0x34BF, vec3(0.0, 0.0, 1.0)), // up
+        tlv(0x34C4, f64le(35.0)), // fov
+        tlv(0x34C2, Uint8List.fromList([parallel ? 0 : 1])),
+        tlv(0x34C3, f64le(240.0)), // ortho height
+      ]);
+      final hiddenParts = [
+        for (final i in hiddenIds) Uint8List.fromList([1, i])
+      ];
+      final hidden = concatBytes(hiddenParts);
+      final body = concatBytes([
+        tlv(0x6F54, tlv(0x6F55, Uint8List.fromList(utf8.encode(name)))),
+        tlv(0x714A, tlv(0x34BC, cam)),
+        tlv(0x7150, hidden),
+      ]);
+      return tlv(0x7148, body);
+    }
+
+    test('parses a synthetic 0702 record', () {
+      final payload = tlv(
+          0x6D60,
+          tlv(
+              0x6D61,
+              concatBytes([
+                pageRecord('Planta', true, [2]),
+                pageRecord('Vista 3D', false)
+              ])));
+      final node = TlvNode(
+          offset: 0, tag: '0702', size: payload.length, payload: payload);
+      final pages = parsePages(node);
+
+      expect(pages.map((p) => p.name).toList(), ['Planta', 'Vista 3D']);
+      final planta = pages[0];
+      expect(planta.parallel, isTrue);
+      expect(planta.orthoHeight, 240.0);
+      expect(planta.eye, (100.0, -200.0, 50.0));
+      expect(planta.up, (0.0, 0.0, 1.0));
+      expect(planta.hiddenLayerIds, [2]);
+      expect(pages[1].parallel, isFalse);
+      expect(pages[1].fov, 35.0);
+    });
+
+    test('is empty when absent', () {
+      expect(parsePages(null), isEmpty);
+    });
+
+    test('a file with no pages parses with an empty pages list', () {
+      final model = SkpFile.open('$fixturesDir/SU_File.skp').parse();
+      expect(model.pages, isEmpty);
+    });
+  });
+}

--- a/packages/dotnet/OpenSkp.Tests/PagesDimensionsTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/PagesDimensionsTests.cs
@@ -1,0 +1,201 @@
+using System;
+using System.Collections.Generic;
+using OpenSkp;
+using Xunit;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>VFF scenes ("pages") and linear dimensions - ported from
+    /// Python's test_pages_dimensions.py (PR #190).
+    ///
+    /// Dimensions are exercised against the repository's own Untitled.skp
+    /// fixture (drawn in SketchUp 2025, it carries 13 linear dimensions);
+    /// scenes have no fixture yet, so their parser is exercised on a
+    /// synthetic "0702" record byte-for-byte shaped like the real ones (the
+    /// layout was decoded from production survey files and calibrated
+    /// against the scene thumbnails SketchUp embeds in the .skp itself).</summary>
+    public class PagesDimensionsTests
+    {
+        // ── helpers: build TLV runs in the flat (u16-LE tag, u32 len) form ──
+
+        private static byte[] Tlv(ushort tag, byte[] payload)
+        {
+            var result = new byte[6 + payload.Length];
+            result[0] = (byte)(tag & 0xFF);
+            result[1] = (byte)(tag >> 8);
+            uint len = (uint)payload.Length;
+            result[2] = (byte)(len & 0xFF);
+            result[3] = (byte)((len >> 8) & 0xFF);
+            result[4] = (byte)((len >> 16) & 0xFF);
+            result[5] = (byte)((len >> 24) & 0xFF);
+            Array.Copy(payload, 0, result, 6, payload.Length);
+            return result;
+        }
+
+        private static byte[] Vec3(double x, double y, double z)
+        {
+            var result = new byte[24];
+            Array.Copy(BitConverter.GetBytes(x), 0, result, 0, 8);
+            Array.Copy(BitConverter.GetBytes(y), 0, result, 8, 8);
+            Array.Copy(BitConverter.GetBytes(z), 0, result, 16, 8);
+            return result;
+        }
+
+        private static byte[] Concat(params byte[][] parts)
+        {
+            int total = 0;
+            foreach (var p in parts) total += p.Length;
+            var result = new byte[total];
+            int off = 0;
+            foreach (var p in parts) { Array.Copy(p, 0, result, off, p.Length); off += p.Length; }
+            return result;
+        }
+
+        private static string Hex(byte[] b) => BitConverter.ToString(b).Replace("-", "");
+
+        // ── linear dimensions ────────────────────────────────────────────
+
+        [Fact]
+        public void UntitledFixtureHas13Dimensions()
+        {
+            var model = SkpFile.Open(System.IO.Path.Combine("fixtures", "Untitled.skp"));
+            Assert.Equal(13, model.Dimensions.Count);
+            foreach (var d in model.Dimensions)
+            {
+                Assert.NotNull(d.A);
+                Assert.NotNull(d.B);
+                var dx = d.A!.Value.X - d.B!.Value.X;
+                var dy = d.A.Value.Y - d.B.Value.Y;
+                var dz = d.A.Value.Z - d.B.Value.Z;
+                Assert.True(Math.Sqrt(dx * dx + dy * dy + dz * dz) > 0.0); // a real measured segment
+                Assert.NotNull(d.Normal);
+                Assert.NotNull(d.PlaneX);
+            }
+        }
+
+        [Fact]
+        public void DimensionFreePointsSynthetic()
+        {
+            // A 5BCC record with two type-1 (free, world-space) connection points.
+            byte[] PointBlock(ushort wrapTag, double x, double y, double z)
+            {
+                var inner = Concat(Tlv(0x5209, BitConverter.GetBytes((uint)1)), Tlv(0x520A, Vec3(x, y, z)));
+                return Tlv(wrapTag, Tlv(0x5208, inner));
+            }
+
+            var body = Concat(
+                PointBlock(0x5BCD, 0.0, 0.0, 0.0),
+                PointBlock(0x5BCE, 100.0, 0.0, 0.0),
+                Tlv(0x5BCF, Vec3(1.0, 0.0, 0.0)),   // plane x-axis
+                Tlv(0x5BD0, Vec3(0.0, 0.0, 1.0)),   // plane normal
+                Tlv(0x5BD2, BitConverter.GetBytes(15.5))); // offset
+            var blob = Concat(new byte[8], Tlv(0x5BCC, body), new byte[8]);
+
+            var modelDat = ChunkedBuffer.FromArray(blob);
+            var dims = PagesDimensions.ParseDimensions(modelDat,
+                new Dictionary<string, (double X, double Y, double Z)>(),
+                new Dictionary<string, List<double>?>());
+
+            Assert.Single(dims);
+            var d = dims[0];
+            Assert.Equal((0.0, 0.0, 0.0), d.A);
+            Assert.Equal((100.0, 0.0, 0.0), d.B);
+            Assert.Equal(15.5, d.Offset);
+            Assert.Equal((1.0, 0.0, 0.0), d.PlaneX);
+            Assert.Equal((0.0, 0.0, 1.0), d.Normal);
+        }
+
+        [Fact]
+        public void DimensionConnectedPointResolvesThroughInstance()
+        {
+            // A type-2 connection (vertex id + instance id): the vertex position
+            // is definition-local and must be lifted to world by the instance's
+            // transform. An unresolvable reference drops the dimension (fail-safe).
+            byte[] vid = { 0xAA, 0xBB, 0x01 };
+            byte[] iid = { 0xCC, 0xDD, 0x02 };
+
+            byte[] Connected(ushort wrapTag)
+            {
+                var idLenPrefixed = Concat(new byte[] { (byte)iid.Length }, iid);
+                var refTlv = Tlv(0x53FC, Concat(Tlv(0x53FD, vid), Tlv(0x53FE, idLenPrefixed)));
+                var inner = Concat(Tlv(0x5209, BitConverter.GetBytes((uint)2)), Tlv(0x520B, refTlv));
+                return Tlv(wrapTag, Tlv(0x5208, inner));
+            }
+
+            byte[] Free(ushort wrapTag)
+            {
+                var inner = Concat(Tlv(0x5209, BitConverter.GetBytes((uint)1)), Tlv(0x520A, Vec3(0.0, 0.0, 0.0)));
+                return Tlv(wrapTag, Tlv(0x5208, inner));
+            }
+
+            var body = Concat(Connected(0x5BCD), Free(0x5BCE), Tlv(0x5BD2, BitConverter.GetBytes(0.0)));
+            var blob = Tlv(0x5BCC, body);
+
+            // Identity-ish transform that translates by (10, 20, 30).
+            var world = new List<double> { 1, 0, 0, 0, 1, 0, 0, 0, 1, 10.0, 20.0, 30.0, 1.0 };
+            var id2pos = new Dictionary<string, (double X, double Y, double Z)> { [Hex(vid)] = (1.0, 2.0, 3.0) };
+            var instWorld = new Dictionary<string, List<double>?> { [Hex(iid)] = world };
+
+            var modelDat = ChunkedBuffer.FromArray(blob);
+            var dims = PagesDimensions.ParseDimensions(modelDat, id2pos, instWorld);
+            Assert.Single(dims);
+            Assert.Equal((11.0, 22.0, 33.0), dims[0].A); // local + translation
+
+            // Same record, but the vertex id is unknown: the dimension is dropped.
+            var emptyDims = PagesDimensions.ParseDimensions(modelDat,
+                new Dictionary<string, (double X, double Y, double Z)>(),
+                new Dictionary<string, List<double>?>());
+            Assert.Empty(emptyDims);
+        }
+
+        // ── scenes (pages) ───────────────────────────────────────────────
+
+        private static byte[] PageRecord(string name, bool parallel, int[]? hiddenIds = null)
+        {
+            hiddenIds ??= Array.Empty<int>();
+            var cam = Concat(
+                Tlv(0x34BD, Vec3(100.0, -200.0, 50.0)), // eye
+                Tlv(0x34BE, Vec3(0.0, 0.0, 0.0)),       // target
+                Tlv(0x34BF, Vec3(0.0, 0.0, 1.0)),       // up
+                Tlv(0x34C4, BitConverter.GetBytes(35.0)),                    // fov
+                Tlv(0x34C2, new byte[] { (byte)(parallel ? 0 : 1) }),
+                Tlv(0x34C3, BitConverter.GetBytes(240.0)));                  // ortho height
+            var hiddenParts = new List<byte[]>();
+            foreach (var i in hiddenIds) hiddenParts.Add(new byte[] { 1, (byte)i });
+            var hidden = Concat(hiddenParts.ToArray());
+            var body = Concat(
+                Tlv(0x6F54, Tlv(0x6F55, System.Text.Encoding.UTF8.GetBytes(name))),
+                Tlv(0x714A, Tlv(0x34BC, cam)),
+                Tlv(0x7150, hidden));
+            return Tlv(0x7148, body);
+        }
+
+        [Fact]
+        public void ParsePagesSynthetic()
+        {
+            var payload = Tlv(0x6D60, Tlv(0x6D61, Concat(
+                PageRecord("Planta", true, new[] { 2 }),
+                PageRecord("Vista 3D", false))));
+            var node = new TlvNode { Tag = "0702", Payload = payload };
+            var pages = PagesDimensions.ParsePages(node);
+
+            Assert.Equal(new[] { "Planta", "Vista 3D" }, pages.ConvertAll(p => p.Name));
+            var planta = pages[0];
+            Assert.True(planta.Parallel);
+            Assert.Equal(240.0, planta.OrthoHeight);
+            Assert.Equal((100.0, -200.0, 50.0), planta.Eye);
+            Assert.Equal((0.0, 0.0, 1.0), planta.Up);
+            Assert.Equal(new List<long> { 2 }, planta.HiddenLayerIds);
+            Assert.False(pages[1].Parallel);
+            Assert.Equal(35.0, pages[1].Fov);
+        }
+
+        [Fact]
+        public void PagesAbsentIsEmpty()
+        {
+            Assert.Empty(PagesDimensions.ParsePages(null));
+            var model = SkpFile.Open(System.IO.Path.Combine("fixtures", "SU_File.skp"));
+            Assert.Empty(model.Pages);
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/ChunkedBuffer.cs
+++ b/packages/dotnet/OpenSkp/ChunkedBuffer.cs
@@ -81,6 +81,58 @@ namespace OpenSkp
             return (uint)(_scratch8[0] | (_scratch8[1] << 8) | (_scratch8[2] << 16) | (_scratch8[3] << 24));
         }
 
+        /// <summary>Find the first occurrence of `needle` at or after `start`,
+        /// or -1 if absent. Mirrors Python's `bytes.find()` for the one place
+        /// that needs a raw byte-pattern search over the whole buffer (linear
+        /// dimensions, whose 5BCC record is located by literal bytes rather
+        /// than walked via the TLV tree). Scans within each chunk's backing
+        /// array directly (cheap - short needle, plain byte[] indexing);
+        /// falls back to the slow per-byte indexer only for the handful of
+        /// candidate positions near a chunk boundary where the needle could
+        /// straddle two chunks.</summary>
+        public long IndexOf(byte[] needle, long start)
+        {
+            if (needle.Length == 0) return start < 0 ? 0 : start;
+            long pos = start < 0 ? 0 : start;
+            long limit = Length - needle.Length;
+            while (pos <= limit)
+            {
+                int chunkIdx = (int)(pos / _chunkSize);
+                int offsetInChunk = (int)(pos % _chunkSize);
+                byte[] chunk = _chunks[chunkIdx];
+                int maxOffsetInChunk = chunk.Length - needle.Length;
+                if (offsetInChunk <= maxOffsetInChunk)
+                {
+                    int idx = IndexOfInArray(chunk, needle, offsetInChunk, maxOffsetInChunk);
+                    if (idx >= 0) return pos + (idx - offsetInChunk);
+                    pos += (maxOffsetInChunk - offsetInChunk) + 1;
+                    continue;
+                }
+                bool match = true;
+                for (int j = 0; j < needle.Length; j++)
+                {
+                    if (this[pos + j] != needle[j]) { match = false; break; }
+                }
+                if (match) return pos;
+                pos++;
+            }
+            return -1;
+        }
+
+        private static int IndexOfInArray(byte[] hay, byte[] needle, int from, int to)
+        {
+            for (int i = from; i <= to; i++)
+            {
+                bool ok = true;
+                for (int j = 0; j < needle.Length; j++)
+                {
+                    if (hay[i + j] != needle[j]) { ok = false; break; }
+                }
+                if (ok) return i;
+            }
+            return -1;
+        }
+
         /// <summary>Read the whole buffer, chunk by chunk, from a stream
         /// whose total decompressed length is already known (from the ZIP
         /// entry's recorded uncompressed size) - so each chunk can be

--- a/packages/dotnet/OpenSkp/Core.cs
+++ b/packages/dotnet/OpenSkp/Core.cs
@@ -26,6 +26,8 @@ namespace OpenSkp
             // defaults to visible.
             public Dictionary<string, bool> LayerHidden = new Dictionary<string, bool>();
             public Dictionary<long, string> LayerIdToName = new Dictionary<long, string>();
+            public List<RawPage> Pages = new List<RawPage>();
+            public List<RawDimension> Dimensions = new List<RawDimension>();
             public Dictionary<long, string> MaterialIdToName = new Dictionary<long, string>();
             public Dictionary<string, Geometry.RawMaterial> Materials = new Dictionary<string, Geometry.RawMaterial>();
             public Dictionary<string, Geometry.RawMaterial> MaterialsByFolder = new Dictionary<string, Geometry.RawMaterial>();
@@ -169,6 +171,9 @@ namespace OpenSkp
             var materialIdToName = new Dictionary<long, string>();
             var defsDictRaw = new Dictionary<long, Geometry.RawDefinition>();
             var rootBuilder = new GeometryBuilder();
+            var vertexPositions = new Dictionary<string, (double X, double Y, double Z)>();
+            var instanceWorld = new Dictionary<string, List<double>?>();
+            TlvNode? pageNode = null;
 
             foreach (var rec in Tlv.IterTopLevelLazy(modelDat, 0, modelDat.Length, Tlv.ContainerTags))
             {
@@ -179,6 +184,12 @@ namespace OpenSkp
                     Geometry.CollectLayers(single, layerIdToName);
                     Geometry.CollectMaterialIds(single, materialIdToName);
                     Geometry.CollectDefs(single, defsDictRaw);
+                    PagesDimensions.ScanVertexPositions(el, vertexPositions);
+                    PagesDimensions.ScanInstanceTransforms(el, instanceWorld);
+                    if (pageNode == null)
+                    {
+                        pageNode = PagesDimensions.FindPageNode(el);
+                    }
                     if (el.Tag == "F601")
                     {
                         Geometry.ExtractGeometryFromNodes(el.Children, rootBuilder);
@@ -250,6 +261,8 @@ namespace OpenSkp
                 LayerColors = layerColors,
                 LayerHidden = layerHidden,
                 LayerIdToName = layerIdToName,
+                Pages = PagesDimensions.ParsePages(pageNode),
+                Dimensions = PagesDimensions.ParseDimensions(modelDat, vertexPositions, instanceWorld),
                 MaterialIdToName = materialIdToName,
                 Materials = materials,
                 MaterialsByFolder = materialsByFolder,

--- a/packages/dotnet/OpenSkp/Model.cs
+++ b/packages/dotnet/OpenSkp/Model.cs
@@ -152,10 +152,64 @@ namespace OpenSkp
         public bool Hidden { get; set; }
     }
 
+    /// <summary>A linear dimension (SketchUp's Dimension tool).
+    ///
+    /// The legacy (pre-2021) reader recovers only Text/Hidden. The VFF
+    /// reader (2021+) recovers the full geometry - see
+    /// <see cref="SkpModel.Dimensions"/> for the model-level, world-space
+    /// list.</summary>
     public sealed class Dimension
     {
+        /// <summary>The displayed text. Empty when the dimension shows its
+        /// auto-computed measured value (the caller formats |B - A|).</summary>
         public string Text { get; set; } = "";
         public bool Hidden { get; set; }
+
+        /// <summary>First measured point (x, y, z) in inches (world space),
+        /// or null when only the text was recovered.</summary>
+        public (double X, double Y, double Z)? A { get; set; }
+
+        /// <summary>Second measured point.</summary>
+        public (double X, double Y, double Z)? B { get; set; }
+
+        /// <summary>Offset distance (inches) - how far the dimension line
+        /// sits from the A-B segment, along the in-plane perpendicular.</summary>
+        public double Offset { get; set; }
+
+        /// <summary>The dimension plane's x-axis, or null.</summary>
+        public (double X, double Y, double Z)? PlaneX { get; set; }
+
+        /// <summary>The dimension plane's normal, or null.</summary>
+        public (double X, double Y, double Z)? Normal { get; set; }
+    }
+
+    /// <summary>A saved scene (SketchUp's "Scenes" tabs; "pages" in the SDK).</summary>
+    public sealed class Page
+    {
+        /// <summary>Scene name as shown on its tab.</summary>
+        public string Name { get; set; } = "";
+
+        /// <summary>Camera position (x, y, z) in inches, or null.</summary>
+        public (double X, double Y, double Z)? Eye { get; set; }
+
+        /// <summary>Point the camera looks at, in inches.</summary>
+        public (double X, double Y, double Z)? Target { get; set; }
+
+        /// <summary>Camera up vector.</summary>
+        public (double X, double Y, double Z)? Up { get; set; }
+
+        /// <summary>Field of view in degrees (SketchUp default 35).</summary>
+        public double Fov { get; set; } = 35.0;
+
+        /// <summary>True when the scene uses parallel (orthographic)
+        /// projection; Fov still holds the stored perspective angle.</summary>
+        public bool Parallel { get; set; }
+
+        /// <summary>Visible height in inches when Parallel.</summary>
+        public double OrthoHeight { get; set; }
+
+        /// <summary>Names of the layers this scene hides.</summary>
+        public List<string> HiddenLayers { get; set; } = new List<string>();
     }
 
     public sealed class Definition
@@ -199,6 +253,16 @@ namespace OpenSkp
         public Definition Root { get; set; } = new Definition { Name = "ROOT_MODEL" };
 
         public List<Layer> Layers { get; set; } = new List<Layer>();
+
+        /// <summary>The file's saved scenes (VFF files; classic pre-2021
+        /// files import with none).</summary>
+        public List<Page> Pages { get; set; } = new List<Page>();
+
+        /// <summary>Model-level linear dimensions with world-space endpoints
+        /// (VFF files). Legacy files surface text-only dimensions per
+        /// definition instead (<see cref="Definition.Dimensions"/>).</summary>
+        public List<Dimension> Dimensions { get; set; } = new List<Dimension>();
+
         public List<Material> Materials { get; set; } = new List<Material>();
 
         /// <summary>Join table for Face.MaterialId / Instance.MaterialId:

--- a/packages/dotnet/OpenSkp/PagesDimensions.cs
+++ b/packages/dotnet/OpenSkp/PagesDimensions.cs
@@ -1,0 +1,364 @@
+using System;
+using System.Collections.Generic;
+
+namespace OpenSkp
+{
+    /// <summary>VFF (2021+) scenes ("pages") and linear dimensions. Ported
+    /// from Python's _core.py (PR #190) - see that module's
+    /// _scan_vertex_positions / _scan_instance_transforms / _parse_dimensions
+    /// / _find_page_node / _parse_pages for the byte-format details this
+    /// file mirrors.</summary>
+    internal sealed class RawPage
+    {
+        public string Name = "";
+        public (double X, double Y, double Z)? Eye;
+        public (double X, double Y, double Z)? Target;
+        public (double X, double Y, double Z)? Up;
+        public double Fov = 35.0;
+        public bool Parallel;
+        public double OrthoHeight;
+        public List<long> HiddenLayerIds = new List<long>();
+    }
+
+    internal sealed class RawDimension
+    {
+        public (double X, double Y, double Z) A;
+        public (double X, double Y, double Z) B;
+        public double Offset;
+        public (double X, double Y, double Z)? PlaneX;
+        public (double X, double Y, double Z)? Normal;
+        public string Text = "";
+    }
+
+    internal static class PagesDimensions
+    {
+        // ── flat TLV, integer tags ──────────────────────────────────────
+        // A second, deliberately separate flat-TLV reader from Tlv.ParseFlat/
+        // FindFlat: those use the STRING byte-order tag convention the main
+        // tree already relies on (e.g. "C409"), while the sub-records this
+        // feature reads (5208, 520A, 53FC, 5BCD, ...) are most directly and
+        // safely ported from Python's own _tlv_items/_tlv_find (which read
+        // the tag as a little-endian uint16) by keeping the SAME integer
+        // convention here, copying Python's numeric constants byte-for-byte
+        // rather than hand-converting each one to the swapped string form.
+
+        internal readonly struct FlatTlvItem
+        {
+            public readonly ushort Tag;
+            public readonly byte[] Payload;
+            public FlatTlvItem(ushort tag, byte[] payload) { Tag = tag; Payload = payload; }
+        }
+
+        internal static List<FlatTlvItem>? TlvItemsInt(byte[]? buf)
+        {
+            if (buf == null) return null;
+            var items = new List<FlatTlvItem>();
+            int off = 0;
+            int n = buf.Length;
+            while (off < n)
+            {
+                if (off + 6 > n) return null;
+                ushort tag = (ushort)(buf[off] | (buf[off + 1] << 8));
+                uint ln = Tlv.ReadU32(buf, off + 2);
+                if (tag == 0 || off + 6 + ln > n) return null;
+                var payload = new byte[ln];
+                Array.Copy(buf, off + 6, payload, 0, (int)ln);
+                items.Add(new FlatTlvItem(tag, payload));
+                off += 6 + (int)ln;
+            }
+            return items;
+        }
+
+        internal static byte[]? TlvFindInt(List<FlatTlvItem>? items, ushort tag)
+        {
+            if (items == null) return null;
+            foreach (var it in items)
+            {
+                if (it.Tag == tag) return it.Payload;
+            }
+            return null;
+        }
+
+        private static byte[] StripDe05(byte[] p)
+        {
+            if (p.Length >= 2 && p[0] == 0xDE && p[1] == 0x05)
+            {
+                uint idlen = Tlv.ReadU32(p, 2);
+                var idb = new byte[idlen];
+                Array.Copy(p, 6, idb, 0, (int)idlen);
+                return idb;
+            }
+            return p;
+        }
+
+        /// <summary>Accumulate every vertex's persistent id (hex) -> (x, y, z)
+        /// inches. A vertex is a "C409" record: "DC05" holds its persistent
+        /// id (the "DE05" var-int payload), "C509" its 3xf64 position.
+        /// Dimension connection points reference geometry by this id.
+        /// Called once per top-level record - full_parse streams the TLV
+        /// tree and never holds it whole.</summary>
+        public static void ScanVertexPositions(TlvNode top, Dictionary<string, (double X, double Y, double Z)> id2pos)
+        {
+            void Walk(List<TlvNode> nodes)
+            {
+                foreach (var el in nodes)
+                {
+                    if (el.Tag == "C409")
+                    {
+                        var dc05 = Geometry.FindChildTag(el.Children, "DC05");
+                        var c509 = Geometry.FindChildTag(el.Children, "C509");
+                        if (dc05 != null && c509 != null && c509.Payload.Length == 24)
+                        {
+                            var idb = StripDe05(dc05.Payload);
+                            id2pos[Tlv.ToHexUpper(idb)] = (
+                                Tlv.ReadF64(c509.Payload, 0),
+                                Tlv.ReadF64(c509.Payload, 8),
+                                Tlv.ReadF64(c509.Payload, 16));
+                        }
+                    }
+                    if (el.Children.Count > 0) Walk(el.Children);
+                }
+            }
+            Walk(new List<TlvNode> { top });
+        }
+
+        /// <summary>Accumulate each instance's persistent id (hex) -> its
+        /// WORLD transform (a 13-double matrix), walking the instance tree
+        /// and composing parent x local at every "6419". Per top-level
+        /// record, like ScanVertexPositions - an instance chain never
+        /// crosses top-level records.
+        ///
+        /// A dimension connects to geometry INSIDE a placed component; its
+        /// connection reference names the vertex AND the instance holding
+        /// it. The vertex position is definition-local, so it must be
+        /// lifted to world by the instance's transform for the dimension to
+        /// land where the author drew it.</summary>
+        public static void ScanInstanceTransforms(TlvNode top, Dictionary<string, List<double>?> world)
+        {
+            void Walk(List<TlvNode> nodes, List<double>? parent)
+            {
+                foreach (var el in nodes)
+                {
+                    if (el.Tag == "6419")
+                    {
+                        var d007 = Geometry.FindChildTag(el.Children, "D007");
+                        var dc05 = d007 != null ? Geometry.FindChildTag(d007.Children, "DC05") : null;
+                        string? iid = dc05 != null ? Tlv.ToHexUpper(StripDe05(dc05.Payload)) : null;
+
+                        var m = Geometry.FindChildTag(el.Children, "6619");
+                        List<double>? mat = null;
+                        if (m != null && m.Payload.Length == 104)
+                        {
+                            mat = new List<double>(13);
+                            for (int i = 0; i < 13; i++) mat.Add(Tlv.ReadF64(m.Payload, i * 8));
+                        }
+                        List<double>? here = mat != null ? Transforms.MultiplyMatrices(parent!, mat) : parent;
+                        if (iid != null) world[iid] = here;
+                        Walk(el.Children, here);
+                    }
+                    else if (el.Children.Count > 0)
+                    {
+                        Walk(el.Children, parent);
+                    }
+                }
+            }
+            Walk(new List<TlvNode> { top }, null);
+        }
+
+        /// <summary>Linear dimensions (SketchUp's Dimension tool).
+        ///
+        /// A dimension entity is a "5BCC" record (raw bytes cc 5b) holding:
+        ///
+        /// * 5BCD / 5BCE - the two connection points. Each wraps a 5208 whose
+        ///   5209 is the connection TYPE (1 = a free explicit point in 520A,
+        ///   already world space; 2 = connected to geometry, 520A is zero and
+        ///   520B -> 53FC names the target: 53FD = the vertex by persistent
+        ///   id, 53FE = a length-prefixed persistent id of the INSTANCE
+        ///   holding it - the vertex position is definition-local, so it is
+        ///   lifted to world by that instance's transform).
+        /// * 5BCF - the dimension plane's x-axis; 5BD0 - its normal.
+        /// * 5BD2 - the offset distance (inches): how far the dimension line
+        ///   sits from the measured segment, along the in-plane
+        ///   perpendicular.
+        ///
+        /// The measured value is auto-computed from the two points (no
+        /// cached text on the samples seen), so callers format it
+        /// themselves. Endpoints come out in WORLD space (inches). A
+        /// connection point that cannot be resolved drops the whole
+        /// dimension (fail-safe).</summary>
+        public static List<RawDimension> ParseDimensions(
+            ChunkedBuffer modelDat,
+            Dictionary<string, (double X, double Y, double Z)> id2pos,
+            Dictionary<string, List<double>?> instWorld)
+        {
+            var dims = new List<RawDimension>();
+            var needle = new byte[] { 0xCC, 0x5B };
+            long i = 0;
+            long n = modelDat.Length;
+
+            (double X, double Y, double Z)? Point(byte[]? blockPayload)
+            {
+                if (blockPayload == null) return null;
+                var blk = TlvFindInt(TlvItemsInt(blockPayload), 0x5208);
+                if (blk == null) return null;
+                var sub = TlvItemsInt(blk);
+                var typB = TlvFindInt(sub, 0x5209);
+                uint? typ = (typB != null && typB.Length == 4) ? Tlv.ReadU32(typB, 0) : (uint?)null;
+                if (typ == 1)
+                {
+                    var pos = TlvFindInt(sub, 0x520A);
+                    if (pos == null || pos.Length != 24) return null;
+                    return (Tlv.ReadF64(pos, 0), Tlv.ReadF64(pos, 8), Tlv.ReadF64(pos, 16));
+                }
+                // type 2: resolve the geometry reference (vertex + instance).
+                var refB = TlvFindInt(sub, 0x520B);
+                byte[]? f53fc = refB != null ? TlvFindInt(TlvItemsInt(refB), 0x53FC) : null;
+                var fi = f53fc != null ? TlvItemsInt(f53fc) : null;
+                var vid = TlvFindInt(fi, 0x53FD);
+                var iid = TlvFindInt(fi, 0x53FE);
+                if (vid == null) return null;
+                if (!id2pos.TryGetValue(Tlv.ToHexUpper(vid), out var local)) return null;
+                if (iid != null && iid.Length >= 1 && iid[0] > 0 && 1 + iid[0] <= iid.Length)
+                {
+                    var idBytes = new byte[iid[0]];
+                    Array.Copy(iid, 1, idBytes, 0, iid[0]);
+                    if (instWorld.TryGetValue(Tlv.ToHexUpper(idBytes), out var w) && w != null)
+                    {
+                        return Transforms.TransformPoint(w.ToArray(), local);
+                    }
+                }
+                return local; // model-root vertex - already world
+            }
+
+            while (true)
+            {
+                long j = modelDat.IndexOf(needle, i);
+                if (j < 0) break;
+                i = j + 1;
+                if (j + 6 > n) continue;
+                uint ln = modelDat.ReadU32(j + 2);
+                if (ln < 40 || j + 6 + ln > n) continue;
+                byte[] bodyBytes = modelDat.Slice(j + 6, (int)ln);
+                var body = TlvItemsInt(bodyBytes);
+                if (body == null) continue;
+                bool has5Bcd = false, has5Bce = false;
+                foreach (var it in body)
+                {
+                    if (it.Tag == 0x5BCD) has5Bcd = true;
+                    if (it.Tag == 0x5BCE) has5Bce = true;
+                }
+                if (!has5Bcd || !has5Bce) continue;
+
+                var a = Point(TlvFindInt(body, 0x5BCD));
+                var b = Point(TlvFindInt(body, 0x5BCE));
+                if (a == null || b == null) continue;
+
+                var xaxisB = TlvFindInt(body, 0x5BCF);
+                var normalB = TlvFindInt(body, 0x5BD0);
+                var offB = TlvFindInt(body, 0x5BD2);
+
+                dims.Add(new RawDimension
+                {
+                    A = a.Value,
+                    B = b.Value,
+                    PlaneX = (xaxisB != null && xaxisB.Length == 24)
+                        ? (Tlv.ReadF64(xaxisB, 0), Tlv.ReadF64(xaxisB, 8), Tlv.ReadF64(xaxisB, 16))
+                        : ((double, double, double)?)null,
+                    Normal = (normalB != null && normalB.Length == 24)
+                        ? (Tlv.ReadF64(normalB, 0), Tlv.ReadF64(normalB, 8), Tlv.ReadF64(normalB, 16))
+                        : ((double, double, double)?)null,
+                    Offset = (offB != null && offB.Length == 8) ? Tlv.ReadF64(offB, 0) : 0.0,
+                });
+            }
+            return dims;
+        }
+
+        /// <summary>Return the "0702" scenes node inside top's subtree, or
+        /// null. Called per top-level record; retaining the (small) 0702
+        /// subtree is the only thing kept alive past the streaming loop.</summary>
+        public static TlvNode? FindPageNode(TlvNode top)
+        {
+            return Geometry.FindChildTag(new List<TlvNode> { top }, "0702");
+        }
+
+        /// <summary>Scenes ("pages"). The 0702 node's payload nests
+        /// 6D60 > 6D61 > one 7148 record per page:
+        ///
+        /// * 6F54 > 6F55 - page name (UTF-8)
+        /// * 714A > 34BC - camera: 34BD eye, 34BE target, 34BF up (3xf64,
+        ///   inches), 34C4 field of view (degrees), 34C2 u8 = PERSPECTIVE
+        ///   flag (00 = parallel projection - calibrated against the
+        ///   bundled scene thumbnails: parallel plans/elevations carry 00
+        ///   and their 34C3 visible height matches the thumbnail framing
+        ///   exactly, while perspective scenes carry 01 with a stale 34C3),
+        ///   34C3 f64 = visible height when parallel (inches)
+        /// * 7150 - layers hidden in this page: (u8 length, var-int layer
+        ///   id) runs</summary>
+        public static List<RawPage> ParsePages(TlvNode? node)
+        {
+            var pages = new List<RawPage>();
+            if (node == null) return pages;
+
+            static (double X, double Y, double Z)? Vec3(byte[]? p) =>
+                (p != null && p.Length == 24) ? (Tlv.ReadF64(p, 0), Tlv.ReadF64(p, 8), Tlv.ReadF64(p, 16)) : ((double, double, double)?)null;
+
+            var t60Items = TlvItemsInt(node.Payload);
+            if (t60Items == null) return pages;
+            foreach (var it60 in t60Items)
+            {
+                if (it60.Tag != 0x6D60) continue;
+                var t61Items = TlvItemsInt(it60.Payload);
+                if (t61Items == null) continue;
+                foreach (var it61 in t61Items)
+                {
+                    if (it61.Tag != 0x6D61) continue;
+                    var t48Items = TlvItemsInt(it61.Payload);
+                    if (t48Items == null) continue;
+                    foreach (var it48 in t48Items)
+                    {
+                        if (it48.Tag != 0x7148) continue;
+                        var items = TlvItemsInt(it48.Payload);
+                        if (items == null) continue;
+
+                        var page = new RawPage();
+
+                        var head = TlvItemsInt(TlvFindInt(items, 0x6F54));
+                        var name = TlvFindInt(head, 0x6F55);
+                        if (name != null && name.Length > 0)
+                        {
+                            page.Name = System.Text.Encoding.UTF8.GetString(name);
+                        }
+
+                        var camWrap = TlvItemsInt(TlvFindInt(items, 0x714A));
+                        var cam = camWrap != null ? TlvItemsInt(TlvFindInt(camWrap, 0x34BC)) : null;
+                        if (cam != null)
+                        {
+                            page.Eye = Vec3(TlvFindInt(cam, 0x34BD));
+                            page.Target = Vec3(TlvFindInt(cam, 0x34BE));
+                            page.Up = Vec3(TlvFindInt(cam, 0x34BF));
+                            var fov = TlvFindInt(cam, 0x34C4);
+                            if (fov != null && fov.Length == 8) page.Fov = Tlv.ReadF64(fov, 0);
+                            var flag = TlvFindInt(cam, 0x34C2);
+                            page.Parallel = flag != null && flag.Length > 0 && flag[0] == 0;
+                            var height = TlvFindInt(cam, 0x34C3);
+                            if (height != null && height.Length == 8) page.OrthoHeight = Tlv.ReadF64(height, 0);
+                        }
+
+                        var hidden = TlvFindInt(items, 0x7150);
+                        int off = 0;
+                        while (hidden != null && off + 1 <= hidden.Length)
+                        {
+                            int ln = hidden[off];
+                            if (ln == 0 || off + 1 + ln > hidden.Length) break;
+                            page.HiddenLayerIds.Add(Tlv.ParseVarInt(hidden, off + 1, ln));
+                            off += 1 + ln;
+                        }
+
+                        if (page.Eye != null && page.Target != null) pages.Add(page);
+                    }
+                }
+            }
+            return pages;
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Parser.cs
+++ b/packages/dotnet/OpenSkp/Parser.cs
@@ -38,6 +38,45 @@ namespace OpenSkp
                 model.Layers.Add(new Layer { Name = kv.Key, ColorR = kv.Value.R, ColorG = kv.Value.G, ColorB = kv.Value.B, Hidden = hidden });
             }
 
+            // Convert pages (saved scenes) - hidden layer ids resolve to
+            // names; unknown ids (stale refs) are dropped.
+            foreach (var pg in parsed.Pages)
+            {
+                var hiddenLayers = new List<string>();
+                foreach (var id in pg.HiddenLayerIds)
+                {
+                    if (parsed.LayerIdToName.TryGetValue(id, out var layerName))
+                    {
+                        hiddenLayers.Add(layerName);
+                    }
+                }
+                model.Pages.Add(new Page
+                {
+                    Name = pg.Name,
+                    Eye = pg.Eye,
+                    Target = pg.Target,
+                    Up = pg.Up,
+                    Fov = pg.Fov,
+                    Parallel = pg.Parallel,
+                    OrthoHeight = pg.OrthoHeight,
+                    HiddenLayers = hiddenLayers,
+                });
+            }
+
+            // Convert model-level linear dimensions (VFF; world space).
+            foreach (var dm in parsed.Dimensions)
+            {
+                model.Dimensions.Add(new Dimension
+                {
+                    A = dm.A,
+                    B = dm.B,
+                    Offset = dm.Offset,
+                    PlaneX = dm.PlaneX,
+                    Normal = dm.Normal,
+                    Text = dm.Text,
+                });
+            }
+
             var matForData = new Dictionary<Geometry.RawMaterial, Material>(ReferenceEqualityComparer.Instance);
             foreach (var rawMat in parsed.Materials.Values)
             {

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,5 +1,5 @@
 import { extractSkpContents, readMetaUnits } from './vff';
-import { iterTopLevelLazy, readU32, parseVarInt } from './parser';
+import { iterTopLevelLazy, readU32, parseVarInt, TlvNode } from './parser';
 import { SkpParseError } from './errors';
 import { ParseOptions, PROGRESS_INTERVAL, emitLog, emitProgress } from './observability';
 import {
@@ -29,6 +29,7 @@ import {
   SceneOptions,
 } from './model';
 import { isLegacy, parseLegacyToRaw } from './legacy';
+import { scanVertexPositions, scanInstanceTransforms, findPageNode, parsePages, parseDimensions } from './pages-dimensions';
 import { encodeIndices } from './gltf-indices';
 import { buildInstancedSceneFromParsed, InstancedScene } from './instanced';
 import { extractThumbnail, SkpThumbnail } from './thumbnail';
@@ -254,12 +255,20 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
 
   const defsDict = new Map<number | string, ParsedDefinition>();
   const rootBuilder = new GeometryBuilder();
+  const vertexPositions = new Map<string, [number, number, number]>();
+  const instanceWorld = new Map<string, number[] | null>();
+  let pageNode: TlvNode | null = null;
 
   for (const { index, total, node: el } of iterTopLevelLazy(modelData, 0, modelData.length)) {
     try {
       collectLayers([el], layerIdToName, options);
       collectMaterialIds([el]);
       collectDefs([el], defsDict, options);
+      scanVertexPositions(el, vertexPositions);
+      scanInstanceTransforms(el, instanceWorld);
+      if (pageNode === null) {
+        pageNode = findPageNode(el);
+      }
       if (el.tag === 'F601') {
         extractGeometryFromNodes(el.children, rootBuilder, options);
       }
@@ -311,6 +320,8 @@ function parseToRaw(buffer: ArrayBuffer, options?: ParseOptions): ParsedRawData 
     layerColors,
     layerHidden,
     layerIdToName,
+    pages: parsePages(pageNode),
+    dimensions: parseDimensions(modelData, vertexPositions, instanceWorld),
     materialIdToName,
     materialsMap,
     materialsByFolder,

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -1812,6 +1812,12 @@ export function parseLegacyToRaw(data: Uint8Array, options?: ParseOptions): Pars
     layerColors,
     layerHidden,
     layerIdToName,
+    // Classic (pre-2021) files carry no equivalent VFF entity families -
+    // the legacy CArchive walker never surfaces scenes or model-level
+    // linear dimensions (legacy files still surface text-only dimensions
+    // per definition, via each entity list's own CDimensionLinear reads).
+    pages: [],
+    dimensions: [],
     materialIdToName,
     materialsMap,
     materialsByFolder: new Map(),

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -3,6 +3,7 @@ import { extractDynamicProperties, ParsedDefinition } from './geometry';
 import { buildLocalFaceGroups } from './face-groups';
 import { SkpParseError } from './errors';
 import { ParseOptions, PROGRESS_INTERVAL, emitLog, emitProgress } from './observability';
+import { RawPage, RawDimension } from './pages-dimensions';
 
 export interface SkpModel {
   version: string;
@@ -13,6 +14,13 @@ export interface SkpModel {
    * at the top level. Corresponds to .NET/Dart's `Root`/`root`. */
   root: Definition;
   layers: Layer[];
+  /** The file's saved scenes (VFF files; classic pre-2021 files import
+   * with none). */
+  pages: Page[];
+  /** Model-level linear dimensions with world-space endpoints (VFF
+   * files). Legacy files surface text-only dimensions per definition
+   * instead (`Definition.dimensions`). */
+  dimensions: Dimension[];
   materials: Material[];
   materialsById: Map<number, Material>;
   styles: Style[];
@@ -35,9 +43,51 @@ export interface TextEntity {
   hidden: boolean;
 }
 
+/**
+ * A linear dimension (SketchUp's Dimension tool).
+ *
+ * The legacy (pre-2021) reader recovers only `text`/`hidden`. The VFF
+ * reader (2021+) recovers the full geometry - see `SkpModel.dimensions`
+ * for the model-level, world-space list.
+ */
 export interface Dimension {
+  /** The displayed text. Empty when the dimension shows its auto-computed
+   * measured value (the caller formats `|b - a|`). */
   text: string;
   hidden: boolean;
+  /** First measured point [x, y, z] in inches (world space), or null when
+   * only the text was recovered. */
+  a: [number, number, number] | null;
+  /** Second measured point. */
+  b: [number, number, number] | null;
+  /** Offset distance (inches) - how far the dimension line sits from the
+   * a-b segment, along the in-plane perpendicular. */
+  offset: number;
+  /** The dimension plane's x-axis, or null. */
+  planeX: [number, number, number] | null;
+  /** The dimension plane's normal, or null. */
+  normal: [number, number, number] | null;
+}
+
+/** A saved scene (SketchUp's "Scenes" tabs; "pages" in the SDK). */
+export interface Page {
+  /** Scene name as shown on its tab. */
+  name: string;
+  /** Camera position [x, y, z] in inches, or null. */
+  eye: [number, number, number] | null;
+  /** Point the camera looks at, in inches. */
+  target: [number, number, number] | null;
+  /** Camera up vector. */
+  up: [number, number, number] | null;
+  /** Field of view in degrees (SketchUp default 35). */
+  fov: number;
+  /** True when the scene uses parallel (orthographic) projection; `fov`
+   * still holds the stored perspective angle. */
+  parallel: boolean;
+  /** Visible height in inches when `parallel`. */
+  orthoHeight: number;
+  /** Names of the layers this scene hides. */
+  hiddenLayers: string[];
 }
 
 export interface Definition {
@@ -376,6 +426,8 @@ export interface ParsedRawData {
   layerColors: Map<string, [number, number, number]>;
   layerHidden: Map<string, boolean>;
   layerIdToName: Map<number, string>;
+  pages: RawPage[];
+  dimensions: RawDimension[];
   materialIdToName: Map<number, string>;
   materialsMap: Map<string, Material>;
   materialsByFolder: Map<string, Material>;
@@ -390,6 +442,8 @@ export function buildModelFromParsed(parsed: ParsedRawData): SkpModel {
     layerColors,
     layerHidden,
     layerIdToName,
+    pages,
+    dimensions,
     materialIdToName,
     materialsMap,
     materialsByFolder,
@@ -419,6 +473,32 @@ export function buildModelFromParsed(parsed: ParsedRawData): SkpModel {
 
   const finalMaterialsList: Material[] = Array.from(materialsMap.values());
 
+  // Convert pages (saved scenes) - hidden layer ids resolve to names;
+  // unknown ids (stale refs) are dropped.
+  const finalPagesList: Page[] = pages.map((pg) => ({
+    name: pg.name,
+    eye: pg.eye,
+    target: pg.target,
+    up: pg.up,
+    fov: pg.fov,
+    parallel: pg.parallel,
+    orthoHeight: pg.orthoHeight,
+    hiddenLayers: pg.hiddenLayerIds
+      .map((id) => layerIdToName.get(id))
+      .filter((name): name is string => name !== undefined),
+  }));
+
+  // Convert model-level linear dimensions (VFF; world space).
+  const finalDimensionsList: Dimension[] = dimensions.map((dm) => ({
+    a: dm.a,
+    b: dm.b,
+    offset: dm.offset,
+    planeX: dm.planeX,
+    normal: dm.normal,
+    text: dm.text,
+    hidden: false,
+  }));
+
   const finalDefinitions = new Map<number, Definition>();
   let rootDefinition: Definition | null = null;
   for (const [id, d] of defsDict.entries()) {
@@ -440,6 +520,8 @@ export function buildModelFromParsed(parsed: ParsedRawData): SkpModel {
     // matching the .NET and Dart ports' `Root`/`root` field.
     root: rootDefinition ?? { id: 0, guid: 'ROOT', name: 'ROOT_MODEL', vertices: [], edges: [], faces: [], instances: [], sectionPlanes: [], texts: [], dimensions: [], isImage: false, alwaysFacesCamera: false, shadowsFaceSun: false },
     layers: finalLayersList,
+    pages: finalPagesList,
+    dimensions: finalDimensionsList,
     materials: finalMaterialsList,
     materialsById,
     styles,
@@ -501,6 +583,11 @@ function buildDefinition(id: number, d: ParsedDefinition, layerIdToName?: Map<nu
   const dimensions: Dimension[] = (d.builder.dimensions || []).map((dim) => ({
     text: dim.text || '',
     hidden: dim.hidden || false,
+    a: null,
+    b: null,
+    offset: 0,
+    planeX: null,
+    normal: null,
   }));
 
   return {

--- a/packages/typescript/src/pages-dimensions.ts
+++ b/packages/typescript/src/pages-dimensions.ts
@@ -1,0 +1,356 @@
+/**
+ * VFF (2021+) scenes ("pages") and linear dimensions. Ported from Python's
+ * _core.py (PR #190) - see that module's _scan_vertex_positions /
+ * _scan_instance_transforms / _parse_dimensions / _find_page_node /
+ * _parse_pages for the byte-format details this file mirrors.
+ */
+import { TlvNode, readU32, readF64, parseVarInt } from './parser';
+import { findChildTag } from './geometry';
+import { multiplyMatrices, transformPoint } from './transforms';
+
+export interface RawPage {
+  name: string;
+  eye: [number, number, number] | null;
+  target: [number, number, number] | null;
+  up: [number, number, number] | null;
+  fov: number;
+  parallel: boolean;
+  orthoHeight: number;
+  hiddenLayerIds: number[];
+}
+
+export interface RawDimension {
+  a: [number, number, number];
+  b: [number, number, number];
+  offset: number;
+  planeX: [number, number, number] | null;
+  normal: [number, number, number] | null;
+  text: string;
+}
+
+// ── flat TLV, integer tags ──────────────────────────────────────────────
+// A second, deliberately separate flat-TLV reader from the string byte-order
+// tag convention the main tree uses (TlvNode.tag, e.g. "C409"): the
+// sub-records this feature reads (5208, 520A, 53FC, 5BCD, ...) are most
+// directly and safely ported from Python's own _tlv_items/_tlv_find (which
+// read the tag as a little-endian uint16) by keeping the SAME integer
+// convention here, copying Python's numeric constants byte-for-byte rather
+// than hand-converting each one to the swapped string form.
+
+interface FlatTlvItem {
+  tag: number;
+  payload: Uint8Array;
+}
+
+function tlvItemsInt(buf: Uint8Array | null): FlatTlvItem[] | null {
+  if (buf === null) return null;
+  const items: FlatTlvItem[] = [];
+  let off = 0;
+  const n = buf.length;
+  while (off < n) {
+    if (off + 6 > n) return null;
+    const tag = buf[off] | (buf[off + 1] << 8);
+    const ln = readU32(buf, off + 2);
+    if (tag === 0 || off + 6 + ln > n) return null;
+    items.push({ tag, payload: buf.subarray(off + 6, off + 6 + ln) });
+    off += 6 + ln;
+  }
+  return items;
+}
+
+function tlvFindInt(items: FlatTlvItem[] | null, tag: number): Uint8Array | null {
+  if (items === null) return null;
+  for (const it of items) {
+    if (it.tag === tag) return it.payload;
+  }
+  return null;
+}
+
+function toHex(data: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < data.length; i++) {
+    const h = data[i].toString(16).toUpperCase();
+    s += h.length === 1 ? '0' + h : h;
+  }
+  return s;
+}
+
+function stripDe05(p: Uint8Array): Uint8Array {
+  if (p.length >= 2 && p[0] === 0xde && p[1] === 0x05) {
+    const idlen = readU32(p, 2);
+    return p.subarray(6, 6 + idlen);
+  }
+  return p;
+}
+
+function findBytes(data: Uint8Array, needle: Uint8Array, start = 0): number {
+  const nlen = needle.length;
+  const limit = data.length - nlen;
+  outer: for (let i = start; i <= limit; i++) {
+    for (let j = 0; j < nlen; j++) {
+      if (data[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
+
+/**
+ * Accumulate every vertex's persistent id (hex) -> (x, y, z) inches. A
+ * vertex is a "C409" record: "DC05" holds its persistent id (the "DE05"
+ * var-int payload), "C509" its 3xf64 position. Dimension connection points
+ * reference geometry by this id. Called once per top-level record -
+ * parseSkp streams the TLV tree and never holds it whole.
+ */
+export function scanVertexPositions(top: TlvNode, id2pos: Map<string, [number, number, number]>): void {
+  function walk(nodes: TlvNode[]) {
+    for (const el of nodes) {
+      if (el.tag === 'C409') {
+        const dc05 = findChildTag(el.children, 'DC05');
+        const c509 = findChildTag(el.children, 'C509');
+        if (dc05 && c509 && c509.payload.length === 24) {
+          const idb = stripDe05(dc05.payload);
+          id2pos.set(toHex(idb), [
+            readF64(c509.payload, 0),
+            readF64(c509.payload, 8),
+            readF64(c509.payload, 16),
+          ]);
+        }
+      }
+      if (el.children.length > 0) walk(el.children);
+    }
+  }
+  walk([top]);
+}
+
+/**
+ * Accumulate each instance's persistent id (hex) -> its WORLD transform (a
+ * 13-number matrix), walking the instance tree and composing parent x local
+ * at every "6419". Per top-level record, like scanVertexPositions - an
+ * instance chain never crosses top-level records.
+ *
+ * A dimension connects to geometry INSIDE a placed component; its
+ * connection reference names the vertex AND the instance holding it. The
+ * vertex position is definition-local, so it must be lifted to world by the
+ * instance's transform for the dimension to land where the author drew it.
+ */
+export function scanInstanceTransforms(top: TlvNode, world: Map<string, number[] | null>): void {
+  function walk(nodes: TlvNode[], parent: number[] | null) {
+    for (const el of nodes) {
+      if (el.tag === '6419') {
+        const d007 = findChildTag(el.children, 'D007');
+        const dc05 = d007 ? findChildTag(d007.children, 'DC05') : null;
+        const iid = dc05 ? toHex(stripDe05(dc05.payload)) : null;
+
+        const m = findChildTag(el.children, '6619');
+        let mat: number[] | null = null;
+        if (m && m.payload.length === 104) {
+          mat = [];
+          for (let i = 0; i < 13; i++) mat.push(readF64(m.payload, i * 8));
+        }
+        const here: number[] | null = mat !== null ? multiplyMatrices(parent as number[], mat) : parent;
+        if (iid !== null) world.set(iid, here);
+        walk(el.children, here);
+      } else if (el.children.length > 0) {
+        walk(el.children, parent);
+      }
+    }
+  }
+  walk([top], null);
+}
+
+/**
+ * Linear dimensions (SketchUp's Dimension tool).
+ *
+ * A dimension entity is a "5BCC" record (raw bytes cc 5b) holding:
+ *
+ * - 5BCD / 5BCE - the two connection points. Each wraps a 5208 whose 5209
+ *   is the connection TYPE (1 = a free explicit point in 520A, already
+ *   world space; 2 = connected to geometry, 520A is zero and 520B -> 53FC
+ *   names the target: 53FD = the vertex by persistent id, 53FE = a
+ *   length-prefixed persistent id of the INSTANCE holding it - the vertex
+ *   position is definition-local, so it is lifted to world by that
+ *   instance's transform).
+ * - 5BCF - the dimension plane's x-axis; 5BD0 - its normal.
+ * - 5BD2 - the offset distance (inches): how far the dimension line sits
+ *   from the measured segment, along the in-plane perpendicular.
+ *
+ * The measured value is auto-computed from the two points (no cached text
+ * on the samples seen), so callers format it themselves. Endpoints come out
+ * in WORLD space (inches). A connection point that cannot be resolved drops
+ * the whole dimension (fail-safe).
+ */
+export function parseDimensions(
+  modelData: Uint8Array,
+  id2pos: Map<string, [number, number, number]>,
+  instWorld: Map<string, number[] | null>
+): RawDimension[] {
+  const dims: RawDimension[] = [];
+  const needle = new Uint8Array([0xcc, 0x5b]);
+  let i = 0;
+  const n = modelData.length;
+
+  function point(blockPayload: Uint8Array | null): [number, number, number] | null {
+    if (blockPayload === null) return null;
+    const blk = tlvFindInt(tlvItemsInt(blockPayload), 0x5208);
+    if (blk === null) return null;
+    const sub = tlvItemsInt(blk);
+    const typB = tlvFindInt(sub, 0x5209);
+    const typ = typB !== null && typB.length === 4 ? readU32(typB, 0) : null;
+    if (typ === 1) {
+      const pos = tlvFindInt(sub, 0x520a);
+      if (pos === null || pos.length !== 24) return null;
+      return [readF64(pos, 0), readF64(pos, 8), readF64(pos, 16)];
+    }
+    // type 2: resolve the geometry reference (vertex + instance).
+    const refB = tlvFindInt(sub, 0x520b);
+    const f53fc = refB !== null ? tlvFindInt(tlvItemsInt(refB), 0x53fc) : null;
+    const fi = f53fc !== null ? tlvItemsInt(f53fc) : null;
+    const vid = tlvFindInt(fi, 0x53fd);
+    const iid = tlvFindInt(fi, 0x53fe);
+    if (vid === null) return null;
+    const local = id2pos.get(toHex(vid));
+    if (local === undefined) return null;
+    if (iid !== null && iid.length >= 1 && iid[0] > 0 && 1 + iid[0] <= iid.length) {
+      const idBytes = iid.subarray(1, 1 + iid[0]);
+      const w = instWorld.get(toHex(idBytes));
+      if (w) {
+        return transformPoint(w, local);
+      }
+    }
+    return local; // model-root vertex - already world
+  }
+
+  while (true) {
+    const j = findBytes(modelData, needle, i);
+    if (j < 0) break;
+    i = j + 1;
+    if (j + 6 > n) continue;
+    const ln = readU32(modelData, j + 2);
+    if (ln < 40 || j + 6 + ln > n) continue;
+    const bodyBytes = modelData.subarray(j + 6, j + 6 + ln);
+    const body = tlvItemsInt(bodyBytes);
+    if (body === null) continue;
+    let has5Bcd = false;
+    let has5Bce = false;
+    for (const it of body) {
+      if (it.tag === 0x5bcd) has5Bcd = true;
+      if (it.tag === 0x5bce) has5Bce = true;
+    }
+    if (!has5Bcd || !has5Bce) continue;
+
+    const a = point(tlvFindInt(body, 0x5bcd));
+    const b = point(tlvFindInt(body, 0x5bce));
+    if (a === null || b === null) continue;
+
+    const xaxisB = tlvFindInt(body, 0x5bcf);
+    const normalB = tlvFindInt(body, 0x5bd0);
+    const offB = tlvFindInt(body, 0x5bd2);
+
+    dims.push({
+      a,
+      b,
+      planeX: xaxisB !== null && xaxisB.length === 24
+        ? [readF64(xaxisB, 0), readF64(xaxisB, 8), readF64(xaxisB, 16)]
+        : null,
+      normal: normalB !== null && normalB.length === 24
+        ? [readF64(normalB, 0), readF64(normalB, 8), readF64(normalB, 16)]
+        : null,
+      offset: offB !== null && offB.length === 8 ? readF64(offB, 0) : 0.0,
+      text: '',
+    });
+  }
+  return dims;
+}
+
+/**
+ * Return the "0702" scenes node inside top's subtree, or null. Called per
+ * top-level record; retaining the (small) 0702 subtree is the only thing
+ * kept alive past the streaming loop.
+ */
+export function findPageNode(top: TlvNode): TlvNode | null {
+  return findChildTag([top], '0702');
+}
+
+/**
+ * Scenes ("pages"). The 0702 node's payload nests 6D60 > 6D61 > one 7148
+ * record per page:
+ *
+ * - 6F54 > 6F55 - page name (UTF-8)
+ * - 714A > 34BC - camera: 34BD eye, 34BE target, 34BF up (3xf64, inches),
+ *   34C4 field of view (degrees), 34C2 u8 = PERSPECTIVE flag (00 = parallel
+ *   projection - calibrated against the bundled scene thumbnails: parallel
+ *   plans/elevations carry 00 and their 34C3 visible height matches the
+ *   thumbnail framing exactly, while perspective scenes carry 01 with a
+ *   stale 34C3), 34C3 f64 = visible height when parallel (inches)
+ * - 7150 - layers hidden in this page: (u8 length, var-int layer id) runs
+ */
+export function parsePages(node: TlvNode | null): RawPage[] {
+  const pages: RawPage[] = [];
+  if (node === null) return pages;
+
+  function vec3(p: Uint8Array | null): [number, number, number] | null {
+    return p !== null && p.length === 24 ? [readF64(p, 0), readF64(p, 8), readF64(p, 16)] : null;
+  }
+
+  const t60Items = tlvItemsInt(node.payload);
+  if (t60Items === null) return pages;
+  for (const it60 of t60Items) {
+    if (it60.tag !== 0x6d60) continue;
+    const t61Items = tlvItemsInt(it60.payload);
+    if (t61Items === null) continue;
+    for (const it61 of t61Items) {
+      if (it61.tag !== 0x6d61) continue;
+      const t48Items = tlvItemsInt(it61.payload);
+      if (t48Items === null) continue;
+      for (const it48 of t48Items) {
+        if (it48.tag !== 0x7148) continue;
+        const items = tlvItemsInt(it48.payload);
+        if (items === null) continue;
+
+        const page: RawPage = {
+          name: '',
+          eye: null,
+          target: null,
+          up: null,
+          fov: 35.0,
+          parallel: false,
+          orthoHeight: 0.0,
+          hiddenLayerIds: [],
+        };
+
+        const head = tlvItemsInt(tlvFindInt(items, 0x6f54));
+        const name = tlvFindInt(head, 0x6f55);
+        if (name !== null && name.length > 0) {
+          page.name = new TextDecoder('utf-8').decode(name);
+        }
+
+        const camWrap = tlvItemsInt(tlvFindInt(items, 0x714a));
+        const cam = camWrap !== null ? tlvItemsInt(tlvFindInt(camWrap, 0x34bc)) : null;
+        if (cam !== null) {
+          page.eye = vec3(tlvFindInt(cam, 0x34bd));
+          page.target = vec3(tlvFindInt(cam, 0x34be));
+          page.up = vec3(tlvFindInt(cam, 0x34bf));
+          const fov = tlvFindInt(cam, 0x34c4);
+          if (fov !== null && fov.length === 8) page.fov = readF64(fov, 0);
+          const flag = tlvFindInt(cam, 0x34c2);
+          page.parallel = flag !== null && flag.length > 0 && flag[0] === 0;
+          const height = tlvFindInt(cam, 0x34c3);
+          if (height !== null && height.length === 8) page.orthoHeight = readF64(height, 0);
+        }
+
+        const hidden = tlvFindInt(items, 0x7150);
+        let off = 0;
+        while (hidden !== null && off + 1 <= hidden.length) {
+          const ln = hidden[off];
+          if (ln === 0 || off + 1 + ln > hidden.length) break;
+          page.hiddenLayerIds.push(parseVarInt(hidden, off + 1, ln));
+          off += 1 + ln;
+        }
+
+        if (page.eye !== null && page.target !== null) pages.push(page);
+      }
+    }
+  }
+  return pages;
+}

--- a/packages/typescript/tests/face-instance-hidden.test.ts
+++ b/packages/typescript/tests/face-instance-hidden.test.ts
@@ -18,6 +18,8 @@ function parsed(defsDict: Map<number | string, any>): ParsedRawData {
     layerColors: new Map(),
     layerHidden: new Map(),
     layerIdToName: new Map(),
+    pages: [],
+    dimensions: [],
     materialIdToName: new Map(),
     materialsMap: new Map(),
     materialsByFolder: new Map(),

--- a/packages/typescript/tests/layer-hidden.test.ts
+++ b/packages/typescript/tests/layer-hidden.test.ts
@@ -16,6 +16,8 @@ function parsed(layerColors: Map<string, [number, number, number]>, layerHidden:
     layerColors,
     layerHidden,
     layerIdToName: new Map(),
+    pages: [],
+    dimensions: [],
     materialIdToName: new Map(),
     materialsMap: new Map(),
     materialsByFolder: new Map(),

--- a/packages/typescript/tests/meta-units.test.ts
+++ b/packages/typescript/tests/meta-units.test.ts
@@ -87,6 +87,8 @@ function parsed(overrides: Partial<ParsedRawData>): ParsedRawData {
     layerColors: new Map(),
     layerHidden: new Map(),
     layerIdToName: new Map(),
+    pages: [],
+    dimensions: [],
     materialIdToName: new Map(),
     materialsMap: new Map(),
     materialsByFolder: new Map(),

--- a/packages/typescript/tests/pages-dimensions.test.ts
+++ b/packages/typescript/tests/pages-dimensions.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseSkp } from '../src/index';
+import { parsePages, parseDimensions } from '../src/pages-dimensions';
+import { TlvNode } from '../src/parser';
+
+/**
+ * VFF scenes ("pages") and linear dimensions - ported from Python's
+ * test_pages_dimensions.py (PR #190).
+ *
+ * Dimensions are exercised against the repository's own Untitled.skp
+ * fixture (drawn in SketchUp 2025, it carries 13 linear dimensions); scenes
+ * have no fixture yet, so their parser is exercised on a synthetic "0702"
+ * record byte-for-byte shaped like the real ones (the layout was decoded
+ * from production survey files and calibrated against the scene thumbnails
+ * SketchUp embeds in the .skp itself).
+ */
+
+// ── helpers: build TLV runs in the flat (u16-LE tag, u32 len) form ────────
+
+function tlv(tag: number, payload: Uint8Array): Uint8Array {
+  const result = new Uint8Array(6 + payload.length);
+  result[0] = tag & 0xff;
+  result[1] = (tag >> 8) & 0xff;
+  const len = payload.length;
+  result[2] = len & 0xff;
+  result[3] = (len >> 8) & 0xff;
+  result[4] = (len >> 16) & 0xff;
+  result[5] = (len >> 24) & 0xff;
+  result.set(payload, 6);
+  return result;
+}
+
+function f64le(v: number): Uint8Array {
+  const buf = new Uint8Array(8);
+  new DataView(buf.buffer).setFloat64(0, v, true);
+  return buf;
+}
+
+function u32le(v: number): Uint8Array {
+  const buf = new Uint8Array(4);
+  new DataView(buf.buffer).setUint32(0, v, true);
+  return buf;
+}
+
+function vec3(x: number, y: number, z: number): Uint8Array {
+  return concat(f64le(x), f64le(y), f64le(z));
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((s, p) => s + p.length, 0);
+  const result = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    result.set(p, off);
+    off += p.length;
+  }
+  return result;
+}
+
+function toHex(data: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < data.length; i++) {
+    const h = data[i].toString(16).toUpperCase();
+    s += h.length === 1 ? '0' + h : h;
+  }
+  return s;
+}
+
+const FIXTURES = path.join(__dirname, 'fixtures');
+
+// ── linear dimensions ──────────────────────────────────────────────────
+
+describe('linear dimensions', () => {
+  it('the Untitled.skp fixture has 13 dimensions', () => {
+    const buf = fs.readFileSync(path.join(FIXTURES, 'Untitled.skp'));
+    const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+    const model = parseSkp(arrayBuffer);
+    expect(model.dimensions.length).toBe(13);
+    for (const d of model.dimensions) {
+      expect(d.a).not.toBeNull();
+      expect(d.b).not.toBeNull();
+      const [ax, ay, az] = d.a!;
+      const [bx, by, bz] = d.b!;
+      const dist = Math.hypot(ax - bx, ay - by, az - bz);
+      expect(dist).toBeGreaterThan(0.0); // a real measured segment
+      expect(d.normal).not.toBeNull();
+      expect(d.planeX).not.toBeNull();
+    }
+  });
+
+  it('parses two free (world-space) connection points', () => {
+    // A 5BCC record with two type-1 (free, world-space) connection points.
+    function pointBlock(wrapTag: number, x: number, y: number, z: number): Uint8Array {
+      const inner = concat(tlv(0x5209, u32le(1)), tlv(0x520a, vec3(x, y, z)));
+      return tlv(wrapTag, tlv(0x5208, inner));
+    }
+
+    const body = concat(
+      pointBlock(0x5bcd, 0.0, 0.0, 0.0),
+      pointBlock(0x5bce, 100.0, 0.0, 0.0),
+      tlv(0x5bcf, vec3(1.0, 0.0, 0.0)), // plane x-axis
+      tlv(0x5bd0, vec3(0.0, 0.0, 1.0)), // plane normal
+      tlv(0x5bd2, f64le(15.5)) // offset
+    );
+    const blob = concat(new Uint8Array(8), tlv(0x5bcc, body), new Uint8Array(8));
+
+    const dims = parseDimensions(blob, new Map(), new Map());
+    expect(dims.length).toBe(1);
+    const d = dims[0];
+    expect(d.a).toEqual([0.0, 0.0, 0.0]);
+    expect(d.b).toEqual([100.0, 0.0, 0.0]);
+    expect(d.offset).toBe(15.5);
+    expect(d.planeX).toEqual([1.0, 0.0, 0.0]);
+    expect(d.normal).toEqual([0.0, 0.0, 1.0]);
+  });
+
+  it('resolves a connected point through its instance transform, and drops an unresolvable one', () => {
+    // A type-2 connection (vertex id + instance id): the vertex position is
+    // definition-local and must be lifted to world by the instance's
+    // transform. An unresolvable reference drops the dimension (fail-safe).
+    const vid = new Uint8Array([0xaa, 0xbb, 0x01]);
+    const iid = new Uint8Array([0xcc, 0xdd, 0x02]);
+
+    function connected(wrapTag: number): Uint8Array {
+      const idLenPrefixed = concat(new Uint8Array([iid.length]), iid);
+      const refTlv = tlv(0x53fc, concat(tlv(0x53fd, vid), tlv(0x53fe, idLenPrefixed)));
+      const inner = concat(tlv(0x5209, u32le(2)), tlv(0x520b, refTlv));
+      return tlv(wrapTag, tlv(0x5208, inner));
+    }
+
+    function free(wrapTag: number): Uint8Array {
+      const inner = concat(tlv(0x5209, u32le(1)), tlv(0x520a, vec3(0.0, 0.0, 0.0)));
+      return tlv(wrapTag, tlv(0x5208, inner));
+    }
+
+    const body = concat(connected(0x5bcd), free(0x5bce), tlv(0x5bd2, f64le(0.0)));
+    const blob = tlv(0x5bcc, body);
+
+    // Identity-ish transform that translates by (10, 20, 30).
+    const world = [1, 0, 0, 0, 1, 0, 0, 0, 1, 10.0, 20.0, 30.0, 1.0];
+    const id2pos = new Map<string, [number, number, number]>([[toHex(vid), [1.0, 2.0, 3.0]]]);
+    const instWorld = new Map<string, number[] | null>([[toHex(iid), world]]);
+
+    const dims = parseDimensions(blob, id2pos, instWorld);
+    expect(dims.length).toBe(1);
+    expect(dims[0].a).toEqual([11.0, 22.0, 33.0]); // local + translation
+
+    // Same record, but the vertex id is unknown: the dimension is dropped.
+    const emptyDims = parseDimensions(blob, new Map(), new Map());
+    expect(emptyDims.length).toBe(0);
+  });
+});
+
+// ── scenes (pages) ─────────────────────────────────────────────────────
+
+function pageRecord(name: string, parallel: boolean, hiddenIds: number[] = []): Uint8Array {
+  const cam = concat(
+    tlv(0x34bd, vec3(100.0, -200.0, 50.0)), // eye
+    tlv(0x34be, vec3(0.0, 0.0, 0.0)), // target
+    tlv(0x34bf, vec3(0.0, 0.0, 1.0)), // up
+    tlv(0x34c4, f64le(35.0)), // fov
+    tlv(0x34c2, new Uint8Array([parallel ? 0 : 1])),
+    tlv(0x34c3, f64le(240.0)) // ortho height
+  );
+  const hiddenParts = hiddenIds.map((i) => new Uint8Array([1, i]));
+  const hidden = concat(...hiddenParts);
+  const body = concat(
+    tlv(0x6f54, tlv(0x6f55, new TextEncoder().encode(name))),
+    tlv(0x714a, tlv(0x34bc, cam)),
+    tlv(0x7150, hidden)
+  );
+  return tlv(0x7148, body);
+}
+
+describe('scenes (pages)', () => {
+  it('parses a synthetic 0702 record', () => {
+    const payload = tlv(
+      0x6d60,
+      tlv(0x6d61, concat(pageRecord('Planta', true, [2]), pageRecord('Vista 3D', false)))
+    );
+    const node: TlvNode = { offset: 0, tag: '0702', size: payload.length, children: [], payload };
+    const pages = parsePages(node);
+
+    expect(pages.map((p) => p.name)).toEqual(['Planta', 'Vista 3D']);
+    const planta = pages[0];
+    expect(planta.parallel).toBe(true);
+    expect(planta.orthoHeight).toBe(240.0);
+    expect(planta.eye).toEqual([100.0, -200.0, 50.0]);
+    expect(planta.up).toEqual([0.0, 0.0, 1.0]);
+    expect(planta.hiddenLayerIds).toEqual([2]);
+    expect(pages[1].parallel).toBe(false);
+    expect(pages[1].fov).toBe(35.0);
+  });
+
+  it('is empty when absent', () => {
+    expect(parsePages(null)).toEqual([]);
+  });
+
+  it('a file with no pages parses with an empty pages list', () => {
+    const buf = fs.readFileSync(path.join(FIXTURES, 'SU_File.skp'));
+    const arrayBuffer = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+    const model = parseSkp(arrayBuffer);
+    expect(model.pages).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Ports two new VFF (2021+) entity families from Python's `_core.py`/`model.py` (PR #190, Python-only) to TypeScript, .NET, Dart, and C++:

1. **Scenes ("pages")**: the `0702` record nests `6D60 › 6D61 ›` one `7148` per page — name, camera (eye/target/up/fov), parallel-vs-perspective projection flag, visible height when parallel, and hidden-layer-id runs. Surfaces as `SkpModel.pages`; hidden layer ids resolve to layer names.
2. **Linear dimensions**: the `5BCC` record's two connection points, each either an explicit world-space point or a reference to a vertex inside a placed component, resolved to world space through that instance's transform. Two new streaming-friendly per-top-level-record scans (vertex-id → position, instance-id → world-transform) feed the resolution. Surfaces as `SkpModel.dimensions` with world-space endpoints; the existing per-definition text-only `Dimension` fields are untouched.

`_core.py` was completely untouched between #190's merge and this port, so the merge diff itself is the exact, still-current spec — no scope-boundary reconciliation needed (unlike #194).

## Key porting decision
Each language got its own small integer-tag flat-TLV reader for this feature's sub-records, rather than reusing the existing string byte-order tag convention the main tree relies on. Python's new `_tlv_items`/`_tlv_find` read tags as raw little-endian `uint16`s — a genuinely different convention from the main tree's byte-order hex strings (e.g. `"C409"`). Hand-swapping ~15 numeric tag constants into their string-equivalent byte-swapped form was judged too easy to get silently wrong (a bad tag just makes lookups return null, not throw), so each language copies Python's numeric constants byte-for-byte instead.

## Verification
- All four: full local test suite green, plus byte-for-byte synthetic unit tests ported from Python's own `test_pages_dimensions.py` (free-point dimension, instance-transform-resolved connected-point dimension incl. fail-safe drop, synthetic `0702` scene record).
- TypeScript/.NET/Dart (verified locally): the repo's own `Untitled.skp` fixture parses to exactly 13 dimensions, matching Python's own test assertion.
- **.NET**: added `ChunkedBuffer.IndexOf` for the raw dimension-record byte-pattern scan, since `model.dat` is a multi-segment buffer there (not a flat array — see the earlier #200 port).
- **C++**: no local compiler in this environment (standing constraint) — relies on CI. Caught and fixed a real dangling-pointer bug during manual review before it ever reached CI: an initial draft wrapped `top` nodes in a synthetic one-element vector (safe in the other, reference/GC-managed languages; unsafe in C++, where `TlvNode` is a value type and the wrapper is a real temporary whose lifetime ends at the full expression). Rewrote the three entry points to recurse by reference directly instead.

## Test plan
- [ ] CI green across all 5 languages (Python unaffected/unchanged)
- [ ] C++ build green (extra scrutiny warranted — no local verification was possible)