### PR TITLE
Fix corrupted default texture applied-height; close a TypeScript replay gap

### DIFF
--- a/packages/cpp/include/openskp/create.hpp
+++ b/packages/cpp/include/openskp/create.hpp
@@ -381,14 +381,11 @@ class OPENSKP_EXPORT SkpBuilder {
   /// pass as `FaceOptions::material`. The format is detected from the file's own magic bytes,
   /// not its extension. Same ordering rules as `add_material`.
   ///
-  /// If this material will ever be used with `FaceOptions::front_uv`/`back_uv` pinning, pass
-  /// `applied_height = 1.0` (matching those pins' own 0..1 range) - the read-side UV formula
-  /// divides by this field even for a positioned mapping, and the default (an internal sentinel,
-  /// real SketchUp's own byte pattern for "never explicitly scaled") is astronomically small,
-  /// which corrupts ANY face using this material, not just default-projected ones (confirmed
-  /// against real SketchUp 2026-08-27 - see `write_textured_material`'s own note in create.cpp).
-  /// Left at the default for the plain default-planar-projection case, matching this method's
-  /// original, narrower scope.
+  /// `applied_height` defaults to 1.0 (matching applied width, always 1.0). Pass a different
+  /// value to make a default-projected face's texture repeat at a specific real-world size
+  /// instead of every 1 inch - see `write_textured_material`'s own note in create.cpp for why
+  /// this field matters even for `FaceOptions::front_uv`/`back_uv` pinning (a positioned mapping
+  /// still divides by it).
   int add_texture_material(const std::string& name, const std::filesystem::path& image_path,
                            std::optional<double> applied_height = std::nullopt);
 
@@ -441,20 +438,16 @@ class OPENSKP_EXPORT SkpBuilder {
   /// material to be registered before any geometry section begins.
   ///
   /// The image's quad and UV mapping are pinned explicitly (`FaceOptions::front_uv`), not left
-  /// to the default per-material tile-size projection - `add_texture_material` is called with
-  /// `applied_height = 1.0` for exactly this reason: the read-side UV formula divides by the
-  /// material's applied height even for a pinned mapping, and the library default there (a
-  /// ground-truth sentinel, not a real number) is astronomically small - confirmed via real
-  /// SketchUp screenshots (2026-08-27, Python writer) to render as a corrupted, vertically-
-  /// smeared texture when left in place. 1.0 makes that division a no-op against this method's
-  /// own 0..1 pins.
+  /// to the default per-material tile-size projection - the read-side UV formula divides by the
+  /// material's applied height even for a pinned mapping, and `add_texture_material`'s default
+  /// height (1.0) makes that division a no-op against this method's own 0..1 pins.
   ///
   /// Unlike every other entity this writer produces, CImage's exact binary schema version (see
   /// `kImageSchema` in create.cpp) is a best-effort guess, not calibrated against a real
   /// SketchUp-authored Image entity - none was available. This project's own reader round-trips
   /// the result correctly, but real SketchUp's acceptance of the file is unverified beyond the
   /// Python port's own real-SketchUp test (placement/orientation/texture all confirmed correct
-  /// there after the applied_height fix - see CHECKLIST.md).
+  /// there - see CHECKLIST.md).
   void add_image(const std::filesystem::path& image_path, double width, double height,
                  const ImageOptions& options = {});
 

--- a/packages/cpp/src/codegen.cpp
+++ b/packages/cpp/src/codegen.cpp
@@ -246,10 +246,11 @@ std::string to_cpp_code(const SkpModel& model) {
         auto dot = mat.texture->filename.find_last_of('.');
         if (dot != std::string::npos) suffix = mat.texture->filename.substr(dot);
         if (suffix.empty()) suffix = ".png";
-        // applied_height: 1.0 - see add_texture_material's own note on why the library default
-        // (an internal sentinel) corrupts ANY face using this material. Every face using a
-        // textured material is written below with explicit front_uv/back_uv, never left to
-        // default projection, so the original applied width/height never needs to be reproduced.
+        // applied_height: 1.0 - every face using a textured material is written below with
+        // explicit front_uv/back_uv, never left to default projection, so the material's own
+        // applied height must be an exact no-op divisor (matches add_texture_material's own
+        // default too, but kept explicit since it's a hard requirement here, not just a safe
+        // default).
         //
         // var_name is declared here, then only ASSIGNED inside the nested `{ }` block below (its
         // temp-file cleanup needs its own scope) - a fresh declaration in that inner scope would

--- a/packages/cpp/src/create.cpp
+++ b/packages/cpp/src/create.cpp
@@ -130,9 +130,17 @@ constexpr std::uint8_t kAttrTypeInt32 = 0x04;
 constexpr std::uint8_t kAttrTypeDouble = 0x06;
 constexpr std::uint8_t kAttrTypeString = 0x0A;
 
-// Ground-truth byte pattern (not a meaningful float) real SketchUp writes for a texture's
-// "applied height" when the caller never explicitly overrides scale/aspect.
-constexpr std::uint8_t kTextureHSentinel[8] = {240, 255, 255, 255, 255, 255, 255, 15};
+// Byte pattern found in one SDK-authored textured-material sample's "applied height" field,
+// decoding to ~1.29e-231 as an f64 - not a meaningful height value. Confirmed 2026-08-27 via
+// real SketchUp screenshots that a material written with this exact value renders as a
+// corrupted, vertically-smeared texture, so it was never a genuine "never scaled" default -
+// almost certainly uninitialized memory in the one sample file this was calibrated against,
+// given write_textured_material's applied WIDTH is unconditionally 1.0 (a clearly deliberate
+// value) with no equivalent garbage pattern. No longer used as this project's own default (see
+// write_textured_material, which now defaults to 1.0 instead) - kept only as a documented
+// historical artifact of what real SketchUp can apparently write here.
+[[maybe_unused]] constexpr std::uint8_t kTextureHSentinel[8] = {240, 255, 255, 255,
+                                                                255, 255, 255, 15};
 
 // The definition record's 22-byte "base block" (immediately after its own preamble, before the
 // embedded layer list) - all zero except offsets 3-4 (the same 1,1 padding convention drawbase
@@ -765,15 +773,14 @@ class ArchiveWriter {
 
   // `subtype` is CDib's image format tag (4 for PNG, 1 for JPEG - see detect_image_subtype).
   //
-  // `applied_height`, if given, is written in place of kTextureHSentinel (applied width stays a
-  // fixed 1.0 either way). Needed because the reader's own ground-truth-derived UV formula
-  // divides a face's final UV by the material's applied width/height EVEN for a positioned
-  // (front_uv) mapping, not just the default projection - the sentinel decodes to ~1.29e-231,
-  // and dividing by it blows up to an astronomical value, which real SketchUp visibly renders as
-  // a corrupted, vertically-smeared texture (confirmed against real SketchUp 2026-08-27 via the
-  // Python writer - see create.py's own note on this). A caller positioning this material via
-  // front_uv/back_uv should pass a real applied_height (add_image uses 1.0, matching its own
-  // pins' 0..1 range) so that division is a no-op instead of a corruption.
+  // `applied_height` defaults to 1.0, matching applied width (always 1.0, unconditionally). Pass
+  // a different value for a textured material used with default (unpositioned) projection, to
+  // make the texture repeat at a specific real-world size instead of every 1 inch - the reader's
+  // own ground-truth-derived UV formula divides a face's final UV by the material's applied
+  // width/height, for a default-projected face exactly as much as a positioned (front_uv/back_uv)
+  // one. Until 2026-08-28 this defaulted to a corrupted sentinel byte pattern instead (see
+  // kTextureHSentinel's own comment) - confirmed via real SketchUp screenshots to render as a
+  // streaky, vertically-smeared texture regardless of projection mode.
   int write_textured_material(const std::string& name, const ByteBuffer& image_bytes,
                               const std::string& texture_path, int subtype,
                               std::optional<double> applied_height = std::nullopt) {
@@ -792,11 +799,7 @@ class ArchiveWriter {
       append_u32(buf, 90);
     }
     append_f64(buf, 1.0);  // applied width - ground truth default when unscaled
-    if (applied_height) {
-      append_f64(buf, *applied_height);
-    } else {
-      append_bytes(buf, kTextureHSentinel, sizeof(kTextureHSentinel));
-    }
+    append_f64(buf, applied_height.value_or(1.0));
     write_str(texture_path);
     // avg color: neutral near-opaque white. Alpha is 254, not fully-opaque 255 - the reader
     // treats alpha=255 here as one of its two "this material is colorized" signals; a plain
@@ -1756,8 +1759,8 @@ void SkpBuilder::add_instance(const ComponentDefinitionBuilder& definition,
 
 void SkpBuilder::add_image(const std::filesystem::path& image_path, double width, double height,
                            const ImageOptions& options) {
-  int mat = add_texture_material("__openskp_image_" + std::to_string(impl_->material_count),
-                                 image_path, 1.0);
+  int mat =
+      add_texture_material("__openskp_image_" + std::to_string(impl_->material_count), image_path);
   auto& image_def = add_component_definition("Image" + std::to_string(impl_->definition_count));
   // Standard (0,0)-at-bottom-left, V increasing upward - no vertical flip. Every other UV-related
   // fact in this file is calibrated against real SketchUp output; this one specific sense is NOT

--- a/packages/cpp/src/edit.cpp
+++ b/packages/cpp/src/edit.cpp
@@ -119,10 +119,9 @@ std::map<const Material*, int> replay_materials(SkpBuilder& builder, const SkpMo
         // bake in the SOURCE's real tile size via compute_face_uv - the
         // material's own stored applied height must be a no-op divisor
         // (1.0) or the read-side UV formula divides by it a second time.
-        // Leaving this at the library default (an internal sentinel,
-        // ~1.29e-231) was confirmed against real SketchUp 2026-08-27 to
-        // corrupt the texture into a vertically-smeared mess - see
-        // add_texture_material's own note.
+        // This happens to match add_texture_material's own default too,
+        // but is kept explicit here since it's a hard requirement of this
+        // call site specifically, not just a safe default.
         slot = builder.add_texture_material(mat.name, tmp_path, 1.0);
       } catch (...) {
         std::error_code ec;

--- a/packages/cpp/tests/create_test.cpp
+++ b/packages/cpp/tests/create_test.cpp
@@ -143,6 +143,60 @@ TEST(Create, TexturedMaterialRoundTrips) {
   EXPECT_EQ(*mat.texture->data, fake_png_bytes());
 }
 
+TEST(Create, TexturedMaterialDefaultAppliedHeightIsOneNotCorrupted) {
+  // Regression test for a real bug: until 2026-08-28, an omitted
+  // applied_height wrote a corrupted internal sentinel byte pattern
+  // (~1.29e-231) instead of a real number - confirmed via real SketchUp
+  // screenshots to render as a streaky, vertically-smeared texture.
+  // add_texture_material's applied WIDTH is unconditionally 1.0 (a
+  // deliberate ground-truth value); height should match it by default
+  // now, not silently corrupt every caller who doesn't know to pass
+  // applied_height=1.0 explicitly.
+  auto tmp_path = std::filesystem::temp_directory_path() / "openskp_create_test_texture_height.png";
+  {
+    std::ofstream f(tmp_path, std::ios::binary);
+    ByteBuffer png = fake_png_bytes();
+    f.write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+  }
+
+  auto builder = create();
+  int brick = builder->add_texture_material("Brick", tmp_path);
+  FaceOptions opts;
+  opts.material = brick;
+  builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, opts);
+
+  SkpModel model = round_trip(*builder);
+  std::filesystem::remove(tmp_path);
+
+  ASSERT_EQ(model.materials.size(), 1u);
+  ASSERT_TRUE(model.materials[0].texture.has_value());
+  EXPECT_DOUBLE_EQ(model.materials[0].texture->width, 1.0);
+  EXPECT_DOUBLE_EQ(model.materials[0].texture->height, 1.0);
+}
+
+TEST(Create, TexturedMaterialExplicitAppliedHeightStillOverridable) {
+  auto tmp_path =
+      std::filesystem::temp_directory_path() / "openskp_create_test_texture_height2.png";
+  {
+    std::ofstream f(tmp_path, std::ios::binary);
+    ByteBuffer png = fake_png_bytes();
+    f.write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+  }
+
+  auto builder = create();
+  int brick = builder->add_texture_material("Brick", tmp_path, 48.0);
+  FaceOptions opts;
+  opts.material = brick;
+  builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, opts);
+
+  SkpModel model = round_trip(*builder);
+  std::filesystem::remove(tmp_path);
+
+  ASSERT_EQ(model.materials.size(), 1u);
+  ASSERT_TRUE(model.materials[0].texture.has_value());
+  EXPECT_DOUBLE_EQ(model.materials[0].texture->height, 48.0);
+}
+
 TEST(Create, AddImagePlacesARealImageEntityNotAPlainTexturedFace) {
   auto tmp_path = std::filesystem::temp_directory_path() / "openskp_create_test_image.png";
   {

--- a/packages/cpp/tests/edit_test.cpp
+++ b/packages/cpp/tests/edit_test.cpp
@@ -19,6 +19,14 @@ std::filesystem::path temp_skp(const char* stem) {
          (std::string("openskp_edit_test_") + stem + ".skp");
 }
 
+// A syntactically-tiny PNG - just the magic bytes plus filler, matching create_test.cpp's own
+// fake_png_bytes() (not shared across translation units, so duplicated here).
+ByteBuffer fake_png_bytes() {
+  ByteBuffer data = {0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'};
+  data.insert(data.end(), 64, 0x42);
+  return data;
+}
+
 TEST(Edit, RejectsAModernNonLegacyFile) {
   EXPECT_THROW(open_existing(test::fixture("Untitled.skp")), SkpWriteError);
 }
@@ -66,6 +74,75 @@ TEST(Edit, RoundTripsAFreshlyBuiltFile) {
   EXPECT_EQ(rebuilt.root().instances.size(), 1u);
 
   std::filesystem::remove(path);
+}
+
+TEST(Edit, DefaultProjectedTextureGetsAnExplicitUvPinNotLeftCorrupted) {
+  // Found via cross-language analysis (2026-08-28): replay_materials wrote every rebuilt texture
+  // material with the library's (until now) corrupted default applied height, and replay_uv only
+  // replayed a face's UV when it already had an explicit uv_transform - leaving a DEFAULT-projected
+  // textured face's material (and thus its real SketchUp rendering) corrupted end to end. Both are
+  // fixed; this checks the rebuilt face actually gets a pin (not just that some texture data
+  // round-tripped) and that the material's applied height isn't the corrupted sentinel.
+  auto png_path = std::filesystem::temp_directory_path() / "openskp_edit_test_uv_texture.png";
+  {
+    std::ofstream f(png_path, std::ios::binary);
+    ByteBuffer png = fake_png_bytes();
+    f.write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+  }
+  auto path = temp_skp("default_projected_texture");
+  {
+    auto builder = create();
+    int brick = builder->add_texture_material("Brick", png_path);
+    FaceOptions opts;
+    opts.material = brick;
+    builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, opts);  // no front_uv
+    builder->save(path);
+  }
+  std::filesystem::remove(png_path);
+
+  OpenExistingResult result = open_existing(path);
+  ASSERT_NE(result.builder, nullptr);
+  ByteBuffer rebuilt_bytes = result.builder->to_bytes();
+  SkpModel rebuilt = SkpFile::from_buffer(rebuilt_bytes).parse();
+  std::filesystem::remove(path);
+
+  ASSERT_EQ(rebuilt.materials.size(), 1u);
+  ASSERT_TRUE(rebuilt.materials[0].texture.has_value());
+  EXPECT_DOUBLE_EQ(rebuilt.materials[0].texture->width, 1.0);
+  EXPECT_DOUBLE_EQ(rebuilt.materials[0].texture->height, 1.0);
+  ASSERT_EQ(rebuilt.root().faces.size(), 1u);
+  EXPECT_TRUE(rebuilt.root().faces.begin()->second.uv_transform.has_value());
+}
+
+TEST(Edit, GenuinelyEmptyInstanceNameIsPreservedNotReplaced) {
+  // Found via cross-language analysis (2026-08-28): add_instance's own name.value_or(definition
+  // name) fallback and replay_instance's `if (!inst.name.empty()) options.name = inst.name;` both
+  // silently replaced a genuinely empty instance name with its definition's name - a real
+  // difference, not cosmetic (a later rename of the definition would no longer show through).
+  auto path = temp_skp("empty_instance_name");
+  {
+    auto builder = create();
+    auto& box = builder->add_component_definition("Box");
+    box.add_face({{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}});
+    box.close();
+    InstanceOptions iopts;
+    iopts.name = "";
+    builder->add_instance(box, iopts);
+    builder->save(path);
+  }
+
+  SkpModel source = SkpFile::open(path).parse();
+  ASSERT_EQ(source.root().instances.size(), 1u);
+  EXPECT_EQ(source.root().instances[0].name, "");
+
+  OpenExistingResult result = open_existing(path);
+  ASSERT_NE(result.builder, nullptr);
+  ByteBuffer rebuilt_bytes = result.builder->to_bytes();
+  SkpModel rebuilt = SkpFile::from_buffer(rebuilt_bytes).parse();
+  std::filesystem::remove(path);
+
+  ASSERT_EQ(rebuilt.root().instances.size(), 1u);
+  EXPECT_EQ(rebuilt.root().instances[0].name, "");
 }
 
 TEST(Edit, ReturnedBuilderCanAddMoreGeometryAndCannotRegisterNewSections) {

--- a/packages/dart/lib/src/codegen.dart
+++ b/packages/dart/lib/src/codegen.dart
@@ -171,12 +171,12 @@ String toDartCode(SkpModel model) {
     if (tex != null && tex.data != null && tex.data!.isNotEmpty) {
       texturedMats.add(mat.name);
       final b64 = base64Encode(tex.data!);
-      // appliedHeight: 1.0 - see addTextureMaterial's own note on why the
-      // library default (an internal sentinel) corrupts ANY face using
-      // this material. Every face using a textured material is written
-      // below with explicit frontUv/backUv, never left to default
-      // projection, so the original applied width/height never needs to
-      // be reproduced.
+      // appliedHeight: 1.0 - every face using a textured material is
+      // written below with explicit frontUv/backUv, never left to
+      // default projection, so the material's own applied height must be
+      // an exact no-op divisor (matches addTextureMaterial's own default
+      // too, but kept explicit since it's a hard requirement here, not
+      // just a safe default).
       push('  final _texBytes$i = base64Decode(');
       push("    '$b64',");
       push('  );');

--- a/packages/dart/lib/src/create.dart
+++ b/packages/dart/lib/src/create.dart
@@ -167,12 +167,19 @@ const int _pidCounterPos = 1987;
 const int _materialSchema = 12;
 const int _dibSchema = 3;
 
-/// Ground-truth byte pattern (not a meaningful float) that real SketchUp
-/// writes for a texture's "applied height" when the caller never
-/// explicitly overrides the texture's scale/aspect. Present verbatim
-/// rather than derived from a formula since its bit pattern doesn't
-/// correspond to any sensible height value (it decodes as ~1.29e-231 as an
-/// f64).
+/// Byte pattern found in one SDK-authored textured-material sample's
+/// "applied height" field, decoding to ~1.29e-231 as an f64 - not a
+/// meaningful height value. Confirmed 2026-08-27 via real SketchUp
+/// screenshots that a material written with this exact value renders as a
+/// corrupted, vertically-smeared texture, so it was never a genuine
+/// "never scaled" default - almost certainly uninitialized memory in the
+/// one sample file this was calibrated against, given
+/// [writeTexturedMaterial]'s applied WIDTH is unconditionally 1.0 (a
+/// clearly deliberate value) with no equivalent garbage pattern. No
+/// longer used as this project's own default (that method now defaults to
+/// 1.0 instead) - kept only as a documented historical artifact of what
+/// real SketchUp can apparently write here.
+// ignore: unused_element
 final List<int> _textureHSentinel = _hexBytes('f0ffffffffffff0f');
 
 const int _definitionSchema = 11;
@@ -1029,18 +1036,17 @@ class _ArchiveWriter {
   /// CDib's image format tag (4 for PNG, 1 for JPEG - see
   /// [_detectImageSubtype]).
   ///
-  /// [appliedHeight], if given, is written in place of [_textureHSentinel]
-  /// (applied width stays a fixed 1.0 either way). Needed because the
-  /// reader's own ground-truth-derived UV formula divides a face's final UV
-  /// by the material's applied width/height EVEN for a positioned
-  /// (`frontUv`) mapping, not just the default projection - the sentinel
-  /// decodes to ~1.29e-231, and dividing by it blows up to an astronomical
-  /// value, which real SketchUp visibly renders as a corrupted,
-  /// vertically-smeared texture (confirmed against real SketchUp
-  /// 2026-08-27 via the Python writer - see create.py's own note on this).
-  /// A caller positioning this material via `frontUv`/`backUv` should pass
-  /// a real [appliedHeight] ([addImage] uses 1.0, matching its own pins'
-  /// 0..1 range) so that division is a no-op instead of a corruption.
+  /// [appliedHeight] defaults to 1.0, matching applied width (always 1.0,
+  /// unconditionally). Pass a different value for a textured material used
+  /// with default (unpositioned) projection, to make the texture repeat at
+  /// a specific real-world size instead of every 1 inch - the reader's own
+  /// ground-truth-derived UV formula divides a face's final UV by the
+  /// material's applied width/height, for a default-projected face exactly
+  /// as much as a positioned (`frontUv`/`backUv`) one. Until 2026-08-28
+  /// this defaulted to a corrupted sentinel byte pattern instead (see
+  /// [_textureHSentinel]'s own comment) - confirmed via real SketchUp
+  /// screenshots to render as a streaky, vertically-smeared texture
+  /// regardless of projection mode.
   int writeTexturedMaterial(String name, Uint8List imageBytes, String texturePath, int subtype,
       {double? appliedHeight}) {
     final slot = _newOfKnownClass('CMaterial', schema: _materialSchema);
@@ -1059,7 +1065,7 @@ class _ArchiveWriter {
       buf.addAll(_u32(90));
     }
     buf.addAll(_f64(1.0)); // applied width - ground truth default when unscaled
-    buf.addAll(appliedHeight != null ? _f64(appliedHeight) : _textureHSentinel);
+    buf.addAll(_f64(appliedHeight ?? 1.0));
     _writeStr(texturePath);
     // avg color (RGBA + pad + RGBA repeated) - neutral near-opaque white
     // rather than a real image average, since this project doesn't depend
@@ -2127,16 +2133,12 @@ class SkpBuilder implements GeometryHost {
   /// format is detected from the file's own magic bytes, not its
   /// extension. Same ordering rules as [addMaterial].
   ///
-  /// If this material will ever be used with `addFace`'s `frontUv`/
-  /// `backUv` pinning, pass `appliedHeight: 1.0` (matching those pins' own
-  /// 0..1 range) - the read-side UV formula divides by this field even for
-  /// a positioned mapping, and the default (an internal sentinel, real
-  /// SketchUp's own byte pattern for "never explicitly scaled") is
-  /// astronomically small, which corrupts ANY face using this material,
-  /// not just default-projected ones (confirmed against real SketchUp
-  /// 2026-08-27 - see [_ArchiveWriter.writeTexturedMaterial]'s own note).
-  /// Left at the default for the plain default-planar-projection case,
-  /// matching this method's original, narrower scope.
+  /// [appliedHeight] defaults to 1.0 (matching applied width, always 1.0).
+  /// Pass a different value to make a default-projected face's texture
+  /// repeat at a specific real-world size instead of every 1 inch - see
+  /// [_ArchiveWriter.writeTexturedMaterial]'s own comment for why this
+  /// field matters even for `addFace`'s `frontUv`/`backUv` pinning (a
+  /// positioned mapping still divides by it).
   int addTextureMaterial(String name, String imagePath, {double? appliedHeight}) {
     if (_geometryWriter != null) {
       throw SkpWriteError('addTextureMaterial must be called before any addFace calls');
@@ -2397,14 +2399,10 @@ class SkpBuilder implements GeometryHost {
   ///
   /// The image's quad and UV mapping are pinned explicitly (`addFace`'s
   /// `frontUv`), not left to the default per-material tile-size projection
-  /// - [addTextureMaterial] is called with `appliedHeight: 1.0` for exactly
-  /// this reason: the read-side UV formula divides by the material's
-  /// applied height even for a pinned mapping, and the library default
-  /// there (a ground-truth sentinel, not a real number) is astronomically
-  /// small - confirmed via real SketchUp screenshots (2026-08-27, Python
-  /// writer) to render as a corrupted, vertically-smeared texture when left
-  /// in place. 1.0 makes that division a no-op against this method's own
-  /// 0..1 pins.
+  /// - the read-side UV formula divides by the material's applied height
+  /// even for a pinned mapping, and [addTextureMaterial]'s default height
+  /// (1.0) makes that division a no-op against this method's own 0..1
+  /// pins.
   ///
   /// Unlike every other entity this writer produces, CImage's exact binary
   /// schema version (see `_imageSchema`) is a best-effort guess, not
@@ -2412,8 +2410,7 @@ class SkpBuilder implements GeometryHost {
   /// available. This project's own reader round-trips the result
   /// correctly, but real SketchUp's acceptance of the file is unverified
   /// beyond the Python port's own real-SketchUp test (placement/
-  /// orientation/texture all confirmed correct there after the
-  /// appliedHeight fix - see CHECKLIST.md).
+  /// orientation/texture all confirmed correct there - see CHECKLIST.md).
   void addImage(
     String imagePath,
     double width,
@@ -2424,7 +2421,7 @@ class SkpBuilder implements GeometryHost {
     int? layer,
     bool hidden = false,
   }) {
-    final mat = addTextureMaterial('__openskp_image_$_materialCount', imagePath, appliedHeight: 1.0);
+    final mat = addTextureMaterial('__openskp_image_$_materialCount', imagePath);
     late final ComponentDefinitionBuilder imageDef;
     imageDef = addComponentDefinition('Image$_definitionCount', (def) {
       // Standard (0,0)-at-bottom-left, V increasing upward - no vertical

--- a/packages/dart/lib/src/edit.dart
+++ b/packages/dart/lib/src/edit.dart
@@ -163,10 +163,9 @@ Map<Material, int> _replayMaterials(SkpBuilder builder, SkpModel model, List<Str
         // bake in the SOURCE's real tile size via computeFaceUv - the
         // material's own stored applied height must be a no-op divisor
         // (1.0) or the read-side UV formula divides by it a second time.
-        // Leaving this at the library default (an internal sentinel,
-        // ~1.29e-231) was confirmed against real SketchUp 2026-08-27 to
-        // corrupt the texture into a vertically-smeared mess - see
-        // addTextureMaterial's own note.
+        // This happens to match addTextureMaterial's own default too, but
+        // is kept explicit here since it's a hard requirement of this
+        // call site specifically, not just a safe default.
         slot = builder.addTextureMaterial(mat.name, tmpFile.path, appliedHeight: 1.0);
       } finally {
         tmpDir.deleteSync(recursive: true);

--- a/packages/dart/test/create_test.dart
+++ b/packages/dart/test/create_test.dart
@@ -371,6 +371,47 @@ void main() {
       }
     });
 
+    test('default applied height is 1.0, not the corrupted sentinel', () {
+      // Regression test for a real bug: until 2026-08-28, an omitted
+      // appliedHeight wrote a corrupted internal sentinel byte pattern
+      // (~1.29e-231) instead of a real number - confirmed via real
+      // SketchUp screenshots to render as a streaky, vertically-smeared
+      // texture. addTextureMaterial's applied WIDTH is unconditionally
+      // 1.0 (a deliberate ground-truth value); height should match it by
+      // default now, not silently corrupt every caller who doesn't know
+      // to pass appliedHeight: 1.0 explicitly.
+      final tmpDir = Directory.systemTemp.createTempSync('openskp_tex_');
+      final pngPath = '${tmpDir.path}${Platform.pathSeparator}tex.png';
+      File(pngPath).writeAsBytesSync(makeFakePng());
+      try {
+        final builder = create();
+        final tex = builder.addTextureMaterial('Brick', pngPath);
+        builder.addFace(square, material: tex);
+        final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+        final mat = model.materials.single;
+        expect(mat.texture!.width, 1.0);
+        expect(mat.texture!.height, 1.0);
+      } finally {
+        tmpDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('explicit applied height is still overridable', () {
+      final tmpDir = Directory.systemTemp.createTempSync('openskp_tex_');
+      final pngPath = '${tmpDir.path}${Platform.pathSeparator}tex.png';
+      File(pngPath).writeAsBytesSync(makeFakePng());
+      try {
+        final builder = create();
+        final tex = builder.addTextureMaterial('Brick', pngPath, appliedHeight: 48.0);
+        builder.addFace(square, material: tex);
+        final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+        final mat = model.materials.single;
+        expect(mat.texture!.height, 48.0);
+      } finally {
+        tmpDir.deleteSync(recursive: true);
+      }
+    });
+
     test('an unrecognized image format throws', () {
       final tmpDir = Directory.systemTemp.createTempSync('openskp_tex_');
       final badPath = '${tmpDir.path}${Platform.pathSeparator}tex.jpg';

--- a/packages/dotnet/OpenSkp.Tests/CreateTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CreateTests.cs
@@ -187,6 +187,56 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
+        public void TexturedMaterialDefaultAppliedHeightIsOneNotCorrupted()
+        {
+            // Regression test for a real bug: until 2026-08-28, an omitted
+            // appliedHeight wrote a corrupted internal sentinel byte
+            // pattern (~1.29e-231) instead of a real number - confirmed
+            // via real SketchUp screenshots to render as a streaky,
+            // vertically-smeared texture. AddTextureMaterial's applied
+            // WIDTH is unconditionally 1.0 (a deliberate ground-truth
+            // value); height should match it by default now, not
+            // silently corrupt every caller who doesn't know to pass
+            // appliedHeight: 1.0 explicitly.
+            string pngPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+            File.WriteAllBytes(pngPath, TinyPng());
+            try
+            {
+                var builder = SkpCreate.NewFile();
+                int brick = builder.AddTextureMaterial("Brick", pngPath);
+                builder.AddFace(Square(), material: brick);
+                var model = SkpFile.Parse(builder.ToBytes());
+                var mat = model.Materials.Single();
+                Assert.Equal(1.0, mat.Texture!.Width);
+                Assert.Equal(1.0, mat.Texture.Height);
+            }
+            finally
+            {
+                File.Delete(pngPath);
+            }
+        }
+
+        [Fact]
+        public void TexturedMaterialExplicitAppliedHeightStillOverridable()
+        {
+            string pngPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+            File.WriteAllBytes(pngPath, TinyPng());
+            try
+            {
+                var builder = SkpCreate.NewFile();
+                int brick = builder.AddTextureMaterial("Brick", pngPath, appliedHeight: 48.0);
+                builder.AddFace(Square(), material: brick);
+                var model = SkpFile.Parse(builder.ToBytes());
+                var mat = model.Materials.Single();
+                Assert.Equal(48.0, mat.Texture!.Height);
+            }
+            finally
+            {
+                File.Delete(pngPath);
+            }
+        }
+
+        [Fact]
         public void UnrecognizedImageFormatThrows()
         {
             string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".bin");

--- a/packages/dotnet/OpenSkp/Codegen.cs
+++ b/packages/dotnet/OpenSkp/Codegen.cs
@@ -85,13 +85,13 @@ namespace OpenSkp
                     string b64 = Convert.ToBase64String(mat.Texture.Data);
                     string ext = System.IO.Path.GetExtension(mat.Texture.Filename ?? "");
                     if (string.IsNullOrEmpty(ext)) ext = ".png";
-                    // appliedHeight: 1.0 - see AddTextureMaterial's own note
-                    // on why the library default (an internal sentinel)
-                    // corrupts ANY face using this material. Every face
-                    // using a textured material is written below with
-                    // explicit frontUv/backUv, never left to default
-                    // projection, so the original applied width/height
-                    // never needs to be reproduced.
+                    // appliedHeight: 1.0 - every face using a textured
+                    // material is written below with explicit
+                    // frontUv/backUv, never left to default projection,
+                    // so the material's own applied height must be an
+                    // exact no-op divisor (matches AddTextureMaterial's
+                    // own default too, but kept explicit since it's a
+                    // hard requirement here, not just a safe default).
                     Push($"        var _texPath{i} = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + \"{ext}\");");
                     Push($"        System.IO.File.WriteAllBytes(_texPath{i}, Convert.FromBase64String(\"{b64}\"));");
                     Push("        int " + varName + $" = builder.AddTextureMaterial({CsString(mat.Name)}, _texPath{i}, appliedHeight: 1.0);");

--- a/packages/dotnet/OpenSkp/Create.cs
+++ b/packages/dotnet/OpenSkp/Create.cs
@@ -185,13 +185,19 @@ namespace OpenSkp
         internal const int MaterialSchema = 12;
         internal const int DibSchema = 3;
 
-        // Ground-truth byte pattern (not a meaningful float) that real
-        // SketchUp writes for a texture's "applied height" when the caller
-        // never explicitly overrides the texture's scale/aspect - found by
-        // diffing an SDK-authored textured-material file; present verbatim
-        // rather than derived from a formula since its bit pattern doesn't
-        // correspond to any sensible height value (it decodes as ~1.29e-231
-        // as an f64).
+        // Byte pattern found in one SDK-authored textured-material sample's
+        // "applied height" field, decoding to ~1.29e-231 as an f64 - not a
+        // meaningful height value. Confirmed 2026-08-27 via real SketchUp
+        // screenshots that a material written with this exact value renders
+        // as a corrupted, vertically-smeared texture, so it was never a
+        // genuine "never scaled" default - almost certainly uninitialized
+        // memory in the one sample file this was calibrated against, given
+        // WriteTexturedMaterial's applied WIDTH is unconditionally 1.0 (a
+        // clearly deliberate value) with no equivalent garbage pattern. No
+        // longer used as this project's own default (see
+        // WriteTexturedMaterial, which now defaults to 1.0 instead) - kept
+        // only as a documented historical artifact of what real SketchUp
+        // can apparently write here.
         internal static readonly byte[] TextureHSentinel = FromHex("f0ffffffffffff0f");
 
         internal const int DefinitionSchema = 11;
@@ -1071,20 +1077,19 @@ namespace OpenSkp
         /// slot. texturePath is stored as-is. subtype is CDib's image
         /// format tag (4 for PNG, 1 for JPEG).
         ///
-        /// appliedHeight, if given, is written in place of
-        /// CreateConstants.TextureHSentinel (applied width stays a fixed
-        /// 1.0 either way). Needed because the reader's own
-        /// ground-truth-derived UV formula divides a face's final UV by
-        /// the material's applied width/height EVEN for a positioned
-        /// (frontUv) mapping, not just the default projection - the
-        /// sentinel decodes to ~1.29e-231, and dividing by it blows up to
-        /// an astronomical value, which real SketchUp visibly renders as a
-        /// corrupted, vertically-smeared texture (confirmed against real
-        /// SketchUp 2026-08-27 via the Python writer - see create.py's own
-        /// note on this). A caller positioning this material via
-        /// frontUv/backUv should pass a real appliedHeight (AddImage uses
-        /// 1.0, matching its own pins' 0..1 range) so that division is a
-        /// no-op instead of a corruption.</summary>
+        /// appliedHeight defaults to 1.0, matching applied width (always
+        /// 1.0, unconditionally). Pass a different value for a textured
+        /// material used with default (unpositioned) projection, to make
+        /// the texture repeat at a specific real-world size instead of
+        /// every 1 inch - the reader's own ground-truth-derived UV formula
+        /// divides a face's final UV by the material's applied
+        /// width/height, for a default-projected face exactly as much as
+        /// a positioned (frontUv/backUv) one. Until 2026-08-28 this
+        /// defaulted to a corrupted sentinel byte pattern instead (see
+        /// CreateConstants.TextureHSentinel's own comment) - confirmed via
+        /// real SketchUp screenshots to render as a streaky,
+        /// vertically-smeared texture regardless of projection
+        /// mode.</summary>
         internal int WriteTexturedMaterial(string name, byte[] imageBytes, string texturePath, int subtype, double? appliedHeight = null)
         {
             int slot = NewOfKnownClass("CMaterial", CreateConstants.MaterialSchema);
@@ -1104,14 +1109,7 @@ namespace OpenSkp
                 AddU32(90);
             }
             AddF64(1.0); // applied width - ground truth default when unscaled
-            if (appliedHeight.HasValue)
-            {
-                AddF64(appliedHeight.Value);
-            }
-            else
-            {
-                AddRaw(CreateConstants.TextureHSentinel);
-            }
+            AddF64(appliedHeight ?? 1.0);
             WriteStr(texturePath);
             // avg color (RGBA + pad + RGBA repeated) - neutral near-opaque
             // white rather than a real image average, since this project
@@ -2171,17 +2169,12 @@ namespace OpenSkp
         /// project has confirmed the on-disk CDib subtype tag for via SDK
         /// ground truth. Same ordering rules as AddMaterial.
         ///
-        /// If this material will ever be used with AddFace's frontUv/
-        /// backUv pinning, pass appliedHeight: 1.0 (matching those pins'
-        /// own 0..1 range) - the read-side UV formula divides by this
-        /// field even for a positioned mapping, and the default (an
-        /// internal sentinel, real SketchUp's own byte pattern for "never
-        /// explicitly scaled") is astronomically small, which corrupts ANY
-        /// face using this material, not just default-projected ones
-        /// (confirmed against real SketchUp 2026-08-27 - see
-        /// WriteTexturedMaterial's own note). Left at the default for the
-        /// plain default-planar-projection case, matching this method's
-        /// original, narrower scope.</summary>
+        /// appliedHeight defaults to 1.0 (matching applied width, always
+        /// 1.0). Pass a different value to make a default-projected
+        /// face's texture repeat at a specific real-world size instead of
+        /// every 1 inch - see WriteTexturedMaterial's own note for why
+        /// this field matters even for AddFace's frontUv/backUv pinning
+        /// (a positioned mapping still divides by it).</summary>
         public int AddTextureMaterial(string name, string imagePath, double? appliedHeight = null)
         {
             if (_geometryWriter != null)
@@ -2439,15 +2432,10 @@ namespace OpenSkp
         ///
         /// The image's quad and UV mapping are pinned explicitly (AddFace's
         /// frontUv), not left to the default per-material tile-size
-        /// projection - AddTextureMaterial is called with appliedHeight:
-        /// 1.0 for exactly this reason: the read-side UV formula divides
-        /// by the material's applied height even for a pinned mapping, and
-        /// the library default there (a ground-truth sentinel, not a real
-        /// number) is astronomically small - confirmed via real SketchUp
-        /// screenshots (2026-08-27, Python writer) to render as a
-        /// corrupted, vertically-smeared texture when left in place. 1.0
-        /// makes that division a no-op against this method's own 0..1
-        /// pins.
+        /// projection - the read-side UV formula divides by the
+        /// material's applied height even for a pinned mapping, and
+        /// AddTextureMaterial's default height (1.0) makes that division
+        /// a no-op against this method's own 0..1 pins.
         ///
         /// Unlike every other entity this writer produces, CImage's exact
         /// binary schema version (see CreateConstants.ImageSchema) is a
@@ -2456,8 +2444,7 @@ namespace OpenSkp
         /// project's own reader round-trips the result correctly, but real
         /// SketchUp's acceptance of the file is unverified beyond the
         /// Python port's own real-SketchUp test (placement/orientation/
-        /// texture all confirmed correct there after the appliedHeight fix
-        /// - see CHECKLIST.md).</summary>
+        /// texture all confirmed correct there - see CHECKLIST.md).</summary>
         public void AddImage(
             string imagePath, double width, double height,
             (double X, double Y, double Z) translation = default,
@@ -2466,7 +2453,7 @@ namespace OpenSkp
             int? layer = null,
             bool hidden = false)
         {
-            int mat = AddTextureMaterial($"__openskp_image_{_materialCount}", imagePath, appliedHeight: 1.0);
+            int mat = AddTextureMaterial($"__openskp_image_{_materialCount}", imagePath);
             ComponentDefinitionBuilder imageDef;
             using (imageDef = AddComponentDefinition($"Image{_definitionCount}"))
             {

--- a/packages/dotnet/OpenSkp/Edit.cs
+++ b/packages/dotnet/OpenSkp/Edit.cs
@@ -175,12 +175,11 @@ namespace OpenSkp
                         // SOURCE's real tile size via ComputeFaceUv - the
                         // material's own stored applied height must be a
                         // no-op divisor (1.0) or the read-side UV formula
-                        // divides by it a second time. Leaving this at the
-                        // library default (an internal sentinel,
-                        // ~1.29e-231) was confirmed against real SketchUp
-                        // 2026-08-27 to corrupt the texture into a
-                        // vertically-smeared mess - see
-                        // AddTextureMaterial's own note.
+                        // divides by it a second time. This happens to
+                        // match AddTextureMaterial's own default too, but
+                        // is kept explicit here since it's a hard
+                        // requirement of this call site specifically, not
+                        // just a safe default.
                         slot = builder.AddTextureMaterial(mat.Name, tmpPath, appliedHeight: 1.0);
                     }
                     finally

--- a/packages/python/src/openskp/codegen.py
+++ b/packages/python/src/openskp/codegen.py
@@ -138,12 +138,12 @@ def to_python_code(model: SkpModel) -> str:
             b64 = base64.b64encode(mat.texture.data).decode("ascii")
             suffix = "".join(ch for ch in (mat.texture.filename or "").rsplit(".", 1)[-1:] if ch.isalnum())
             suffix = f".{suffix}" if suffix else ".png"
-            # appliedHeight=1.0 - see add_texture_material's own note on
-            # why the library default (an internal sentinel) corrupts ANY
-            # face using this material. Every face using a textured
-            # material is written below with explicit front_uv/back_uv,
-            # never left to default projection, so the original applied
-            # width/height never needs to be reproduced.
+            # applied_height=1.0 - every face using a textured material is
+            # written below with explicit front_uv/back_uv, never left to
+            # default projection, so the material's own applied height
+            # must be an exact no-op divisor (matches
+            # add_texture_material's own default too, but kept explicit
+            # since it's a hard requirement here, not just a safe default).
             push(f"    _tex_fd, _tex_path = tempfile.mkstemp(suffix={suffix!r})")
             push("    with os.fdopen(_tex_fd, 'wb') as _f:")
             push(f"        _f.write(base64.b64decode({b64!r}))")

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -192,12 +192,17 @@ _PID_COUNTER_POS = 1987
 _MATERIAL_SCHEMA = 12
 _DIB_SCHEMA = 3
 
-# Ground-truth byte pattern (not a meaningful float) that real SketchUp
-# writes for a texture's "applied height" when the caller never explicitly
-# overrides the texture's scale/aspect - found by diffing an SDK-authored
-# textured-material file; present verbatim rather than derived from a
-# formula since its bit pattern doesn't correspond to any sensible height
-# value (it decodes as ~1.29e-231 as an f64).
+# Byte pattern found in one SDK-authored textured-material sample's "applied
+# height" field, decoding to ~1.29e-231 as an f64 - not a meaningful height
+# value. Confirmed 2026-08-27 via real SketchUp screenshots that a material
+# written with this exact value renders as a corrupted, vertically-smeared
+# texture, so it was never a genuine "never scaled" default - almost
+# certainly uninitialized memory in the one sample file this was calibrated
+# against, given `write_textured_material`'s applied WIDTH is unconditionally
+# 1.0 (a clearly deliberate value) with no equivalent garbage pattern. No
+# longer used as this project's own default (see write_textured_material,
+# which now defaults to 1.0 instead) - kept only as a documented historical
+# artifact of what real SketchUp can apparently write here.
 _TEXTURE_H_SENTINEL = bytes.fromhex("f0ffffffffffff0f")
 
 _DEFINITION_SCHEMA = 11
@@ -921,22 +926,19 @@ class _ArchiveWriter:
         string round-trips fine structurally. ``subtype`` is CDib's image
         format tag (4 for PNG, 1 for JPEG - see :func:`_detect_image_subtype`).
 
-        ``applied_height``, if given, is written in place of
-        ``_TEXTURE_H_SENTINEL`` (applied width stays a fixed 1.0 either
-        way). Needed because `_face_groups.compute_face_uv` - this
-        project's own reverse-engineered, ground-truth-derived read-side
-        formula - divides a face's final UV by the material's applied
-        width/height EVEN for a `write_face`-positioned (``front_uv``)
-        mapping, not just the default projection. The sentinel decodes to
-        ~1.29e-231 - dividing by it blows up to an astronomical value,
-        which real SketchUp visibly renders as a corrupted, vertically-
-        smeared texture (confirmed 2026-08-27: two independent real-
-        SketchUp screenshots of a sentinel-height material, one default-
-        projected and one front_uv-positioned, showed the identical
-        streaky corruption). A caller that's going to position this
-        material via `front_uv`/`back_uv` should pass a real
-        ``applied_height`` (`add_image` uses 1.0, matching its own pins'
-        0..1 range) so that division is a no-op instead of a corruption.
+        ``applied_height`` defaults to 1.0, matching applied width (always
+        1.0, unconditionally). Pass a different value for a textured
+        material used with default (unpositioned) projection, to make the
+        texture repeat at a specific real-world size instead of every 1
+        inch - `_face_groups.compute_face_uv`, this project's own
+        reverse-engineered read-side formula, divides a face's final UV by
+        the material's applied width/height, for a default-projected face
+        exactly as much as a `front_uv`/`back_uv`-positioned one. Until
+        2026-08-28 this defaulted to a corrupted sentinel byte pattern
+        instead (see ``_TEXTURE_H_SENTINEL``'s own comment) - confirmed via
+        real SketchUp screenshots to render as a streaky, vertically-smeared
+        texture regardless of projection mode, so every prior caller that
+        didn't explicitly override it was shipping a broken texture.
         """
         slot = self._new_of_known_class("CMaterial", schema=_MATERIAL_SCHEMA)
         self._preamble()
@@ -955,7 +957,7 @@ class _ArchiveWriter:
             # project computes from the image; PNG has no such field.
             self.buf += _u32(90)
         self.buf += _f64(1.0)  # applied width - ground truth default when unscaled
-        self.buf += _f64(applied_height) if applied_height is not None else _TEXTURE_H_SENTINEL
+        self.buf += _f64(applied_height if applied_height is not None else 1.0)
         self._write_str(texture_path)
         # avg color (RGBA + pad + RGBA repeated, per legacy.py's _read_material
         # comment) - neutral near-opaque white rather than a real image
@@ -2081,16 +2083,12 @@ class SkpBuilder:
         truth (4 and 1 respectively; see :meth:`_ArchiveWriter.
         write_textured_material`).
 
-        If this material will ever be used with `add_face`'s ``front_uv``/
-        ``back_uv`` pinning, pass ``applied_height=1.0`` (matching those
-        pins' own 0..1 range) - the read-side UV formula divides by this
-        field even for a positioned mapping, and the default (an internal
-        sentinel, real SketchUp's own byte pattern for "never explicitly
-        scaled") is astronomically small, which corrupts ANY face using
-        this material, not just default-projected ones (confirmed against
-        real SketchUp 2026-08-27 - see `write_textured_material`'s own
-        note). Left at the default for the plain default-planar-projection
-        case, matching this method's original, narrower scope.
+        ``applied_height`` defaults to 1.0 (matching applied width, always
+        1.0). Pass a different value to make a default-projected face's
+        texture repeat at a specific real-world size instead of every 1
+        inch - see `write_textured_material`'s own docstring for why this
+        field matters even for `add_face`'s ``front_uv``/``back_uv``
+        pinning (a positioned mapping still divides by it).
 
         Same ordering rules as `add_material` - must be called before any
         `add_layer`, `add_component_definition`, or `add_face` call.
@@ -2392,14 +2390,10 @@ class SkpBuilder:
 
         The image's quad and UV mapping are pinned explicitly (`add_face`'s
         ``front_uv``), not left to the default per-material tile-size
-        projection - `add_texture_material` is called with
-        ``applied_height=1.0`` for exactly this reason: the read-side UV
-        formula divides by the material's applied height even for a
-        pinned mapping, and the library default there (a ground-truth
-        sentinel, not a real number) is astronomically small - confirmed
-        via real SketchUp screenshots (2026-08-27) to render as a
-        corrupted, vertically-smeared texture when left in place. 1.0
-        makes that division a no-op against this method's own 0..1 pins.
+        projection - the read-side UV formula divides by the material's
+        applied height even for a pinned mapping, and `add_texture_material`'s
+        default height (1.0) makes that division a no-op against this
+        method's own 0..1 pins.
 
         ⚠️ Unlike every other entity this writer produces, CImage's exact
         binary schema version (see `_IMAGE_SCHEMA`) is a best-effort guess,
@@ -2409,9 +2403,7 @@ class SkpBuilder:
         unverified - open the output in real SketchUp before relying on
         this, and please report back what you find either way.
         """
-        mat = self.add_texture_material(
-            f"__openskp_image_{self._material_count}", image_path, applied_height=1.0,
-        )
+        mat = self.add_texture_material(f"__openskp_image_{self._material_count}", image_path)
         with self.add_component_definition(f"Image{self._definition_count}") as image_def:
             # Standard (0,0)-at-bottom-left, V increasing upward - no
             # vertical flip. Every other UV-related fact in this file is

--- a/packages/python/src/openskp/edit.py
+++ b/packages/python/src/openskp/edit.py
@@ -176,11 +176,10 @@ def _replay_materials(builder: SkpBuilder, model: SkpModel, warnings: List[str])
                 # pins already bake in the SOURCE's real tile size via
                 # compute_face_uv - the material's own stored applied
                 # height must be a no-op divisor (1.0) or the read-side UV
-                # formula divides by it a second time. Leaving this at the
-                # library default (an internal sentinel, ~1.29e-231) was
-                # confirmed against real SketchUp 2026-08-27 to corrupt the
-                # texture into a vertically-smeared mess - see
-                # add_texture_material's own note.
+                # formula divides by it a second time. This happens to
+                # match add_texture_material's own default too, but is
+                # kept explicit here since it's a hard requirement of this
+                # call site specifically, not just a safe default.
                 slot = builder.add_texture_material(mat.name, tmp_path, applied_height=1.0)
             finally:
                 os.unlink(tmp_path)

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1110,6 +1110,41 @@ class TestTextures:
         face = [v for (_, n, v) in root if n == "CFace"][0]
         assert face["db"]["mat"] == tex
 
+    def test_texture_material_default_applied_height_is_one_not_corrupted(self, tmp_path):
+        # Regression test for a real bug: until 2026-08-28, an omitted
+        # applied_height wrote a corrupted internal sentinel byte pattern
+        # (~1.29e-231) instead of a real number - confirmed via real
+        # SketchUp screenshots to render as a streaky, vertically-smeared
+        # texture. add_texture_material's applied WIDTH is unconditionally
+        # 1.0 (a deliberate ground-truth value); height should match it by
+        # default now, not silently corrupt every caller who doesn't know
+        # to pass applied_height=1.0 explicitly.
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png(size=4, rgb=(200, 50, 50)))
+
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        builder.add_face(SQUARE, material=tex)
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        mat_by_slot = {s: v for s, v in materials}
+        assert mat_by_slot[tex]["tex_w"] == 1.0
+        assert mat_by_slot[tex]["tex_h"] == 1.0
+
+    def test_texture_material_explicit_applied_height_still_overridable(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png(size=4, rgb=(200, 50, 50)))
+
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path), applied_height=48.0)
+        builder.add_face(SQUARE, material=tex)
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        mat_by_slot = {s: v for s, v in materials}
+        assert mat_by_slot[tex]["tex_h"] == 48.0
+
     def test_jpeg_texture_material_self_parses(self, tmp_path):
         jpg_path = tmp_path / "tex.jpg"
         jpg_path.write_bytes(_JPEG_FIXTURE)

--- a/packages/typescript/src/codegen.ts
+++ b/packages/typescript/src/codegen.ts
@@ -113,12 +113,12 @@ export function toTypeScriptCode(model: SkpModel): string {
     if (mat.texture && mat.texture.data) {
       texturedMats.add(mat.name);
       const b64 = toBase64(mat.texture.data);
-      // appliedHeight: 1.0 - see addTextureMaterial's own note on why the
-      // library default (an internal sentinel) corrupts ANY face using
-      // this material. Every face using a textured material is written
-      // below with explicit frontUv/backUv, never left to default
-      // projection, so the original applied width/height never needs to
-      // be reproduced.
+      // appliedHeight: 1.0 - every face using a textured material is
+      // written below with explicit frontUv/backUv, never left to
+      // default projection, so the material's own applied height must be
+      // an exact no-op divisor (matches addTextureMaterial's own default
+      // too, but kept explicit since it's a hard requirement here, not
+      // just a safe default).
       //
       // atob/charCodeAt (not Buffer) so the generated code runs in a
       // browser too, matching addTextureMaterial's own byte-based (not

--- a/packages/typescript/src/create.ts
+++ b/packages/typescript/src/create.ts
@@ -139,11 +139,19 @@ const PID_COUNTER_POS = 1987;
 const MATERIAL_SCHEMA = 12;
 const DIB_SCHEMA = 3;
 
-/** Ground-truth byte pattern (not a meaningful float) real SketchUp
- * writes for a texture's "applied height" when unscaled - present
- * verbatim since its bit pattern doesn't correspond to any sensible
- * height value (~1.29e-231 as an f64). */
-const TEXTURE_H_SENTINEL = hexToBytes('f0ffffffffffff0f');
+/** Byte pattern found in one SDK-authored textured-material sample's
+ * "applied height" field, decoding to ~1.29e-231 as an f64 - not a
+ * meaningful height value. Confirmed 2026-08-27 via real SketchUp
+ * screenshots that a material written with this exact value renders as a
+ * corrupted, vertically-smeared texture, so it was never a genuine
+ * "never scaled" default - almost certainly uninitialized memory in the
+ * one sample file this was calibrated against, given `writeTexturedMaterial`'s
+ * applied WIDTH is unconditionally 1.0 (a clearly deliberate value) with
+ * no equivalent garbage pattern. No longer used as this project's own
+ * default (see `writeTexturedMaterial`, which now defaults to 1.0
+ * instead) - kept only as a documented historical artifact of what real
+ * SketchUp can apparently write here. */
+const _TEXTURE_H_SENTINEL = hexToBytes('f0ffffffffffff0f');
 
 const DEFINITION_SCHEMA = 11;
 const INSTANCE_SCHEMA = 6;
@@ -760,18 +768,17 @@ class ArchiveWriter {
    * verbatim inside a CDib sub-object) and return its slot. `subtype` is
    * CDib's image format tag (4 for PNG, 1 for JPEG).
    *
-   * `appliedHeight`, if given, is written in place of TEXTURE_H_SENTINEL
-   * (applied width stays a fixed 1.0 either way). Needed because the
-   * reader's own ground-truth-derived UV formula divides a face's final
-   * UV by the material's applied width/height EVEN for a positioned
-   * (`frontUv`) mapping, not just the default projection - the sentinel
-   * decodes to ~1.29e-231, and dividing by it blows up to an astronomical
-   * value, which real SketchUp visibly renders as a corrupted,
-   * vertically-smeared texture (confirmed against real SketchUp
-   * 2026-08-27 via the Python writer - see create.py's own note on this).
-   * A caller positioning this material via `frontUv`/`backUv` should pass
-   * a real `appliedHeight` (addImage uses 1.0, matching its own pins'
-   * 0..1 range) so that division is a no-op instead of a corruption. */
+   * `appliedHeight` defaults to 1.0, matching applied width (always 1.0,
+   * unconditionally). Pass a different value for a textured material used
+   * with default (unpositioned) projection, to make the texture repeat at
+   * a specific real-world size instead of every 1 inch - the reader's own
+   * ground-truth-derived UV formula divides a face's final UV by the
+   * material's applied width/height, for a default-projected face exactly
+   * as much as a positioned (`frontUv`/`backUv`) one. Until 2026-08-28
+   * this defaulted to a corrupted sentinel byte pattern instead (see
+   * _TEXTURE_H_SENTINEL's own comment) - confirmed via real SketchUp
+   * screenshots to render as a streaky, vertically-smeared texture
+   * regardless of projection mode. */
   writeTexturedMaterial(
     name: string, imageBytes: Uint8Array, texturePath: string, subtype: number, appliedHeight?: number
   ): number {
@@ -791,11 +798,7 @@ class ArchiveWriter {
       this.pushU32(90);
     }
     this.pushF64(1.0); // applied width - ground truth default when unscaled
-    if (appliedHeight !== undefined) {
-      this.pushF64(appliedHeight);
-    } else {
-      this.pushBytes(TEXTURE_H_SENTINEL);
-    }
+    this.pushF64(appliedHeight !== undefined ? appliedHeight : 1.0);
     this.writeStr(texturePath);
     // avg color: neutral near-opaque white, alpha 254 not 255 - legacy.ts's
     // own reader treats alpha=255 here as one of its two "this material is
@@ -1630,11 +1633,12 @@ export class SkpBuilder {
    * record (SketchUp shows it as the texture's original file path); it
    * has no effect on the embedded image bytes themselves.
    *
-   * If this material will ever be used with addFace's `frontUv`/`backUv`
-   * pinning, pass `appliedHeight: 1.0` (matching those pins' own 0..1
-   * range) - see writeTexturedMaterial's own note on why the default
-   * (an internal sentinel) corrupts any face using this material, not
-   * just default-projected ones. */
+   * `appliedHeight` defaults to 1.0 (matching applied width, always 1.0).
+   * Pass a different value to make a default-projected face's texture
+   * repeat at a specific real-world size instead of every 1 inch - see
+   * writeTexturedMaterial's own comment for why this field matters even
+   * for addFace's `frontUv`/`backUv` pinning (a positioned mapping still
+   * divides by it). */
   addTextureMaterial(name: string, imageBytes: Uint8Array, texturePath = '', appliedHeight?: number): number {
     if (this.geometryWriter !== null) {
       throw new SkpWriteError('addTextureMaterial must be called before any addFace calls');
@@ -1821,14 +1825,10 @@ export class SkpBuilder {
    *
    * The image's quad and UV mapping are pinned explicitly (addFace's
    * `frontUv`), not left to the default per-material tile-size projection
-   * - addTextureMaterial is called with `appliedHeight: 1.0` for exactly
-   * this reason: the read-side UV formula divides by the material's
-   * applied height even for a pinned mapping, and the library default
-   * there (a ground-truth sentinel, not a real number) is astronomically
-   * small - confirmed via real SketchUp screenshots (2026-08-27, Python
-   * writer) to render as a corrupted, vertically-smeared texture when
-   * left in place. 1.0 makes that division a no-op against this method's
-   * own 0..1 pins.
+   * - the read-side UV formula divides by the material's applied height
+   * even for a pinned mapping, and addTextureMaterial's default height
+   * (1.0) makes that division a no-op against this method's own 0..1
+   * pins.
    *
    * ⚠️ Unlike every other entity this writer produces, CImage's exact
    * binary schema version (see IMAGE_SCHEMA) is a best-effort guess, not
@@ -1836,12 +1836,9 @@ export class SkpBuilder {
    * available. This project's own reader round-trips the result
    * correctly, but real SketchUp's acceptance of the file is unverified
    * beyond the Python port's own real-SketchUp test (placement/
-   * orientation/texture all confirmed correct there after the
-   * appliedHeight fix - see CHECKLIST.md). */
+   * orientation/texture all confirmed correct there - see CHECKLIST.md). */
   addImage(imageBytes: Uint8Array, width: number, height: number, options: AddImageOptions = {}): void {
-    const mat = this.addTextureMaterial(
-      `__openskp_image_${this.materialCount}`, imageBytes, options.texturePath ?? '', 1.0
-    );
+    const mat = this.addTextureMaterial(`__openskp_image_${this.materialCount}`, imageBytes, options.texturePath ?? '');
     const imageDef = this.addComponentDefinition(`Image${this.definitionCount}`, (def) => {
       // Standard (0,0)-at-bottom-left, V increasing upward - no vertical
       // flip. Every other UV-related fact in this file is calibrated

--- a/packages/typescript/src/edit.ts
+++ b/packages/typescript/src/edit.ts
@@ -54,10 +54,11 @@
  *   source mapping won't interpolate identically between them. A
  *   *projected* (draped) texture has no equivalent at all and falls back
  *   to the default projection.
- * - A material's original texture tile size isn't preserved -
- *   `addTextureMaterial` has no scale parameter yet. A colorized
- *   (tinted) material variant is replayed as its plain source texture,
- *   losing the tint.
+ * - A colorized (tinted) material variant is replayed as its plain
+ *   source texture, losing the tint. A material's real-world texture
+ *   tile size *is* preserved, via an explicit frontUv/backUv pin
+ *   computed from it on every replayed textured face (not left to
+ *   addTextureMaterial's own default projection).
  * - Per-face material/layer painting: only a face's front/back
  *   *material* is replayed - this package's reader doesn't expose a
  *   per-face layer assignment at all (only instances carry an explicit
@@ -205,10 +206,15 @@ function replayMaterials(builder: SkpBuilder, model: SkpModel, warnings: string[
   for (const mat of model.materials) {
     let slot: number;
     if (mat.texture !== null && mat.texture.data !== null) {
-      slot = builder.addTextureMaterial(mat.name, mat.texture.data, mat.texture.filename || 'texture');
-      if (mat.texture.width || mat.texture.height) {
-        warnings.push(`material ${JSON.stringify(mat.name)}: original texture tile size not preserved`);
-      }
+      // appliedHeight: 1.0 - every textured face is now replayed with an
+      // explicit frontUv/backUv (see replayUv), whose pins already bake
+      // in the SOURCE's real tile size via computeFaceUv - the
+      // material's own stored applied height must be a no-op divisor
+      // (1.0) or the read-side UV formula divides by it a second time.
+      // This happens to match addTextureMaterial's own default too, but
+      // is kept explicit here since it's a hard requirement of this call
+      // site specifically, not just a safe default.
+      slot = builder.addTextureMaterial(mat.name, mat.texture.data, mat.texture.filename || 'texture', 1.0);
       if (mat.colorized) {
         warnings.push(`material ${JSON.stringify(mat.name)}: colorized tint not reproduced (base texture only)`);
       }
@@ -381,6 +387,34 @@ function replayFace(
   }
 }
 
+// front_uv/back_uv need exactly 3 correspondences whose (u, v) values are
+// NOT collinear (an affine fit is impossible otherwise) - real faces can
+// have a "flat" vertex (three consecutive vertices genuinely collinear in
+// 3D, seen on real building geometry), which points[0..2] alone isn't
+// guaranteed to avoid. Search for the first non-collinear triple instead of
+// assuming the first 3 vertices work.
+function nonCollinearTriple(points: readonly Point3[]): [Point3, Point3, Point3] | undefined {
+  for (let i = 0; i < points.length; i++) {
+    for (let j = i + 1; j < points.length; j++) {
+      for (let k = j + 1; k < points.length; k++) {
+        const [ax, ay, az] = points[i];
+        const [bx, by, bz] = points[j];
+        const [cx, cy, cz] = points[k];
+        const e1 = [bx - ax, by - ay, bz - az];
+        const e2 = [cx - ax, cy - ay, cz - az];
+        const cross = [
+          e1[1] * e2[2] - e1[2] * e2[1],
+          e1[2] * e2[0] - e1[0] * e2[2],
+          e1[0] * e2[1] - e1[1] * e2[0],
+        ];
+        const mag2 = cross[0] * cross[0] + cross[1] * cross[1] + cross[2] * cross[2];
+        if (mag2 > 1e-9) return [points[i], points[j], points[k]];
+      }
+    }
+  }
+  return undefined;
+}
+
 function replayUv(
   materialId: number | null,
   uvTransform: number[] | null,
@@ -392,17 +426,25 @@ function replayUv(
   context: string,
   side: 'front' | 'back'
 ): UvPair[] | undefined {
-  if (uvTransform === null) return undefined;
+  // Explicit frontUv/backUv for EVERY textured face, not just
+  // already-positioned ones - computeFaceUv already computes the correct
+  // final UV for the untouched-projection case too (uvTransform === null)
+  // using the source's real tile size, so this reproduces a
+  // default-projected face's true rendering exactly without needing the
+  // material's own applied width/height to match (which, post-replay, is
+  // intentionally 1.0 - see replayMaterials).
+  if (materialId === null) return undefined;
+  const mat = model.materialsById.get(materialId);
+  if (!mat || !mat.texture) return undefined; // solid color - no UV to replay
   if (projected) {
     warnings.push(`${context}: ${side} texture is projected/draped - falls back to default projection`);
     return undefined;
   }
-  const mat = materialId !== null ? model.materialsById.get(materialId) : undefined;
-  const tileW = (mat && mat.texture ? mat.texture.width : 0) || 1.0;
-  const tileH = (mat && mat.texture ? mat.texture.height : 0) || 1.0;
+  const tileW = mat.texture.width || 1.0;
+  const tileH = mat.texture.height || 1.0;
   const { xr, yr } = faceUvBasis(normal as [number, number, number]);
-  const sample = points.slice(0, 3);
-  if (sample.length < 3) return undefined;
+  const sample = nonCollinearTriple(points);
+  if (!sample) return undefined;
   return sample.map((p): UvPair => {
     const [u, v] = computeFaceUv(p, xr, yr, uvTransform, tileW, tileH);
     return [p, [u, v]];
@@ -430,7 +472,13 @@ function replayInstance(
   const layer = inst.layer ? layerSlots.get(inst.layer) : undefined;
   try {
     target.addInstance(defBuilder, {
-      name: inst.name || undefined,
+      // inst.name unconditionally, not `inst.name || undefined` - an
+      // explicit empty string is a real, valid instance name (SketchUp
+      // shows the definition's own name in the Outliner as a UI-level
+      // fallback only, without storing it) - `|| undefined` would omit
+      // it, letting addInstance's own default silently substitute the
+      // definition's name instead.
+      name: inst.name,
       translation,
       matrix3x3,
       material,

--- a/packages/typescript/tests/edit.test.ts
+++ b/packages/typescript/tests/edit.test.ts
@@ -4,6 +4,8 @@ import * as path from 'path';
 import { openExisting } from '../src/edit';
 import { create, SkpWriteError, Point3 } from '../src/create';
 import { parseSkp } from '../src/index';
+import { SkpModel, faceUvBasis, computeFaceUv } from '../src/model';
+import { reconstructLoopVertices } from '../src/geometry';
 
 /**
  * Tests for edit.ts - loading an existing legacy .skp file and rebuilding
@@ -154,52 +156,53 @@ describe('openExisting', () => {
     expect(() => newBuilder.addGroup(() => {}, { name: 'NewGroup' })).toThrow(SkpWriteError);
   });
 
-  it('a positioned texture round-trips', () => {
-    // Minimal 4x4 solid-color PNG (same generator as create.test.ts's
-    // Textures suite - kept local here to avoid a cross-file test dependency).
-    function makeTestPng(): Uint8Array {
-      function crc32(buf: number[]): number {
-        const table: number[] = [];
-        for (let n = 0; n < 256; n++) {
-          let c = n;
-          for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
-          table[n] = c >>> 0;
-        }
-        let crc = 0xffffffff;
-        for (const b of buf) crc = table[(crc ^ b) & 0xff] ^ (crc >>> 8);
-        return (crc ^ 0xffffffff) >>> 0;
+  // Minimal 4x4 solid-color PNG (same generator as create.test.ts's Textures
+  // suite - kept local here to avoid a cross-file test dependency). Shared
+  // by every test in this describe block that needs a real texture.
+  function makeTestPng(): Uint8Array {
+    function crc32(buf: number[]): number {
+      const table: number[] = [];
+      for (let n = 0; n < 256; n++) {
+        let c = n;
+        for (let k = 0; k < 8; k++) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+        table[n] = c >>> 0;
       }
-      function u32be(v: number): number[] {
-        return [(v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff];
-      }
-      function chunk(tag: number[], data: number[]): number[] {
-        return [...u32be(data.length), ...tag, ...data, ...u32be(crc32([...tag, ...data]))];
-      }
-      const size = 4;
-      const rgb = [200, 50, 50];
-      const rawRows: number[][] = [];
-      for (let y = 0; y < size; y++) {
-        const row = [0];
-        for (let x = 0; x < size; x++) row.push(...rgb);
-        rawRows.push(row);
-      }
-      const rawData = rawRows.flat();
-      let adler1 = 1;
-      let adler2 = 0;
-      for (const b of rawData) {
-        adler1 = (adler1 + b) % 65521;
-        adler2 = (adler2 + adler1) % 65521;
-      }
-      const deflate: number[] = [];
-      deflate.push(1, rawData.length & 0xff, (rawData.length >> 8) & 0xff, ~rawData.length & 0xff, (~rawData.length >> 8) & 0xff, ...rawData);
-      const zlibStream = [0x78, 0x01, ...deflate, (adler2 >> 8) & 0xff, adler2 & 0xff, (adler1 >> 8) & 0xff, adler1 & 0xff];
-      const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
-      const ihdr = chunk([0x49, 0x48, 0x44, 0x52], [...u32be(size), ...u32be(size), 8, 2, 0, 0, 0]);
-      const idat = chunk([0x49, 0x44, 0x41, 0x54], zlibStream);
-      const iend = chunk([0x49, 0x45, 0x4e, 0x44], []);
-      return Uint8Array.from([...sig, ...ihdr, ...idat, ...iend]);
+      let crc = 0xffffffff;
+      for (const b of buf) crc = table[(crc ^ b) & 0xff] ^ (crc >>> 8);
+      return (crc ^ 0xffffffff) >>> 0;
     }
+    function u32be(v: number): number[] {
+      return [(v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff];
+    }
+    function chunk(tag: number[], data: number[]): number[] {
+      return [...u32be(data.length), ...tag, ...data, ...u32be(crc32([...tag, ...data]))];
+    }
+    const size = 4;
+    const rgb = [200, 50, 50];
+    const rawRows: number[][] = [];
+    for (let y = 0; y < size; y++) {
+      const row = [0];
+      for (let x = 0; x < size; x++) row.push(...rgb);
+      rawRows.push(row);
+    }
+    const rawData = rawRows.flat();
+    let adler1 = 1;
+    let adler2 = 0;
+    for (const b of rawData) {
+      adler1 = (adler1 + b) % 65521;
+      adler2 = (adler2 + adler1) % 65521;
+    }
+    const deflate: number[] = [];
+    deflate.push(1, rawData.length & 0xff, (rawData.length >> 8) & 0xff, ~rawData.length & 0xff, (~rawData.length >> 8) & 0xff, ...rawData);
+    const zlibStream = [0x78, 0x01, ...deflate, (adler2 >> 8) & 0xff, adler2 & 0xff, (adler1 >> 8) & 0xff, adler1 & 0xff];
+    const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    const ihdr = chunk([0x49, 0x48, 0x44, 0x52], [...u32be(size), ...u32be(size), 8, 2, 0, 0, 0]);
+    const idat = chunk([0x49, 0x44, 0x41, 0x54], zlibStream);
+    const iend = chunk([0x49, 0x45, 0x4e, 0x44], []);
+    return Uint8Array.from([...sig, ...ihdr, ...idat, ...iend]);
+  }
 
+  it('a positioned texture round-trips', () => {
     const builder = create();
     const png = makeTestPng();
     const brick = builder.addTextureMaterial('Brick', png, 'brick.png');
@@ -246,6 +249,72 @@ describe('openExisting', () => {
     const { builder: newBuilder } = openExisting(toBuffer(builder.toBytes()));
     const rebuilt = parseSkp(toBuffer(newBuilder.toBytes()));
     expect(rebuilt.root.edges.every((e) => e.hidden && e.soft && e.smooth)).toBe(true);
+  });
+
+  it('a default-projected texture UV matches the source (not left corrupted)', () => {
+    // Found via cross-language analysis (2026-08-28): replayMaterials wrote
+    // every rebuilt texture material with the library's (until now)
+    // corrupted default applied height, and replayUv only replayed a
+    // face's UV when it already had an explicit uvTransform - leaving a
+    // DEFAULT-projected textured face's material (and thus its real
+    // SketchUp rendering) corrupted end to end. Both are fixed; this
+    // checks the actual rendered UV at every vertex matches, not just
+    // "some texture data round-tripped".
+    const png = makeTestPng();
+    const builder = create();
+    const brick = builder.addTextureMaterial('Brick', png, 'brick.png');
+    builder.addFace(SQUARE, { material: brick }); // no frontUv - default projection
+
+    const source = parseSkp(toBuffer(builder.toBytes()));
+    const { builder: newBuilder, warnings } = openExisting(toBuffer(builder.toBytes()));
+    expect(warnings.some((w) => w.includes('tile size'))).toBe(false);
+    const rebuilt = parseSkp(toBuffer(newBuilder.toBytes()));
+
+    function faceUvs(model: SkpModel): [number, number][] {
+      const mat = model.materials[0];
+      const face = model.root.faces[0];
+      const edges = new Map<number, [number | null, number | null]>();
+      for (const e of model.root.edges) edges.set(e.id, [e.v1Id, e.v2Id]);
+      const vids = reconstructLoopVertices(face.loops[0], edges);
+      const verticesById = new Map(model.root.vertices.map((v) => [v.id, v]));
+      const pts: Point3[] = vids.map((v) => {
+        const vertex = verticesById.get(v)!;
+        return [vertex.x, vertex.y, vertex.z];
+      });
+      const { xr, yr } = faceUvBasis(face.normal as [number, number, number]);
+      const tileW = mat.texture!.width || 1.0;
+      const tileH = mat.texture!.height || 1.0;
+      return pts.map((p) => computeFaceUv(p, xr, yr, face.uvTransform, tileW, tileH));
+    }
+
+    const sourceUvs = faceUvs(source);
+    const rebuiltUvs = faceUvs(rebuilt);
+    expect(rebuiltUvs.length).toBe(sourceUvs.length);
+    for (let i = 0; i < sourceUvs.length; i++) {
+      expect(rebuiltUvs[i][0]).toBeCloseTo(sourceUvs[i][0], 6);
+      expect(rebuiltUvs[i][1]).toBeCloseTo(sourceUvs[i][1], 6);
+    }
+  });
+
+  it('a genuinely empty instance name is preserved, not replaced', () => {
+    // Found via cross-language analysis (2026-08-28): addInstance's own
+    // `name ?? definition.name` fallback and replayInstance's
+    // `inst.name || undefined` both silently replaced a genuinely empty
+    // instance name with its definition's name - a real difference, not
+    // cosmetic (a later rename of the definition would no longer show
+    // through).
+    const builder = create();
+    const box = builder.addComponentDefinition('Box', (def) => {
+      def.addFace([[0, 0, 0], [10, 0, 0], [10, 10, 0], [0, 10, 0]]);
+    });
+    builder.addInstance(box, { name: '', translation: [0, 0, 0] });
+
+    const source = parseSkp(toBuffer(builder.toBytes()));
+    expect(source.root.instances[0].name).toBe('');
+
+    const { builder: newBuilder } = openExisting(toBuffer(builder.toBytes()));
+    const rebuilt = parseSkp(toBuffer(newBuilder.toBytes()));
+    expect(rebuilt.root.instances[0].name).toBe('');
   });
 });
 


### PR DESCRIPTION
## Summary
- `add_texture_material()`'s applied **HEIGHT** defaulted to a corrupted internal sentinel byte pattern (~1.29e-231, decodes to no sensible height) whenever a caller omitted it, while applied **WIDTH** has always unconditionally defaulted to 1.0. Confirmed via real SketchUp screenshots (2026-08-27) that this renders as a streaky, vertically-smeared texture, regardless of default or explicitly-pinned (`front_uv`/`back_uv`) projection. Since width already has a clearly deliberate 1.0 default with no equivalent garbage byte pattern, the working theory is the height sentinel was never a genuine "never scaled" default at all - almost certainly uninitialized memory in the one SDK sample file this was calibrated against.
- **Fixed in all 5 languages**: applied height now defaults to `1.0`, matching width - this closes the corruption trap for *every* future direct caller of `add_texture_material()`/`AddTextureMaterial()` who doesn't know to pass an explicit value, not just `add_image()` and the `open_existing`/codegen replay paths, which already worked around it locally with an explicit `applied_height=1.0`/`appliedHeight: 1.0` pass. The `applied_height` parameter itself is unchanged - still overridable for a caller who wants a specific real-world texture-tile size on a default-projected face. The old sentinel constant is kept in each language, now unused, purely as a documented historical artifact (`_TEXTURE_H_SENTINEL`/`TextureHSentinel`/`kTextureHSentinel`).
- Every stale source-level docstring claiming "texture scale/tile size isn't preserved" or "`add_texture_material` has no scale parameter yet" is corrected to match (root/package docs were already fixed in #235; this covers the module docstrings that PR didn't touch).

- **Found alongside this, unrelated but from the same audit pass**: TypeScript's `edit.ts` had never actually received *any* of the 4 replay-path bug fixes (instance-level paint dropped, empty instance name replaced, texture corruption, collinear UV sampling) that Python/.NET/Dart/C++ got during the SKP-to-code generator work (#234). This was missed because TypeScript was treated as the already-complete "reference" port for that work and never re-audited on its own - the reference implementation itself still had every one of these bugs, confirmed by direct inspection, not assumption. All 4 fixed the same way as the other 4 languages, plus a stale "texture tile size isn't preserved" doc claim in `edit.ts`'s own module docstring. 2 new regression tests added to `edit.test.ts` (mirroring Python's `test_edit.py`) - the pre-existing suite passed both before and after the fix, meaning it never actually exercised these cases.
- Also found: C++'s `edit_test.cpp` already had the 4 bug fixes (from the earlier PR #234 session) but, unlike Python, had no dedicated regression tests for any of them either - 2 new tests added there too.

## Test plan
- [x] Python: 394 tests pass, `ruff==0.15.13` clean; new tests confirm `add_texture_material()`'s default applied width/height are both `1.0` (not the sentinel), and that an explicit override still works
- [x] TypeScript: 345 tests pass (343 + 2 new `edit.test.ts` regressions), `tsc --noEmit` clean, `eslint` clean
- [x] .NET: 174 tests pass (172 + 2 new), `dotnet format --verify-no-changes` clean, `-warnaserror` build clean
- [x] Dart: 200 tests pass (198 + 2 new), `dart analyze --fatal-infos` clean
- [x] C++: 173 tests pass in Release config (169 + 4 new: 2 in `create_test.cpp`, 2 in `edit_test.cpp`), `clang-format-18 --dry-run --Werror` clean
- [x] Every new test confirms both directions: the *default* is now 1.0 (not corrupted), and an *explicit* `applied_height`/`appliedHeight` override still works exactly as before