### PR TITLE
Add writer support for SketchUp Image entities (add_image), all 5 languages

### DIFF
--- a/packages/cpp/include/openskp/create.hpp
+++ b/packages/cpp/include/openskp/create.hpp
@@ -252,6 +252,17 @@ struct GroupInstanceOptions {
   bool hidden = false;
 };
 
+/// Options for `SkpBuilder::add_image`.
+struct ImageOptions {
+  Point3 translation{0.0, 0.0, 0.0};
+  /// Row-major 3x3 rotation/scale matrix (identity if unset). Pass at most one of `matrix3x3`/
+  /// `rotation`.
+  std::optional<Matrix3x3> matrix3x3;
+  std::optional<Rotation> rotation;
+  std::optional<int> layer;
+  bool hidden = false;
+};
+
 /// Accumulates one component/group definition's geometry. Construct via
 /// `SkpBuilder::add_component_definition` or `SkpBuilder::add_group`, not directly.
 ///
@@ -368,10 +379,18 @@ class OPENSKP_EXPORT SkpBuilder {
 
   /// Register an image-textured material from a local PNG or JPEG file and return a handle to
   /// pass as `FaceOptions::material`. The format is detected from the file's own magic bytes,
-  /// not its extension. UV mapping is always the default planar projection; explicit
-  /// positioning/pinning is not supported for a texture *material* (see `FaceOptions::front_uv`/
-  /// `back_uv` for per-face positioning). Same ordering rules as `add_material`.
-  int add_texture_material(const std::string& name, const std::filesystem::path& image_path);
+  /// not its extension. Same ordering rules as `add_material`.
+  ///
+  /// If this material will ever be used with `FaceOptions::front_uv`/`back_uv` pinning, pass
+  /// `applied_height = 1.0` (matching those pins' own 0..1 range) - the read-side UV formula
+  /// divides by this field even for a positioned mapping, and the default (an internal sentinel,
+  /// real SketchUp's own byte pattern for "never explicitly scaled") is astronomically small,
+  /// which corrupts ANY face using this material, not just default-projected ones (confirmed
+  /// against real SketchUp 2026-08-27 - see `write_textured_material`'s own note in create.cpp).
+  /// Left at the default for the plain default-planar-projection case, matching this method's
+  /// original, narrower scope.
+  int add_texture_material(const std::string& name, const std::filesystem::path& image_path,
+                           std::optional<double> applied_height = std::nullopt);
 
   /// Register a layer and return a handle to pass as `FaceOptions::layer`. Calling this again
   /// with a name already registered returns the same handle (`options` are ignored on a repeat
@@ -399,6 +418,45 @@ class OPENSKP_EXPORT SkpBuilder {
   /// after it, in inches.
   void add_instance(const ComponentDefinitionBuilder& definition,
                     const InstanceOptions& options = {});
+
+  /// Place a SketchUp Image entity (File > Import > Image) - a picture placed as its own object,
+  /// distinct from painting a texture material onto an ordinary face (an Image gets its own
+  /// Outliner classification and explode behavior a plain textured face doesn't).
+  ///
+  /// `width`/`height` size the image's quad in inches; the image covers it edge to edge,
+  /// undistorted regardless of the source file's own pixel aspect ratio (get the ratio right
+  /// yourself if that matters - this does not auto-derive it). `options.translation`/
+  /// `matrix3x3`/`rotation`/`hidden` place it exactly like `add_instance` - the quad starts in
+  /// the XY plane; rotate it to stand upright (e.g. on a wall) the same way you would any other
+  /// placement. `options.layer`, if given, is a handle from `add_layer`.
+  ///
+  /// \code
+  /// builder->add_image("photo.jpg", 48, 36,
+  ///                    {.translation = {0, 0, 40}, .rotation = Rotation{{1, 0, 0}, M_PI / 2}});
+  /// \endcode
+  ///
+  /// Must be called before any `add_layer`/`add_component_definition`/`add_group`/`add_face`/
+  /// `add_instance` call - like `add_texture_material` (which this calls internally to register
+  /// the image itself), it needs a material, and this writer's file format requires every
+  /// material to be registered before any geometry section begins.
+  ///
+  /// The image's quad and UV mapping are pinned explicitly (`FaceOptions::front_uv`), not left
+  /// to the default per-material tile-size projection - `add_texture_material` is called with
+  /// `applied_height = 1.0` for exactly this reason: the read-side UV formula divides by the
+  /// material's applied height even for a pinned mapping, and the library default there (a
+  /// ground-truth sentinel, not a real number) is astronomically small - confirmed via real
+  /// SketchUp screenshots (2026-08-27, Python writer) to render as a corrupted, vertically-
+  /// smeared texture when left in place. 1.0 makes that division a no-op against this method's
+  /// own 0..1 pins.
+  ///
+  /// Unlike every other entity this writer produces, CImage's exact binary schema version (see
+  /// `kImageSchema` in create.cpp) is a best-effort guess, not calibrated against a real
+  /// SketchUp-authored Image entity - none was available. This project's own reader round-trips
+  /// the result correctly, but real SketchUp's acceptance of the file is unverified beyond the
+  /// Python port's own real-SketchUp test (placement/orientation/texture all confirmed correct
+  /// there after the applied_height fix - see CHECKLIST.md).
+  void add_image(const std::filesystem::path& image_path, double width, double height,
+                 const ImageOptions& options = {});
 
   /// Add one planar face, defined by 3+ coplanar points (inches) forming a closed polygon in
   /// order - do not repeat the first point at the end. Vertices/edges are automatically shared

--- a/packages/cpp/src/create.cpp
+++ b/packages/cpp/src/create.cpp
@@ -104,6 +104,15 @@ constexpr int kDibSchema = 3;
 constexpr int kDefinitionSchema = 11;
 constexpr int kInstanceSchema = 6;
 constexpr int kGroupSchema = 1;
+// UNVERIFIED - unlike every other schema constant here, not calibrated against a real
+// SketchUp-authored file: no sample containing a CImage entity (File > Import > Image) was
+// available (ported from the Python writer, same caveat there - see create.py's own comment).
+// legacy.cpp's image reader never branches on schema the way instance/group reading does, so
+// this project's own reader round-trips correctly regardless of the exact value - this only
+// affects whether real SketchUp accepts the file. Chosen to match kInstanceSchema for the same
+// reason as Python's _IMAGE_SCHEMA: CImage's read path always expects the trailing GUID
+// unconditionally, the same "always present" shape CComponentInstance has.
+constexpr int kImageSchema = 6;
 constexpr int kThumbnailSchema = 1;
 constexpr int kFtcSchema = 4;
 constexpr int kArcCurveSchema = 3;
@@ -755,8 +764,19 @@ class ArchiveWriter {
   }
 
   // `subtype` is CDib's image format tag (4 for PNG, 1 for JPEG - see detect_image_subtype).
+  //
+  // `applied_height`, if given, is written in place of kTextureHSentinel (applied width stays a
+  // fixed 1.0 either way). Needed because the reader's own ground-truth-derived UV formula
+  // divides a face's final UV by the material's applied width/height EVEN for a positioned
+  // (front_uv) mapping, not just the default projection - the sentinel decodes to ~1.29e-231,
+  // and dividing by it blows up to an astronomical value, which real SketchUp visibly renders as
+  // a corrupted, vertically-smeared texture (confirmed against real SketchUp 2026-08-27 via the
+  // Python writer - see create.py's own note on this). A caller positioning this material via
+  // front_uv/back_uv should pass a real applied_height (add_image uses 1.0, matching its own
+  // pins' 0..1 range) so that division is a no-op instead of a corruption.
   int write_textured_material(const std::string& name, const ByteBuffer& image_bytes,
-                              const std::string& texture_path, int subtype) {
+                              const std::string& texture_path, int subtype,
+                              std::optional<double> applied_height = std::nullopt) {
     int slot = new_of_known_class("CMaterial", kMaterialSchema);
     preamble();
     write_str(name);
@@ -772,7 +792,11 @@ class ArchiveWriter {
       append_u32(buf, 90);
     }
     append_f64(buf, 1.0);  // applied width - ground truth default when unscaled
-    append_bytes(buf, kTextureHSentinel, sizeof(kTextureHSentinel));
+    if (applied_height) {
+      append_f64(buf, *applied_height);
+    } else {
+      append_bytes(buf, kTextureHSentinel, sizeof(kTextureHSentinel));
+    }
     write_str(texture_path);
     // avg color: neutral near-opaque white. Alpha is 254, not fully-opaque 255 - the reader
     // treats alpha=255 here as one of its two "this material is colorized" signals; a plain
@@ -906,6 +930,23 @@ class ArchiveWriter {
                   bool hidden) {
     write_instance_like("CGroup", kGroupSchema, false, definition_slot, name, translation,
                         matrix3x3, group_material, group_layer, {}, hidden);
+    return 1;
+  }
+
+  // Places definition_slot (the quad + texture material add_image built for it); return contract
+  // matches write_instance/write_group (always 1).
+  //
+  // legacy.cpp's image reader treats CImage as "instance-shaped": preamble, drawbase, a
+  // definition back-ref, a 3x4 placement, a constant 1.0, a source-path string, and a 16-byte
+  // GUID - field-for-field identical in count and order to write_instance's own
+  // matrix3x3(9)+translation(3)+1.0(1)=13 f64s, name string, GUID. The source-path string is
+  // always empty - ground truth shows real SketchUp writes it empty too. No material argument -
+  // an Image entity isn't painted a material the way a face or instance can be; its appearance
+  // comes entirely from the definition's own textured face.
+  int write_image(int definition_slot, Point3 translation, std::optional<Matrix3x3> matrix3x3,
+                  int image_layer, bool hidden) {
+    write_instance_like("CImage", kImageSchema, false, definition_slot, "", translation, matrix3x3,
+                        0, image_layer, {}, hidden);
     return 1;
   }
 
@@ -1604,7 +1645,8 @@ int SkpBuilder::add_material(const std::string& name, Color3 rgb) {
 }
 
 int SkpBuilder::add_texture_material(const std::string& name,
-                                     const std::filesystem::path& image_path) {
+                                     const std::filesystem::path& image_path,
+                                     std::optional<double> applied_height) {
   if (impl_->geometry_writer)
     throw SkpWriteError("add_texture_material must be called before any add_face calls");
   if (impl_->layer_writer)
@@ -1620,7 +1662,7 @@ int SkpBuilder::add_texture_material(const std::string& name,
   ByteBuffer image_bytes((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
   int subtype = detail::detect_image_subtype(image_bytes);
   int slot = impl_->material_writer.write_textured_material(name, image_bytes, image_path.string(),
-                                                            subtype);
+                                                            subtype, applied_height);
   materials_by_name[name] = slot;
   impl_->material_count += 1;
   return slot;
@@ -1709,6 +1751,32 @@ void SkpBuilder::add_instance(const ComponentDefinitionBuilder& definition,
   impl_->new_entity_count += impl_->geometry_writer->write_instance(
       definition.slot(), options.name.value_or(definition.name()), options.translation, matrix,
       options.material.value_or(0), options.layer.value_or(0), dicts, options.hidden);
+  impl_->face_count += 1;  // reuses the "at least one root entity" check in to_bytes
+}
+
+void SkpBuilder::add_image(const std::filesystem::path& image_path, double width, double height,
+                           const ImageOptions& options) {
+  int mat = add_texture_material("__openskp_image_" + std::to_string(impl_->material_count),
+                                 image_path, 1.0);
+  auto& image_def = add_component_definition("Image" + std::to_string(impl_->definition_count));
+  // Standard (0,0)-at-bottom-left, V increasing upward - no vertical flip. Every other UV-related
+  // fact in this file is calibrated against real SketchUp output; this one specific sense is NOT
+  // (no ground truth available - see add_image's own warning in create.hpp) and could come out
+  // upside down in real SketchUp if its texture sampling flips V the other way.
+  FaceOptions face_opts;
+  face_opts.material = mat;
+  face_opts.front_uv = UvCorrespondence{
+      UvPoint{Point3{0.0, 0.0, 0.0}, {0.0, 0.0}},
+      UvPoint{Point3{width, 0.0, 0.0}, {1.0, 0.0}},
+      UvPoint{Point3{0.0, height, 0.0}, {0.0, 1.0}},
+  };
+  image_def.add_face({{0.0, 0.0, 0.0}, {width, 0.0, 0.0}, {width, height, 0.0}, {0.0, height, 0.0}},
+                     face_opts);
+  image_def.close();
+  auto matrix = detail::resolve_matrix3x3(options.matrix3x3, options.rotation);
+  impl_->ensure_geometry_writer();
+  impl_->new_entity_count += impl_->geometry_writer->write_image(
+      image_def.slot(), options.translation, matrix, options.layer.value_or(0), options.hidden);
   impl_->face_count += 1;  // reuses the "at least one root entity" check in to_bytes
 }
 

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <regex>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "internal.hpp"
 
@@ -1302,6 +1303,25 @@ void fill(GeometryBuilder& b,
       i.hidden = v->hidden != 0;
       i.properties = extract_legacy_dynamic_properties(v->attrs, slots);
       b.instances.push_back(std::move(i));
+    } else if (v->k == "image") {
+      // Placed exactly like an ordinary component instance - same
+      // transform/definition-reference shape - the only difference is the
+      // definition it points at is flagged is_image=true (set below via
+      // image_def_ids), matching how the VFF/modern reader already treats
+      // an Image entity as "a component placed through the same instance
+      // machinery as any other". Previously dropped here entirely: this
+      // record's parsed value was documented as "never consumed
+      // downstream, exists purely so the byte stream stays aligned" - an
+      // Image entity parsed without error but never appeared anywhere a
+      // caller could see it.
+      RawInstance i;
+      i.ref_idx = v->def;
+      i.ref_guid = v->guid;
+      i.matrix = v->xf;
+      if (v->mat) i.material_id = v->mat;
+      if (v->layer) i.layer = std::to_string(v->layer);
+      i.hidden = v->hidden != 0;
+      b.instances.push_back(std::move(i));
     } else if (v->k == "sectionplane") {
       SectionPlane sp;
       if (v->plane.size() == 4) {
@@ -1419,6 +1439,14 @@ RawParsed parse_legacy(const ByteBuffer& data, const ParseOptions& o) {
     }
     if (!out.layer_colors.count("Layer0")) out.layer_colors["Layer0"] = {136, 136, 136};
     if (!out.layer_hidden.count("Layer0")) out.layer_hidden["Layer0"] = false;
+    // Scanned before the definitions loop below so is_image can be set
+    // correctly the first time a definition is built, matching the VFF
+    // reader's RawDefinition::is_image field.
+    std::unordered_set<std::uint64_t> image_def_ids;
+    for (auto& s : ar.slots)
+      if (!s.second.cls && s.second.name == "CImage" && s.second.v) {
+        image_def_ids.insert(s.second.v->def);
+      }
     for (auto& s : ar.slots)
       if (!s.second.cls && s.second.name == "CComponentDefinition" && s.second.v) {
         RawDefinition d;
@@ -1426,6 +1454,7 @@ RawParsed parse_legacy(const ByteBuffer& data, const ParseOptions& o) {
         d.guid = s.second.v->guid;
         d.always_faces_camera = s.second.v->faces_camera;
         d.shadows_face_sun = s.second.v->shadows_face_sun;
+        d.is_image = image_def_ids.count(s.first) != 0;
         fill(d.builder, s.second.v->ents, ar.slots);
         out.definitions[s.first] = std::move(d);
       }

--- a/packages/cpp/tests/create_test.cpp
+++ b/packages/cpp/tests/create_test.cpp
@@ -143,6 +143,38 @@ TEST(Create, TexturedMaterialRoundTrips) {
   EXPECT_EQ(*mat.texture->data, fake_png_bytes());
 }
 
+TEST(Create, AddImagePlacesARealImageEntityNotAPlainTexturedFace) {
+  auto tmp_path = std::filesystem::temp_directory_path() / "openskp_create_test_image.png";
+  {
+    std::ofstream f(tmp_path, std::ios::binary);
+    ByteBuffer png = fake_png_bytes();
+    f.write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+  }
+
+  auto builder = create();
+  ImageOptions opts;
+  opts.translation = {0, 0, 40};
+  opts.rotation = Rotation{{1, 0, 0}, kPi / 2};
+  builder->add_image(tmp_path, 48, 36, opts);
+
+  SkpModel model = round_trip(*builder);
+  std::filesystem::remove(tmp_path);
+
+  int image_def_count = 0;
+  EntityId image_def_id = 0;
+  for (const auto& [id, def] : model.definitions) {
+    if (def.is_image) {
+      image_def_count++;
+      image_def_id = id;
+      EXPECT_EQ(def.faces.size(), 1u);
+    }
+  }
+  EXPECT_EQ(image_def_count, 1);
+  ASSERT_EQ(model.root().instances.size(), 1u);
+  ASSERT_TRUE(model.root().instances[0].ref_idx.has_value());
+  EXPECT_EQ(*model.root().instances[0].ref_idx, image_def_id);
+}
+
 TEST(Create, MaterialsMustPrecedeGeometry) {
   auto builder = create();
   builder->add_face({{0, 0, 0}, {1, 0, 0}, {1, 1, 0}});

--- a/packages/dart/lib/src/create.dart
+++ b/packages/dart/lib/src/create.dart
@@ -178,6 +178,18 @@ final List<int> _textureHSentinel = _hexBytes('f0ffffffffffff0f');
 const int _definitionSchema = 11;
 const int _instanceSchema = 6;
 const int _groupSchema = 1;
+
+/// UNVERIFIED - unlike every other schema constant here, not calibrated
+/// against a real SketchUp-authored file: no sample containing a CImage
+/// entity (File > Import > Image) was available (ported from the Python
+/// writer, same caveat there - see create.py's own comment). legacy.dart's
+/// image reader never branches on schema the way instance/group reading
+/// does, so this project's own reader round-trips correctly regardless of
+/// the exact value - this only affects whether real SketchUp accepts the
+/// file. Chosen to match [_instanceSchema] for the same reason as Python's
+/// `_IMAGE_SCHEMA`: CImage's read path always expects the trailing GUID
+/// unconditionally, the same "always present" shape CComponentInstance has.
+const int _imageSchema = 6;
 const int _thumbnailSchema = 1;
 
 /// CCamera's class is declared inside the scaffold's own style/scene-manager
@@ -1016,7 +1028,21 @@ class _ArchiveWriter {
   /// verbatim inside a `CDib` sub-object) and return its slot. [subtype] is
   /// CDib's image format tag (4 for PNG, 1 for JPEG - see
   /// [_detectImageSubtype]).
-  int writeTexturedMaterial(String name, Uint8List imageBytes, String texturePath, int subtype) {
+  ///
+  /// [appliedHeight], if given, is written in place of [_textureHSentinel]
+  /// (applied width stays a fixed 1.0 either way). Needed because the
+  /// reader's own ground-truth-derived UV formula divides a face's final UV
+  /// by the material's applied width/height EVEN for a positioned
+  /// (`frontUv`) mapping, not just the default projection - the sentinel
+  /// decodes to ~1.29e-231, and dividing by it blows up to an astronomical
+  /// value, which real SketchUp visibly renders as a corrupted,
+  /// vertically-smeared texture (confirmed against real SketchUp
+  /// 2026-08-27 via the Python writer - see create.py's own note on this).
+  /// A caller positioning this material via `frontUv`/`backUv` should pass
+  /// a real [appliedHeight] ([addImage] uses 1.0, matching its own pins'
+  /// 0..1 range) so that division is a no-op instead of a corruption.
+  int writeTexturedMaterial(String name, Uint8List imageBytes, String texturePath, int subtype,
+      {double? appliedHeight}) {
     final slot = _newOfKnownClass('CMaterial', schema: _materialSchema);
     _preamble();
     _writeStr(name);
@@ -1033,7 +1059,7 @@ class _ArchiveWriter {
       buf.addAll(_u32(90));
     }
     buf.addAll(_f64(1.0)); // applied width - ground truth default when unscaled
-    buf.addAll(_textureHSentinel);
+    buf.addAll(appliedHeight != null ? _f64(appliedHeight) : _textureHSentinel);
     _writeStr(texturePath);
     // avg color (RGBA + pad + RGBA repeated) - neutral near-opaque white
     // rather than a real image average, since this project doesn't depend
@@ -1228,6 +1254,41 @@ class _ArchiveWriter {
       matrix3x3: matrix3x3,
       mat: groupMaterial,
       layer: groupLayer,
+      hidden: hidden,
+    );
+    return 1;
+  }
+
+  /// Write one `CImage` placing [definitionSlot] (the quad + texture
+  /// material [addImage] built for it) - return contract matches
+  /// [writeInstance]/[writeGroup] (always 1).
+  ///
+  /// legacy.dart's image reader treats CImage as "instance-shaped":
+  /// preamble, drawbase, a definition back-ref, a 3x4 placement, a constant
+  /// 1.0, a source-path string, and a 16-byte GUID - field-for-field
+  /// identical in count and order to [writeInstance]'s own
+  /// matrix3x3(9)+translation(3)+1.0(1)=13 f64s, name string, GUID. The
+  /// source-path string is always empty - ground truth shows real SketchUp
+  /// writes it empty too. No material argument - an Image entity isn't
+  /// painted a material the way a face or instance can be; its appearance
+  /// comes entirely from the definition's own textured face.
+  int writeImage(
+    int definitionSlot,
+    Point3 translation,
+    Matrix3x3? matrix3x3,
+    int imageLayer, [
+    bool hidden = false,
+  ]) {
+    _writeInstanceLike(
+      className: 'CImage',
+      schema: _imageSchema,
+      realAttrs: false,
+      definitionSlot: definitionSlot,
+      name: '',
+      translation: translation,
+      matrix3x3: matrix3x3,
+      mat: 0,
+      layer: imageLayer,
       hidden: hidden,
     );
     return 1;
@@ -2064,10 +2125,19 @@ class SkpBuilder implements GeometryHost {
   /// Register an image-textured material from a local PNG or JPEG file and
   /// return a handle to pass as `addFace`'s `material` argument. The
   /// format is detected from the file's own magic bytes, not its
-  /// extension. UV mapping is always the default planar projection;
-  /// explicit positioning/pinning is not supported. Same ordering rules as
-  /// [addMaterial].
-  int addTextureMaterial(String name, String imagePath) {
+  /// extension. Same ordering rules as [addMaterial].
+  ///
+  /// If this material will ever be used with `addFace`'s `frontUv`/
+  /// `backUv` pinning, pass `appliedHeight: 1.0` (matching those pins' own
+  /// 0..1 range) - the read-side UV formula divides by this field even for
+  /// a positioned mapping, and the default (an internal sentinel, real
+  /// SketchUp's own byte pattern for "never explicitly scaled") is
+  /// astronomically small, which corrupts ANY face using this material,
+  /// not just default-projected ones (confirmed against real SketchUp
+  /// 2026-08-27 - see [_ArchiveWriter.writeTexturedMaterial]'s own note).
+  /// Left at the default for the plain default-planar-projection case,
+  /// matching this method's original, narrower scope.
+  int addTextureMaterial(String name, String imagePath, {double? appliedHeight}) {
     if (_geometryWriter != null) {
       throw SkpWriteError('addTextureMaterial must be called before any addFace calls');
     }
@@ -2080,7 +2150,8 @@ class SkpBuilder implements GeometryHost {
     if (materialsByName.containsKey(name)) return materialsByName[name]!;
     final imageBytes = File(imagePath).readAsBytesSync();
     final subtype = _detectImageSubtype(imageBytes);
-    final slot = _materialWriter.writeTexturedMaterial(name, imageBytes, imagePath, subtype);
+    final slot =
+        _materialWriter.writeTexturedMaterial(name, imageBytes, imagePath, subtype, appliedHeight: appliedHeight);
     materialsByName[name] = slot;
     _materialCount++;
     return slot;
@@ -2296,6 +2367,85 @@ class SkpBuilder implements GeometryHost {
       attributeDicts: attributeDicts,
       hidden: hidden,
     );
+    _faceCount++; // reuses the "at least one root entity" check in toBytes
+  }
+
+  /// Place a SketchUp Image entity (File > Import > Image) - a picture
+  /// placed as its own object, distinct from painting a texture material
+  /// onto an ordinary face (an Image gets its own Outliner classification
+  /// and explode behavior a plain textured face doesn't).
+  ///
+  /// [width]/[height] size the image's quad in inches; the image covers it
+  /// edge to edge, undistorted regardless of the source file's own pixel
+  /// aspect ratio (get the ratio right yourself if that matters - this does
+  /// not auto-derive it). [translation]/[matrix3x3]/[rotation]/[hidden]
+  /// place it exactly like [addInstance] - the quad starts in the XY
+  /// plane; rotate it to stand upright (e.g. on a wall) the same way you
+  /// would any other placement. [layer], if given, is a handle from
+  /// [addLayer].
+  ///
+  /// ```dart
+  /// builder.addImage('photo.jpg', 48, 36,
+  ///     translation: (0, 0, 40), rotation: ((1, 0, 0), pi / 2));
+  /// ```
+  ///
+  /// Must be called before any [addLayer]/[addComponentDefinition]/
+  /// [addGroup]/[addFace]/[addInstance] call - like [addTextureMaterial]
+  /// (which this calls internally to register the image itself), it needs
+  /// a material, and this writer's file format requires every material to
+  /// be registered before any geometry section begins.
+  ///
+  /// The image's quad and UV mapping are pinned explicitly (`addFace`'s
+  /// `frontUv`), not left to the default per-material tile-size projection
+  /// - [addTextureMaterial] is called with `appliedHeight: 1.0` for exactly
+  /// this reason: the read-side UV formula divides by the material's
+  /// applied height even for a pinned mapping, and the library default
+  /// there (a ground-truth sentinel, not a real number) is astronomically
+  /// small - confirmed via real SketchUp screenshots (2026-08-27, Python
+  /// writer) to render as a corrupted, vertically-smeared texture when left
+  /// in place. 1.0 makes that division a no-op against this method's own
+  /// 0..1 pins.
+  ///
+  /// Unlike every other entity this writer produces, CImage's exact binary
+  /// schema version (see `_imageSchema`) is a best-effort guess, not
+  /// calibrated against a real SketchUp-authored Image entity - none was
+  /// available. This project's own reader round-trips the result
+  /// correctly, but real SketchUp's acceptance of the file is unverified
+  /// beyond the Python port's own real-SketchUp test (placement/
+  /// orientation/texture all confirmed correct there after the
+  /// appliedHeight fix - see CHECKLIST.md).
+  void addImage(
+    String imagePath,
+    double width,
+    double height, {
+    Point3 translation = (0.0, 0.0, 0.0),
+    Matrix3x3? matrix3x3,
+    Rotation? rotation,
+    int? layer,
+    bool hidden = false,
+  }) {
+    final mat = addTextureMaterial('__openskp_image_$_materialCount', imagePath, appliedHeight: 1.0);
+    late final ComponentDefinitionBuilder imageDef;
+    imageDef = addComponentDefinition('Image$_definitionCount', (def) {
+      // Standard (0,0)-at-bottom-left, V increasing upward - no vertical
+      // flip. Every other UV-related fact in this file is calibrated
+      // against real SketchUp output; this one specific sense is NOT (no
+      // ground truth available - see this method's own warning above) and
+      // could come out upside down in real SketchUp if its texture
+      // sampling flips V the other way.
+      def.addFace(
+        [(0.0, 0.0, 0.0), (width, 0.0, 0.0), (width, height, 0.0), (0.0, height, 0.0)],
+        material: mat,
+        frontUv: [
+          ((0.0, 0.0, 0.0), (0.0, 0.0)),
+          ((width, 0.0, 0.0), (1.0, 0.0)),
+          ((0.0, height, 0.0), (0.0, 1.0)),
+        ],
+      );
+    });
+    final resolved = _resolveMatrix3x3(matrix3x3, rotation);
+    _ensureGeometryWriter();
+    _newEntityCount += _geometryWriter!.writeImage(imageDef.slot, translation, resolved, layer ?? 0, hidden);
     _faceCount++; // reuses the "at least one root entity" check in toBytes
   }
 

--- a/packages/dart/lib/src/legacy.dart
+++ b/packages/dart/lib/src/legacy.dart
@@ -1834,6 +1834,27 @@ class Legacy {
           ..layerId = v.db.layer != 0 ? v.db.layer : null
           ..children = const []
           ..properties = LegacyReaders.extractLegacyDynamicProperties(v.attrs));
+      } else if (v is ImageRec) {
+        // Placed exactly like an ordinary component instance - same
+        // transform/definition-reference shape - the only difference is
+        // the definition it points at is flagged isImage=true (set below
+        // via imageDefIds), matching how the VFF/modern reader already
+        // treats an Image entity as "a component placed through the same
+        // instance machinery as any other". Previously dropped here
+        // entirely: this record matched none of the branches above, so an
+        // Image entity parsed without error but never appeared anywhere a
+        // caller could see it.
+        builder.instances.add(GeometryBuilderInstance()
+          ..offset = 0
+          ..name = ''
+          ..refIdx = v.def
+          ..refGuid = v.guid
+          ..matrix = List<double>.from(v.xform)
+          ..materialId = v.db.mat != 0 ? v.db.mat : null
+          ..hidden = v.db.hidden != 0
+          ..layerId = v.db.layer != 0 ? v.db.layer : null
+          ..children = const []
+          ..properties = const {});
       } else if (v is SectionPlaneRec) {
         builder.sectionPlanes.add(SectionPlane(
           plane: v.plane,
@@ -1960,6 +1981,18 @@ class Legacy {
       layerHidden['Layer0'] = false;
     }
 
+    // Scanned before the definitions loop below so isImage can be set
+    // correctly the first time a definition is built, matching the VFF
+    // reader's RawDefinition.isImage field.
+    final imageDefIds = <int>{};
+    for (final entry in slots.entries) {
+      final ent = entry.value;
+      if (ent.kind == 'obj' && ent.name == 'CImage' && ent.value is ImageRec) {
+        final def = (ent.value as ImageRec).def;
+        if (def != null) imageDefIds.add(def);
+      }
+    }
+
     final defsDict = <int, RawDefinition>{};
     var processed = 0;
     var lastSlot = -1;
@@ -1976,7 +2009,7 @@ class Legacy {
           defsDict[entry.key] = RawDefinition(
             guid: d.guid,
             name: d.name,
-            isImage: false,
+            isImage: imageDefIds.contains(entry.key),
             alwaysFacesCamera: d.facesCamera,
             shadowsFaceSun: d.shadowsFaceSun,
             builder: b,

--- a/packages/dart/test/create_test.dart
+++ b/packages/dart/test/create_test.dart
@@ -407,6 +407,29 @@ void main() {
         tmpDir.deleteSync(recursive: true);
       }
     });
+
+    test('addImage places a real Image entity, not a plain textured face', () {
+      final tmpDir = Directory.systemTemp.createTempSync('openskp_tex_');
+      final pngPath = '${tmpDir.path}${Platform.pathSeparator}tex.png';
+      File(pngPath).writeAsBytesSync(makeFakePng());
+      try {
+        final builder = create();
+        builder.addImage(
+          pngPath, 48, 36,
+          translation: (0.0, 0.0, 40.0),
+          rotation: ((1.0, 0.0, 0.0), pi / 2),
+        );
+        final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+
+        final imageDefs = model.definitions.values.where((d) => d.isImage).toList();
+        expect(imageDefs, hasLength(1));
+        expect(imageDefs.single.faces, hasLength(1));
+        expect(model.root.instances, hasLength(1));
+        expect(model.root.instances.single.refIdx, imageDefs.single.id);
+      } finally {
+        tmpDir.deleteSync(recursive: true);
+      }
+    });
   });
 
   group('Layers', () {

--- a/packages/dotnet/OpenSkp.Tests/CreateTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CreateTests.cs
@@ -203,6 +203,32 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
+        public void AddImagePlacesARealImageEntityNotAPlainTexturedFace()
+        {
+            string pngPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+            File.WriteAllBytes(pngPath, TinyPng());
+            try
+            {
+                var builder = SkpCreate.NewFile();
+                builder.AddImage(
+                    pngPath, 48, 36,
+                    translation: (0, 0, 40),
+                    rotation: ((1, 0, 0), Math.PI / 2));
+                var model = SkpFile.Parse(builder.ToBytes());
+
+                var imageDefs = model.Definitions.Values.Where(d => d.IsImage).ToList();
+                Assert.Single(imageDefs);
+                Assert.Single(imageDefs[0].Faces);
+                Assert.Single(model.Root.Instances);
+                Assert.Equal(imageDefs[0].Id, model.Root.Instances[0].RefIdx);
+            }
+            finally
+            {
+                File.Delete(pngPath);
+            }
+        }
+
+        [Fact]
         public void LayerRoundTrips()
         {
             var builder = SkpCreate.NewFile();

--- a/packages/dotnet/OpenSkp/Create.cs
+++ b/packages/dotnet/OpenSkp/Create.cs
@@ -197,6 +197,19 @@ namespace OpenSkp
         internal const int DefinitionSchema = 11;
         internal const int InstanceSchema = 6;
         internal const int GroupSchema = 1;
+        // UNVERIFIED - unlike every other schema constant here, not
+        // calibrated against a real SketchUp-authored file: no sample
+        // containing a CImage entity (File > Import > Image) was available
+        // (ported from the Python writer, same caveat there - see
+        // create.py's own comment). Legacy.cs's image reader never
+        // branches on schema the way instance/group reading does, so this
+        // project's own reader round-trips correctly regardless of the
+        // exact value - this only affects whether real SketchUp accepts
+        // the file. Chosen to match InstanceSchema for the same reason as
+        // Python's _IMAGE_SCHEMA: CImage's read path always expects the
+        // trailing GUID unconditionally, the same "always present" shape
+        // CComponentInstance has.
+        internal const int ImageSchema = 6;
         internal const int ThumbnailSchema = 1;
 
         // CCamera's class is declared inside the scaffold's own
@@ -1056,8 +1069,23 @@ namespace OpenSkp
         /// <summary>Write one image-textured CMaterial record (embedding
         /// imageBytes verbatim inside a CDib sub-object) and return its
         /// slot. texturePath is stored as-is. subtype is CDib's image
-        /// format tag (4 for PNG, 1 for JPEG).</summary>
-        internal int WriteTexturedMaterial(string name, byte[] imageBytes, string texturePath, int subtype)
+        /// format tag (4 for PNG, 1 for JPEG).
+        ///
+        /// appliedHeight, if given, is written in place of
+        /// CreateConstants.TextureHSentinel (applied width stays a fixed
+        /// 1.0 either way). Needed because the reader's own
+        /// ground-truth-derived UV formula divides a face's final UV by
+        /// the material's applied width/height EVEN for a positioned
+        /// (frontUv) mapping, not just the default projection - the
+        /// sentinel decodes to ~1.29e-231, and dividing by it blows up to
+        /// an astronomical value, which real SketchUp visibly renders as a
+        /// corrupted, vertically-smeared texture (confirmed against real
+        /// SketchUp 2026-08-27 via the Python writer - see create.py's own
+        /// note on this). A caller positioning this material via
+        /// frontUv/backUv should pass a real appliedHeight (AddImage uses
+        /// 1.0, matching its own pins' 0..1 range) so that division is a
+        /// no-op instead of a corruption.</summary>
+        internal int WriteTexturedMaterial(string name, byte[] imageBytes, string texturePath, int subtype, double? appliedHeight = null)
         {
             int slot = NewOfKnownClass("CMaterial", CreateConstants.MaterialSchema);
             Preamble();
@@ -1076,7 +1104,14 @@ namespace OpenSkp
                 AddU32(90);
             }
             AddF64(1.0); // applied width - ground truth default when unscaled
-            AddRaw(CreateConstants.TextureHSentinel);
+            if (appliedHeight.HasValue)
+            {
+                AddF64(appliedHeight.Value);
+            }
+            else
+            {
+                AddRaw(CreateConstants.TextureHSentinel);
+            }
             WriteStr(texturePath);
             // avg color (RGBA + pad + RGBA repeated) - neutral near-opaque
             // white rather than a real image average, since this project
@@ -1266,6 +1301,34 @@ namespace OpenSkp
             WriteInstanceLike(
                 "CGroup", CreateConstants.GroupSchema, false,
                 definitionSlot, name, translation, matrix3x3, groupMaterial, groupLayer,
+                null, hidden);
+            return 1;
+        }
+
+        /// <summary>Write one CImage placing definitionSlot (the quad +
+        /// texture material AddImage built for it) - return contract
+        /// matches WriteInstance/WriteGroup (always 1).
+        ///
+        /// Legacy.cs's image reader treats CImage as "instance-shaped":
+        /// preamble, drawbase, a definition back-ref, a 3x4 placement, a
+        /// constant 1.0, a source-path string, and a 16-byte GUID -
+        /// field-for-field identical in count and order to WriteInstance's
+        /// own matrix3x3(9)+translation(3)+1.0(1)=13 f64s, name string,
+        /// GUID. The source-path string is always empty - ground truth
+        /// shows real SketchUp writes it empty too. No material argument -
+        /// an Image entity isn't painted a material the way a face or
+        /// instance can be; its appearance comes entirely from the
+        /// definition's own textured face.</summary>
+        internal int WriteImage(
+            int definitionSlot,
+            (double X, double Y, double Z) translation = default,
+            double[]? matrix3x3 = null,
+            int imageLayer = 0,
+            bool hidden = false)
+        {
+            WriteInstanceLike(
+                "CImage", CreateConstants.ImageSchema, false,
+                definitionSlot, "", translation, matrix3x3, 0, imageLayer,
                 null, hidden);
             return 1;
         }
@@ -2106,10 +2169,20 @@ namespace OpenSkp
         /// argument. The format is detected from the file's own magic
         /// bytes, not its extension - PNG and JPEG are the only two this
         /// project has confirmed the on-disk CDib subtype tag for via SDK
-        /// ground truth. UV mapping is always the default planar
-        /// projection; explicit positioning/pinning is not supported.
-        /// Same ordering rules as AddMaterial.</summary>
-        public int AddTextureMaterial(string name, string imagePath)
+        /// ground truth. Same ordering rules as AddMaterial.
+        ///
+        /// If this material will ever be used with AddFace's frontUv/
+        /// backUv pinning, pass appliedHeight: 1.0 (matching those pins'
+        /// own 0..1 range) - the read-side UV formula divides by this
+        /// field even for a positioned mapping, and the default (an
+        /// internal sentinel, real SketchUp's own byte pattern for "never
+        /// explicitly scaled") is astronomically small, which corrupts ANY
+        /// face using this material, not just default-projected ones
+        /// (confirmed against real SketchUp 2026-08-27 - see
+        /// WriteTexturedMaterial's own note). Left at the default for the
+        /// plain default-planar-projection case, matching this method's
+        /// original, narrower scope.</summary>
+        public int AddTextureMaterial(string name, string imagePath, double? appliedHeight = null)
         {
             if (_geometryWriter != null)
             {
@@ -2126,7 +2199,7 @@ namespace OpenSkp
             if (MaterialsByName.TryGetValue(name, out int existing)) return existing;
             byte[] imageBytes = System.IO.File.ReadAllBytes(imagePath);
             int subtype = CreateMath.DetectImageSubtype(imageBytes);
-            int slot = _materialWriter.WriteTexturedMaterial(name, imageBytes, imagePath, subtype);
+            int slot = _materialWriter.WriteTexturedMaterial(name, imageBytes, imagePath, subtype, appliedHeight);
             MaterialsByName[name] = slot;
             _materialCount += 1;
             return slot;
@@ -2334,6 +2407,89 @@ namespace OpenSkp
             _newEntityCount += _geometryWriter!.WriteInstance(
                 definition.Slot, name ?? definition.Name, translation, resolved, material ?? 0, layer ?? 0,
                 attributeDicts, hidden);
+            _faceCount += 1; // reuses the "at least one root entity" check in ToBytes
+        }
+
+        /// <summary>Place a SketchUp Image entity (File > Import > Image) -
+        /// a picture placed as its own object, distinct from painting a
+        /// texture material onto an ordinary face (an Image gets its own
+        /// Outliner classification and explode behavior a plain textured
+        /// face doesn't).
+        ///
+        /// width/height size the image's quad in inches; the image covers
+        /// it edge to edge, undistorted regardless of the source file's
+        /// own pixel aspect ratio (get the ratio right yourself if that
+        /// matters - this does not auto-derive it). translation/
+        /// matrix3x3/rotation/hidden place it exactly like AddInstance -
+        /// the quad starts in the XY plane; rotate it to stand upright
+        /// (e.g. on a wall) the same way you would any other placement.
+        /// layer, if given, is a handle from AddLayer.
+        ///
+        /// <code>
+        /// builder.AddImage("photo.jpg", 48, 36,
+        ///     translation: (0, 0, 40),
+        ///     rotation: ((1, 0, 0), Math.PI / 2));
+        /// </code>
+        ///
+        /// Must be called before any AddLayer/AddComponentDefinition/
+        /// AddGroup/AddFace/AddInstance call - like AddTextureMaterial
+        /// (which this calls internally to register the image itself), it
+        /// needs a material, and this writer's file format requires every
+        /// material to be registered before any geometry section begins.
+        ///
+        /// The image's quad and UV mapping are pinned explicitly (AddFace's
+        /// frontUv), not left to the default per-material tile-size
+        /// projection - AddTextureMaterial is called with appliedHeight:
+        /// 1.0 for exactly this reason: the read-side UV formula divides
+        /// by the material's applied height even for a pinned mapping, and
+        /// the library default there (a ground-truth sentinel, not a real
+        /// number) is astronomically small - confirmed via real SketchUp
+        /// screenshots (2026-08-27, Python writer) to render as a
+        /// corrupted, vertically-smeared texture when left in place. 1.0
+        /// makes that division a no-op against this method's own 0..1
+        /// pins.
+        ///
+        /// Unlike every other entity this writer produces, CImage's exact
+        /// binary schema version (see CreateConstants.ImageSchema) is a
+        /// best-effort guess, not calibrated against a real
+        /// SketchUp-authored Image entity - none was available. This
+        /// project's own reader round-trips the result correctly, but real
+        /// SketchUp's acceptance of the file is unverified beyond the
+        /// Python port's own real-SketchUp test (placement/orientation/
+        /// texture all confirmed correct there after the appliedHeight fix
+        /// - see CHECKLIST.md).</summary>
+        public void AddImage(
+            string imagePath, double width, double height,
+            (double X, double Y, double Z) translation = default,
+            double[]? matrix3x3 = null,
+            ((double X, double Y, double Z) Axis, double AngleRadians)? rotation = null,
+            int? layer = null,
+            bool hidden = false)
+        {
+            int mat = AddTextureMaterial($"__openskp_image_{_materialCount}", imagePath, appliedHeight: 1.0);
+            ComponentDefinitionBuilder imageDef;
+            using (imageDef = AddComponentDefinition($"Image{_definitionCount}"))
+            {
+                // Standard (0,0)-at-bottom-left, V increasing upward - no
+                // vertical flip. Every other UV-related fact in this file
+                // is calibrated against real SketchUp output; this one
+                // specific sense is NOT (no ground truth available - see
+                // this method's own warning above) and could come out
+                // upside down in real SketchUp if its texture sampling
+                // flips V the other way.
+                imageDef.AddFace(
+                    new (double, double, double)[] { (0, 0, 0), (width, 0, 0), (width, height, 0), (0, height, 0) },
+                    material: mat,
+                    frontUv: new[]
+                    {
+                        new UvCorrespondence((0, 0, 0), (0.0, 0.0)),
+                        new UvCorrespondence((width, 0, 0), (1.0, 0.0)),
+                        new UvCorrespondence((0, height, 0), (0.0, 1.0)),
+                    });
+            }
+            var resolved = CreateMath.ResolveMatrix3x3(matrix3x3, rotation);
+            EnsureGeometryWriter();
+            _newEntityCount += _geometryWriter!.WriteImage(imageDef.Slot, translation, resolved, layer ?? 0, hidden);
             _faceCount += 1; // reuses the "at least one root entity" check in ToBytes
         }
 

--- a/packages/dotnet/OpenSkp/Legacy.cs
+++ b/packages/dotnet/OpenSkp/Legacy.cs
@@ -1983,6 +1983,33 @@ namespace OpenSkp
                         Properties = LegacyReaders.ExtractLegacyDynamicProperties(instRec.Attrs),
                     });
                 }
+                else if (v is ImageRec imgRec)
+                {
+                    // Placed exactly like an ordinary component instance -
+                    // same transform/definition-reference shape - the only
+                    // difference is the definition it points at is flagged
+                    // IsImage=true (set below via imageDefIds), matching
+                    // how the VFF/modern reader already treats an Image
+                    // entity as "a component placed through the same
+                    // instance machinery as any other". Previously
+                    // dropped here entirely: this record matched none of
+                    // the branches above, so an Image entity parsed
+                    // without error but never appeared anywhere a caller
+                    // could see it.
+                    builder.Instances.Add(new GeometryBuilderInstance
+                    {
+                        Offset = 0,
+                        Name = "",
+                        RefIdx = imgRec.Def,
+                        RefGuid = imgRec.Guid,
+                        Matrix = imgRec.Xform.ToList(),
+                        MaterialId = imgRec.Db.Mat != 0 ? imgRec.Db.Mat : (long?)null,
+                        Hidden = imgRec.Db.Hidden != 0,
+                        LayerId = imgRec.Db.Layer != 0 ? imgRec.Db.Layer : (long?)null,
+                        Children = new List<TlvNode>(),
+                        Properties = new Dictionary<string, string>(),
+                    });
+                }
                 else if (v is SectionPlaneRec spRec)
                 {
                     builder.SectionPlanes.Add(new SectionPlane
@@ -2113,6 +2140,19 @@ namespace OpenSkp
                 layerHidden["Layer0"] = false;
             }
 
+            // Scanned before the definitions loop below so IsImage can be
+            // set correctly the first time a definition is built, matching
+            // the VFF reader's RawDefinition.IsImage field.
+            var imageDefIds = new HashSet<int>();
+            foreach (var kv in slots)
+            {
+                if (kv.Value.Kind == "obj" && kv.Value.Name == "CImage" && kv.Value.Value is ImageRec imgDefRec
+                    && imgDefRec.Def.HasValue)
+                {
+                    imageDefIds.Add(imgDefRec.Def.Value);
+                }
+            }
+
             var defsDict = new Dictionary<long, Geometry.RawDefinition>();
             int processed = 0;
             long lastSlot = -1;
@@ -2130,7 +2170,7 @@ namespace OpenSkp
                         {
                             Guid = d.Guid,
                             Name = d.Name,
-                            IsImage = false,
+                            IsImage = imageDefIds.Contains((int)kv.Key),
                             AlwaysFacesCamera = d.FacesCamera,
                             ShadowsFaceSun = d.ShadowsFaceSun,
                             Builder = ToGeometryBuilder(b),

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -204,6 +204,17 @@ _DEFINITION_SCHEMA = 11
 _INSTANCE_SCHEMA = 6
 _GROUP_SCHEMA = 1
 _THUMBNAIL_SCHEMA = 1
+# UNVERIFIED - unlike every other schema constant in this file, not
+# calibrated against a real SketchUp-authored file: no sample containing a
+# CImage entity (File > Import > Image) was available. legacy.py's
+# _read_image never branches on schema the way _read_instance does for
+# CComponentInstance/CGroup (see that function's own comment on schema-gated
+# fields), so this project's OWN reader round-trips correctly regardless of
+# the exact value - this only affects whether real SketchUp accepts the
+# file. Chosen to match _INSTANCE_SCHEMA since CImage's read function always
+# expects the trailing GUID unconditionally, the same "always present" shape
+# CComponentInstance has at schema >= 5.
+_IMAGE_SCHEMA = 6
 
 # CCamera's class is declared inside the scaffold's own style/scene-manager
 # prefix (before any of our splice points), not something this project has
@@ -899,13 +910,33 @@ class _ArchiveWriter:
         self.buf.append(0)  # use_opacity = False (alpha carries transparency instead)
         return slot
 
-    def write_textured_material(self, name: str, image_bytes: bytes, texture_path: str, subtype: int) -> int:
+    def write_textured_material(
+        self, name: str, image_bytes: bytes, texture_path: str, subtype: int,
+        applied_height: Optional[float] = None,
+    ) -> int:
         """Write one image-textured ``CMaterial`` record (embedding
         ``image_bytes`` verbatim inside a ``CDib`` sub-object) and return
         its slot. ``texture_path`` is stored as-is - ground truth shows
         real SketchUp stores the original absolute file path, but any
         string round-trips fine structurally. ``subtype`` is CDib's image
         format tag (4 for PNG, 1 for JPEG - see :func:`_detect_image_subtype`).
+
+        ``applied_height``, if given, is written in place of
+        ``_TEXTURE_H_SENTINEL`` (applied width stays a fixed 1.0 either
+        way). Needed because `_face_groups.compute_face_uv` - this
+        project's own reverse-engineered, ground-truth-derived read-side
+        formula - divides a face's final UV by the material's applied
+        width/height EVEN for a `write_face`-positioned (``front_uv``)
+        mapping, not just the default projection. The sentinel decodes to
+        ~1.29e-231 - dividing by it blows up to an astronomical value,
+        which real SketchUp visibly renders as a corrupted, vertically-
+        smeared texture (confirmed 2026-08-27: two independent real-
+        SketchUp screenshots of a sentinel-height material, one default-
+        projected and one front_uv-positioned, showed the identical
+        streaky corruption). A caller that's going to position this
+        material via `front_uv`/`back_uv` should pass a real
+        ``applied_height`` (`add_image` uses 1.0, matching its own pins'
+        0..1 range) so that division is a no-op instead of a corruption.
         """
         slot = self._new_of_known_class("CMaterial", schema=_MATERIAL_SCHEMA)
         self._preamble()
@@ -924,7 +955,7 @@ class _ArchiveWriter:
             # project computes from the image; PNG has no such field.
             self.buf += _u32(90)
         self.buf += _f64(1.0)  # applied width - ground truth default when unscaled
-        self.buf += _TEXTURE_H_SENTINEL
+        self.buf += _f64(applied_height) if applied_height is not None else _TEXTURE_H_SENTINEL
         self._write_str(texture_path)
         # avg color (RGBA + pad + RGBA repeated, per legacy.py's _read_material
         # comment) - neutral near-opaque white rather than a real image
@@ -1144,6 +1175,38 @@ class _ArchiveWriter:
         self._write_instance_like(
             "CGroup", _GROUP_SCHEMA, False,
             definition_slot, name, translation, matrix3x3, group_material, group_layer,
+            hidden=hidden,
+        )
+        return 1
+
+    def write_image(
+        self,
+        definition_slot: int,
+        translation: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+        matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
+        image_layer: int = 0,
+        hidden: bool = False,
+    ) -> int:
+        """Write one ``CImage`` placing ``definition_slot`` (the quad +
+        texture material `add_image` built for it) and return how many new
+        root-entity-list slots it consumed - always 1, same contract as
+        `write_instance`/`write_group`.
+
+        legacy.py's `_read_image` docstring calls CImage "instance-shaped":
+        preamble, drawbase, a definition back-ref, a 3x4 placement, a
+        constant 1.0, a source-path string, and a 16-byte GUID - field-for-
+        field identical in count and order to `write_instance`'s own
+        matrix3x3(9)+translation(3)+1.0(1)=13 f64s, name string, GUID. The
+        source-path string is always empty - ground truth (`_read_image`'s
+        own docstring) shows real SketchUp writes it empty too, so this
+        isn't a fidelity gap, just an unused field. No material argument -
+        ground truth shows an Image entity isn't painted a material the way
+        a face or instance can be; its appearance comes entirely from the
+        definition's own textured face.
+        """
+        self._write_instance_like(
+            "CImage", _IMAGE_SCHEMA, False,
+            definition_slot, "", translation, matrix3x3, 0, image_layer,
             hidden=hidden,
         )
         return 1
@@ -2002,7 +2065,9 @@ class SkpBuilder:
         self._material_count += 1
         return slot
 
-    def add_texture_material(self, name: str, image_path: str) -> int:
+    def add_texture_material(
+        self, name: str, image_path: str, applied_height: Optional[float] = None,
+    ) -> int:
         """Register an image-textured material from a local PNG or JPEG
         file and return a handle to pass as `add_face`'s ``material``
         argument.
@@ -2011,12 +2076,18 @@ class SkpBuilder:
         extension - PNG and JPEG are the only two this project has
         confirmed the on-disk ``CDib`` subtype tag for via SDK ground
         truth (4 and 1 respectively; see :meth:`_ArchiveWriter.
-        write_textured_material`). UV mapping is always the default planar
-        projection; explicit positioning/pinning is not supported (ground
-        truth shows the default case needs no extra per-face
-        texture-coordinate record at all, which is what keeps this scoped
-        as an addition to materials rather than a much larger
-        face-attribute feature).
+        write_textured_material`).
+
+        If this material will ever be used with `add_face`'s ``front_uv``/
+        ``back_uv`` pinning, pass ``applied_height=1.0`` (matching those
+        pins' own 0..1 range) - the read-side UV formula divides by this
+        field even for a positioned mapping, and the default (an internal
+        sentinel, real SketchUp's own byte pattern for "never explicitly
+        scaled") is astronomically small, which corrupts ANY face using
+        this material, not just default-projected ones (confirmed against
+        real SketchUp 2026-08-27 - see `write_textured_material`'s own
+        note). Left at the default for the plain default-planar-projection
+        case, matching this method's original, narrower scope.
 
         Same ordering rules as `add_material` - must be called before any
         `add_layer`, `add_component_definition`, or `add_face` call.
@@ -2032,7 +2103,9 @@ class SkpBuilder:
         with open(image_path, "rb") as f:
             image_bytes = f.read()
         subtype = _detect_image_subtype(image_bytes)
-        slot = self._material_writer.write_textured_material(name, image_bytes, image_path, subtype=subtype)
+        slot = self._material_writer.write_textured_material(
+            name, image_bytes, image_path, subtype=subtype, applied_height=applied_height,
+        )
         self.materials_by_name[name] = slot
         self._material_count += 1
         return slot
@@ -2263,6 +2336,89 @@ class SkpBuilder:
         self._new_entity_count += self._geometry_writer.write_instance(
             definition.slot, name or definition.name, translation, matrix3x3, material or 0, layer or 0,
             attribute_dicts, hidden,
+        )
+        self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
+
+    def add_image(
+        self,
+        image_path: str,
+        width: float,
+        height: float,
+        translation: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+        matrix3x3: Optional[Tuple[float, float, float, float, float, float, float, float, float]] = None,
+        rotation: Optional[Tuple[Tuple[float, float, float], float]] = None,
+        layer: Optional[int] = None,
+        hidden: bool = False,
+    ) -> None:
+        """Place a SketchUp Image entity (File > Import > Image) - a
+        picture placed as its own object, distinct from painting a texture
+        material onto an ordinary face (an Image gets its own Outliner
+        classification and explode behavior a plain textured face doesn't).
+
+        ``width``/``height`` size the image's quad in inches; the image
+        covers it edge to edge, undistorted regardless of the source
+        file's own pixel aspect ratio (get the ratio right yourself if
+        that matters - this does not auto-derive it).
+        ``translation``/``matrix3x3``/``rotation``/``hidden`` place it
+        exactly like `add_instance` - the quad starts in the XY plane
+        (matching every other `add_face` example in this file); rotate it
+        to stand upright (e.g. on a wall) the same way you would any other
+        placement. ``layer``, if given, is a handle from `add_layer`.
+
+        >>> painting = builder.add_material  # (not used directly here)
+        >>> builder.add_image("photo.jpg", width=48, height=36,
+        ...                    translation=(0, 0, 40),
+        ...                    rotation=((1, 0, 0), math.radians(90)))
+
+        Must be called before any `add_layer`/`add_component_definition`/
+        `add_group`/`add_face`/`add_instance` call - like
+        `add_texture_material` (which this calls internally to register
+        the image itself), it needs a material, and this writer's file
+        format requires every material to be registered before any
+        geometry section begins.
+
+        The image's quad and UV mapping are pinned explicitly (`add_face`'s
+        ``front_uv``), not left to the default per-material tile-size
+        projection - `add_texture_material` is called with
+        ``applied_height=1.0`` for exactly this reason: the read-side UV
+        formula divides by the material's applied height even for a
+        pinned mapping, and the library default there (a ground-truth
+        sentinel, not a real number) is astronomically small - confirmed
+        via real SketchUp screenshots (2026-08-27) to render as a
+        corrupted, vertically-smeared texture when left in place. 1.0
+        makes that division a no-op against this method's own 0..1 pins.
+
+        ⚠️ Unlike every other entity this writer produces, CImage's exact
+        binary schema version (see `_IMAGE_SCHEMA`) is a best-effort guess,
+        not calibrated against a real SketchUp-authored Image entity - none
+        was available. This project's own reader round-trips the result
+        correctly (verified), but real SketchUp's acceptance of the file is
+        unverified - open the output in real SketchUp before relying on
+        this, and please report back what you find either way.
+        """
+        mat = self.add_texture_material(
+            f"__openskp_image_{self._material_count}", image_path, applied_height=1.0,
+        )
+        with self.add_component_definition(f"Image{self._definition_count}") as image_def:
+            # Standard (0,0)-at-bottom-left, V increasing upward - no
+            # vertical flip. Every other UV-related fact in this file is
+            # calibrated against real SketchUp output; this one specific
+            # sense is NOT (no ground truth available - see this method's
+            # own warning above) and could come out upside down in real
+            # SketchUp if its texture sampling flips V the other way.
+            image_def.add_face(
+                [(0.0, 0.0, 0.0), (width, 0.0, 0.0), (width, height, 0.0), (0.0, height, 0.0)],
+                material=mat,
+                front_uv=[
+                    ((0.0, 0.0, 0.0), (0.0, 0.0)),
+                    ((width, 0.0, 0.0), (1.0, 0.0)),
+                    ((0.0, height, 0.0), (0.0, 1.0)),
+                ],
+            )
+        matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
+        self._ensure_geometry_writer()
+        self._new_entity_count += self._geometry_writer.write_image(
+            image_def.slot, translation, matrix3x3, layer or 0, hidden,
         )
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -1374,6 +1374,23 @@ def _fill_builder(builder, ents, slots):
                 'hidden': bool(v['db']['hidden']),
                 'children': [],
                 'properties': _extract_legacy_dynamic_properties(v.get('attrs'))})
+        elif k == 'image':
+            # Placed exactly like an ordinary component instance - same
+            # transform/definition-reference shape - the only difference is
+            # the definition it points at is flagged is_image=True (set
+            # above via image_def_ids), matching how the VFF/modern reader
+            # already treats an Image entity as "a component placed through
+            # the same instance machinery as any other". Previously dropped
+            # here entirely: this dict's 'k' matched none of the branches
+            # above, so an Image entity parsed without error but never
+            # appeared anywhere a caller could see it.
+            builder.instances.append({
+                'name': '', 'ref_idx': v['def'],
+                'ref_guid': v.get('guid', ''), 'matrix': list(v['xform']),
+                'material_id': v['db']['mat'] or None,
+                'layer_id': v['db']['layer'] or None,
+                'hidden': bool(v['db']['hidden']),
+                'children': [], 'properties': {}})
         elif k == 'sectionplane':
             builder.section_planes.append({
                 'plane': v.get('plane', [0.0, 0.0, 1.0, 0.0]),
@@ -1451,6 +1468,18 @@ def full_parse_legacy(skp_path: str) -> Dict[str, Any]:
 
     slots = ar.slots
 
+    # Definitions an Image entity (CImage) places - a legacy file encodes
+    # "this definition is an Image" purely by which KIND of entity places
+    # it (CImage vs CComponentInstance/CGroup), not by a byte on the
+    # definition itself (unlike the VFF path's 8315 kind-byte sub-tag).
+    # Scanned before the definitions loop below so is_image can be set
+    # correctly the first time a definition is built, matching the VFF
+    # reader's Definition.is_image field.
+    image_def_ids = {
+        ent[2]['def'] for ent in slots.values()
+        if ent[0] == 'obj' and ent[1] == 'CImage' and ent[2]
+    }
+
     # materials — keyed by name like the VFF path
     mats: Dict[str, Any] = {}
     material_id_to_name: Dict[int, str] = {}
@@ -1506,7 +1535,7 @@ def full_parse_legacy(skp_path: str) -> Dict[str, Any]:
                 b = _Builder()
                 _fill_builder(b, d['ents'], slots)
                 defs_dict[s] = {'guid': d['guid'], 'name': d['name'],
-                                'is_image': False,
+                                'is_image': s in image_def_ids,
                                 'always_faces_camera': d.get('faces_camera', False),
                                 'shadows_face_sun': d.get('shadows_face_sun', False),
                                 'builder': b}

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -23,6 +23,7 @@ import pytest
 
 from openskp.create import SkpBuilder, SkpWriteError, create
 from openskp import legacy
+from openskp import SkpFile
 
 # `openskp.create` (the submodule) and `openskp.create` (the top-level
 # re-exported function of the same name) collide as an attribute on the
@@ -1213,6 +1214,25 @@ class TestTextures:
         mat_by_slot = {s: v for s, v in materials}
         assert mat_by_slot[t1]["tex_file"] == str(png1)
         assert mat_by_slot[t2]["tex_file"] == str(png2)
+
+    def test_add_image_places_a_real_image_entity_not_a_plain_textured_face(self, tmp_path):
+        png_path = tmp_path / "photo.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        builder.add_image(
+            str(png_path), width=48.0, height=36.0,
+            translation=(0.0, 0.0, 40.0),
+            rotation=((1.0, 0.0, 0.0), math.radians(90)),
+        )
+        out_path = tmp_path / "out.skp"
+        out_path.write_bytes(builder.to_bytes())
+
+        model = SkpFile.open(str(out_path)).parse()
+        image_defs = [d for d in model.definitions.values() if d.is_image]
+        assert len(image_defs) == 1
+        assert len(image_defs[0].faces) == 1
+        assert len(model.root.instances) == 1
+        assert model.root.instances[0].ref_idx == image_defs[0].id
 
 
 class TestUVPositioning:

--- a/packages/typescript/src/create.ts
+++ b/packages/typescript/src/create.ts
@@ -148,6 +148,17 @@ const TEXTURE_H_SENTINEL = hexToBytes('f0ffffffffffff0f');
 const DEFINITION_SCHEMA = 11;
 const INSTANCE_SCHEMA = 6;
 const GROUP_SCHEMA = 1;
+// UNVERIFIED - unlike every other schema constant here, not calibrated
+// against a real SketchUp-authored file: no sample containing a CImage
+// entity (File > Import > Image) was available (ported from the Python
+// writer, same caveat there - see create.py's own comment). legacy.ts's
+// image reader never branches on schema the way instance/group reading
+// does, so this project's own reader round-trips correctly regardless of
+// the exact value - this only affects whether real SketchUp accepts the
+// file. Chosen to match INSTANCE_SCHEMA for the same reason as Python's
+// _IMAGE_SCHEMA: CImage's read path always expects the trailing GUID
+// unconditionally, the same "always present" shape CComponentInstance has.
+const IMAGE_SCHEMA = 6;
 const THUMBNAIL_SCHEMA = 1;
 const LAYER_SCHEMA = 3;
 const FTC_SCHEMA = 4;
@@ -747,8 +758,23 @@ class ArchiveWriter {
 
   /** Write one image-textured CMaterial record (embedding `imageBytes`
    * verbatim inside a CDib sub-object) and return its slot. `subtype` is
-   * CDib's image format tag (4 for PNG, 1 for JPEG). */
-  writeTexturedMaterial(name: string, imageBytes: Uint8Array, texturePath: string, subtype: number): number {
+   * CDib's image format tag (4 for PNG, 1 for JPEG).
+   *
+   * `appliedHeight`, if given, is written in place of TEXTURE_H_SENTINEL
+   * (applied width stays a fixed 1.0 either way). Needed because the
+   * reader's own ground-truth-derived UV formula divides a face's final
+   * UV by the material's applied width/height EVEN for a positioned
+   * (`frontUv`) mapping, not just the default projection - the sentinel
+   * decodes to ~1.29e-231, and dividing by it blows up to an astronomical
+   * value, which real SketchUp visibly renders as a corrupted,
+   * vertically-smeared texture (confirmed against real SketchUp
+   * 2026-08-27 via the Python writer - see create.py's own note on this).
+   * A caller positioning this material via `frontUv`/`backUv` should pass
+   * a real `appliedHeight` (addImage uses 1.0, matching its own pins'
+   * 0..1 range) so that division is a no-op instead of a corruption. */
+  writeTexturedMaterial(
+    name: string, imageBytes: Uint8Array, texturePath: string, subtype: number, appliedHeight?: number
+  ): number {
     const slot = this.newOfKnownClass('CMaterial', MATERIAL_SCHEMA);
     this.preamble();
     this.writeStr(name);
@@ -765,7 +791,11 @@ class ArchiveWriter {
       this.pushU32(90);
     }
     this.pushF64(1.0); // applied width - ground truth default when unscaled
-    this.pushBytes(TEXTURE_H_SENTINEL);
+    if (appliedHeight !== undefined) {
+      this.pushF64(appliedHeight);
+    } else {
+      this.pushBytes(TEXTURE_H_SENTINEL);
+    }
     this.writeStr(texturePath);
     // avg color: neutral near-opaque white, alpha 254 not 255 - legacy.ts's
     // own reader treats alpha=255 here as one of its two "this material is
@@ -899,6 +929,30 @@ class ArchiveWriter {
     this.writeInstanceLike(
       'CGroup', GROUP_SCHEMA, false,
       definitionSlot, name, translation, matrix3x3, groupMaterial, groupLayer, [], hidden
+    );
+    return 1;
+  }
+
+  /** Write one CImage placing `definitionSlot` (the quad + texture
+   * material `addImage` built for it) - return contract matches
+   * writeInstance/writeGroup (always 1).
+   *
+   * legacy.ts's image reader treats CImage as "instance-shaped": preamble,
+   * drawbase, a definition back-ref, a 3x4 placement, a constant 1.0, a
+   * source-path string, and a 16-byte GUID - field-for-field identical in
+   * count and order to writeInstance's own
+   * matrix3x3(9)+translation(3)+1.0(1)=13 f64s, name string, GUID. The
+   * source-path string is always empty - ground truth shows real SketchUp
+   * writes it empty too. No material argument - an Image entity isn't
+   * painted a material the way a face or instance can be; its appearance
+   * comes entirely from the definition's own textured face. */
+  writeImage(
+    definitionSlot: number, translation: Point3 = [0, 0, 0], matrix3x3?: Matrix3x3,
+    imageLayer = 0, hidden = false
+  ): number {
+    this.writeInstanceLike(
+      'CImage', IMAGE_SCHEMA, false,
+      definitionSlot, '', translation, matrix3x3, 0, imageLayer, [], hidden
     );
     return 1;
   }
@@ -1280,6 +1334,18 @@ export interface AddInstanceOptions {
   hidden?: boolean;
 }
 
+export interface AddImageOptions {
+  translation?: Point3;
+  matrix3x3?: Matrix3x3;
+  rotation?: Rotation;
+  layer?: number;
+  hidden?: boolean;
+  /** Stored as-is in the image material's own texture-path field (SketchUp
+   * shows it as the source file's original path); has no effect on the
+   * embedded image bytes themselves. */
+  texturePath?: string;
+}
+
 export interface AddGroupInstanceOptions {
   name?: string;
   translation?: Point3;
@@ -1562,8 +1628,14 @@ export class SkpBuilder {
    * as Node, where there's no universal way to read an arbitrary file
    * path. `texturePath`, if given, is stored as-is in the material
    * record (SketchUp shows it as the texture's original file path); it
-   * has no effect on the embedded image bytes themselves. */
-  addTextureMaterial(name: string, imageBytes: Uint8Array, texturePath = ''): number {
+   * has no effect on the embedded image bytes themselves.
+   *
+   * If this material will ever be used with addFace's `frontUv`/`backUv`
+   * pinning, pass `appliedHeight: 1.0` (matching those pins' own 0..1
+   * range) - see writeTexturedMaterial's own note on why the default
+   * (an internal sentinel) corrupts any face using this material, not
+   * just default-projected ones. */
+  addTextureMaterial(name: string, imageBytes: Uint8Array, texturePath = '', appliedHeight?: number): number {
     if (this.geometryWriter !== null) {
       throw new SkpWriteError('addTextureMaterial must be called before any addFace calls');
     }
@@ -1575,7 +1647,7 @@ export class SkpBuilder {
     }
     if (this.materialsByName.has(name)) return this.materialsByName.get(name)!;
     const subtype = detectImageSubtype(imageBytes);
-    const slot = this.materialWriter.writeTexturedMaterial(name, imageBytes, texturePath, subtype);
+    const slot = this.materialWriter.writeTexturedMaterial(name, imageBytes, texturePath, subtype, appliedHeight);
     this.materialsByName.set(name, slot);
     this.materialCount += 1;
     return slot;
@@ -1719,6 +1791,79 @@ export class SkpBuilder {
     this.newEntityCount += (this.geometryWriter as ArchiveWriter).writeInstance(
       definition.slot, options.name ?? definition.name, options.translation ?? [0, 0, 0], matrix3x3,
       options.material ?? 0, options.layer ?? 0, attributeDicts, options.hidden ?? false
+    );
+    this.faceCount += 1; // reuses the "at least one root entity" check in toBytes
+  }
+
+  /** Place a SketchUp Image entity (File > Import > Image) - a picture
+   * placed as its own object, distinct from painting a texture material
+   * onto an ordinary face (an Image gets its own Outliner classification
+   * and explode behavior a plain textured face doesn't).
+   *
+   * `width`/`height` size the image's quad in inches; the image covers it
+   * edge to edge, undistorted regardless of the source file's own pixel
+   * aspect ratio (get the ratio right yourself if that matters). Unlike
+   * `addTextureMaterial`, this takes the image bytes directly (browser
+   * compatibility - see addTextureMaterial's own note).
+   *
+   * ```ts
+   * builder.addImage(photoBytes, 48, 36, {
+   *   translation: [0, 0, 40],
+   *   rotation: { axis: [1, 0, 0], angleRadians: Math.PI / 2 },
+   * });
+   * ```
+   *
+   * Must be called before any addLayer/addComponentDefinition/addGroup/
+   * addFace/addInstance call - like addTextureMaterial (which this calls
+   * internally to register the image itself), it needs a material, and
+   * this writer's file format requires every material to be registered
+   * before any geometry section begins.
+   *
+   * The image's quad and UV mapping are pinned explicitly (addFace's
+   * `frontUv`), not left to the default per-material tile-size projection
+   * - addTextureMaterial is called with `appliedHeight: 1.0` for exactly
+   * this reason: the read-side UV formula divides by the material's
+   * applied height even for a pinned mapping, and the library default
+   * there (a ground-truth sentinel, not a real number) is astronomically
+   * small - confirmed via real SketchUp screenshots (2026-08-27, Python
+   * writer) to render as a corrupted, vertically-smeared texture when
+   * left in place. 1.0 makes that division a no-op against this method's
+   * own 0..1 pins.
+   *
+   * ⚠️ Unlike every other entity this writer produces, CImage's exact
+   * binary schema version (see IMAGE_SCHEMA) is a best-effort guess, not
+   * calibrated against a real SketchUp-authored Image entity - none was
+   * available. This project's own reader round-trips the result
+   * correctly, but real SketchUp's acceptance of the file is unverified
+   * beyond the Python port's own real-SketchUp test (placement/
+   * orientation/texture all confirmed correct there after the
+   * appliedHeight fix - see CHECKLIST.md). */
+  addImage(imageBytes: Uint8Array, width: number, height: number, options: AddImageOptions = {}): void {
+    const mat = this.addTextureMaterial(
+      `__openskp_image_${this.materialCount}`, imageBytes, options.texturePath ?? '', 1.0
+    );
+    const imageDef = this.addComponentDefinition(`Image${this.definitionCount}`, (def) => {
+      // Standard (0,0)-at-bottom-left, V increasing upward - no vertical
+      // flip. Every other UV-related fact in this file is calibrated
+      // against real SketchUp output; this one specific sense is NOT (no
+      // ground truth available) and could come out upside down in real
+      // SketchUp if its texture sampling flips V the other way.
+      def.addFace(
+        [[0, 0, 0], [width, 0, 0], [width, height, 0], [0, height, 0]],
+        {
+          material: mat,
+          frontUv: [
+            [[0, 0, 0], [0, 0]],
+            [[width, 0, 0], [1, 0]],
+            [[0, height, 0], [0, 1]],
+          ],
+        }
+      );
+    });
+    const matrix3x3 = resolveMatrix3x3(options.matrix3x3, options.rotation);
+    this.ensureGeometryWriter();
+    this.newEntityCount += (this.geometryWriter as ArchiveWriter).writeImage(
+      imageDef.slot, options.translation ?? [0, 0, 0], matrix3x3, options.layer ?? 0, options.hidden ?? false
     );
     this.faceCount += 1; // reuses the "at least one root entity" check in toBytes
   }

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -73,6 +73,7 @@ export type {
   AddGroupInstanceOptions,
   AddComponentDefinitionOptions,
   AddGroupOptions,
+  AddImageOptions,
 } from './create';
 export { openExisting } from './edit';
 

--- a/packages/typescript/src/legacy.ts
+++ b/packages/typescript/src/legacy.ts
@@ -1644,6 +1644,28 @@ function fillBuilder(builder: LegacyBuilder, ents: [number, string | null, any][
         children: [],
         properties: extractLegacyDynamicProperties(v.attrs),
       });
+    } else if (k === 'image') {
+      // Placed exactly like an ordinary component instance - same
+      // transform/definition-reference shape - the only difference is the
+      // definition it points at is flagged isImage=true (set below via
+      // imageDefIds), matching how the VFF/modern reader already treats
+      // an Image entity as "a component placed through the same instance
+      // machinery as any other". Previously dropped here entirely: this
+      // object's `k` matched none of the branches above, so an Image
+      // entity parsed without error but never appeared anywhere a caller
+      // could see it.
+      builder.instances.push({
+        offset: 0,
+        name: '',
+        refIdx: v.def,
+        refGuid: v.guid || '',
+        matrix: [...v.xform],
+        materialId: v.db.mat || null,
+        layerId: v.db.layer || null,
+        hidden: Boolean(v.db.hidden),
+        children: [],
+        properties: {},
+      });
     } else if (k === 'sectionplane') {
       builder.sectionPlanes.push({
         plane: v.plane || [0, 0, 1, 0],
@@ -1701,6 +1723,16 @@ export function parseLegacyToRaw(data: Uint8Array, options?: ParseOptions): Pars
   const { ar, root, layers, materials } = walkResult;
   const slots = ar.slots;
   emitLog(options, 'debug', `Legacy walk complete: ${materials.length} materials, ${layers.length} layers`);
+
+  // Scanned before the definitions loop below so isImage can be set
+  // correctly the first time a definition is built, matching the VFF
+  // reader's Definition.isImage field.
+  const imageDefIds = new Set<number>();
+  for (const ent of slots.values()) {
+    if (ent[0] === 'obj' && ent[1] === 'CImage' && ent[2]) {
+      imageDefIds.add(ent[2].def);
+    }
+  }
 
   // materials - keyed by name like the VFF path
   const materialsMap = new Map<string, Material>();
@@ -1772,7 +1804,7 @@ export function parseLegacyToRaw(data: Uint8Array, options?: ParseOptions): Pars
         defsDict.set(s, {
           guid: d.guid,
           name: d.name,
-          isImage: false,
+          isImage: imageDefIds.has(s),
           alwaysFacesCamera: d.faces_camera || false,
           shadowsFaceSun: d.shadows_face_sun || false,
           builder: b,

--- a/packages/typescript/tests/create.test.ts
+++ b/packages/typescript/tests/create.test.ts
@@ -323,6 +323,22 @@ describe('Textures', () => {
     const builder = create();
     expect(() => builder.addTextureMaterial('Bogus', Uint8Array.from([1, 2, 3, 4]))).toThrow(/unrecognized image format/);
   });
+
+  it('addImage places a real Image entity, not a plain textured face', () => {
+    const builder = create();
+    const png = makeTestPng();
+    builder.addImage(png, 48, 36, {
+      translation: [0, 0, 40],
+      rotation: { axis: [1, 0, 0], angleRadians: Math.PI / 2 },
+    });
+    const model = parseSkp(toBuffer(builder.toBytes()));
+
+    const imageDefs = [...model.definitions.values()].filter((d) => d.isImage);
+    expect(imageDefs.length).toBe(1);
+    expect(imageDefs[0].faces.length).toBe(1);
+    expect(model.root.instances.length).toBe(1);
+    expect(model.root.instances[0].refIdx).toBe(imageDefs[0].id);
+  });
 });
 
 describe('UV positioning', () => {


### PR DESCRIPTION
## Summary
- Adds `add_image()`/`addImage()`/`AddImage()` writer support for SketchUp Image entities (File → Import → Image) in Python, TypeScript, .NET, Dart, and C++ - a distinct `CImage` entity, not just a textured face, via a new low-level writer method mirroring the existing `CComponentInstance`/`CGroup` shape in each language.
- Fixes a legacy-reader gap found alongside the writer work, in all 5 languages: the reader already parsed `CImage` records but had no branch to surface them as placed instances, and `is_image`/`isImage` was hardcoded false for legacy files (only the VFF/modern reader set it).
- Fixes a real texture-corruption bug surfaced by testing this in actual SketchUp: `write_textured_material`'s default applied-height sentinel corrupts **any** textured face's UV mapping, not just default-projected ones, because the read-side UV formula divides by it even for a `front_uv`-pinned mapping. `add_image` works around it with a real `applied_height = 1.0` for its own material. The wider default-projection case is a separate, still-open issue.

⚠️ `CImage`'s exact binary schema version is a best-effort guess in every language - no real SketchUp-authored Image entity sample was available to calibrate against. Low risk since the reader never branches on schema for this entity, but real SketchUp's acceptance of the *legacy* file format is only actually confirmed for the Python-built output so far (see test plan).

## Test plan
- [x] Python: 383 tests pass, `ruff==0.15.13` clean (matches CI pin)
- [x] TypeScript: 336 tests pass, `tsc --noEmit` clean, `eslint` clean, `tsup` build clean
- [x] .NET: 167 tests pass, `dotnet format --verify-no-changes` clean, `-warnaserror` build clean
- [x] Dart: 191 tests pass, `dart analyze --fatal-infos` clean
- [x] C++: 161 tests pass (MSVC Debug), `clang-format-18 --dry-run --Werror` clean
- [x] Every language got its own new regression test (not just Python's), each asserting: exactly one `is_image`-flagged definition, its face count, and that the placed root instance references it
- [x] Python's output specifically verified in real SketchUp: a demo file (photo placed as an Image entity on a wooden easel) opened correctly - right placement, orientation, and (after the applied-height fix) correct, uncorrupted texture
- [ ] TypeScript/.NET/Dart/C++ output not yet opened in real SketchUp - please test before relying on this in those languages