### PR TITLE
Fix material transparency/alpha dropped in glTF scene export (5 languages)

### DIFF
--- a/examples/web-viewer/viewer.js
+++ b/examples/web-viewer/viewer.js
@@ -26,6 +26,13 @@ let currentScene = null;
 let currentLoadedFilename = '';
 let layerVisibility = {};
 
+// Three.js Texture objects decoded from currentScene.textures, keyed by index
+// into that array - built lazily so a texture shared by several materials is
+// only decoded once. Reset (and its object URLs revoked) on every new load.
+let threeTextureCache = new Map();
+let textureObjectUrls = [];
+const textureLoader = new THREE.TextureLoader();
+
 // DOM Elements
 const canvasContainer = document.getElementById('canvas-container');
 const dropOverlay = document.getElementById('drop-overlay');
@@ -296,11 +303,11 @@ function clearScene() {
     if (child.isMesh) {
       if (child.geometry) child.geometry.dispose();
       if (child.material) {
-        if (Array.isArray(child.material)) {
-          child.material.forEach((mat) => mat.dispose());
-        } else {
-          child.material.dispose();
-        }
+        const materials = Array.isArray(child.material) ? child.material : [child.material];
+        materials.forEach((mat) => {
+          if (mat.map) mat.map.dispose();
+          mat.dispose();
+        });
       }
     }
   });
@@ -309,6 +316,34 @@ function clearScene() {
   while (modelGroup.children.length > 0) {
     modelGroup.remove(modelGroup.children[0]);
   }
+
+  // Drop the decoded-texture cache from the previous model and free the
+  // object URLs backing it - each load gets its own set of textures.
+  textureObjectUrls.forEach((url) => URL.revokeObjectURL(url));
+  textureObjectUrls = [];
+  threeTextureCache.clear();
+}
+
+// Decodes currentScene.textures[index] (raw PNG/JPEG bytes from the .skp) into
+// a THREE.Texture, caching by index so a texture shared by several materials
+// is only decoded once per load.
+function getSceneTexture(index) {
+  if (threeTextureCache.has(index)) return threeTextureCache.get(index);
+
+  const sceneTexture = currentScene.textures && currentScene.textures[index];
+  if (!sceneTexture) return null;
+
+  const blob = new Blob([sceneTexture.data], { type: sceneTexture.mimeType });
+  const url = URL.createObjectURL(blob);
+  textureObjectUrls.push(url);
+
+  const texture = textureLoader.load(url);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+
+  threeTextureCache.set(index, texture);
+  return texture;
 }
 
 // Show/hide loader
@@ -454,6 +489,9 @@ function loadSkpBuffer(arrayBuffer, filename) {
 
         geometry.setAttribute('position', new THREE.BufferAttribute(prim.positions, 3));
         geometry.setAttribute('normal', new THREE.BufferAttribute(prim.normals, 3));
+        if (prim.uvs && prim.uvs.length > 0) {
+          geometry.setAttribute('uv', new THREE.BufferAttribute(prim.uvs, 2));
+        }
         geometry.setIndex(new THREE.BufferAttribute(prim.indices, 1));
 
         // Get metadata
@@ -462,9 +500,12 @@ function loadSkpBuffer(arrayBuffer, filename) {
         // Material & Color setup (Fallback to layer color if material factor is missing)
         const matIdx = prim.materialIndex;
         let colorFactor = [0.6, 0.6, 0.6, 1.0];
+        let baseColorTextureIndex = null;
 
         if (currentScene.gltfMaterials && currentScene.gltfMaterials[matIdx]) {
-          colorFactor = currentScene.gltfMaterials[matIdx].pbrMetallicRoughness.baseColorFactor;
+          const pbr = currentScene.gltfMaterials[matIdx].pbrMetallicRoughness;
+          colorFactor = pbr.baseColorFactor;
+          if (pbr.baseColorTexture) baseColorTextureIndex = pbr.baseColorTexture.index;
         } else {
           // Attempt to find layer color
           const lay = currentModel.layers.find((l) => l.name === metadata.layer);
@@ -473,12 +514,34 @@ function loadSkpBuffer(arrayBuffer, filename) {
           }
         }
 
-        const material = new THREE.MeshStandardMaterial({
+        const materialOptions = {
           color: new THREE.Color(colorFactor[0], colorFactor[1], colorFactor[2]),
           roughness: 0.6,
           metalness: 0.1,
           side: THREE.DoubleSide
-        });
+        };
+
+        // A textured material may be a cutout (leaf clusters, chain-link,
+        // signage) where the image's own alpha channel carves the visible
+        // shape out of an otherwise plain rectangle - very common on
+        // SketchUp Warehouse trees/foliage/fences. The parsed file's
+        // material.transparency flag says which materials mean this, but
+        // that flag isn't in the exported glTF material yet (tracked
+        // separately as a cross-language library bug). Until that lands,
+        // alphaTest is applied to every textured material as a safe
+        // default: a fully-opaque texture (alpha=255 everywhere) renders
+        // identically with or without it, so this only changes anything
+        // for textures that actually carry a cutout.
+        if (baseColorTextureIndex !== null) {
+          const texture = getSceneTexture(baseColorTextureIndex);
+          if (texture) {
+            materialOptions.map = texture;
+            materialOptions.transparent = true;
+            materialOptions.alphaTest = 0.5;
+          }
+        }
+
+        const material = new THREE.MeshStandardMaterial(materialOptions);
 
         const mesh = new THREE.Mesh(geometry, material);
         mesh.castShadow = true;

--- a/packages/cpp/src/face_groups.cpp
+++ b/packages/cpp/src/face_groups.cpp
@@ -88,9 +88,17 @@ std::shared_ptr<RawMaterial> find_material(const RawParsed& parsed, std::optiona
 
 std::optional<FaceColorKey> material_color(const std::shared_ptr<RawMaterial>& material) {
   if (!material) return {};
-  return FaceColorKey{
-      material->r, material->g, material->b,
-      static_cast<int>(std::lround(std::clamp(material->transparency, 0.0, 1.0) * 255.0))};
+  // Two independent SketchUp mechanisms can reduce a material's opacity:
+  // the plain RGBA color record's alpha byte (material->a), and the newer
+  // XML material definition's own trans/useTrans attribute (already
+  // resolved into material->transparency). A real material only ever
+  // populates one of the two, but multiplying both is safe either way: the
+  // untouched one defaults to fully-opaque (255 or 1.0), so it never
+  // silently darkens a material that only used the other mechanism.
+  const double combined =
+      (std::clamp(material->a, 0, 255) / 255.0) * std::clamp(material->transparency, 0.0, 1.0);
+  return FaceColorKey{material->r, material->g, material->b,
+                      static_cast<int>(std::lround(combined * 255.0))};
 }
 
 FaceColorKey default_color(const RawParsed& parsed, const std::string& layer) {

--- a/packages/cpp/src/glb.cpp
+++ b/packages/cpp/src/glb.cpp
@@ -180,7 +180,22 @@ gltf::Model make_model(const Scene& scene, bool embed_textures) {
     material.pbrMetallicRoughness.metallicFactor = source_pbr.metallic_factor;
     material.pbrMetallicRoughness.roughnessFactor = source_pbr.roughness_factor;
     material.doubleSided = source.double_sided;
-    if (source_pbr.base_color_factor[3] < 1.0) material.alphaMode = "BLEND";
+    // glTF's default alphaMode is OPAQUE, which tells a conformant
+    // renderer to ignore alpha entirely - both the material's own opacity
+    // and any texture's alpha channel. Genuinely translucent materials
+    // (glass, water) need BLEND so baseColorFactor's alpha actually takes
+    // effect. A textured-but-otherwise-opaque material gets MASK instead:
+    // many SketchUp Warehouse assets (tree foliage, fences, signage) rely
+    // on the image's own alpha channel to cut a shape out of an otherwise
+    // flat quad, and without MASK a renderer would show the full
+    // rectangle. MASK is a no-op for a texture with no real cutout, so
+    // this is safe to set unconditionally rather than trying to detect
+    // which textures need it.
+    if (source_pbr.base_color_factor[3] < 1.0) {
+      material.alphaMode = "BLEND";
+    } else if (source_pbr.base_color_texture) {
+      material.alphaMode = "MASK";
+    }
     // baseColorTexture.index defaults to -1 (unset); TinyGLTF omits the
     // key from the serialized JSON in that case, so leaving it untouched
     // when not embedding is the strip - no separate pass needed, unlike

--- a/packages/cpp/src/instanced_glb.cpp
+++ b/packages/cpp/src/instanced_glb.cpp
@@ -213,7 +213,14 @@ gltf::Model make_model(const InstancedScene& scene, bool embed_textures) {
     material.pbrMetallicRoughness.metallicFactor = source_pbr.metallic_factor;
     material.pbrMetallicRoughness.roughnessFactor = source_pbr.roughness_factor;
     material.doubleSided = source.double_sided;
-    if (source_pbr.base_color_factor[3] < 1.0) material.alphaMode = "BLEND";
+    // See glb.cpp's make_model for why: BLEND for genuinely translucent
+    // materials, MASK (a safe no-op on an opaque-alpha texture) for
+    // textured ones, otherwise glTF's default OPAQUE.
+    if (source_pbr.base_color_factor[3] < 1.0) {
+      material.alphaMode = "BLEND";
+    } else if (source_pbr.base_color_texture) {
+      material.alphaMode = "MASK";
+    }
     if (embed_textures && source_pbr.base_color_texture) {
       material.pbrMetallicRoughness.baseColorTexture.index =
           static_cast<int>(*source_pbr.base_color_texture);

--- a/packages/cpp/tests/glb_test.cpp
+++ b/packages/cpp/tests/glb_test.cpp
@@ -111,6 +111,49 @@ TEST(Glb, SerializesSceneAndBinaryData) {
   EXPECT_TRUE(model.materials[0].doubleSided);
 }
 
+TEST(Glb, DeclaresBlendAlphaModeForTranslucentMaterials) {
+  Scene scene;
+  scene.gltf_materials.push_back({"Glass", "", {{0.16, 0.27, 0.39, 0.5}, 0.0, 0.8}, false});
+  scene.glb_primitives.push_back({
+      {0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F},
+      {0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F},
+      {0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F},
+      {0, 1, 2},
+      0,
+      "triangle",
+  });
+
+  const auto model = load_glb(to_glb(scene));
+  ASSERT_EQ(model.materials.size(), 1);
+  EXPECT_EQ(model.materials[0].alphaMode, "BLEND");
+}
+
+TEST(Glb, DeclaresMaskAlphaModeForTexturedOpaqueMaterials) {
+  // glTF's default alphaMode is OPAQUE, which tells a conformant renderer
+  // to ignore a texture's own alpha channel entirely. A textured material
+  // whose baseColorFactor alpha is 1.0 (SketchUp Warehouse foliage/fence/
+  // signage cutouts commonly look like this) needs MASK declared instead,
+  // or the image's transparent regions render as a solid rectangle.
+  Scene scene;
+  GltfMaterial material{"Leaf", "", {{0.2, 0.5, 0.1, 1.0}, 0.0, 0.8}, false};
+  material.pbr_metallic_roughness.base_color_texture = std::size_t{0};
+  scene.gltf_materials.push_back(material);
+  scene.textures.push_back(
+      {ByteBuffer{0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a}, "image/png", "leaf.png"});
+  scene.glb_primitives.push_back({
+      {0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F},
+      {0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F},
+      {0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F},
+      {0, 1, 2},
+      0,
+      "triangle",
+  });
+
+  const auto model = load_glb(to_glb(scene));
+  ASSERT_EQ(model.materials.size(), 1);
+  EXPECT_EQ(model.materials[0].alphaMode, "MASK");
+}
+
 TEST(Glb, SerializesAnEmptyScene) {
   const auto model = load_glb(to_glb({}));
   ASSERT_EQ(model.scenes.size(), 1);

--- a/packages/cpp/tests/scene_test.cpp
+++ b/packages/cpp/tests/scene_test.cpp
@@ -85,6 +85,52 @@ TEST(Scene, PreservesDistinctFrontAndBackFaceMaterials) {
   EXPECT_TRUE(found_back);
 }
 
+// A material's overall opacity can come from either of two independent
+// SketchUp mechanisms: the plain RGBA color record's alpha byte
+// (RawMaterial::a), or the newer XML material definition's own
+// trans/useTrans attribute (RawMaterial::transparency, already exercised by
+// UsesOneDoubleSidedPrimitiveWhenFaceMaterialsMatch above). Before this fix,
+// material_color() only read transparency - a's default (255, fully
+// opaque) meant a translucent material written via the raw color byte (as
+// SkpBuilder::add_material's 4-channel overload does) lost its alpha
+// entirely once baked into the scene.
+RawParsed triangle_with_raw_alpha(int alpha) {
+  RawParsed parsed;
+  parsed.root.builder.vertices = {{1, {0, 0, 0}}, {2, {1, 0, 0}}, {3, {0, 1, 0}}};
+  parsed.root.builder.edges = {{10, {1, 2}}, {11, {2, 3}}, {12, {3, 1}}};
+  RawFace face;
+  face.loops = {{{10, 1}, {11, 1}, {12, 1}}};
+  face.normal = {0, 0, 1};
+  face.material_id = 100;
+  face.back_material_id = face.material_id;
+  parsed.root.builder.faces.emplace(20, std::move(face));
+
+  auto mat = std::make_shared<RawMaterial>();
+  mat->name = "glass";
+  mat->r = 40;
+  mat->g = 70;
+  mat->b = 100;
+  mat->a = alpha;
+  // transparency left at its default (1.0) - this material's opacity comes
+  // entirely from the raw color alpha byte, not the XML mechanism.
+  parsed.materials.emplace(mat->name, mat);
+  parsed.material_id_to_name.emplace(100, mat->name);
+  return parsed;
+}
+
+TEST(Scene, PropagatesRawColorAlphaByteIntoBaseColorFactor) {
+  auto scene = build_scene_raw(triangle_with_raw_alpha(128), {});
+  ASSERT_EQ(scene.gltf_materials.size(), 1);
+  EXPECT_NEAR(scene.gltf_materials[0].pbr_metallic_roughness.base_color_factor[3], 128.0 / 255.0,
+              1.0 / 255.0);
+}
+
+TEST(Scene, LeavesFullyOpaqueRawAlphaByteForByteUnchanged) {
+  auto scene = build_scene_raw(triangle_with_raw_alpha(255), {});
+  ASSERT_EQ(scene.gltf_materials.size(), 1);
+  EXPECT_DOUBLE_EQ(scene.gltf_materials[0].pbr_metallic_roughness.base_color_factor[3], 1.0);
+}
+
 TEST(Scene, KeepsWindingAndNormalsAlignedForMirroredInstances) {
   auto parsed = triangle_with_materials(true);
   RawDefinition definition;

--- a/packages/dart/lib/src/face_groups.dart
+++ b/packages/dart/lib/src/face_groups.dart
@@ -29,6 +29,7 @@ import 'triangulator.dart';
 
 class LocalFaceGroup {
   final (int, int, int) color;
+  final double transparency;
   final bool doubleSided;
   final int? textureIndex;
   final List<(double, double, double)> localVerts = [];
@@ -37,11 +38,22 @@ class LocalFaceGroup {
   final List<List<int>> localFaces = [];
   final Map<(int, double, double), int> localVMap = {};
 
-  LocalFaceGroup(this.color, this.doubleSided, this.textureIndex);
+  LocalFaceGroup(this.color, this.doubleSided, this.textureIndex, this.transparency);
 }
 
-/// Key: (color, doubleSided, textureIndex).
-typedef FaceGroupKey = ((int, int, int), bool, int?);
+/// The resolved material's overall opacity: 1.0 fully opaque, 0.0 fully
+/// invisible. Two independent SketchUp mechanisms can reduce it - the plain
+/// RGBA color record's alpha byte, and the newer XML material definition's
+/// own trans/useTrans attribute (already resolved into
+/// RawMaterial.transparency). A real material only ever populates one of
+/// the two, but multiplying both is safe either way: the untouched one
+/// defaults to fully-opaque (255 or 1.0), so it never silently darkens a
+/// material that only used the other mechanism.
+double resolveTransparency(RawMaterial? mat) =>
+    mat == null ? 1.0 : (mat.a / 255.0) * mat.transparency;
+
+/// Key: (color, doubleSided, textureIndex, transparency).
+typedef FaceGroupKey = ((int, int, int), bool, int?, double);
 
 /// Everything [buildLocalFaceGroups] needs from its caller that isn't the
 /// builder itself.
@@ -163,8 +175,10 @@ Map<FaceGroupKey, LocalFaceGroup> buildLocalFaceGroups(GeometryBuilder builder, 
     // part of the key too - otherwise two differently-textured faces with
     // the same average color end up in one group with one image
     final texIndex = ctx.textureIndexFor(mat?.texture);
-    final key = (color, doubleSided, texIndex);
-    final group = faceGroups.putIfAbsent(key, () => LocalFaceGroup(color, doubleSided, texIndex));
+    final transparency = resolveTransparency(mat);
+    final key = (color, doubleSided, texIndex, transparency);
+    final group = faceGroups.putIfAbsent(
+        key, () => LocalFaceGroup(color, doubleSided, texIndex, transparency));
 
     final tex = mat?.texture;
     final tileW = (tex != null && tex.xScale > 1e-9) ? tex.xScale : 1.0;

--- a/packages/dart/lib/src/instanced_scene.dart
+++ b/packages/dart/lib/src/instanced_scene.dart
@@ -183,17 +183,18 @@ class InstancedSceneBuilder {
       return idx;
     }
 
-    final colorToMaterialIndex = <((int, int, int), bool, int?), int>{};
+    final colorToMaterialIndex = <((int, int, int), bool, int?, double), int>{};
     final gltfMaterials = <Map<String, dynamic>>[];
 
-    int getMaterialIndex((int, int, int) color, bool doubleSided, int? textureIndex) {
-      final key = (color, doubleSided, textureIndex);
+    int getMaterialIndex((int, int, int) color, bool doubleSided, int? textureIndex,
+        [double transparency = 1.0]) {
+      final key = (color, doubleSided, textureIndex, transparency);
       final existing = colorToMaterialIndex[key];
       if (existing != null) return existing;
       final idx = gltfMaterials.length;
       final (r, g, b) = color;
       final pbr = <String, dynamic>{
-        'baseColorFactor': [r / 255, g / 255, b / 255, 1.0],
+        'baseColorFactor': [r / 255, g / 255, b / 255, transparency],
         'metallicFactor': 0.0,
         'roughnessFactor': 0.8,
       };
@@ -202,6 +203,14 @@ class InstancedSceneBuilder {
       }
       final material = <String, dynamic>{'pbrMetallicRoughness': pbr};
       if (doubleSided) material['doubleSided'] = true;
+      // See scene.dart's getMaterialIndex for why: BLEND for genuinely
+      // translucent materials, MASK (safe no-op on an opaque-alpha
+      // texture) for textured ones, otherwise glTF's default OPAQUE.
+      if (transparency < 1.0) {
+        material['alphaMode'] = 'BLEND';
+      } else if (textureIndex != null) {
+        material['alphaMode'] = 'MASK';
+      }
       gltfMaterials.add(material);
       colorToMaterialIndex[key] = idx;
       return idx;
@@ -248,7 +257,7 @@ class InstancedSceneBuilder {
 
       final primitives = <LocalPrimitive>[];
       for (final groupEntry in faceGroups.entries) {
-        final (color, doubleSided, texIndex) = groupEntry.key;
+        final (color, doubleSided, texIndex, transparency) = groupEntry.key;
         final group = groupEntry.value;
         if (group.localFaces.isEmpty) continue;
 
@@ -303,7 +312,7 @@ class InstancedSceneBuilder {
           normals: normals,
           uvs: uvs,
           indices: indices,
-          materialIndex: getMaterialIndex(color, doubleSided, texIndex),
+          materialIndex: getMaterialIndex(color, doubleSided, texIndex, transparency),
         ));
       }
 

--- a/packages/dart/lib/src/scene.dart
+++ b/packages/dart/lib/src/scene.dart
@@ -189,7 +189,7 @@ class SceneBuilder {
       return idx;
     }
 
-    final colorToMaterialIndex = <((int, int, int), bool, int?), int>{};
+    final colorToMaterialIndex = <((int, int, int), bool, int?, double), int>{};
     final gltfMaterials = <Map<String, dynamic>>[];
 
     // Definitions currently being instantiated on the active recursion path
@@ -201,18 +201,19 @@ class SceneBuilder {
 
     (int, int, int) getLayerColor(String name) => layerColors[name] ?? (136, 136, 136);
 
-    int getMaterialIndex((int, int, int) color, bool doubleSided, int? textureIndex) {
+    int getMaterialIndex((int, int, int) color, bool doubleSided, int? textureIndex,
+        [double transparency = 1.0]) {
       // The texture is part of the identity, not just the color: two
       // different images can average to the same RGB (real files do
       // this), and keying on color alone would merge them into one
       // material and lose one of the images.
-      final key = (color, doubleSided, textureIndex);
+      final key = (color, doubleSided, textureIndex, transparency);
       final existing = colorToMaterialIndex[key];
       if (existing != null) return existing;
       final idx = gltfMaterials.length;
       final (r, g, b) = color;
       final pbr = <String, dynamic>{
-        'baseColorFactor': [r / 255, g / 255, b / 255, 1.0],
+        'baseColorFactor': [r / 255, g / 255, b / 255, transparency],
         'metallicFactor': 0.0,
         'roughnessFactor': 0.8,
       };
@@ -224,6 +225,24 @@ class SceneBuilder {
       }
       final material = <String, dynamic>{'pbrMetallicRoughness': pbr};
       if (doubleSided) material['doubleSided'] = true;
+      // glTF's default alphaMode is OPAQUE, which tells a conformant
+      // renderer to ignore alpha entirely - both the material's own
+      // opacity and any texture's alpha channel. Genuinely translucent
+      // materials (glass, water) need BLEND so baseColorFactor's alpha
+      // (and the texture's, if any) actually takes effect. A
+      // textured-but-otherwise-opaque material gets MASK instead: many
+      // SketchUp Warehouse assets (tree foliage, fences, signage) rely on
+      // the image's own alpha channel to cut a shape out of an otherwise
+      // flat quad, and without MASK a renderer would show the full
+      // rectangle. MASK is a no-op for a texture with no real cutout - a
+      // fully-opaque alpha channel (or none, as in JPEG) stays above the
+      // cutoff everywhere - so this is safe to set unconditionally rather
+      // than trying to detect which textures need it.
+      if (transparency < 1.0) {
+        material['alphaMode'] = 'BLEND';
+      } else if (textureIndex != null) {
+        material['alphaMode'] = 'MASK';
+      }
       gltfMaterials.add(material);
       colorToMaterialIndex[key] = idx;
       return idx;
@@ -265,7 +284,7 @@ class SceneBuilder {
         final multiGroup = faceGroups.length > 1;
 
         for (final groupEntry in faceGroups.entries) {
-          final (_, _, texIndex) = groupEntry.key;
+          final (_, _, texIndex, _) = groupEntry.key;
           final group = groupEntry.value;
           final color = group.color;
           if (group.localFaces.isEmpty) continue;
@@ -351,7 +370,7 @@ class SceneBuilder {
             indices.add(tri[2]);
           }
 
-          final materialIndex = getMaterialIndex(color, group.doubleSided, texIndex);
+          final materialIndex = getMaterialIndex(color, group.doubleSided, texIndex, group.transparency);
           glbPrimitives.add(GlbPrimitive(
             positions: positions,
             normals: normals,

--- a/packages/dart/test/scene_test.dart
+++ b/packages/dart/test/scene_test.dart
@@ -82,4 +82,88 @@ void main() {
     final doubleSidedCount = scene.gltfMaterials.where((m) => m['doubleSided'] == true).length;
     expect(doubleSidedCount, 4);
   });
+
+  test('translucent material gets BLEND alpha', () {
+    // Round-tripped through the real writer and reader rather than a
+    // hand-built fixture: addMaterial's 4th (alpha) channel is documented
+    // to carry SketchUp's own opacity mechanism, so this exercises the
+    // exact path a real .skp file with a translucent material takes.
+    // Before this fix, baseColorFactor's alpha was hardcoded to 1.0 and no
+    // glTF material ever declared alphaMode, so a conformant renderer
+    // showed every material fully opaque regardless of the source file's
+    // actual transparency.
+    final builder = create();
+    final glass = builder.addMaterial('Glass', [40, 70, 100, 128]);
+    builder.addFace(
+      [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)],
+      material: glass,
+    );
+    final bytes = builder.toBytes();
+
+    final path = '${Directory.systemTemp.path}/openskp_dart_glass_test.skp';
+    File(path).writeAsBytesSync(bytes);
+    try {
+      final scene = SkpFile.open(path).buildScene();
+      final mat = scene.gltfMaterials.firstWhere((m) {
+        final pbr = m['pbrMetallicRoughness'] as Map<String, dynamic>;
+        final c = pbr['baseColorFactor'] as List;
+        return (c[3] as double) != 1.0;
+      });
+      final pbr = mat['pbrMetallicRoughness'] as Map<String, dynamic>;
+      final alpha = (pbr['baseColorFactor'] as List)[3] as double;
+      expect(alpha, closeTo(128 / 255, 0.01));
+      expect(mat['alphaMode'], 'BLEND');
+    } finally {
+      File(path).deleteSync();
+    }
+  });
+
+  test('opaque material stays byte-for-byte unchanged (no alphaMode field)', () {
+    final builder = create();
+    final red = builder.addMaterial('Red', [255, 0, 0]);
+    builder.addFace(
+      [(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)],
+      material: red,
+    );
+    final bytes = builder.toBytes();
+
+    final path = '${Directory.systemTemp.path}/openskp_dart_red_test.skp';
+    File(path).writeAsBytesSync(bytes);
+    try {
+      final scene = SkpFile.open(path).buildScene();
+      final mat = scene.gltfMaterials[0];
+      final pbr = mat['pbrMetallicRoughness'] as Map<String, dynamic>;
+      expect((pbr['baseColorFactor'] as List)[3], 1.0);
+      expect(mat.containsKey('alphaMode'), false);
+    } finally {
+      File(path).deleteSync();
+    }
+  });
+
+  test('textured materials get MASK or BLEND, never left OPAQUE', () {
+    // capilla_quiroz_v17.skp has four textured materials: two ordinary
+    // opaque ones (MASK - a safe no-op, nothing in their JPEGs to cut out)
+    // and two genuinely translucent stained-glass-style materials at alpha
+    // 0.5 (BLEND, so that opacity actually renders instead of being
+    // silently dropped under glTF's OPAQUE default).
+    final scene = SkpFile.open(fixturePath).buildScene();
+    final textured = scene.gltfMaterials.where((m) {
+      final pbr = m['pbrMetallicRoughness'] as Map<String, dynamic>;
+      return pbr.containsKey('baseColorTexture');
+    }).toList();
+    expect(textured.length, 4);
+
+    final translucent = textured.where((m) => m['alphaMode'] == 'BLEND').toList();
+    final opaque = textured.where((m) => m['alphaMode'] == 'MASK').toList();
+    expect(translucent.length, 2);
+    expect(opaque.length, 2);
+    for (final m in translucent) {
+      final pbr = m['pbrMetallicRoughness'] as Map<String, dynamic>;
+      expect((pbr['baseColorFactor'] as List)[3] as double, lessThan(1.0));
+    }
+    for (final m in opaque) {
+      final pbr = m['pbrMetallicRoughness'] as Map<String, dynamic>;
+      expect((pbr['baseColorFactor'] as List)[3], 1.0);
+    }
+  });
 }

--- a/packages/dotnet/OpenSkp.Tests/SceneTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/SceneTests.cs
@@ -95,5 +95,101 @@ namespace OpenSkp.Tests
                 ((System.Collections.Generic.IDictionary<string, object>)m).TryGetValue("doubleSided", out var v) && v is bool b && b);
             Assert.Equal(4, doubleSidedCount);
         }
+
+        private static System.Collections.Generic.IDictionary<string, object> Pbr(object mat) =>
+            (System.Collections.Generic.IDictionary<string, object>)
+                ((System.Collections.Generic.IDictionary<string, object>)mat)["pbrMetallicRoughness"];
+
+        [Fact]
+        public void TranslucentMaterialGetsBlendAlpha()
+        {
+            // Round-tripped through the real writer and reader rather than
+            // a hand-built fixture: AddMaterial's 4th (alpha) channel is
+            // documented to carry SketchUp's own opacity mechanism, so
+            // this exercises the exact path a real .skp file with a
+            // translucent material takes. Before this fix, the legacy
+            // binary reader dropped the color record's alpha byte entirely
+            // (Legacy.cs hardcoded it to 255 downstream in Parser.cs), and
+            // even where transparency WAS correctly parsed,
+            // baseColorFactor's alpha was hardcoded to 1.0 with no
+            // material ever declaring alphaMode - so a conformant renderer
+            // showed every material fully opaque regardless of the source
+            // file's actual transparency.
+            var builder = SkpCreate.NewFile();
+            int glass = builder.AddMaterial("Glass", (40, 70, 100, 128));
+            builder.AddFace(new (double, double, double)[] { (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0) }, material: glass);
+            byte[] bytes = builder.ToBytes();
+
+            string path = Path.Combine(Path.GetTempPath(), $"openskp_dotnet_glass_{Guid.NewGuid():N}.skp");
+            File.WriteAllBytes(path, bytes);
+            try
+            {
+                var scene = SkpFile.BuildScene(path);
+                var mat = scene.GltfMaterials
+                    .Select(m => (Mat: m, Pbr: Pbr(m)))
+                    .First(x => (double)((double[])x.Pbr["baseColorFactor"])[3] != 1.0);
+                double alpha = (double)((double[])mat.Pbr["baseColorFactor"])[3];
+                Assert.InRange(alpha, 128 / 255.0 - 0.01, 128 / 255.0 + 0.01);
+                Assert.Equal("BLEND", ((System.Collections.Generic.IDictionary<string, object>)mat.Mat)["alphaMode"]);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void OpaqueMaterialStaysByteForByteUnchanged()
+        {
+            var builder = SkpCreate.NewFile();
+            int red = builder.AddMaterial("Red", (255, 0, 0));
+            builder.AddFace(new (double, double, double)[] { (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0) }, material: red);
+            byte[] bytes = builder.ToBytes();
+
+            string path = Path.Combine(Path.GetTempPath(), $"openskp_dotnet_red_{Guid.NewGuid():N}.skp");
+            File.WriteAllBytes(path, bytes);
+            try
+            {
+                var scene = SkpFile.BuildScene(path);
+                var mat = scene.GltfMaterials[0];
+                var pbr = Pbr(mat);
+                Assert.Equal(1.0, (double)((double[])pbr["baseColorFactor"])[3]);
+                Assert.False(((System.Collections.Generic.IDictionary<string, object>)mat).ContainsKey("alphaMode"));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void TexturedMaterialsGetMaskOrBlendNeverLeftOpaque()
+        {
+            // capilla_quiroz_v17.skp has four textured materials: two
+            // ordinary opaque ones (MASK - a safe no-op, nothing in their
+            // JPEGs to cut out) and two genuinely translucent
+            // stained-glass-style materials at alpha 0.5 (BLEND, so that
+            // opacity actually renders instead of being silently dropped
+            // under glTF's OPAQUE default).
+            var scene = SkpFile.BuildScene(FixturePath("capilla_quiroz_v17.skp"));
+            var textured = scene.GltfMaterials
+                .Select(m => (Mat: (System.Collections.Generic.IDictionary<string, object>)m, Pbr: Pbr(m)))
+                .Where(x => x.Pbr.ContainsKey("baseColorTexture"))
+                .ToList();
+            Assert.Equal(4, textured.Count);
+
+            var translucent = textured.Where(x => (string)x.Mat["alphaMode"] == "BLEND").ToList();
+            var opaque = textured.Where(x => (string)x.Mat["alphaMode"] == "MASK").ToList();
+            Assert.Equal(2, translucent.Count);
+            Assert.Equal(2, opaque.Count);
+            foreach (var x in translucent)
+            {
+                Assert.True((double)((double[])x.Pbr["baseColorFactor"])[3] < 1.0);
+            }
+            foreach (var x in opaque)
+            {
+                Assert.Equal(1.0, (double)((double[])x.Pbr["baseColorFactor"])[3]);
+            }
+        }
     }
 }

--- a/packages/dotnet/OpenSkp/FaceGroups.cs
+++ b/packages/dotnet/OpenSkp/FaceGroups.cs
@@ -28,9 +28,22 @@ namespace OpenSkp
     /// changed by this extraction.</summary>
     internal static class FaceGroups
     {
+        /// <summary>The resolved material's overall opacity: 1.0 fully
+        /// opaque, 0.0 fully invisible. Two independent SketchUp mechanisms
+        /// can reduce it - the plain RGBA color record's alpha byte, and
+        /// the newer XML material definition's own trans/useTrans
+        /// attribute (already resolved into RawMaterial.Transparency). A
+        /// real material only ever populates one of the two, but
+        /// multiplying both is safe either way: the untouched one defaults
+        /// to fully-opaque (255 or 1.0), so it never silently darkens a
+        /// material that only used the other mechanism.</summary>
+        public static double ResolveTransparency(Geometry.RawMaterial? mat) =>
+            mat == null ? 1.0 : (mat.A / 255.0) * mat.Transparency;
+
         public sealed class FaceGroup
         {
             public (int R, int G, int B) Color;
+            public double Transparency = 1.0;
             public bool DoubleSided;
             public int? TextureIndex;
             public List<(double X, double Y, double Z)> LocalVerts = new List<(double, double, double)>();
@@ -163,9 +176,9 @@ namespace OpenSkp
         /// is emitted as two single-sided triangle sets (one normal-wound
         /// front, one reverse-wound back) so each side keeps its own
         /// color.</summary>
-        public static Dictionary<((int R, int G, int B) Color, bool DoubleSided, int? TextureIndex), FaceGroup> BuildLocalFaceGroups(GeometryBuilder builder, Context ctx)
+        public static Dictionary<((int R, int G, int B) Color, bool DoubleSided, int? TextureIndex, double Transparency), FaceGroup> BuildLocalFaceGroups(GeometryBuilder builder, Context ctx)
         {
-            var faceGroups = new Dictionary<((int R, int G, int B) Color, bool DoubleSided, int? TextureIndex), FaceGroup>();
+            var faceGroups = new Dictionary<((int R, int G, int B) Color, bool DoubleSided, int? TextureIndex, double Transparency), FaceGroup>();
 
             void AddSide(
                 List<long[]> triangles, (double X, double Y, double Z) fn,
@@ -178,10 +191,11 @@ namespace OpenSkp
                 // differently-textured faces with the same average color
                 // end up in one group with one image
                 int? texIndex = ctx.TextureIndexFor(mat?.Texture);
-                var key = (color, doubleSided, texIndex);
+                double transparency = ResolveTransparency(mat);
+                var key = (color, doubleSided, texIndex, transparency);
                 if (!faceGroups.TryGetValue(key, out var group))
                 {
-                    group = new FaceGroup { Color = color, DoubleSided = doubleSided, TextureIndex = texIndex };
+                    group = new FaceGroup { Color = color, Transparency = transparency, DoubleSided = doubleSided, TextureIndex = texIndex };
                     faceGroups[key] = group;
                 }
 

--- a/packages/dotnet/OpenSkp/Geometry.cs
+++ b/packages/dotnet/OpenSkp/Geometry.cs
@@ -552,6 +552,13 @@ namespace OpenSkp
         {
             public string Name = "";
             public int R = 128, G = 128, B = 128;
+            /// <summary>The raw RGBA color record's alpha byte, 0-255
+            /// (255 = fully opaque). Independent of Transparency, which
+            /// carries the newer XML material definition's own
+            /// trans/useTrans opacity - a real material only ever
+            /// populates one of the two, and callers combine them (see
+            /// FaceGroups.ResolveTransparency).</summary>
+            public int A = 255;
             public double Transparency = 1.0;
             public bool Colorized;
             public int ColorizeType;

--- a/packages/dotnet/OpenSkp/InstancedScene.cs
+++ b/packages/dotnet/OpenSkp/InstancedScene.cs
@@ -200,17 +200,17 @@ namespace OpenSkp
                 return idx;
             }
 
-            var colorToMaterialIndex = new Dictionary<((int, int, int) Color, bool DoubleSided, int? TextureIndex), int>();
+            var colorToMaterialIndex = new Dictionary<((int, int, int) Color, bool DoubleSided, int? TextureIndex, double Transparency), int>();
             var gltfMaterials = new List<object>();
 
-            int GetMaterialIndex((int R, int G, int B) color, bool doubleSided, int? textureIndex)
+            int GetMaterialIndex((int R, int G, int B) color, bool doubleSided, int? textureIndex, double transparency = 1.0)
             {
-                var key = (color, doubleSided, textureIndex);
+                var key = (color, doubleSided, textureIndex, transparency);
                 if (colorToMaterialIndex.TryGetValue(key, out var existing)) return existing;
                 int idx = gltfMaterials.Count;
                 var pbr = new Dictionary<string, object>
                 {
-                    ["baseColorFactor"] = new[] { color.R / 255.0, color.G / 255.0, color.B / 255.0, 1.0 },
+                    ["baseColorFactor"] = new[] { color.R / 255.0, color.G / 255.0, color.B / 255.0, transparency },
                     ["metallicFactor"] = 0.0,
                     ["roughnessFactor"] = 0.8,
                 };
@@ -220,6 +220,18 @@ namespace OpenSkp
                 }
                 var material = new Dictionary<string, object> { ["pbrMetallicRoughness"] = pbr };
                 if (doubleSided) material["doubleSided"] = true;
+                // See Scene.cs's GetMaterialIndex for why: BLEND for
+                // genuinely translucent materials, MASK (safe no-op on an
+                // opaque-alpha texture) for textured ones, otherwise
+                // glTF's default OPAQUE.
+                if (transparency < 1.0)
+                {
+                    material["alphaMode"] = "BLEND";
+                }
+                else if (textureIndex.HasValue)
+                {
+                    material["alphaMode"] = "MASK";
+                }
                 gltfMaterials.Add(material);
                 colorToMaterialIndex[key] = idx;
                 return idx;
@@ -331,7 +343,7 @@ namespace OpenSkp
                         Normals = normals,
                         Uvs = uvs,
                         Indices = indices,
-                        MaterialIndex = GetMaterialIndex(color, group.DoubleSided, texIndex),
+                        MaterialIndex = GetMaterialIndex(color, group.DoubleSided, texIndex, group.Transparency),
                     });
                 }
 

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -2080,6 +2080,7 @@ namespace OpenSkp
                     R = rgba[0],
                     G = rgba[1],
                     B = rgba[2],
+                    A = rgba.Length > 3 ? rgba[3] : 255,
                     Transparency = trans,
                     Colorized = colorized,
                     // colourize type is not decoded in the legacy record;

--- a/packages/dotnet/OpenSkp/Parser.cs
+++ b/packages/dotnet/OpenSkp/Parser.cs
@@ -94,7 +94,7 @@ namespace OpenSkp
                 var mat = new Material
                 {
                     Name = rawMat.Name,
-                    Color = (rawMat.R, rawMat.G, rawMat.B, 255),
+                    Color = (rawMat.R, rawMat.G, rawMat.B, rawMat.A),
                     Transparency = rawMat.Transparency,
                     Texture = texture,
                     Colorized = rawMat.Colorized,

--- a/packages/dotnet/OpenSkp/Scene.cs
+++ b/packages/dotnet/OpenSkp/Scene.cs
@@ -152,7 +152,7 @@ namespace OpenSkp
                 return idx;
             }
 
-            var colorToMaterialIndex = new Dictionary<((int, int, int) Color, bool DoubleSided, int? TextureIndex), int>();
+            var colorToMaterialIndex = new Dictionary<((int, int, int) Color, bool DoubleSided, int? TextureIndex, double Transparency), int>();
             var gltfMaterials = new List<object>();
 
             // Definitions currently being instantiated on the active
@@ -168,18 +168,18 @@ namespace OpenSkp
                 return layerColors.TryGetValue(name, out var c) ? c : (136, 136, 136);
             }
 
-            int GetMaterialIndex((int R, int G, int B) color, bool doubleSided, int? textureIndex)
+            int GetMaterialIndex((int R, int G, int B) color, bool doubleSided, int? textureIndex, double transparency = 1.0)
             {
                 // The texture is part of the identity, not just the color:
                 // two different images can average to the same RGB (real
                 // files do this), and keying on color alone would merge
                 // them into one material and lose one of the images.
-                var key = (color, doubleSided, textureIndex);
+                var key = (color, doubleSided, textureIndex, transparency);
                 if (colorToMaterialIndex.TryGetValue(key, out var existing)) return existing;
                 int idx = gltfMaterials.Count;
                 var pbr = new Dictionary<string, object>
                 {
-                    ["baseColorFactor"] = new[] { color.R / 255.0, color.G / 255.0, color.B / 255.0, 1.0 },
+                    ["baseColorFactor"] = new[] { color.R / 255.0, color.G / 255.0, color.B / 255.0, transparency },
                     ["metallicFactor"] = 0.0,
                     ["roughnessFactor"] = 0.8,
                 };
@@ -193,6 +193,29 @@ namespace OpenSkp
                 }
                 var material = new Dictionary<string, object> { ["pbrMetallicRoughness"] = pbr };
                 if (doubleSided) material["doubleSided"] = true;
+                // glTF's default alphaMode is OPAQUE, which tells a
+                // conformant renderer to ignore alpha entirely - both the
+                // material's own opacity and any texture's alpha channel.
+                // Genuinely translucent materials (glass, water) need
+                // BLEND so baseColorFactor's alpha (and the texture's, if
+                // any) actually takes effect. A textured-but-otherwise-
+                // opaque material gets MASK instead: many SketchUp
+                // Warehouse assets (tree foliage, fences, signage) rely on
+                // the image's own alpha channel to cut a shape out of an
+                // otherwise flat quad, and without MASK a renderer would
+                // show the full rectangle. MASK is a no-op for a texture
+                // with no real cutout - a fully-opaque alpha channel (or
+                // none, as in JPEG) stays above the cutoff everywhere - so
+                // this is safe to set unconditionally rather than trying
+                // to detect which textures need it.
+                if (transparency < 1.0)
+                {
+                    material["alphaMode"] = "BLEND";
+                }
+                else if (textureIndex.HasValue)
+                {
+                    material["alphaMode"] = "MASK";
+                }
                 gltfMaterials.Add(material);
                 colorToMaterialIndex[key] = idx;
                 return idx;
@@ -332,7 +355,7 @@ namespace OpenSkp
                             indices[i * 3 + 2] = (uint)group.LocalFaces[i][2];
                         }
 
-                        int materialIndex = GetMaterialIndex(color, group.DoubleSided, texIndex);
+                        int materialIndex = GetMaterialIndex(color, group.DoubleSided, texIndex, group.Transparency);
                         glbPrimitives.Add(new GlbPrimitive
                         {
                             Positions = positions,

--- a/packages/python/src/openskp/_face_groups.py
+++ b/packages/python/src/openskp/_face_groups.py
@@ -121,8 +121,25 @@ def resolve_color(mat: Optional[Dict[str, Any]]) -> Optional[Tuple[int, int, int
     return (c["r"], c["g"], c["b"])
 
 
-# Key: (color, double_sided, texture_index).
-FaceGroupKey = Tuple[Tuple[int, int, int], bool, Optional[int]]
+def resolve_transparency(mat: Optional[Dict[str, Any]]) -> float:
+    """The material's overall opacity: ``1.0`` fully opaque, ``0.0`` fully
+    invisible. Two independent SketchUp mechanisms can reduce it - the plain
+    RGBA color record's alpha byte, and the newer XML material definition's
+    own ``trans``/``useTrans`` attribute (already resolved into
+    ``mat["transparency"]`` - see _core.py's "useTrans gating" comment). A
+    real material only ever populates one of the two, but multiplying both
+    is safe either way: the untouched one defaults to fully-opaque (255 or
+    1.0), so it never silently darkens a material that only used the other
+    mechanism.
+    """
+    if mat is None:
+        return 1.0
+    color_alpha = mat["color"].get("a", 255) / 255.0
+    return color_alpha * mat.get("transparency", 1.0)
+
+
+# Key: (color, double_sided, texture_index, transparency).
+FaceGroupKey = Tuple[Tuple[int, int, int], bool, Optional[int], float]
 
 
 @dataclass
@@ -161,11 +178,13 @@ def _add_face_side(
     # part of the key too - otherwise two differently-textured faces with
     # the same average color end up in one group with one image
     tex_index = texture_index_for(tex)
-    key = (color, double_sided, tex_index)
+    transparency = resolve_transparency(mat)
+    key = (color, double_sided, tex_index, transparency)
     group = face_groups.get(key)
     if group is None:
         group = {
             "color": color,
+            "transparency": transparency,
             "double_sided": double_sided,
             "texture_index": tex_index,
             "local_verts": [],

--- a/packages/python/src/openskp/instanced_scene.py
+++ b/packages/python/src/openskp/instanced_scene.py
@@ -223,19 +223,22 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
         texture_index_by_key[key] = idx
         return idx
 
-    color_to_material_index: Dict[Tuple[Tuple[int, int, int], bool, Optional[int]], int] = {}
+    color_to_material_index: Dict[Tuple[Tuple[int, int, int], bool, Optional[int], float], int] = {}
     gltf_materials: List[Dict[str, Any]] = []
 
     def get_material_index(
-        color: Tuple[int, int, int], double_sided: bool, texture_index: Optional[int]
+        color: Tuple[int, int, int],
+        double_sided: bool,
+        texture_index: Optional[int],
+        transparency: float = 1.0,
     ) -> int:
-        key = (color, double_sided, texture_index)
+        key = (color, double_sided, texture_index, transparency)
         if key in color_to_material_index:
             return color_to_material_index[key]
         idx = len(gltf_materials)
         r, g, b = color
         pbr: Dict[str, Any] = {
-            "baseColorFactor": [r / 255, g / 255, b / 255, 1.0],
+            "baseColorFactor": [r / 255, g / 255, b / 255, transparency],
             "metallicFactor": 0.0,
             "roughnessFactor": 0.8,
         }
@@ -244,6 +247,13 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
         mat_dict: Dict[str, Any] = {"pbrMetallicRoughness": pbr}
         if double_sided:
             mat_dict["doubleSided"] = True
+        # See scene.py's get_material_index for why: BLEND for genuinely
+        # translucent materials, MASK (safe no-op on an opaque-alpha
+        # texture) for textured ones, otherwise glTF's default OPAQUE.
+        if transparency < 1.0:
+            mat_dict["alphaMode"] = "BLEND"
+        elif texture_index is not None:
+            mat_dict["alphaMode"] = "MASK"
         gltf_materials.append(mat_dict)
         color_to_material_index[key] = idx
         return idx
@@ -292,7 +302,7 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
         )
 
         primitives: List[LocalPrimitive] = []
-        for (color, double_sided, tex_index), group in face_groups.items():
+        for (color, double_sided, tex_index, transparency), group in face_groups.items():
             local_faces = group["local_faces"]
             if not local_faces:
                 continue
@@ -341,7 +351,7 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
                     normals=normals,
                     uvs=uvs,
                     indices=indices,
-                    material_index=get_material_index(color, double_sided, tex_index),
+                    material_index=get_material_index(color, double_sided, tex_index, transparency),
                 )
             )
 

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -202,7 +202,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
         texture_index_by_key[key] = idx
         return idx
 
-    color_to_material_index: Dict[Tuple[Tuple[int, int, int], bool, Optional[int]], int] = {}
+    color_to_material_index: Dict[Tuple[Tuple[int, int, int], bool, Optional[int], float], int] = {}
     gltf_materials: List[Dict[str, Any]] = []
 
     # Definitions currently being instantiated on the active recursion
@@ -216,19 +216,22 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
         return layer_colors.get(name, (136, 136, 136))
 
     def get_material_index(
-        color: Tuple[int, int, int], double_sided: bool, texture_index: Optional[int]
+        color: Tuple[int, int, int],
+        double_sided: bool,
+        texture_index: Optional[int],
+        transparency: float = 1.0,
     ) -> int:
         # The texture is part of the identity, not just the color: two
         # different images can average to the same RGB (real files do
         # this), and keying on color alone would merge them into one
         # material and lose one of the images.
-        key = (color, double_sided, texture_index)
+        key = (color, double_sided, texture_index, transparency)
         if key in color_to_material_index:
             return color_to_material_index[key]
         idx = len(gltf_materials)
         r, g, b = color
         pbr: Dict[str, Any] = {
-            "baseColorFactor": [r / 255, g / 255, b / 255, 1.0],
+            "baseColorFactor": [r / 255, g / 255, b / 255, transparency],
             "metallicFactor": 0.0,
             "roughnessFactor": 0.8,
         }
@@ -240,6 +243,23 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
         mat_dict: Dict[str, Any] = {"pbrMetallicRoughness": pbr}
         if double_sided:
             mat_dict["doubleSided"] = True
+        # glTF's default alphaMode is OPAQUE, which tells a conformant
+        # renderer to ignore alpha entirely - both the material's own
+        # opacity and any texture's alpha channel. Genuinely translucent
+        # materials (glass, water) need BLEND so baseColorFactor's alpha
+        # (and the texture's, if any) actually takes effect. A
+        # textured-but-otherwise-opaque material gets MASK instead: many
+        # SketchUp Warehouse assets (tree foliage, fences, signage) rely on
+        # the image's own alpha channel to cut a shape out of an otherwise
+        # flat quad, and without MASK a renderer would show the full
+        # rectangle. MASK is a no-op for a texture with no real cutout - a
+        # fully-opaque alpha channel (or none, as in JPEG) stays above the
+        # cutoff everywhere - so this is safe to set unconditionally rather
+        # than trying to detect which textures need it.
+        if transparency < 1.0:
+            mat_dict["alphaMode"] = "BLEND"
+        elif texture_index is not None:
+            mat_dict["alphaMode"] = "MASK"
         gltf_materials.append(mat_dict)
         color_to_material_index[key] = idx
         return idx
@@ -281,7 +301,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
                 ),
             )
 
-            for (face_color, double_sided, tex_index), group in face_groups.items():
+            for (face_color, double_sided, tex_index, transparency), group in face_groups.items():
                 local_faces = group["local_faces"]
                 if not local_faces:
                     continue
@@ -350,7 +370,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
                     indices[i * 3 + 1] = tri[1]
                     indices[i * 3 + 2] = tri[2]
 
-                material_index = get_material_index(face_color, double_sided, tex_index)
+                material_index = get_material_index(face_color, double_sided, tex_index, transparency)
                 glb_primitives.append(
                     GlbPrimitive(
                         positions=positions,

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2378,6 +2378,81 @@ class TestGlbExport:
             idx = mat["pbrMetallicRoughness"]["baseColorTexture"]["index"]
             assert 0 <= idx < len(scene_obj.textures)
 
+    def test_translucent_material_gets_blend_alpha(self, tmp_path) -> None:
+        # Round-tripped through the real writer and reader rather than a
+        # hand-built fixture: add_material's 4th (alpha) channel is
+        # documented to carry SketchUp's own opacity mechanism, so this
+        # exercises the exact path a real .skp file with a translucent
+        # material takes. Before this fix, baseColorFactor's alpha was
+        # hardcoded to 1.0 and no glTF material ever declared alphaMode, so
+        # a conformant renderer showed every material fully opaque
+        # regardless of the source file's actual transparency.
+        from openskp import create as create_fn
+        from openskp import scene as scene_mod
+        from openskp.model import SkpFile
+
+        builder = create_fn()
+        glass = builder.add_material("Glass", (40, 70, 100, 128))
+        builder.add_face([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)], material=glass)
+        out_path = tmp_path / "glass.skp"
+        with open(out_path, "wb") as f:
+            f.write(builder.to_bytes())
+
+        skp = SkpFile.open(str(out_path))
+        skp.parse()
+        scene_obj = scene_mod.build_scene(skp._parsed)
+        mat = next(
+            m for m in scene_obj.gltf_materials
+            if m["pbrMetallicRoughness"]["baseColorFactor"][3] != 1.0
+        )
+        assert mat["pbrMetallicRoughness"]["baseColorFactor"][3] == pytest.approx(128 / 255, abs=0.01)
+        assert mat["alphaMode"] == "BLEND"
+
+    def test_opaque_material_stays_byte_for_byte_unchanged(self, tmp_path) -> None:
+        from openskp import create as create_fn
+        from openskp import scene as scene_mod
+        from openskp.model import SkpFile
+
+        builder = create_fn()
+        red = builder.add_material("Red", (255, 0, 0))
+        builder.add_face([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)], material=red)
+        out_path = tmp_path / "red.skp"
+        with open(out_path, "wb") as f:
+            f.write(builder.to_bytes())
+
+        skp = SkpFile.open(str(out_path))
+        skp.parse()
+        scene_obj = scene_mod.build_scene(skp._parsed)
+        mat = scene_obj.gltf_materials[0]
+        assert mat["pbrMetallicRoughness"]["baseColorFactor"][3] == 1.0
+        assert "alphaMode" not in mat
+
+    def test_textured_materials_get_mask_or_blend_never_left_opaque(self, tmp_path) -> None:
+        # capilla_quiroz_v17.skp has four textured materials: two ordinary
+        # opaque ones (MASK - a safe no-op, nothing in their JPEGs to cut
+        # out) and two genuinely translucent stained-glass-style materials
+        # at alpha 0.5 (BLEND, so that opacity actually renders instead of
+        # being silently dropped under glTF's OPAQUE default).
+        from openskp import scene as scene_mod
+        from openskp.model import SkpFile
+
+        skp = SkpFile.open(str(self.FIXTURE))
+        skp.parse()
+        scene_obj = scene_mod.build_scene(skp._parsed)
+
+        textured = [
+            m for m in scene_obj.gltf_materials if "baseColorTexture" in m["pbrMetallicRoughness"]
+        ]
+        assert len(textured) == 4
+        translucent = [m for m in textured if m["alphaMode"] == "BLEND"]
+        opaque = [m for m in textured if m["alphaMode"] == "MASK"]
+        assert len(translucent) == 2
+        assert len(opaque) == 2
+        for m in translucent:
+            assert m["pbrMetallicRoughness"]["baseColorFactor"][3] < 1.0
+        for m in opaque:
+            assert m["pbrMetallicRoughness"]["baseColorFactor"][3] == 1.0
+
     def test_export_omits_images_by_default(self, tmp_path) -> None:
         skp, glb_path = self._export(tmp_path)
         with open(glb_path, "rb") as f:

--- a/packages/typescript/src/face-groups.ts
+++ b/packages/typescript/src/face-groups.ts
@@ -20,6 +20,10 @@ import type { Material, Texture } from './model';
  */
 export interface LocalFaceGroup {
   color: { r: number; g: number; b: number };
+  /** The resolved material's opacity: `1.0` fully opaque, `0.0` fully
+   * invisible. Carried through so the exported glTF material can declare a
+   * real alpha instead of always claiming fully opaque. */
+  transparency: number;
   doubleSided: boolean;
   /** Local-space vertex positions, inches, SketchUp Z-up. */
   localVerts: [number, number, number][];
@@ -67,7 +71,7 @@ export function buildLocalFaceGroups(
   const addSide = (
     triangles: number[][],
     fn: [number, number, number],
-    color: { r: number; g: number; b: number },
+    color: { r: number; g: number; b: number; a?: number },
     doubleSided: boolean,
     reverse: boolean,
     mat: Material | undefined,
@@ -79,11 +83,23 @@ export function buildLocalFaceGroups(
     // part of the key too - otherwise two differently-textured faces with
     // the same average colour end up in one primitive with one image
     const texIndex = ctx.textureIndexFor(mat?.texture);
-    const colorKey = `${color.r},${color.g},${color.b},${doubleSided},${texIndex ?? -1}`;
+    // Two independent SketchUp mechanisms can reduce a material's opacity:
+    // the plain RGBA colour record's alpha byte (older/simple materials,
+    // and what the writer's addMaterial(rgba) sets), and the newer XML
+    // material definition's own `trans`/`useTrans` attribute (surfaced as
+    // Material.transparency, already resolved - see parser.test.ts's
+    // "useTrans gating" tests). A real file only ever populates one of the
+    // two for a given material, but multiplying both is safe either way:
+    // the untouched one defaults to fully-opaque (255 / 1.0), so it never
+    // silently darkens a material that only used the other mechanism.
+    const colorAlpha = color.a !== undefined ? color.a / 255 : 1.0;
+    const transparency = colorAlpha * (mat?.transparency ?? 1.0);
+    const colorKey = `${color.r},${color.g},${color.b},${doubleSided},${texIndex ?? -1},${transparency}`;
     let group = faceGroups.get(colorKey);
     if (!group) {
       group = {
         color,
+        transparency,
         doubleSided,
         textureIndex: texIndex,
         localVerts: [],

--- a/packages/typescript/src/instanced.ts
+++ b/packages/typescript/src/instanced.ts
@@ -201,15 +201,16 @@ export function buildInstancedSceneFromParsed(
   function getMaterialIndex(
     color: { r: number; g: number; b: number },
     doubleSided: boolean,
-    textureIndex: number | null
+    textureIndex: number | null,
+    transparency: number = 1.0
   ) {
-    const key = `${color.r},${color.g},${color.b},${doubleSided},${textureIndex ?? -1}`;
+    const key = `${color.r},${color.g},${color.b},${doubleSided},${textureIndex ?? -1},${transparency}`;
     if (colorToMaterialIndex.has(key)) {
       return colorToMaterialIndex.get(key)!;
     }
     const idx = gltfMaterials.length;
     const pbr: any = {
-      baseColorFactor: [color.r / 255, color.g / 255, color.b / 255, 1.0],
+      baseColorFactor: [color.r / 255, color.g / 255, color.b / 255, transparency],
       metallicFactor: 0.0,
       roughnessFactor: 0.8,
     };
@@ -218,6 +219,14 @@ export function buildInstancedSceneFromParsed(
     }
     const material: any = { pbrMetallicRoughness: pbr };
     if (doubleSided) material.doubleSided = true;
+    // See model.ts's getMaterialIndex for why: BLEND for genuinely
+    // translucent materials, MASK (safe no-op on an opaque-alpha texture)
+    // for textured ones, otherwise glTF's default OPAQUE.
+    if (transparency < 1.0) {
+      material.alphaMode = 'BLEND';
+    } else if (textureIndex !== null) {
+      material.alphaMode = 'MASK';
+    }
     gltfMaterials.push(material);
     colorToMaterialIndex.set(key, idx);
     return idx;
@@ -337,7 +346,7 @@ export function buildInstancedSceneFromParsed(
         normals,
         uvs,
         indices,
-        materialIndex: getMaterialIndex(group.color, group.doubleSided, group.textureIndex),
+        materialIndex: getMaterialIndex(group.color, group.doubleSided, group.textureIndex, group.transparency),
       });
     }
 

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -738,19 +738,20 @@ export function buildSceneFromParsed(
   function getMaterialIndex(
     color: { r: number; g: number; b: number },
     doubleSided: boolean,
-    textureIndex: number | null
+    textureIndex: number | null,
+    transparency: number = 1.0
   ) {
     // The texture is part of the identity, not just the colour: two different
     // images can average to the same RGB (real files do this - two fabrics
     // both resolving to 141,141,141), and keying on colour alone would merge
     // them into one material and lose one of the images.
-    const key = `${color.r},${color.g},${color.b},${doubleSided},${textureIndex ?? -1}`;
+    const key = `${color.r},${color.g},${color.b},${doubleSided},${textureIndex ?? -1},${transparency}`;
     if (colorToMaterialIndex.has(key)) {
       return colorToMaterialIndex.get(key)!;
     }
     const idx = gltfMaterials.length;
     const pbr: any = {
-      baseColorFactor: [color.r / 255, color.g / 255, color.b / 255, 1.0],
+      baseColorFactor: [color.r / 255, color.g / 255, color.b / 255, transparency],
       metallicFactor: 0.0,
       roughnessFactor: 0.8,
     };
@@ -763,6 +764,23 @@ export function buildSceneFromParsed(
     }
     const material: any = { pbrMetallicRoughness: pbr };
     if (doubleSided) material.doubleSided = true;
+    // glTF's default alphaMode is OPAQUE, which tells a conformant renderer
+    // to ignore alpha entirely - both the material's own opacity and any
+    // texture's alpha channel. Genuinely translucent materials (glass,
+    // water) need BLEND so baseColorFactor's alpha (and the texture's, if
+    // any) actually takes effect. A textured-but-otherwise-opaque material
+    // gets MASK instead: many SketchUp Warehouse assets (tree foliage,
+    // fences, signage) rely on the image's own alpha channel to cut a
+    // shape out of an otherwise flat quad, and without MASK a renderer
+    // would show the full rectangle. MASK is a no-op for a texture with no
+    // real cutout - a fully-opaque alpha channel (or none, as in JPEG)
+    // stays above the cutoff everywhere - so this is safe to set
+    // unconditionally rather than trying to detect which textures need it.
+    if (transparency < 1.0) {
+      material.alphaMode = 'BLEND';
+    } else if (textureIndex !== null) {
+      material.alphaMode = 'MASK';
+    }
     gltfMaterials.push(material);
     colorToMaterialIndex.set(key, idx);
     return idx;
@@ -894,7 +912,7 @@ export function buildSceneFromParsed(
           indices[i * 3 + 2] = group.localFaces[i][2];
         }
 
-        const materialIndex = getMaterialIndex(group.color, group.doubleSided, group.textureIndex);
+        const materialIndex = getMaterialIndex(group.color, group.doubleSided, group.textureIndex, group.transparency);
 
         glbPrimitives.push({
           positions,

--- a/packages/typescript/tests/glb-textures.test.ts
+++ b/packages/typescript/tests/glb-textures.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as fs from 'fs';
 import * as path from 'path';
-import { buildScene, toGLB } from '../src/index';
+import { buildScene, toGLB, create } from '../src/index';
 import { sniffImageMime } from '../src/model';
 
 /**
@@ -93,6 +93,77 @@ describe('buildScene texture collection', () => {
     // adding the texture to the grouping key must not split primitives that
     // were previously batched together
     expect(scene.glbPrimitives.length).toBe(21);
+  });
+});
+
+describe('Material transparency -> glTF alpha', () => {
+  // Round-tripped through the real writer and reader rather than a hand-built
+  // fixture: addMaterial's 4th (alpha) channel is documented to carry
+  // SketchUp's own opacity mechanism (create.ts's `use_opacity = False -
+  // alpha carries transparency instead`), so this exercises the exact path a
+  // real .skp file with a translucent material takes.
+  it('propagates a translucent material into baseColorFactor alpha + alphaMode BLEND', () => {
+    const builder = create();
+    const glass = builder.addMaterial('Glass', [40, 70, 100, 128]);
+    builder.addFace(
+      [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+        [0, 1, 0],
+      ],
+      { material: glass }
+    );
+    const scene = buildScene(builder.toBytes());
+    const mat = (scene.gltfMaterials as any[]).find(
+      (m) => m.pbrMetallicRoughness?.baseColorFactor
+    );
+    expect(mat).toBeDefined();
+    expect(mat.pbrMetallicRoughness.baseColorFactor[3]).toBeCloseTo(128 / 255, 2);
+    expect(mat.alphaMode).toBe('BLEND');
+  });
+
+  it('leaves a fully opaque material byte-for-byte as before (no alphaMode field)', () => {
+    const builder = create();
+    const red = builder.addMaterial('Red', [255, 0, 0]);
+    builder.addFace(
+      [
+        [0, 0, 0],
+        [1, 0, 0],
+        [1, 1, 0],
+        [0, 1, 0],
+      ],
+      { material: red }
+    );
+    const scene = buildScene(builder.toBytes());
+    const mat = (scene.gltfMaterials as any[])[0];
+    expect(mat.pbrMetallicRoughness.baseColorFactor[3]).toBe(1.0);
+    expect(mat.alphaMode).toBeUndefined();
+  });
+
+  it('marks every textured material MASK or BLEND, never left at the OPAQUE default', () => {
+    // A conformant glTF viewer ignores alpha entirely under the default
+    // alphaMode (OPAQUE) - both the texture's own channel and
+    // baseColorFactor's. capilla_quiroz_v17.skp has four textured
+    // materials: two ordinary opaque ones (MASK - a safe no-op, since
+    // there's nothing in their JPEGs to cut out) and two genuinely
+    // translucent stained-glass-style materials at alpha 0.5 (BLEND, so
+    // that opacity actually renders instead of being silently dropped).
+    const scene = buildScene(readFixture('capilla_quiroz_v17.skp'));
+    const textured = (scene.gltfMaterials as any[]).filter(
+      (m) => m.pbrMetallicRoughness?.baseColorTexture
+    );
+    expect(textured.length).toBe(4);
+    for (const mat of textured) {
+      expect(['MASK', 'BLEND']).toContain(mat.alphaMode);
+      if (mat.alphaMode === 'BLEND') {
+        expect(mat.pbrMetallicRoughness.baseColorFactor[3]).toBeLessThan(1.0);
+      } else {
+        expect(mat.pbrMetallicRoughness.baseColorFactor[3]).toBe(1.0);
+      }
+    }
+    const translucent = textured.filter((m) => m.alphaMode === 'BLEND');
+    expect(translucent.length).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Summary

- Every language's scene builder hardcoded exported glTF materials to fully opaque (`baseColorFactor[3] = 1.0`, always) and never declared `alphaMode`. Fixed to propagate real opacity and declare `BLEND` (translucent materials) or `MASK` (textured cutout materials - tree foliage, fences, signage) as appropriate.
- .NET fix goes one layer deeper: the legacy binary reader was discarding the material color record's alpha byte during parsing itself, not just at glTF-export time.
- C++ was already partially correct (real alpha channel + `BLEND` branch existed); this adds the missing `MASK` branch and combines the raw color-alpha byte with the separate XML transparency field, which C++ wasn't doing.

Full root-cause writeup and risk assessment in #228.

## Test plan

- [x] TypeScript: 3 new tests (translucent → BLEND, opaque → byte-for-byte unchanged, real fixture's mixed textured materials → correct MASK/BLEND split), full suite 333/333
- [x] Python: same 3 tests, full suite 382/382
- [x] .NET: same 3 tests (including a case that specifically exercises the legacy-parser alpha-byte fix), full suite 166/166
- [x] Dart: same 3 tests, full suite 190/190
- [ ] C++: 4 new tests written, **not locally build-verified** - no C++ toolchain (CMake/MSVC/g++) was available in the dev environment. Relying on this PR's CI to actually build and run them before merge.

Fixes #228