### PR TITLE
Fix CoEdge orientation normalization in Python, TypeScript, .NET, Dart

### DIFF
--- a/packages/dart/lib/src/geometry.dart
+++ b/packages/dart/lib/src/geometry.dart
@@ -307,7 +307,10 @@ class Geometry {
                   subPos += 6 + subSize;
                 }
                 if (edgeId != null && orient != null) {
-                  coEdges.add((edgeId, orient));
+                  // Normalize to the documented CoEdge contract (+1 = same
+                  // direction as the edge, -1 = reversed) - the raw A20F
+                  // value is SketchUp's own bit (0 = forward, 1 = reversed).
+                  coEdges.add((edgeId, orient == 0 ? 1 : -1));
                 }
               }
               if (coEdges.isNotEmpty) loops.add(coEdges);

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -1792,7 +1792,10 @@ class Legacy {
             final ent = slots[es];
             if (ent == null || ent.value == null) continue;
             _addEdge(builder, es, ent.value as EdgeRec, slots);
-            loop.add((es, u.sense != 0 ? 1 : 0));
+            // Normalize to the documented CoEdge contract (+1 = same
+            // direction as the edge, -1 = reversed) - u.sense is the raw
+            // SketchUp bit (0 = forward, 1 = reversed).
+            loop.add((es, u.sense != 0 ? -1 : 1));
           }
           loops.add(loop);
         }

--- a/packages/dart/test/coedge_orientation_test.dart
+++ b/packages/dart/test/coedge_orientation_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:openskp/openskp.dart';
+import 'package:test/test.dart';
+
+/// Regression coverage for the CoEdge orientation contract (+1 = same
+/// direction as the edge's own v1Id->v2Id, -1 = reversed). Both the legacy
+/// (pre-2021 MFC) and modern (VFF) readers used to leak SketchUp's raw
+/// storage bit (0 = forward, 1 = reversed) straight through instead of
+/// normalizing it - counting coedges or checking their type does not catch
+/// this, since a face with every coedge reversed still has the same edge
+/// count and loop length, just the wrong winding. The only thing that
+/// catches it is checking that consecutive coedges in a loop actually
+/// connect head-to-tail.
+void main() {
+  String fixture(String name) =>
+      '${Directory.current.path}/test/fixtures/$name';
+
+  void assertConnectedNormalizedLoops(Iterable<Definition> definitions) {
+    for (final def in definitions) {
+      for (final face in def.faces.values) {
+        for (final loop in face.loops) {
+          expect(loop, isNotEmpty, reason: 'empty loop');
+          final n = loop.length;
+          for (var i = 0; i < n; i++) {
+            final (edgeId, orientation) = loop[i];
+            final (nextEdgeId, nextOrientation) = loop[(i + 1) % n];
+            expect(orientation, anyOf(1, -1));
+            final edge = def.edges[edgeId];
+            final nextEdge = def.edges[nextEdgeId];
+            expect(edge, isNotNull);
+            expect(nextEdge, isNotNull);
+            final end = orientation == 1 ? edge!.v2Id : edge!.v1Id;
+            final nextStart =
+                nextOrientation == 1 ? nextEdge!.v1Id : nextEdge!.v2Id;
+            expect(end, nextStart);
+          }
+        }
+      }
+    }
+  }
+
+  test('legacy MFC reader (capilla_quiroz_v17.skp)', () {
+    final model = SkpFile.open(fixture('capilla_quiroz_v17.skp')).parse();
+    assertConnectedNormalizedLoops([...model.definitions.values, model.root]);
+  });
+
+  test('modern VFF reader (Untitled.skp)', () {
+    final model = SkpFile.open(fixture('Untitled.skp')).parse();
+    assertConnectedNormalizedLoops([...model.definitions.values, model.root]);
+  });
+}

--- a/packages/dotnet/OpenSkp.Tests/CoEdgeOrientationTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CoEdgeOrientationTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+using OpenSkp;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>
+    /// Regression coverage for the CoEdge orientation contract (+1 = same
+    /// direction as the edge's own V1Id->V2Id, -1 = reversed). Both the
+    /// legacy (pre-2021 MFC) and modern (VFF) readers used to leak
+    /// SketchUp's raw storage bit (0 = forward, 1 = reversed) straight
+    /// through instead of normalizing it - counting coedges or checking
+    /// their type does not catch this, since a face with every coedge
+    /// reversed still has the same edge count and loop length, just the
+    /// wrong winding. The only thing that catches it is checking that
+    /// consecutive coedges in a loop actually connect head-to-tail.
+    /// </summary>
+    public class CoEdgeOrientationTests
+    {
+        private static string FixturePath(string name) =>
+            Path.Combine(AppContext.BaseDirectory, "fixtures", name);
+
+        private static void AssertConnectedNormalizedLoops(IEnumerable<Definition> definitions)
+        {
+            foreach (var def in definitions)
+            {
+                foreach (var face in def.Faces.Values)
+                {
+                    foreach (var loop in face.Loops)
+                    {
+                        Assert.True(loop.Count > 0, "empty loop");
+                        int n = loop.Count;
+                        for (int i = 0; i < n; i++)
+                        {
+                            var (edgeId, orientation) = loop[i];
+                            var (nextEdgeId, nextOrientation) = loop[(i + 1) % n];
+                            Assert.True(orientation == 1 || orientation == -1);
+                            Assert.True(def.Edges.TryGetValue(edgeId, out var edge));
+                            Assert.True(def.Edges.TryGetValue(nextEdgeId, out var nextEdge));
+                            long end = orientation == 1 ? edge!.V2Id : edge!.V1Id;
+                            long nextStart = nextOrientation == 1 ? nextEdge!.V1Id : nextEdge!.V2Id;
+                            Assert.Equal(nextStart, end);
+                        }
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void LegacyMfcReaderCapillaQuirozV17()
+        {
+            var model = SkpFile.Open(FixturePath("capilla_quiroz_v17.skp"));
+            AssertConnectedNormalizedLoops(model.Definitions.Values.Append(model.Root));
+        }
+
+        [Fact]
+        public void ModernVffReaderUntitled()
+        {
+            var model = SkpFile.Open(FixturePath("Untitled.skp"));
+            AssertConnectedNormalizedLoops(model.Definitions.Values.Append(model.Root));
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Geometry.cs
+++ b/packages/dotnet/OpenSkp/Geometry.cs
@@ -280,7 +280,10 @@ namespace OpenSkp
                                     }
                                     if (edgeId != null && orient != null)
                                     {
-                                        coEdges.Add((edgeId.Value, orient.Value));
+                                        // Normalize to the documented CoEdge contract (+1 = same
+                                        // direction as the edge, -1 = reversed) - the raw A20F
+                                        // value is SketchUp's own bit (0 = forward, 1 = reversed).
+                                        coEdges.Add((edgeId.Value, orient.Value == 0 ? 1 : -1));
                                     }
                                 }
                                 if (coEdges.Count > 0) loops.Add(coEdges);

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -1931,7 +1931,10 @@ namespace OpenSkp
                             int? es = u.Edge;
                             if (es == null || !slots.TryGetValue(es.Value, out var ent) || ent.Value == null) continue;
                             AddEdge(builder, es.Value, (EdgeRec)ent.Value, slots);
-                            loop.Add((es.Value, u.Sense != 0 ? 1 : 0));
+                            // Normalize to the documented CoEdge contract (+1 = same
+                            // direction as the edge, -1 = reversed) - u.Sense is the raw
+                            // SketchUp bit (0 = forward, 1 = reversed).
+                            loop.Add((es.Value, u.Sense != 0 ? -1 : 1));
                         }
                         loops.Add(loop);
                     }

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -695,7 +695,13 @@ def _extract_geometry_from_nodes(elements, builder):
                                         orient = val
                                 sub_pos += 6 + sub_size
                             if edge_id is not None and orient is not None:
-                                co_edges.append((edge_id, orient))
+                                # Normalize to the documented CoEdge
+                                # contract (+1 = same direction as the
+                                # edge, -1 = reversed) - the raw A20F
+                                # value is SketchUp's own bit (0 = forward,
+                                # 1 = reversed).
+                                co_edges.append(
+                                    (edge_id, 1 if orient == 0 else -1))
                         if co_edges:
                             loops.append(co_edges)
                 face_mat_id = None

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -1344,7 +1344,10 @@ def _fill_builder(builder, ents, slots):
                     if ent is None or ent[2] is None:
                         continue
                     _add_edge(builder, es, ent[2], slots)
-                    loop.append((es, 1 if u['sense'] else 0))
+                    # Normalize to the documented CoEdge contract (+1 = same
+                    # direction as the edge, -1 = reversed) - u['sense'] is
+                    # the raw SketchUp bit (0 = forward, 1 = reversed).
+                    loop.append((es, -1 if u['sense'] else 1))
                 loops.append(loop)
             face = {'loops': loops, 'normal': tuple(v['plane'][:3]),
                     'material_id': v['db']['mat'] or None,

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -1714,6 +1714,33 @@ class TestLegacyStrings:
 # ── Legacy real-file regression (binary fixture) ─────────────────────────
 
 
+def _assert_connected_normalized_loops(definitions) -> None:
+    """Every face loop's coedges must (1) carry a normalized +1/-1
+    orientation (the public contract - see ``Face.loops`` docs) and (2)
+    actually connect head-to-tail: the vertex the coedge ENDS at
+    (accounting for its own orientation) must be where the next coedge in
+    the loop STARTS. A loop that "parses" without this holding describes
+    disconnected or misordered geometry - counting coedges or checking
+    their type alone does not catch a flipped orientation bit, since a
+    face with reversed coedges still has the same edge count and loop
+    length, just the wrong winding."""
+    for d in definitions:
+        for face in d.faces.values():
+            for loop in face.loops:
+                assert loop, "empty loop"
+                n = len(loop)
+                for i in range(n):
+                    edge_id, orientation = loop[i]
+                    next_edge_id, next_orientation = loop[(i + 1) % n]
+                    assert orientation in (1, -1)
+                    edge = d.edges[edge_id]
+                    next_edge = d.edges[next_edge_id]
+                    end = edge.v2_id if orientation == 1 else edge.v1_id
+                    next_start = (next_edge.v1_id if next_orientation == 1
+                                  else next_edge.v2_id)
+                    assert end == next_start
+
+
 class TestLegacyRealFile:
     """Decode a real classic (v17 MFC) ``.skp`` end to end and assert the
     geometry against known ground truth.
@@ -1785,6 +1812,11 @@ class TestLegacyRealFile:
         # its internal "ROOT" sentinel key - it has its own field.
         assert "ROOT" not in model.definitions
         assert all(isinstance(k, int) for k in model.definitions)
+
+    def test_coedge_orientations_are_normalized_and_connected(self) -> None:
+        model = self._model()
+        _assert_connected_normalized_loops(
+            list(model.definitions.values()) + [model.root])
 
 
 class TestModernRealFile:
@@ -1944,6 +1976,11 @@ class TestModernRealFile:
         assert len(scene.mesh_index) == 1
         first_mesh = next(iter(scene.mesh_index.values()))
         assert first_mesh.definition_name == "ROOT_MODEL"
+
+    def test_coedge_orientations_are_normalized_and_connected(self) -> None:
+        model = self._model(self.FIXTURE_UNTITLED).parse()
+        _assert_connected_normalized_loops(
+            list(model.definitions.values()) + [model.root])
 
 
 class TestLegacyDynamicProperties:

--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -249,7 +249,10 @@ export function extractGeometryFromNodes(
                 subPos += 6 + subSize;
               }
               if (edgeId !== null && orient !== null) {
-                coEdges.push({ edgeId, orientation: orient });
+                // Normalize to the documented CoEdge contract (+1 = same
+                // direction as the edge, -1 = reversed) - the raw A20F
+                // value is SketchUp's own bit (0 = forward, 1 = reversed).
+                coEdges.push({ edgeId, orientation: orient === 0 ? 1 : -1 });
               }
             }
             if (coEdges.length > 0) {

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -1598,7 +1598,10 @@ function fillBuilder(builder: LegacyBuilder, ents: [number, string | null, any][
           const ent = slots.get(es);
           if (ent === undefined || ent[2] === null) continue;
           addEdge(builder, es, ent[2], slots);
-          loop.push({ edgeId: es, orientation: u.sense ? 1 : 0 });
+          // Normalize to the documented CoEdge contract (+1 = same
+          // direction as the edge, -1 = reversed) - u.sense is the raw
+          // SketchUp bit (0 = forward, 1 = reversed).
+          loop.push({ edgeId: es, orientation: u.sense ? -1 : 1 });
         }
         loops.push(loop);
       }

--- a/packages/typescript/tests/coedge-orientation.test.ts
+++ b/packages/typescript/tests/coedge-orientation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'path';
+import { SkpFile } from '../src/index';
+import { Definition } from '../src/model';
+
+/**
+ * Regression coverage for the CoEdge orientation contract (+1 = same
+ * direction as the edge's own v1->v2, -1 = reversed). Both the legacy
+ * (pre-2021 MFC) and modern (VFF) readers used to leak SketchUp's raw
+ * storage bit (0 = forward, 1 = reversed) straight through instead of
+ * normalizing it - counting coedges or checking their type does not catch
+ * this, since a face with every coedge reversed still has the same edge
+ * count and loop length, just the wrong winding. The only thing that
+ * catches it is checking that consecutive coedges in a loop actually
+ * connect head-to-tail.
+ */
+function assertConnectedNormalizedLoops(definitions: Definition[]): void {
+  for (const def of definitions) {
+    const edgesById = new Map(def.edges.map((e) => [e.id, e]));
+    for (const face of def.faces) {
+      for (const loop of face.loops) {
+        expect(loop.length).toBeGreaterThan(0);
+        const n = loop.length;
+        for (let i = 0; i < n; i++) {
+          const { edgeId, orientation } = loop[i];
+          const { edgeId: nextEdgeId, orientation: nextOrientation } = loop[(i + 1) % n];
+          expect([1, -1]).toContain(orientation);
+          const edge = edgesById.get(edgeId);
+          const nextEdge = edgesById.get(nextEdgeId);
+          expect(edge).toBeDefined();
+          expect(nextEdge).toBeDefined();
+          const end = orientation === 1 ? edge!.v2Id : edge!.v1Id;
+          const nextStart = nextOrientation === 1 ? nextEdge!.v1Id : nextEdge!.v2Id;
+          expect(end).toBe(nextStart);
+        }
+      }
+    }
+  }
+}
+
+describe('CoEdge orientation is normalized and connected', () => {
+  it('legacy MFC reader (capilla_quiroz_v17.skp)', () => {
+    const filePath = path.join(__dirname, 'fixtures', 'capilla_quiroz_v17.skp');
+    const model = SkpFile.open(filePath).parse();
+    assertConnectedNormalizedLoops([...model.definitions.values(), model.root]);
+  });
+
+  it('modern VFF reader (Untitled.skp)', () => {
+    const filePath = path.join(__dirname, 'fixtures', 'Untitled.skp');
+    const model = SkpFile.open(filePath).parse();
+    assertConnectedNormalizedLoops([...model.definitions.values(), model.root]);
+  });
+});


### PR DESCRIPTION
## Summary
- `CoEdge.orientation` is documented everywhere as `+1` = same direction as the edge, `-1` = reversed, but several readers passed SketchUp's raw storage bit (`0` = forward, `1` = reversed) straight through instead — flipping forward/reversed for any consumer following the documented contract.
- Fixed: Python (legacy path in `legacy.py`, and the modern path in `_core.py` which turned out to have the same bug despite an unrelated dead code path in `geometry.py` already normalizing correctly), TypeScript (both paths), .NET (both paths), Dart (both paths).
- C++ already had this fixed via #223, which is also where the stronger connectivity-check test pattern (verifying consecutive coedges in a loop actually connect head-to-tail) originated — that pattern is now ported to the other four languages against real legacy and modern fixtures, since counting coedges or checking their type alone doesn't catch a flipped orientation bit.

## Test plan
- [x] Python: full suite (379 tests) + ruff, green
- [x] TypeScript: full suite (330 tests) + eslint + tsc, green
- [x] .NET: full suite (162 tests), green
- [x] Dart: full suite (187 tests) + `dart analyze`, green
- [x] For each language, confirmed the new connectivity test fails against the pre-fix code and passes post-fix