### PR TITLE
Cache-bust viewer.js on every GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -52,6 +52,16 @@ jobs:
           cd packages/typescript
           npm run copy-dist
 
+      - name: Cache-bust viewer.js
+        # GitHub Pages' CDN sets Cache-Control: max-age=600 on viewer.js, so
+        # a returning visitor within that window can keep running code from
+        # before this deploy with no visible sign anything is stale. The
+        # commit SHA in the query string gives every deploy a distinct URL,
+        # so the browser is forced to fetch fresh instead of reusing a
+        # cached response from an earlier commit.
+        run: |
+          sed -i "s/src=\"viewer.js\"/src=\"viewer.js?v=${GITHUB_SHA}\"/" examples/web-viewer/index.html
+
       - name: Setup Pages
         uses: actions/configure-pages@v6
 


### PR DESCRIPTION
GitHub Pages' CDN caches viewer.js for 10 minutes (Cache-Control: max-age=600). A visitor who loaded the page shortly before a deploy can keep running stale code for that window with no visible sign anything changed - this is exactly what made the material-transparency fix look like it hadn't deployed right after it had.

Appends the commit SHA as a query string to the script tag during the deploy workflow, so every deploy gets a distinct URL and browsers can't serve a cached response from an earlier commit.