### PR TITLE
Give heavy real-fixture TS tests explicit timeout budgets

### DIFF
--- a/packages/typescript/tests/glb-textures.test.ts
+++ b/packages/typescript/tests/glb-textures.test.ts
@@ -218,9 +218,18 @@ describe('toGLB texture embedding', () => {
     }
   });
 
-  it('is a no-op on a model with no textures', () => {
-    const plain = buildScene(readFixture('Untitled.skp'));
-    expect(plain.textures.length).toBe(0);
-    expect(toGLB(plain, { textures: true })).toEqual(toGLB(plain));
-  });
+  it(
+    'is a no-op on a model with no textures',
+    () => {
+      // Parses Untitled.skp and exports it twice for a byte-for-byte
+      // comparison - genuinely takes longer than vitest's 5s default on a
+      // loaded CI runner (observed timing out at ~5.3-5.4s there twice),
+      // not a regression, just more headroom than the default budget. Same
+      // situation as edge-flags.test.ts's randomised-access-pattern test.
+      const plain = buildScene(readFixture('Untitled.skp'));
+      expect(plain.textures.length).toBe(0);
+      expect(toGLB(plain, { textures: true })).toEqual(toGLB(plain));
+    },
+    15000
+  );
 });

--- a/packages/typescript/tests/instanced-fixture-parity.test.ts
+++ b/packages/typescript/tests/instanced-fixture-parity.test.ts
@@ -64,36 +64,51 @@ describe('instanced vs baked parity on real fixtures', () => {
     });
   }
 
-  it('never stores more geometry than the baked path', () => {
-    for (const name of FIXTURES) {
-      const ab = readFixture(name);
-      const bakedBytes = bakedBufferBytes(buildScene(ab));
-      const instBytes = instancedBufferBytes(buildInstancedScene(ab));
-      // Equal when nothing repeats; strictly smaller once anything does.
-      expect(instBytes).toBeLessThanOrEqual(bakedBytes);
-    }
-  });
+  it(
+    'never stores more geometry than the baked path',
+    () => {
+      // Both builders, over all 5 fixtures (including gondola_v20.skp, the
+      // same heavy legacy fixture flagged in legacy-v20.test.ts) in one
+      // test - genuinely takes longer than vitest's 5s default on a loaded
+      // CI runner, not a regression, just more headroom than the default
+      // budget.
+      for (const name of FIXTURES) {
+        const ab = readFixture(name);
+        const bakedBytes = bakedBufferBytes(buildScene(ab));
+        const instBytes = instancedBufferBytes(buildInstancedScene(ab));
+        // Equal when nothing repeats; strictly smaller once anything does.
+        expect(instBytes).toBeLessThanOrEqual(bakedBytes);
+      }
+    },
+    15000
+  );
 
-  it('resolves the same layers and dynamic properties per node', () => {
-    for (const name of FIXTURES) {
-      const ab = readFixture(name);
-      const baked = buildScene(ab);
-      const instanced = buildInstancedScene(ab);
+  it(
+    'resolves the same layers and dynamic properties per node',
+    () => {
+      // Same reason as "never stores more geometry than the baked path"
+      // above: both builders over all 5 fixtures in one test.
+      for (const name of FIXTURES) {
+        const ab = readFixture(name);
+        const baked = buildScene(ab);
+        const instanced = buildInstancedScene(ab);
 
-      // Walk both trees in lockstep: the instance walk order is identical,
-      // so a divergence in metadata shows up as a mismatch here.
-      const walk = (b: any, i: any) => {
-        expect(i.name).toBe(b.name);
-        expect(i.definitionName).toBe(b.definitionName);
-        expect(i.layer).toBe(b.layer);
-        expect(i.positionMm).toEqual(b.positionMm);
-        expect(i.properties).toEqual(b.properties);
-        expect(i.children.length).toBe(b.children.length);
-        for (let k = 0; k < b.children.length; k++) {
-          walk(b.children[k], i.children[k]);
-        }
-      };
-      walk(baked.sceneHierarchy, instanced.sceneHierarchy);
-    }
-  });
+        // Walk both trees in lockstep: the instance walk order is identical,
+        // so a divergence in metadata shows up as a mismatch here.
+        const walk = (b: any, i: any) => {
+          expect(i.name).toBe(b.name);
+          expect(i.definitionName).toBe(b.definitionName);
+          expect(i.layer).toBe(b.layer);
+          expect(i.positionMm).toEqual(b.positionMm);
+          expect(i.properties).toEqual(b.properties);
+          expect(i.children.length).toBe(b.children.length);
+          for (let k = 0; k < b.children.length; k++) {
+            walk(b.children[k], i.children[k]);
+          }
+        };
+        walk(baked.sceneHierarchy, instanced.sceneHierarchy);
+      }
+    },
+    15000
+  );
 });

--- a/packages/typescript/tests/legacy-v20.test.ts
+++ b/packages/typescript/tests/legacy-v20.test.ts
@@ -69,20 +69,29 @@ describe('Legacy MFC reader - SketchUp 2020 (v20) layout', () => {
     expect(vertices).toBe(6543);
   });
 
-  it('places every root instance (a parse that drops them is still broken)', () => {
-    const model = parseSkp(arrayBuffer);
-    // 23 root-level placements: the definitions above are useless if the
-    // instances that position them in the model are lost, which is exactly
-    // what a subtly misaligned walk produces - a file that parses into an
-    // almost-empty scene instead of throwing.
-    expect(model.root.instances.length).toBe(23);
+  it(
+    'places every root instance (a parse that drops them is still broken)',
+    () => {
+      // Both parseSkp() and buildScene() do their own full pass over this
+      // legacy v20 fixture - genuinely takes longer than vitest's 5s
+      // default on a loaded CI runner (same buildScene() cost flagged on
+      // "gives every baked primitive valid uv coordinates" below), not a
+      // regression, just more headroom than the default budget.
+      const model = parseSkp(arrayBuffer);
+      // 23 root-level placements: the definitions above are useless if the
+      // instances that position them in the model are lost, which is exactly
+      // what a subtly misaligned walk produces - a file that parses into an
+      // almost-empty scene instead of throwing.
+      expect(model.root.instances.length).toBe(23);
 
-    const scene = buildScene(arrayBuffer);
-    expect(scene.sceneHierarchy.children.length).toBe(23);
-    expect(scene.glbPrimitives.length).toBe(201);
-    expect(Object.keys(scene.meshIndex).length).toBe(201);
-    expect(scene.gltfMaterials.length).toBe(17);
-  });
+      const scene = buildScene(arrayBuffer);
+      expect(scene.sceneHierarchy.children.length).toBe(23);
+      expect(scene.glbPrimitives.length).toBe(201);
+      expect(Object.keys(scene.meshIndex).length).toBe(201);
+      expect(scene.gltfMaterials.length).toBe(17);
+    },
+    20000
+  );
 
   it('resolves placed instances to definitions that carry geometry', () => {
     // Guards the failure mode that a zero entity count produces: the
@@ -116,35 +125,53 @@ describe('Legacy MFC reader - SketchUp 2020 (v20) layout', () => {
     expect(empty).toEqual([]);
   });
 
-  it('bakes geometry at a plausible real-world scale', () => {
-    const scene = buildScene(arrayBuffer);
-    let min = [Infinity, Infinity, Infinity];
-    let max = [-Infinity, -Infinity, -Infinity];
-    for (const prim of scene.glbPrimitives) {
-      for (let i = 0; i < prim.positions.length; i += 3) {
-        for (let a = 0; a < 3; a++) {
-          const v = prim.positions[i + a];
-          if (v < min[a]) min[a] = v;
-          if (v > max[a]) max[a] = v;
+  it(
+    'bakes geometry at a plausible real-world scale',
+    () => {
+      // Another fresh buildScene() on the same heavy legacy v20 fixture -
+      // see the timeout comment on "gives every baked primitive valid uv
+      // coordinates" below.
+      const scene = buildScene(arrayBuffer);
+      let min = [Infinity, Infinity, Infinity];
+      let max = [-Infinity, -Infinity, -Infinity];
+      for (const prim of scene.glbPrimitives) {
+        for (let i = 0; i < prim.positions.length; i += 3) {
+          for (let a = 0; a < 3; a++) {
+            const v = prim.positions[i + a];
+            if (v < min[a]) min[a] = v;
+            if (v > max[a]) max[a] = v;
+          }
         }
       }
-    }
-    // a shop gondola display: metres, not the 1e3-off or degenerate box a
-    // misaligned read produces
-    expect(max[0] - min[0]).toBeCloseTo(3.82, 1);
-    expect(max[1] - min[1]).toBeCloseTo(3.14, 1);
-    expect(max[2] - min[2]).toBeCloseTo(4.82, 1);
-  });
+      // a shop gondola display: metres, not the 1e3-off or degenerate box a
+      // misaligned read produces
+      expect(max[0] - min[0]).toBeCloseTo(3.82, 1);
+      expect(max[1] - min[1]).toBeCloseTo(3.14, 1);
+      expect(max[2] - min[2]).toBeCloseTo(4.82, 1);
+    },
+    20000
+  );
 
-  it('gives every baked primitive valid uv coordinates', () => {
-    const scene = buildScene(arrayBuffer);
-    expect(scene.glbPrimitives.length).toBeGreaterThan(0);
-    for (const prim of scene.glbPrimitives) {
-      const nVerts = prim.positions.length / 3;
-      expect(prim.uvs.length).toBe(nVerts * 2);
-      for (const uv of prim.uvs) {
-        expect(Number.isFinite(uv)).toBe(true);
+  it(
+    'gives every baked primitive valid uv coordinates',
+    () => {
+      // A fresh full buildScene() on this legacy v20 fixture, then a
+      // per-value assertion over every UV of every primitive - the
+      // heaviest single call in this file. Genuinely takes longer than
+      // vitest's 5s default on a loaded CI runner (observed timing out
+      // there), not a regression, just more headroom than the default
+      // budget. Same situation as edge-flags.test.ts's
+      // randomised-access-pattern test.
+      const scene = buildScene(arrayBuffer);
+      expect(scene.glbPrimitives.length).toBeGreaterThan(0);
+      for (const prim of scene.glbPrimitives) {
+        const nVerts = prim.positions.length / 3;
+        expect(prim.uvs.length).toBe(nVerts * 2);
+        for (const uv of prim.uvs) {
+          expect(Number.isFinite(uv)).toBe(true);
+        }
       }
-    }
-  });
+    },
+    20000
+  );
 });


### PR DESCRIPTION
## Summary

Test-only change, no logic changes. Two tests genuinely timed out at vitest's 5000ms default on a loaded CI runner while landing #231 - twice, on two different tests, across two separate retries (`glb-textures.test.ts`'s "is a no-op on a model with no textures" and `legacy-v20.test.ts`'s "gives every baked primitive valid uv coordinates").

Both - and two siblings in the same files that run the identical expensive `buildScene()`/`parseSkp()` call on the same heavy `gondola_v20.skp` legacy fixture, or run both scene builders over all 5 real fixtures in one test - sit right at the 5s ceiling even locally under load (observed 4841ms on a full local suite run just now).

Same situation already fixed once for `edge-flags.test.ts`'s randomised-access-pattern test (~14,000 assertions, explicit 15s budget). Gave every test in this position an explicit budget (15-20s, sized to the heaviest observed duration) rather than re-running CI each time a different one flakes.

## Test plan

- [x] Full suite: 335/335 passing locally