### PR TITLE
Fix XML entity decoding in material/style name parsing (TypeScript, C++)

### DIFF
--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -6,6 +6,14 @@
 #include "internal.hpp"
 
 namespace openskp {
+
+// Declared here (defined below, outside the anonymous namespace) so it's
+// independently unit-testable via internal.hpp, the same way build_scene_raw
+// and friends are - the anonymous-namespace members below it that call it
+// (attr()) never leave this translation unit, but the decoder itself is a
+// small, self-contained piece worth exercising directly.
+std::string decode_xml_entities(const std::string& value);
+
 namespace {
 struct Zip {
   mz_zip_archive z{};
@@ -102,10 +110,19 @@ std::vector<Header> headers(const ByteBuffer& d, std::size_t start, std::size_t 
 
 std::string str(const ByteBuffer& b) { return {reinterpret_cast<const char*>(b.data()), b.size()}; }
 
+// Decodes the 5 predefined XML entities plus numeric character references
+// (&#39;, &#x27;) in a raw attribute value extracted by regex rather than a
+// real XML parser. A real material name legitimately contains "<"/">" -
+// SketchUp's own "&lt;auto&gt;" default-material naming convention - so
+// without this, names like that come through still escaped instead of as
+// the literal characters a real XML parser (this project's other four
+// ports all use one) would produce. A single regex pass, not five
+// sequential replacements: sequential replacement would double-decode
+// "&amp;lt;" into "<" instead of the correct "&lt;".
 std::string attr(const std::string& s, const std::string& key) {
   std::regex r("(?:^|\\s)" + key + "\\s*=\\s*[\\\"']([^\\\"']*)[\\\"']", std::regex::icase);
   std::smatch m;
-  return std::regex_search(s, m, r) ? m[1].str() : "";
+  return std::regex_search(s, m, r) ? decode_xml_entities(m[1].str()) : "";
 }
 
 int integer(const std::string& s, int fallback) {
@@ -211,6 +228,69 @@ std::optional<RawStyle> style_xml(const ByteBuffer& bytes) {
   return o;
 }
 }  // namespace
+
+// Decodes the 5 predefined XML entities plus numeric character references
+// (&#39;, &#x27;) in a raw attribute value extracted by regex rather than a
+// real XML parser. A real material name legitimately contains "<"/">" -
+// SketchUp's own "&lt;auto&gt;" default-material naming convention - so
+// without this, names like that come through still escaped instead of as
+// the literal characters a real XML parser (this project's other four
+// ports all use one) would produce. A single regex pass, not five
+// sequential replacements: sequential replacement would double-decode
+// "&amp;lt;" into "<" instead of the correct "&lt;".
+std::string decode_xml_entities(const std::string& value) {
+  static const std::regex entity("&(lt|gt|amp|apos|quot|#[0-9]+|#[xX][0-9a-fA-F]+);");
+  std::string out;
+  out.reserve(value.size());
+  auto begin = std::sregex_iterator(value.begin(), value.end(), entity);
+  auto end = std::sregex_iterator();
+  std::size_t lastPos = 0;
+  for (auto it = begin; it != end; ++it) {
+    const auto& m = *it;
+    out.append(value, lastPos, static_cast<std::size_t>(m.position()) - lastPos);
+    const std::string name = m[1].str();
+    if (name == "lt") {
+      out += '<';
+    } else if (name == "gt") {
+      out += '>';
+    } else if (name == "amp") {
+      out += '&';
+    } else if (name == "apos") {
+      out += '\'';
+    } else if (name == "quot") {
+      out += '"';
+    } else if (name[0] == '#') {
+      try {
+        const bool hex = name.size() > 1 && (name[1] == 'x' || name[1] == 'X');
+        const unsigned long codePoint = std::stoul(name.substr(hex ? 2 : 1), nullptr, hex ? 16 : 10);
+        // UTF-8 encode. SketchUp material/style names are practically
+        // always within the BMP, but handle the full range regardless.
+        if (codePoint <= 0x7F) {
+          out += static_cast<char>(codePoint);
+        } else if (codePoint <= 0x7FF) {
+          out += static_cast<char>(0xC0 | (codePoint >> 6));
+          out += static_cast<char>(0x80 | (codePoint & 0x3F));
+        } else if (codePoint <= 0xFFFF) {
+          out += static_cast<char>(0xE0 | (codePoint >> 12));
+          out += static_cast<char>(0x80 | ((codePoint >> 6) & 0x3F));
+          out += static_cast<char>(0x80 | (codePoint & 0x3F));
+        } else {
+          out += static_cast<char>(0xF0 | (codePoint >> 18));
+          out += static_cast<char>(0x80 | ((codePoint >> 12) & 0x3F));
+          out += static_cast<char>(0x80 | ((codePoint >> 6) & 0x3F));
+          out += static_cast<char>(0x80 | (codePoint & 0x3F));
+        }
+      } catch (...) {
+        out += m[0].str();  // malformed numeric reference - leave as-is
+      }
+    } else {
+      out += m[0].str();
+    }
+    lastPos = static_cast<std::size_t>(m.position() + m.length());
+  }
+  out.append(value, lastPos, std::string::npos);
+  return out;
+}
 
 RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
   emit_log(o, LogLevel::information, "Parsing buffer (" + std::to_string(data.size()) + " bytes)");

--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -262,7 +262,8 @@ std::string decode_xml_entities(const std::string& value) {
     } else if (name[0] == '#') {
       try {
         const bool hex = name.size() > 1 && (name[1] == 'x' || name[1] == 'X');
-        const unsigned long codePoint = std::stoul(name.substr(hex ? 2 : 1), nullptr, hex ? 16 : 10);
+        const unsigned long codePoint =
+            std::stoul(name.substr(hex ? 2 : 1), nullptr, hex ? 16 : 10);
         // UTF-8 encode. SketchUp material/style names are practically
         // always within the BMP, but handle the full range regardless.
         if (codePoint <= 0x7F) {

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -157,6 +157,7 @@ struct V20FillerHit {
 std::optional<V20FillerHit> find_count_after_v20_filler(const ByteBuffer&, std::size_t,
                                                         std::uint32_t);
 RawParsed full_parse(const ByteBuffer&, const ParseOptions&);
+std::string decode_xml_entities(const std::string&);
 RawParsed parse_legacy(const ByteBuffer&, const ParseOptions&);
 void collect_geometry(const std::vector<TlvNode>&, GeometryBuilder&);
 void collect_layers(const std::vector<TlvNode>&, std::map<EntityId, std::string>&);

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(
   stl_export_test.cpp
   texture_test.cpp
   triangulator_test.cpp
+  xml_entities_test.cpp
   zip_entry_size_cap_test.cpp
 )
 

--- a/packages/cpp/tests/xml_entities_test.cpp
+++ b/packages/cpp/tests/xml_entities_test.cpp
@@ -12,12 +12,11 @@ namespace {
 // SketchUp's own "<auto>" default-material convention - which the raw XML
 // bytes MUST spell as "&lt;auto&gt;" - came through still escaped.
 
-TEST(XmlEntities, DecodesLtGt) {
-  EXPECT_EQ(decode_xml_entities("&lt;auto&gt;"), "<auto>");
-}
+TEST(XmlEntities, DecodesLtGt) { EXPECT_EQ(decode_xml_entities("&lt;auto&gt;"), "<auto>"); }
 
 TEST(XmlEntities, DecodesAmpApostropheQuote) {
-  EXPECT_EQ(decode_xml_entities("Tom &amp; Jerry&apos;s &quot;Wood&quot;"), "Tom & Jerry's \"Wood\"");
+  EXPECT_EQ(decode_xml_entities("Tom &amp; Jerry&apos;s &quot;Wood&quot;"),
+            "Tom & Jerry's \"Wood\"");
 }
 
 TEST(XmlEntities, DecodesNumericCharacterReferencesDecimalAndHex) {

--- a/packages/cpp/tests/xml_entities_test.cpp
+++ b/packages/cpp/tests/xml_entities_test.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+
+#include "internal.hpp"
+
+namespace openskp {
+namespace {
+
+// material_xml()/style_xml() (core.cpp) extract attributes via std::regex
+// rather than a real XML parser - the only two of this project's five
+// ports that do (the other three use a real XML library and decode
+// entities correctly by construction). Without decoding, a name like
+// SketchUp's own "<auto>" default-material convention - which the raw XML
+// bytes MUST spell as "&lt;auto&gt;" - came through still escaped.
+
+TEST(XmlEntities, DecodesLtGt) {
+  EXPECT_EQ(decode_xml_entities("&lt;auto&gt;"), "<auto>");
+}
+
+TEST(XmlEntities, DecodesAmpApostropheQuote) {
+  EXPECT_EQ(decode_xml_entities("Tom &amp; Jerry&apos;s &quot;Wood&quot;"), "Tom & Jerry's \"Wood\"");
+}
+
+TEST(XmlEntities, DecodesNumericCharacterReferencesDecimalAndHex) {
+  EXPECT_EQ(decode_xml_entities("&#65;&#x42;"), "AB");
+}
+
+TEST(XmlEntities, DoesNotDoubleDecodeAmpLt) {
+  // A single left-to-right pass must consume "&amp;" as one match (5
+  // chars), leaving the trailing "lt;" as literal text - never re-scanning
+  // its own output to find a second "&lt;" to decode into "<".
+  EXPECT_EQ(decode_xml_entities("&amp;lt;"), "&lt;");
+}
+
+TEST(XmlEntities, LeavesPlainTextUnchanged) {
+  EXPECT_EQ(decode_xml_entities("Plain Wood Oak"), "Plain Wood Oak");
+}
+
+TEST(XmlEntities, LeavesMalformedEntityLikeTextAsIs) {
+  // Not a real entity (no trailing ";", unknown name) - passed through
+  // rather than guessed at.
+  EXPECT_EQ(decode_xml_entities("Fish & Chips"), "Fish & Chips");
+  EXPECT_EQ(decode_xml_entities("&nbsp;"), "&nbsp;");
+}
+
+}  // namespace
+}  // namespace openskp

--- a/packages/typescript/src/geometry.ts
+++ b/packages/typescript/src/geometry.ts
@@ -586,6 +586,38 @@ export function reconstructLoopVertices(
   return loopVerts;
 }
 
+/** Decodes the 5 predefined XML entities plus numeric character
+ * references (`&#39;`, `&#x27;`) in a raw attribute value extracted by
+ * regex rather than a real XML parser. A real material name legitimately
+ * contains `<`/`>` - SketchUp's own "&lt;auto&gt;" default-material
+ * naming convention - so without this, names like that come through
+ * still escaped instead of as the literal characters a real XML parser
+ * (this project's other four ports all use one) would produce. A single
+ * regex pass, not five sequential .replace() calls: sequential replacement
+ * would double-decode `&amp;lt;` into `<` instead of the correct `&lt;`. */
+function decodeXmlEntities(value: string): string {
+  return value.replace(/&(lt|gt|amp|apos|quot|#\d+|#x[0-9a-fA-F]+);/g, (whole, entity: string) => {
+    switch (entity) {
+      case 'lt':
+        return '<';
+      case 'gt':
+        return '>';
+      case 'amp':
+        return '&';
+      case 'apos':
+        return "'";
+      case 'quot':
+        return '"';
+      default:
+        if (entity[0] === '#') {
+          const codePoint = entity[1] === 'x' || entity[1] === 'X' ? parseInt(entity.slice(2), 16) : parseInt(entity.slice(1), 10);
+          return Number.isFinite(codePoint) ? String.fromCodePoint(codePoint) : whole;
+        }
+        return whole;
+    }
+  });
+}
+
 export function parseMaterialXml(xmlText: string): {
   name: string;
   r: number;
@@ -607,7 +639,8 @@ export function parseMaterialXml(xmlText: string): {
   const getAttr = (name: string): string | null => {
     const attrRegex = new RegExp(`\\b${name}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`);
     const m = attrsString.match(attrRegex);
-    return m ? (m[1] !== undefined ? m[1] : m[2]) : null;
+    const raw = m ? (m[1] !== undefined ? m[1] : m[2]) : null;
+    return raw === null ? null : decodeXmlEntities(raw);
   };
 
   const name = getAttr('name') || 'unknown';
@@ -647,7 +680,8 @@ export function parseMaterialXml(xmlText: string): {
     const getTexAttr = (n: string): string | null => {
       const r = new RegExp(`\\b${n}\\s*=\\s*(?:"([^"]*)"|'([^']*)')`);
       const m = texAttrs.match(r);
-      return m ? (m[1] !== undefined ? m[1] : m[2]) : null;
+      const raw = m ? (m[1] !== undefined ? m[1] : m[2]) : null;
+      return raw === null ? null : decodeXmlEntities(raw);
     };
     textureFilename = getTexAttr('textureFilename') || '';
     const xs = parseFloat(getTexAttr('xScale') || '0');
@@ -661,7 +695,7 @@ export function parseMaterialXml(xmlText: string): {
   const imageMatch = xmlText.match(
     /<(?:[a-zA-Z0-9_]+:)?image\b[^>]*\bpath\s*=\s*(?:"([^"]*)"|'([^']*)')[^>]*\/?>/
   );
-  const imagePath = imageMatch ? (imageMatch[1] !== undefined ? imageMatch[1] : imageMatch[2]) : '';
+  const imagePath = imageMatch ? decodeXmlEntities(imageMatch[1] !== undefined ? imageMatch[1] : imageMatch[2]!) : '';
 
   return {
     name,

--- a/packages/typescript/tests/parser.test.ts
+++ b/packages/typescript/tests/parser.test.ts
@@ -349,6 +349,32 @@ describe("Material transparency (useTrans gating)", () => {
   });
 });
 
+describe('XML entity decoding (parseMaterialXml uses regex, not a real XML parser)', () => {
+  it('decodes "&lt;auto&gt;" to the literal "<auto>" - SketchUp\'s own default-material naming convention', () => {
+    // A real XML attribute value with < or > MUST be escaped in the
+    // source (the raw bytes literally contain "&lt;auto&gt;") - a real
+    // XML parser (this project's other four ports all use one) decodes
+    // that back to the literal characters automatically. This project's
+    // TS/C++ readers extract attributes via regex instead, which had no
+    // decoding step at all: the name came through still escaped.
+    const xml = '<mat:material name="&lt;auto&gt;" colorRed="255" colorGreen="128" colorBlue="128"/>';
+    const parsed = parseMaterialXml(xml);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.name).toBe('<auto>');
+  });
+
+  it('decodes &amp;/&apos;/&quot; and numeric character references, without double-decoding &amp;lt;', () => {
+    const xml =
+      '<mat:material name="Tom &amp;amp; Jerry&apos;s &quot;Wood&quot; &#65;&#x42;" colorRed="1" colorGreen="1" colorBlue="1"/>';
+    const parsed = parseMaterialXml(xml);
+    expect(parsed).not.toBeNull();
+    // &amp;amp; must decode to the single literal "&amp;", not further to
+    // "&" - a naive multi-pass replace (decode &amp; first, then &lt; on
+    // the result) would over-decode this.
+    expect(parsed!.name).toBe('Tom &amp; Jerry\'s "Wood" AB');
+  });
+});
+
 describe('Edge display flags (D307)', () => {
   it('decodes plain / hidden / soft+smooth edges from the D307 flag byte', () => {
     const buildEdge = (entityId: number, flag: number) => {


### PR DESCRIPTION
## Summary

TypeScript's and C++'s material/style XML parsing (`geometry.ts`'s `parseMaterialXml`, `core.cpp`'s `material_xml`/`style_xml`) extract attributes via regex instead of a real XML parser - Python (`defusedxml`), .NET (`XDocument`), and Dart (`package:xml`) each use a real one and were never affected.

Neither regex path decoded the 5 predefined XML entities (`&lt;` `&gt;` `&amp;` `&apos;` `&quot;`) or numeric character references (`&#39;`, `&#x27;`). A material name containing `<`/`>` is legitimate and common - SketchUp's own `<auto>` default-material naming convention - so the raw XML bytes spell it `&lt;auto&gt;`, and without decoding it came through the reader still escaped.

**Found while building a SKP→code prototype** against a real 113,643-face file, where several materials came through named `&lt;auto&gt;`, `&lt;auto&gt;1`, etc. instead of the correct `<auto>`, `<auto>1` - confirmed by diffing against Python's (correct) output on the same file.

## Fix

A single regex pass in both languages, applied inside the low-level attribute-extraction helper so every caller (name, texture filename, image path, style name) benefits automatically. Deliberately a single pass rather than sequential `.replace()` calls per entity: sequential replacement double-decodes `&amp;lt;` into `<` instead of the correct `&lt;`.

C++'s decoder was moved out of its anonymous namespace and declared in `internal.hpp` so it's independently unit-testable, matching how `build_scene_raw` and other internals are already exposed there for tests.

## Test plan

- [x] TypeScript: 2 new tests (`<auto>` round-trip, `&amp;`/`&apos;`/`&quot;`/numeric refs without double-decoding `&amp;lt;`), full suite 335/335
- [x] C++: 6 new unit tests on the decoder directly, full suite **160/160 - verified locally** (CMake + MSVC Build Tools installed specifically to close the gap from the previous PR, where C++ couldn't be tested before merge)
- [x] Re-verified against the real fixture that surfaced the bug: `<auto>` materials now decode correctly, matching Python's independently-correct output on the same file byte-for-byte