### PR TITLE
Document the SKP-to-code generator; fix stale/broken C++ examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,47 @@ return type and output. TypeScript only; the Python, .NET, Dart and C++
 ports are untouched. See
 [Choosing an API](packages/typescript/README.md#choosing-an-api).
 
+### Added — SKP-to-code generator, all 5 languages
+
+`openskp.to_python_code()` / `toTypeScriptCode()` / `Codegen.ToCSharpCode()`
+/ `toDartCode()` / `to_cpp_code()` walks a parsed `SkpModel` and emits
+human-readable, re-runnable source that calls that same language's own
+writer API to rebuild an equivalent file — a faithful transcript of API
+calls, not a serialized dump. Handles materials (solid and textured, with
+explicit `front_uv`/`back_uv` pins computed for every textured face, even
+ones that originally used default projection), layers, component/group
+definitions built in dependency order, faces (holes, auto-triangulation
+for near-planar real-world faces), and instances (transform,
+instance-level paint, instance-level name — including a genuinely empty
+name, which is different from an omitted one). See
+[Generating code from a file](docs/DEVELOPER_GUIDE.md#generating-code-from-a-file).
+
+Building and testing this against a real, large file (`jeff.skp`: 2713
+definitions, 113643 faces, 2581/2713 painted instances) surfaced three
+pre-existing bugs shared by every language's existing
+`open_existing`/`edit.*` replay path, fixed there too:
+
+- **Instance-level paint silently dropped.** SketchUp lets you paint a
+  whole component/group instance once instead of every internal face;
+  every language's replay path never passed the instance's own `material`
+  option when rebuilding.
+- **Instance names silently replaced.** A genuinely empty stored instance
+  name was converted to the writer's "omitted" sentinel before calling
+  `add_instance`, defeating the writer's own correct
+  name-defaults-to-definition-name fallback and baking in the wrong name.
+- **Textured materials replayed corrupted.** Every replay path called
+  `add_texture_material` without `applied_height`, leaving in place the
+  library's internal corrupted-sentinel default (already fixed in the
+  writer itself for `add_image`, but the replay callers were never
+  updated).
+
+A fourth bug, found while building the new codegen and then also present
+in the existing replay logic: blindly sampling the first 3 vertices for a
+UV correspondence can pick a collinear triple on real "flat" geometry,
+which the writer's UV solver correctly rejects — fixed via a
+non-collinear-triple search helper in both the new codegen and the
+existing replay logic.
+
 ## [1.1.0] — 2026-08-20
 
 **Write support, now in all five languages.** OpenSKP can *create* new

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ OpenSKP is the **first and only** open-source, cross-platform toolkit for Sketch
 
 **Writing** is available in **all five languages**: a from-scratch legacy-format writer (`openskp.create()` / `create()` / `SkpCreate.NewFile()` / `openskp::create()` — see the [Quick Start](#-quick-start) below for the exact call per language) that produces real, editable geometry — materials and textures, layers, nested component definitions and groups, circular/arc curves, freeform polylines, faces with holes cut out — plus an editor (`openskp.open_existing()` / `openExisting()` / `SkpEdit.OpenExisting()` / `openskp::open_existing()`) that loads a file that already exists and extends it. Every writer feature is validated against the real SketchUp SDK, not just against this project's own reader, and it holds up rebuilding complex, real architectural models — not only synthetic test fixtures. Landed in Python first; TypeScript, .NET, Dart, and C++ now match it feature-for-feature, each verified against the same SDK oracle. See [Write capabilities](docs/DEVELOPER_GUIDE.md#write-capabilities) in the Developer Guide for the full picture, including the naming convention each language follows.
 
+**Generating code** turns a parsed file into a source-code transcript instead of an opaque binary: `openskp.to_python_code()` / `toTypeScriptCode()` / `Codegen.ToCSharpCode()` / `toDartCode()` / `to_cpp_code()` walks a model and emits human-readable, re-runnable source that calls the same language's own writer API to rebuild an equivalent file — materials (including textures with explicit UV pins), layers, nested definitions in dependency order, faces with holes, and instance-level paint and names. Useful for handing a real model to an AI coding agent as editable starting code, or getting a diffable, reviewable text representation of a `.skp` file. See [Generating code from a file](docs/DEVELOPER_GUIDE.md#generating-code-from-a-file).
+
 **Converting** puts reading and writing together: OpenSKP is a genuine **SketchUp file converter**, not just a parser with an export bolt-on. Every one of the five languages natively converts a `.skp` file to **7 formats** — glTF (GLB), Wavefront OBJ/MTL, STL, PLY, DXF 3D (AutoCAD), IFC4 (BIM), and JSON — with no third-party CAD/BIM SDK involved, and the DXF converter specifically verified against real desktop AutoCAD, not just lenient readers. Converting `.skp` *into* other formats is fully shipped today; converting *other* formats into `.skp` (glTF/IFC/OBJ → SketchUp) is a planned future direction built on the now-mature writer, not yet under way.
 
 > [!IMPORTANT]
@@ -58,6 +60,7 @@ OpenSKP is the **first and only** open-source, cross-platform toolkit for Sketch
 | **Convert to GLB / OBJ / STL / PLY / DXF 3D / IFC4 / JSON** | ✅ | Native, from-scratch conversion to glTF (GLB), Wavefront OBJ, STL, PLY, DXF 3D (AutoCAD Polyface Mesh), IFC4 (BIM), and JSON metadata — available in all five languages, no third-party CAD/BIM SDK involved — see [Export capabilities](docs/DEVELOPER_GUIDE.md#export-capabilities) |
 | **Write native `.skp` files** | ✅ | Build new `.skp` files from scratch — geometry (including genuine circular/arc curves, freeform polylines, faces with holes cut out, and non-planar auto-triangulation), solid/textured materials, layers, nested component definitions and groups, instance rotation/visibility, and custom attribute dictionaries. No SDK involved — every feature validated against the real SketchUp SDK, in all five languages. See [Write capabilities](docs/DEVELOPER_GUIDE.md#write-capabilities) |
 | **Edit existing `.skp` files** | ✅ | Load an existing legacy-format file and extend it — reuses its materials, layers, and component definitions, adds new geometry or instances, and saves a new file. All five languages. See [Editing an existing file](docs/DEVELOPER_GUIDE.md#editing-an-existing-file) |
+| **Generate rebuild code from a file** | ✅ | Turn a parsed `.skp` file into a human-readable, re-runnable source-code transcript that calls the same language's own writer API to rebuild it — materials, textures, layers, nested definitions, holes, instance-level paint and names. All five languages. See [Generating code from a file](docs/DEVELOPER_GUIDE.md#generating-code-from-a-file) |
 | **AI coding-agent ready** | ✅ | A generic, well-documented writer API (no object-specific helpers needed) that AI coding agents can compose freely — proven on real generated models (furniture, a house, an executive desk, a smartphone modeled from a photo) across two independent AI agents, each built from a natural-language prompt with no primitives library involved. See [AI-Generated Models](docs/AI_MODELING.md) |
 | **Streaming / low-memory parsing** | ✅ | Peak memory bounded by the largest single definition, not the whole file — see [Memory architecture](docs/ARCHITECTURE.md#memory-architecture) |
 | **Pure Implementation** | ✅ | No SketchUp SDK, no native dependencies, no license required |
@@ -289,9 +292,20 @@ int red = builder->add_material("Red", Color3{255, 0, 0});
 auto& chair = builder->add_component_definition("Chair");
 chair.add_face({{0, 0, 0}, {20, 0, 0}, {20, 20, 0}, {0, 20, 0}});
 chair.close();
-builder->add_instance(chair, {.translation = {50, 0, 0}});
-builder->add_instance(chair, {.translation = {100, 0, 0}, .hidden = true});
-builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, {.material = red});
+
+InstanceOptions opts1;
+opts1.translation = {50, 0, 0};
+builder->add_instance(chair, opts1);
+
+InstanceOptions opts2;
+opts2.translation = {100, 0, 0};
+opts2.hidden = true;
+builder->add_instance(chair, opts2);
+
+FaceOptions face_opts;
+face_opts.material = red;
+builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, face_opts);
+
 builder->save("output.skp");
 ```
 

--- a/docs/AI_MODELING.md
+++ b/docs/AI_MODELING.md
@@ -124,7 +124,12 @@ SketchUp (or view it via the [live web viewer](https://iamahsanmehood.github.io/
 by exporting to GLB first) to check it, then iterate — including editing
 an *existing* file with `open_existing()` rather than starting over, the
 same way a human would keep refining a model rather than redrawing it
-from scratch.
+from scratch. When the agent can't execute code directly against a file
+(a chat-only session, or handing off to another agent), `to_python_code()`
+gives it the same starting point as text - a readable transcript of an
+existing model's `create()` calls it can read, reason about, and extend,
+rather than an opaque `.skp` binary. See
+[Generating code from a file](DEVELOPER_GUIDE.md#generating-code-from-a-file).
 
 ## What's next — help build this out
 

--- a/docs/API_DESIGN.md
+++ b/docs/API_DESIGN.md
@@ -188,8 +188,15 @@ int red = builder->add_material("Red", Color3{255, 0, 0});
 auto& chair = builder->add_component_definition("Chair");
 chair.add_face({{0, 0, 0}, {20, 0, 0}, {20, 20, 0}, {0, 20, 0}});
 chair.close();
-builder->add_instance(chair, {.translation = {50, 0, 0}});
-builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, {.material = red});
+
+InstanceOptions opts;
+opts.translation = {50, 0, 0};
+builder->add_instance(chair, opts);
+
+FaceOptions face_opts;
+face_opts.material = red;
+builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, face_opts);
+
 builder->save("output.skp");
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -162,6 +162,14 @@ already-validated output — see
 [Write capabilities](DEVELOPER_GUIDE.md#write-capabilities) in the
 Developer Guide for the full API and the per-language naming convention.
 
+`to_python_code()`/`toTypeScriptCode()`/etc. reuse `open_existing()`'s own
+replay logic (the same UV/hole/instance-paint reconstruction), but emit
+the resulting sequence of writer API calls as **source text** rather than
+executing them directly — a third mode alongside `create()` and
+`open_existing()`, for when the goal is an editable transcript rather
+than an immediately-rebuilt file. See
+[Generating code from a file](DEVELOPER_GUIDE.md#generating-code-from-a-file).
+
 ## Module layout
 
 Each language groups the same responsibilities, named idiomatically per
@@ -183,6 +191,7 @@ platform:
 | Public entry point | `model.py` | `index.ts` | `Parser.cs` | `parser.dart` | `parser.cpp` |
 | Writer (create new files) | `create.py` | `create.ts` | `Create.cs` | `create.dart` | `create.hpp` / `create.cpp` |
 | Writer (edit existing files) | `edit.py` | `edit.ts` | `Edit.cs` | `edit.dart` | `edit.hpp` / `edit.cpp` |
+| Writer (generate rebuild code) | `codegen.py` | `codegen.ts` | `Codegen.cs` | `codegen.dart` | `codegen.hpp` / `codegen.cpp` |
 
 Note Python has no dedicated `observability.py` — it's instrumented
 directly at each call site using the standard-library `logging` module,

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -758,18 +758,29 @@ constexpr double kHalfPi = 1.5707963267948966;  // avoids the M_PI portability w
 
 auto builder = create();
 int red = builder->add_material("Red", Color3{255, 0, 0});
-int roof = builder->add_layer("Roof", {.color = Color4{180, 60, 40, 255}, .hidden = true});
+
+LayerOptions lopts;
+lopts.color = Color4{180, 60, 40, 255};
+lopts.hidden = true;
+int roof = builder->add_layer("Roof", lopts);
+
 DefinitionOptions dopts;
 dopts.attributes = {{"sku", std::string{"CH-100"}}, {"price", 49.99}};
 auto& chair = builder->add_component_definition("Chair", dopts);
 chair.add_face({{0, 0, 0}, {20, 0, 0}, {20, 20, 0}, {0, 20, 0}});
 chair.close();
-builder->add_instance(chair, {
-    .translation = {50, 0, 0},
-    .rotation = Rotation{{0, 0, 1}, kHalfPi},
-    .hidden = true,
-});
-builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, {.material = red, .layer = roof});
+
+InstanceOptions iopts;
+iopts.translation = {50, 0, 0};
+iopts.rotation = Rotation{{0, 0, 1}, kHalfPi};
+iopts.hidden = true;
+builder->add_instance(chair, iopts);
+
+FaceOptions fopts;
+fopts.material = red;
+fopts.layer = roof;
+builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, fopts);
+
 builder->save("output.skp");
 ```
 
@@ -808,14 +819,17 @@ the same reason `openskp.create` only ever writes that format. The
 returned `warnings` list is the honest account of what couldn't be
 faithfully reproduced for that specific file - per-edge flags collapsed
 to a per-face approximation, a projected/distorted texture falling back
-to the default projection, a material's texture scale or colorized tint,
-section planes/text/dimensions (no writer support at all), and an
-original circle/arc's curve grouping (this project's reader doesn't
+to the default projection, a colorized (tinted) material variant losing
+its tint, section planes/text/dimensions (no writer support at all), and
+an original circle/arc's curve grouping (this project's reader doesn't
 preserve it, so it round-trips as a plain straight-edged face) - see
 [`openskp/edit.py`](../packages/python/src/openskp/edit.py)'s own
 module docstring for the complete, itemized list and the reasoning
 behind each one. Round-trip-validated against real, non-writer-authored
 architectural models, not just files this project's own writer produced.
+A material's real-world texture tile size *is* preserved, via an explicit
+`front_uv`/`back_uv` pin computed from it on every replayed textured face
+(not left to the writer's own default projection).
 
 Every material/layer the source had is already reachable on the
 returned `builder` without a separate lookup - `builder.materials_by_name
@@ -836,6 +850,79 @@ definitions must be finalized before any geometry) is already
 satisfied, so `add_material`/`add_layer`/`add_component_definition`/
 `add_group` all raise on this particular builder. Build anything new
 into a separate `create()` call instead.
+
+### Generating code from a file
+
+`openskp.to_python_code()` (and its equivalent in every other language -
+`toTypeScriptCode`, `Codegen.ToCSharpCode`, `toDartCode`, `to_cpp_code`)
+takes the opposite approach from `open_existing()`: instead of returning
+a builder you keep editing programmatically, it returns a **string of
+source code** - a faithful, human-readable, re-runnable transcript of
+`create()`/`SkpBuilder` calls that rebuilds an equivalent file when run:
+
+```python
+from openskp import SkpFile, to_python_code
+
+model = SkpFile.open("building.skp").parse()
+print(to_python_code(model))
+```
+
+```python
+import base64
+import os
+import tempfile
+
+from openskp import create
+
+
+def build():
+    builder = create()
+
+    # --- Materials (1) ---
+    mat0 = builder.add_material('Red', (255, 0, 0, 255))
+
+    # --- Layers (2) ---
+    layer0 = builder.add_layer('Layer0', color=(255, 84, 84), hidden=False)
+    layer1 = builder.add_layer('Roof', color=(200, 60, 60), hidden=False)
+
+    # 'Wheel' - 1 faces, 0 nested instances
+    with builder.add_component_definition('Wheel') as def0:
+        def0.add_face([(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)], material=mat0, auto_triangulate=True)
+
+    # --- Root instances (1) ---
+    builder.add_instance(def0, translation=(50.0, 0.0, 0.0), matrix3x3=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0), material=mat0, name='')
+
+    return builder.to_bytes()
+```
+
+(`base64`/`tempfile` are always imported, whether or not this particular
+model has a textured material - they're only exercised when one does,
+decoding its embedded image data back out to a temp file for
+`add_texture_material` to read)
+
+This is useful anywhere you want a file's structure as *editable code*
+rather than as an opaque binary - handing a real model to an AI coding
+agent as a starting point it can read and modify, generating a diffable/
+reviewable text representation of a `.skp` file for version control, or
+just understanding how a specific file was built without a SketchUp
+license. It's not an alternative to `open_existing()` for programmatic
+editing - the returned string still needs to be executed to produce a
+file, and every fidelity gap `open_existing()` has (see above) applies
+here too, since both share the same UV/hole/instance-paint reconstruction
+logic. One difference: `to_python_code()`'s output always pins UVs
+explicitly (`front_uv`/`back_uv`) on every textured face, even ones that
+originally used default projection, so the regenerated material's applied
+height never needs to match the source's.
+
+Only reproduces geometry reachable by walking a definition's faces -
+standalone/construction edges and curves that don't bound any face aren't
+reproduced (doesn't affect materials, textures, instance paint, or any
+visible face/surface geometry). See each language's own `codegen` module
+docstring (`packages/python/src/openskp/codegen.py`,
+`packages/typescript/src/codegen.ts`, `packages/dotnet/OpenSkp/Codegen.cs`,
+`packages/dart/lib/src/codegen.dart`, `packages/cpp/src/codegen.cpp`) for
+the exact same itemized gap list `open_existing()` has, since both share
+it.
 
 ## The web viewer
 

--- a/examples/web-viewer/docs/index.html
+++ b/examples/web-viewer/docs/index.html
@@ -220,6 +220,7 @@ code[class*="language-"]{font-family:var(--font-code)!important;font-size:12.5px
   <a class="mnav-item" href="#concepts"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 2 7 12 12 22 7 12 2"></polygon><polyline points="2 17 12 22 22 17"></polyline><polyline points="2 12 12 17 22 12"></polyline></svg>Concepts</a>
   <a class="mnav-item" href="#writing-create"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="12" y1="18" x2="12" y2="12"></line><line x1="9" y1="15" x2="15" y2="15"></line></svg>Create</a>
   <a class="mnav-item" href="#writing-edit"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>Edit</a>
+  <a class="mnav-item" href="#writing-codegen"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>Generate Code</a>
   <a class="mnav-item" href="#ai-modeling"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"></rect><circle cx="12" cy="5" r="2"></circle><path d="M12 7v4"></path><line x1="8" y1="16" x2="8" y2="16"></line><line x1="16" y1="16" x2="16" y2="16"></line></svg>AI Modeling</a>
   <a class="mnav-item" href="#data-model"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>Data Model</a>
   <a class="mnav-item" href="#legacy"><svg viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="21 8 21 21 3 21 3 8"></polyline><rect x="1" y="3" width="22" height="5"></rect><line x1="10" y1="12" x2="14" y2="12"></line></svg>Legacy</a>
@@ -252,6 +253,9 @@ code[class*="language-"]{font-family:var(--font-code)!important;font-size:12.5px
     </a>
     <a class="nav-item" href="#writing-edit" onclick="setActive(this)">
       <svg class="nav-icon" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"></path><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4Z"></path></svg>Edit Files
+    </a>
+    <a class="nav-item" href="#writing-codegen" onclick="setActive(this)">
+      <svg class="nav-icon" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg>Generate Code
     </a>
     <a class="nav-item" href="#ai-modeling" onclick="setActive(this)">
       <svg class="nav-icon" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="11" width="18" height="10" rx="2"></rect><circle cx="12" cy="5" r="2"></circle><path d="M12 7v4"></path><line x1="8" y1="16" x2="8" y2="16"></line><line x1="16" y1="16" x2="16" y2="16"></line></svg>AI Modeling
@@ -649,7 +653,7 @@ builder.save("building_edited.skp")</code></pre>
         <tbody>
           <tr><td>Per-edge flags</td><td>hidden/soft/smooth are applied per-face, not per-edge — an "any edge in this boundary has the flag" approximation</td></tr>
           <tr><td>Projective textures</td><td>positioned textures replay via a 3-point affine fit — exact at those points, but a genuinely projective/distorted source mapping won't interpolate identically. A draped/projected texture falls back to the default projection</td></tr>
-          <tr><td>Texture tile size &amp; tint</td><td>a material's original texture scale isn't preserved yet, and a colorized (tinted) material replays as its plain source texture</td></tr>
+          <tr><td>Colorized tint</td><td>a colorized (tinted) material replays as its plain source texture, losing the tint — its real-world texture tile size <em>is</em> preserved, via an explicit UV pin on every replayed textured face</td></tr>
           <tr><td>Per-face layer painting</td><td>only a face's front/back material is replayed — the reader doesn't expose a per-face layer assignment</td></tr>
           <tr><td>Group vs. instance</td><td>every placed thing replays as a plain component instance — visually identical, but no longer shows as a "Group" in SketchUp's Outliner</td></tr>
           <tr><td>Section planes, text, dimensions</td><td>not carried over at all — the writer has no support for these entity types</td></tr>
@@ -659,6 +663,66 @@ builder.save("building_edited.skp")</code></pre>
       </table>
       </div>
       <div class="fn-desc" style="margin-top:14px">See <a href="https://github.com/iamahsanmehmood/openskp/blob/main/packages/python/src/openskp/edit.py" target="_blank" rel="noopener"><code>openskp/edit.py</code></a>'s own module docstring for the complete, itemized list and the reasoning behind each one.</div>
+    </div>
+  </div>
+</section>
+
+<!-- Generate Code -->
+<section id="writing-codegen">
+  <div class="sec-head">
+    <div class="sec-icon"><svg viewBox="0 0 24 24" width="18" height="18" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"></polyline><polyline points="8 6 2 12 8 18"></polyline></svg></div>
+    <div>
+      <div class="sec-title">Generating Code From a File</div>
+      <div class="sec-sub"><code>openskp.to_python_code()</code> — turn a parsed file into re-runnable source, not a builder</div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-body">
+      <div class="fn-desc">Every language has an equivalent — <code>to_python_code()</code>, <code>toTypeScriptCode()</code>, <code>Codegen.ToCSharpCode()</code>, <code>toDartCode()</code>, <code>to_cpp_code()</code>. It takes the opposite approach from <code>open_existing()</code>: instead of a builder you keep editing programmatically, it returns a <strong>string of source code</strong> — a faithful, human-readable, re-runnable transcript of <code>create()</code>/<code>SkpBuilder</code> calls that rebuilds an equivalent file when run. Materials (solid and textured, with explicit UV pins), layers, component/group definitions in dependency order, faces with holes, and instance-level paint and names (including a genuinely empty name) are all reproduced.</div>
+      <div class="code-wrap">
+        <div class="code-hdr"><span class="code-lang">python</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">from openskp import SkpFile, to_python_code
+
+model = SkpFile.open("building.skp").parse()
+print(to_python_code(model))</code></pre>
+      </div>
+      <div class="code-wrap" style="margin-top:12px">
+        <div class="code-hdr"><span class="code-lang">generated output</span><button class="copy-btn" onclick="copy(this)">⎘ Copy</button></div>
+<pre class="language-python"><code class="language-python">import base64
+import os
+import tempfile
+
+from openskp import create
+
+
+def build():
+    builder = create()
+
+    # --- Materials (1) ---
+    mat0 = builder.add_material('Red', (255, 0, 0, 255))
+
+    # --- Layers (2) ---
+    layer0 = builder.add_layer('Layer0', color=(255, 84, 84), hidden=False)
+    layer1 = builder.add_layer('Roof', color=(200, 60, 60), hidden=False)
+
+    # 'Wheel' - 1 faces, 0 nested instances
+    with builder.add_component_definition('Wheel') as def0:
+        def0.add_face([(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)], material=mat0, auto_triangulate=True)
+
+    # --- Root instances (1) ---
+    builder.add_instance(def0, translation=(50.0, 0.0, 0.0), matrix3x3=(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0), material=mat0, name='')
+
+    return builder.to_bytes()</code></pre>
+      </div>
+    </div>
+  </div>
+
+  <div class="fn-block">
+    <div class="fn-head"><div><div class="fn-name">Why generate code instead of editing directly</div></div></div>
+    <div class="fn-body">
+      <div class="fn-desc">Useful anywhere a file's structure is more valuable as <strong>editable code</strong> than as an opaque binary — handing a real model to an AI coding agent as a starting point it can read and modify without executing anything first, generating a diffable, reviewable text representation of a <code>.skp</code> file for version control, or understanding how a specific file was built without a SketchUp license. It's not a replacement for <code>open_existing()</code>'s programmatic editing — the returned string still needs to be executed to produce a file — and shares every fidelity gap listed above, since both reuse the same UV/hole/instance-paint reconstruction logic.</div>
+      <div class="callout">Every textured face gets an explicit UV pin in the generated output — even ones that originally used default projection — so the regenerated material's applied height never needs to match the source's.</div>
     </div>
   </div>
 </section>

--- a/packages/cpp/README.md
+++ b/packages/cpp/README.md
@@ -175,7 +175,9 @@ auto builder = create();
 
 // Materials and layers
 int red = builder->add_material("Red", Color3{255, 0, 0});
-int roof = builder->add_layer("Roof", {.color = Color4{180, 60, 40, 255}});
+LayerOptions roof_opts;
+roof_opts.color = Color4{180, 60, 40, 255};
+int roof = builder->add_layer("Roof", roof_opts);
 
 // All add_component_definition/add_group calls must come before any
 // add_instance/add_face call - placing anything locks in the file's
@@ -183,11 +185,20 @@ int roof = builder->add_layer("Roof", {.color = Color4{180, 60, 40, 255}});
 auto& chair = builder->add_component_definition("Chair");
 chair.add_face({{0, 0, 0}, {20, 0, 0}, {20, 20, 0}, {0, 20, 0}});
 chair.close();
-builder->add_instance(chair, {.translation = {50, 0, 0}});
-builder->add_instance(chair, {.translation = {100, 0, 0}, .hidden = true});
 
-builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}},
-                  {.material = red, .layer = roof});
+InstanceOptions first_chair_opts;
+first_chair_opts.translation = {50, 0, 0};
+builder->add_instance(chair, first_chair_opts);
+
+InstanceOptions second_chair_opts;
+second_chair_opts.translation = {100, 0, 0};
+second_chair_opts.hidden = true;
+builder->add_instance(chair, second_chair_opts);
+
+FaceOptions roof_face_opts;
+roof_face_opts.material = red;
+roof_face_opts.layer = roof;
+builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, roof_face_opts);
 
 builder->save("output.skp");
 ```
@@ -208,6 +219,22 @@ source had is reachable on `result.builder->materials_by_name`/
 `layers_by_name` without a separate lookup, and `result.definitions` maps
 each replayed component definition's own name to its builder for placing
 more instances of something the source already defined.
+
+### Generating code from a file
+
+`to_cpp_code()` takes the opposite approach: instead of a builder you
+keep editing, it returns a **string of source code** — a re-runnable
+transcript of `create()` calls that rebuilds an equivalent file when run:
+
+```cpp
+SkpModel model = SkpFile::open("building.skp").parse();
+std::cout << to_cpp_code(model);
+```
+
+Useful for handing a real model to an AI coding agent as editable
+starting code, or for a diffable, reviewable text representation of a
+`.skp` file. Shares the same fidelity scope as `openskp::open_existing()`
+above.
 
 ## Formatting
 

--- a/packages/dart/README.md
+++ b/packages/dart/README.md
@@ -241,6 +241,22 @@ source had is reachable on `result.builder.materialsByName`/
 each replayed component definition's own name to its builder for placing
 more instances of something the source already defined.
 
+### Generating code from a file
+
+`toDartCode()` takes the opposite approach: instead of a builder you keep
+editing, it returns a **string of source code** — a re-runnable
+transcript of `create()` calls that rebuilds an equivalent file when run:
+
+```dart
+final bytes = await File('building.skp').readAsBytes();
+final model = SkpFile.fromBuffer(bytes).parse();
+print(toDartCode(model));
+```
+
+Useful for handing a real model to an AI coding agent as editable
+starting code, or for a diffable, reviewable text representation of a
+`.skp` file. Shares the same fidelity scope as `openExisting()` above.
+
 ---
 
 ## 📐 API Data Model Reference

--- a/packages/dotnet/OpenSkp/README.md
+++ b/packages/dotnet/OpenSkp/README.md
@@ -199,6 +199,23 @@ source had is reachable on `result.Builder.MaterialsByName`/
 each replayed component definition's own name to its builder for placing
 more instances of something the source already defined.
 
+### Generating code from a file
+
+`Codegen.ToCSharpCode()` takes the opposite approach: instead of a
+builder you keep editing, it returns a **string of source code** — a
+re-runnable transcript of `SkpCreate.NewFile()` calls that rebuilds an
+equivalent file when run:
+
+```csharp
+SkpModel model = SkpFile.Open("building.skp");
+Console.WriteLine(Codegen.ToCSharpCode(model));
+```
+
+Useful for handing a real model to an AI coding agent as editable
+starting code, or for a diffable, reviewable text representation of a
+`.skp` file. Shares the same fidelity scope as `SkpEdit.OpenExisting()`
+above.
+
 ---
 
 ## ⚙️ Target Frameworks

--- a/packages/python/README.md
+++ b/packages/python/README.md
@@ -240,10 +240,27 @@ builder.save("building_edited.skp")
 ```
 
 `warnings` lists anything the source file had that couldn't be
-faithfully reproduced (a projected texture, a material's texture scale,
-and several others) — see
-[`openskp/edit.py`](src/openskp/edit.py) for the complete, itemized
+faithfully reproduced (a projected/draped texture falling back to
+default projection, a colorized material's tint, and several others) —
+see [`openskp/edit.py`](src/openskp/edit.py) for the complete, itemized
 scope.
+
+### Generating code from a file
+
+`to_python_code()` takes the opposite approach: instead of a builder you
+keep editing, it returns a **string of source code** — a re-runnable
+transcript of `create()` calls that rebuilds an equivalent file when run:
+
+```python
+from openskp import SkpFile, to_python_code
+
+model = SkpFile.open("building.skp").parse()
+print(to_python_code(model))
+```
+
+Useful for handing a real model to an AI coding agent as editable
+starting code, or for a diffable, reviewable text representation of a
+`.skp` file. Shares the same fidelity scope as `open_existing()` above.
 
 ## Package Structure
 

--- a/packages/typescript/README.md
+++ b/packages/typescript/README.md
@@ -395,6 +395,23 @@ builder.addCircle([0, 0, 100], [0, 0, 1], 50);
 builder.save('building_edited.skp');
 ```
 
+### Generating code from a file
+
+`toTypeScriptCode()` takes the opposite approach: instead of a builder you
+keep editing, it returns a **string of source code** — a re-runnable
+transcript of `create()` calls that rebuilds an equivalent file when run:
+
+```typescript
+import { SkpFile, toTypeScriptCode } from 'openskp';
+
+const model = SkpFile.open('building.skp').parse();
+console.log(toTypeScriptCode(model));
+```
+
+Useful for handing a real model to an AI coding agent as editable
+starting code, or for a diffable, reviewable text representation of a
+`.skp` file. Shares the same fidelity scope as `openExisting()` above.
+
 `warnings` is the honest account of what couldn't be faithfully
 reproduced from that specific source file. Every material/layer the
 source had is reachable on `builder.materialsByName`/`builder.layersByName`


### PR DESCRIPTION
## Summary
- Adds a "Generating code from a file" section documenting `to_python_code()` / `toTypeScriptCode()` / `Codegen.ToCSharpCode()` / `toDartCode()` / `to_cpp_code()` (merged in #234) to `docs/DEVELOPER_GUIDE.md`, `docs/ARCHITECTURE.md`, `docs/AI_MODELING.md`, the root `README.md` (new feature-table row + intro paragraph), and every per-language package README, plus a CHANGELOG entry under `[Unreleased]` covering both the new feature and the four replay-path bug fixes that came with it.
- Adds the same section to `examples/web-viewer/docs/index.html` - the standalone GitHub Pages developer-reference site that openskp.com's "Full Documentation" nav link points to (both its desktop sidebar nav and its separately-maintained mobile pill nav).
- Removes a stale "a material's texture scale ... not reproduced" line from `docs/DEVELOPER_GUIDE.md`, `packages/python/README.md`, and the GitHub Pages docs page's own fidelity-gap table - #234 made this inaccurate (a source material's real-world tile size is now preserved via explicit UV pins), but the prose was never updated to match.
- **Unrelated pre-existing bug, found while reviewing these same docs**: every C++ example across `README.md`, `docs/API_DESIGN.md`, `docs/DEVELOPER_GUIDE.md`, and `packages/cpp/README.md` used C++20 designated initializers (`{.color = ..., .hidden = true}`) even though `packages/cpp` explicitly targets and requires C++17 (`target_compile_features(OpenSkp PUBLIC cxx_std_17)`, and the README's own tagline says "C++17 edition"). Confirmed via actual compilation this session (building the new codegen feature in #234) that MSVC rejects this syntax outright: `error C7555: use of designated initializers requires at least '/std:c++20'`. Every occurrence is rewritten to the default-construct-then-field-assign style the project's own C++ source (`edit.cpp`, `create_test.cpp`) already uses everywhere else.

Separately (not part of this PR - openskp.com isn't in this repo, no CI): I also updated the openskp.com static site's own "Writing" section with a matching feature card, code example, and docs links, and handed the user a ZIP to deploy manually.

## Test plan
- [x] Docs-only change - no source files touched, no test suite affected
- [x] Every rewritten C++ example checked field-by-field against the actual `FaceOptions`/`InstanceOptions`/`LayerOptions` struct definitions in `packages/cpp/include/openskp/create.hpp`
- [x] The Python code sample used in both `docs/DEVELOPER_GUIDE.md` and the GitHub Pages docs page is real `to_python_code()` output, generated and verified locally against a small synthetic model (not hand-written) - materials, layers (including the implicit default `Layer0`), a component definition, and a root instance
- [x] `grep -rln '{\.\w+ ='` across every `.md` file in the repo confirms zero remaining designated-initializer examples
- [x] GitHub Pages docs page change verified rendering correctly via a local static server (sidebar nav link, mobile pill nav link, and the new section's content/code blocks all confirmed present via DOM inspection)
- [x] All CI checks green