### PR TITLE
Fix legacy Dynamic Component attribute lookup in Python, TypeScript, .NET, Dart

### DIFF
--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -881,8 +881,11 @@ class LegacyReaders {
   /// carries no attribute container or no dynamic_attributes dictionary.
   static Map<String, String> extractLegacyDynamicProperties(AttrsRec? attrs) {
     if (attrs == null) return {};
-    for (final (name, value) in attrs.children) {
-      if (name == _dynamicAttributesDictName && value is DictRec) {
+    // The tuple's first element is the entity CLASS NAME (always
+    // 'CAttributeNamed', from readObject) - never the dictionary's own
+    // declared name, which lives in DictRec.name.
+    for (final (_, value) in attrs.children) {
+      if (value is DictRec && value.name == _dynamicAttributesDictName) {
         return {
           for (final entry in value.entries.entries)
             entry.key: stringifyAttrValue(entry.value)

--- a/packages/dart/test/create_test.dart
+++ b/packages/dart/test/create_test.dart
@@ -577,22 +577,14 @@ void main() {
       );
     });
 
-    test('instance dynamic attributes write without corrupting the file', () {
-      // NOTE: this only checks that writing a "dynamic_attributes"
-      // dictionary produces a self-parsing file, not that
-      // Instance.properties actually comes back populated - it currently
-      // doesn't. LegacyReaders.extractLegacyDynamicProperties (and its
-      // Python counterpart, _extract_legacy_dynamic_properties in
-      // legacy.py - this isn't a Dart-port-specific bug) compares the
-      // *class* name Archive.readObject returns for each
-      // CAttributeContainer child ("CAttributeNamed", always) against the
-      // dictionary's own name instead of comparing DictRec.name, so the
-      // "dynamic_attributes" dictionary is never actually recognized and
-      // Instance.properties reads back empty regardless of what was
-      // written. Confirmed independently against the installed Python
-      // package during this port - a genuine, pre-existing reader-side
-      // gap in both languages, out of scope for this writer port to fix.
-      // Flagged for a separate follow-up rather than silently patched here.
+    test('instance dynamic attributes round-trip through Instance.properties', () {
+      // Was reader-side broken (LegacyReaders.extractLegacyDynamicProperties
+      // compared the *class* name Archive.readObject returns for each
+      // CAttributeContainer child - always "CAttributeNamed" - against the
+      // dictionary's own name instead of comparing DictRec.name, so
+      // "dynamic_attributes" was never recognized) - fixed 2026-08-26,
+      // ported from the same fix in Python's legacy.py. Now genuinely
+      // round-trips.
       final builder = create();
       final chair = builder.addComponentDefinition('Chair', (def) {
         def.addFace(square);
@@ -604,6 +596,7 @@ void main() {
       );
       final model = SkpFile.fromBuffer(builder.toBytes()).parse();
       expect(model.root.instances.single.name, 'Chair');
+      expect(model.root.instances.single.properties, {'sku': 'CH-1', 'qty': '3'});
     });
   });
 

--- a/packages/dart/test/dynamic_properties_test.dart
+++ b/packages/dart/test/dynamic_properties_test.dart
@@ -67,10 +67,14 @@ void main() {
 
   group('extractLegacyDynamicProperties', () {
     test('extracts the dynamic_attributes dict by name', () {
+      // Real shape from readAttrContainer/readAttrNamed: each tuple's
+      // first element is the ENTITY CLASS NAME (always 'CAttributeNamed',
+      // from Archive.readObject) - never the dictionary's own declared
+      // name, which lives in DictRec.name.
       final attrs = AttrsRec([
-        ('SU_DefinitionSet', DictRec('SU_DefinitionSet', {'unrelated': 1})),
+        ('CAttributeNamed', DictRec('SU_DefinitionSet', {'unrelated': 1})),
         (
-          'dynamic_attributes',
+          'CAttributeNamed',
           DictRec('dynamic_attributes', {'width': 10.0, '_width_label': 'Width', 'count': 4}),
         ),
       ]);
@@ -80,7 +84,7 @@ void main() {
 
     test('returns {} when no dynamic_attributes dict is present', () {
       final attrs = AttrsRec([
-        ('SU_DefinitionSet', DictRec('SU_DefinitionSet', {'a': 1})),
+        ('CAttributeNamed', DictRec('SU_DefinitionSet', {'a': 1})),
       ]);
       expect(LegacyReaders.extractLegacyDynamicProperties(attrs), {});
     });

--- a/packages/dotnet/OpenSkp.Tests/CreateTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CreateTests.cs
@@ -394,6 +394,29 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
+        public void InstanceDynamicAttributesRoundTripThroughInstanceProperties()
+        {
+            // Was reader-side broken (LegacyReaders.ExtractLegacyDynamicProperties
+            // compared the *class* name Archive.ReadObject returns for each
+            // CAttributeContainer child - always "CAttributeNamed" - against
+            // the dictionary's own name instead of comparing DictRec.Name,
+            // so "dynamic_attributes" was never recognized) - fixed
+            // 2026-08-26, ported from the same fix in Python's legacy.py.
+            // Now genuinely round-trips.
+            var builder = SkpCreate.NewFile();
+            var chair = builder.AddComponentDefinition("Chair");
+            using (chair) { chair.AddFace(Square()); }
+            builder.AddInstance(
+                chair,
+                attributes: new System.Collections.Generic.Dictionary<string, object> { ["sku"] = "CH-1", ["count"] = 3 },
+                attributeDictName: "dynamic_attributes");
+            var model = SkpFile.Parse(builder.ToBytes());
+            var instance = Assert.Single(model.Root.Instances);
+            Assert.Equal("CH-1", instance.Properties["sku"]);
+            Assert.Equal("3", instance.Properties["count"]);
+        }
+
+        [Fact]
         public void UnsupportedAttributeValueTypeThrows()
         {
             var builder = SkpCreate.NewFile();

--- a/packages/dotnet/OpenSkp.Tests/DynamicPropertiesTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/DynamicPropertiesTests.cs
@@ -59,6 +59,10 @@ namespace OpenSkp.Tests
         [Fact]
         public void ExtractLegacyDynamicProperties_FindsDictByName()
         {
+            // Real shape from ReadAttrContainer/ReadAttrNamed: each child
+            // tuple's Name is the entity CLASS NAME (always
+            // "CAttributeNamed", from Archive.ReadObject) - never the
+            // dictionary's own declared name, which lives in DictRec.Name.
             var dynamicDict = new DictRec
             {
                 Name = "dynamic_attributes",
@@ -67,7 +71,7 @@ namespace OpenSkp.Tests
             var otherDict = new DictRec { Name = "SU_DefinitionSet", Entries = new Dictionary<string, object?> { ["unrelated"] = 1 } };
             var attrs = new AttrsRec
             {
-                Children = new List<(string?, object?)> { ("SU_DefinitionSet", otherDict), ("dynamic_attributes", dynamicDict) },
+                Children = new List<(string?, object?)> { ("CAttributeNamed", otherDict), ("CAttributeNamed", dynamicDict) },
             };
 
             var props = LegacyReaders.ExtractLegacyDynamicProperties(attrs);
@@ -82,7 +86,7 @@ namespace OpenSkp.Tests
         {
             var attrs = new AttrsRec
             {
-                Children = new List<(string?, object?)> { ("SU_DefinitionSet", new DictRec { Name = "SU_DefinitionSet" }) },
+                Children = new List<(string?, object?)> { ("CAttributeNamed", new DictRec { Name = "SU_DefinitionSet" }) },
             };
             Assert.Empty(LegacyReaders.ExtractLegacyDynamicProperties(attrs));
         }

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -1526,9 +1526,12 @@ namespace OpenSkp
         public static Dictionary<string, string> ExtractLegacyDynamicProperties(AttrsRec? attrs)
         {
             if (attrs == null) return new Dictionary<string, string>();
-            foreach (var (name, value) in attrs.Children)
+            // Each child tuple's Name is the entity CLASS NAME (always
+            // 'CAttributeNamed', from Archive.ReadObject) - never the
+            // dictionary's own declared name, which lives in DictRec.Name.
+            foreach (var (_, value) in attrs.Children)
             {
-                if (name == DynamicAttributesDictName && value is DictRec dict)
+                if (value is DictRec dict && dict.Name == DynamicAttributesDictName)
                 {
                     var result = new Dictionary<string, string>();
                     foreach (var kv in dict.Entries) result[kv.Key] = StringifyAttrValue(kv.Value);

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -1304,8 +1304,11 @@ def _extract_legacy_dynamic_properties(attrs):
     container or no dynamic_attributes dictionary."""
     if not isinstance(attrs, dict):
         return {}
-    for name, value in attrs.get('children', []):
-        if name == _DYNAMIC_ATTRIBUTES_DICT_NAME and isinstance(value, dict):
+    for _class_name, value in attrs.get('children', []):
+        # _class_name is the entity class name (always 'CAttributeNamed'
+        # here, from ar.read_object) - the dictionary's own declared name
+        # lives inside the value, as value['name'].
+        if isinstance(value, dict) and value.get('name') == _DYNAMIC_ATTRIBUTES_DICT_NAME:
             entries = value.get('entries', {})
             return {k: _stringify_attr_value(v) for k, v in entries.items()}
     return {}

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2019,11 +2019,15 @@ class TestLegacyDynamicProperties:
 
     def test_extracts_dynamic_attributes_dict_by_name(self) -> None:
         from openskp.legacy import _extract_legacy_dynamic_properties
+        # Real shape from _read_attr_container/_read_attr_named: each
+        # child tuple's first element is the ENTITY CLASS NAME (always
+        # 'CAttributeNamed', from ar.read_object) - never the dictionary's
+        # own declared name, which lives inside the value as value['name'].
         attrs = {
             "k": "attrs",
             "children": [
-                ("SU_DefinitionSet", {"k": "dict", "name": "SU_DefinitionSet", "entries": {"unrelated": 1}}),
-                ("dynamic_attributes", {
+                ("CAttributeNamed", {"k": "dict", "name": "SU_DefinitionSet", "entries": {"unrelated": 1}}),
+                ("CAttributeNamed", {
                     "k": "dict", "name": "dynamic_attributes",
                     "entries": {"width": 10.0, "_width_label": "Width", "count": 4},
                 }),
@@ -2035,7 +2039,7 @@ class TestLegacyDynamicProperties:
     def test_returns_empty_dict_when_no_dynamic_attributes_dict(self) -> None:
         from openskp.legacy import _extract_legacy_dynamic_properties
         attrs = {"k": "attrs", "children": [
-            ("SU_DefinitionSet", {"k": "dict", "name": "SU_DefinitionSet", "entries": {"a": 1}}),
+            ("CAttributeNamed", {"k": "dict", "name": "SU_DefinitionSet", "entries": {"a": 1}}),
         ]}
         assert _extract_legacy_dynamic_properties(attrs) == {}
 

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -689,8 +689,11 @@ export function stringifyAttrValue(value: any): string {
  * carries no attribute container or no dynamic_attributes dictionary. */
 export function extractLegacyDynamicProperties(attrs: any): Record<string, string> {
   if (!attrs || typeof attrs !== 'object') return {};
-  for (const [name, value] of attrs.children || []) {
-    if (name === DYNAMIC_ATTRIBUTES_DICT_NAME && value && typeof value === 'object') {
+  // Each child tuple's first element is the entity CLASS NAME (always
+  // 'CAttributeNamed', from ar.readObject) - never the dictionary's own
+  // declared name, which lives in value.name.
+  for (const [, value] of attrs.children || []) {
+    if (value && typeof value === 'object' && value.name === DYNAMIC_ATTRIBUTES_DICT_NAME) {
       const entries = value.entries || {};
       const properties: Record<string, string> = {};
       for (const key of Object.keys(entries)) {

--- a/packages/typescript/tests/create.test.ts
+++ b/packages/typescript/tests/create.test.ts
@@ -526,12 +526,19 @@ describe('Component definitions', () => {
     expect(model.root.edges.length).toBe(4);
   });
 
-  it('instance attributes round-trip via model.definitions instance properties', () => {
+  it('instance dynamic attributes round-trip through Instance.properties', () => {
+    // Was reader-side broken (extractLegacyDynamicProperties compared the
+    // *class* name ar.readObject returns for each CAttributeContainer
+    // child - always 'CAttributeNamed' - against the dictionary's own
+    // name instead of comparing value.name, so 'dynamic_attributes' was
+    // never recognized) - fixed 2026-08-26, ported from the same fix in
+    // Python's legacy.py. Now genuinely round-trips.
     const builder = create();
     const chair = builder.addComponentDefinition('Chair', (def) => def.addFace(SQUARE));
-    builder.addInstance(chair, { attributes: { sku: 'CH-1', count: 3 } });
+    builder.addInstance(chair, { attributes: { sku: 'CH-1', count: 3 }, attributeDictName: 'dynamic_attributes' });
     const model = parseSkp(toBuffer(builder.toBytes()));
     expect(model.root.instances.length).toBe(1);
+    expect(model.root.instances[0].properties).toEqual({ sku: 'CH-1', count: '3' });
   });
 });
 

--- a/packages/typescript/tests/legacy-dynamic-properties.test.ts
+++ b/packages/typescript/tests/legacy-dynamic-properties.test.ts
@@ -36,12 +36,16 @@ describe('stringifyAttrValue', () => {
 
 describe('extractLegacyDynamicProperties', () => {
   it('extracts the dynamic_attributes dict by name', () => {
+    // Real shape from readAttrContainer/readAttrNamed: each child tuple's
+    // first element is the ENTITY CLASS NAME (always 'CAttributeNamed',
+    // from ar.readObject) - never the dictionary's own declared name,
+    // which lives in the value's own `name` field.
     const attrs = {
       k: 'attrs',
       children: [
-        ['SU_DefinitionSet', { k: 'dict', name: 'SU_DefinitionSet', entries: { unrelated: 1 } }],
+        ['CAttributeNamed', { k: 'dict', name: 'SU_DefinitionSet', entries: { unrelated: 1 } }],
         [
-          'dynamic_attributes',
+          'CAttributeNamed',
           {
             k: 'dict',
             name: 'dynamic_attributes',
@@ -60,7 +64,7 @@ describe('extractLegacyDynamicProperties', () => {
   it('returns {} when no dynamic_attributes dict is present', () => {
     const attrs = {
       k: 'attrs',
-      children: [['SU_DefinitionSet', { k: 'dict', name: 'SU_DefinitionSet', entries: { a: 1 } }]],
+      children: [['CAttributeNamed', { k: 'dict', name: 'SU_DefinitionSet', entries: { a: 1 } }]],
     };
     expect(extractLegacyDynamicProperties(attrs)).toEqual({});
   });


### PR DESCRIPTION
## Summary
- `_extract_legacy_dynamic_properties` (and its TypeScript/.NET/Dart equivalents) compared the wrong field when looking up an entity's `dynamic_attributes` dictionary: it checked the entity CLASS NAME each container child is tagged with (always `"CAttributeNamed"`), not the dictionary's own declared name. The comparison could never match, so every legacy (pre-2021 MFC) file silently reported no Dynamic Component data, even when it genuinely had some — no error, just silent data loss.
- Fixed by comparing the value's own declared name instead, in Python (`legacy.py`), TypeScript (`legacy.ts`), .NET (`Legacy.cs`), and Dart (`legacy.dart`). C++'s `legacy.cpp` already did this correctly, so no change was needed there.
- Each language's existing unit test for this function passed before the fix only because its hand-built mock used the dictionary's real name as the tuple's first element directly — not the shape the real container reader actually produces. Corrected those mocks to match reality, and confirmed each corrected test fails pre-fix and passes post-fix.
- Strengthened the writer round-trip tests: write an instance with an explicit `dynamic_attributes` dictionary, read it back, assert `Instance.properties` actually comes back populated. Dart already had a test like this that explicitly documented the bug as a known limitation (found during the writer port, left unfixed as out of scope); added/strengthened the equivalent in TypeScript and .NET.

## Test plan
- [x] Python: full suite (379 tests) + ruff, green
- [x] TypeScript: full suite (330 tests) + eslint (on touched files) + tsc, green
- [x] .NET: full suite (163 tests), green
- [x] Dart: full suite (187 tests) + `dart analyze`, green
- [x] For each language, confirmed the corrected unit test and the strengthened round-trip test both fail against the pre-fix code and pass post-fix