### PR TITLE
Fix TLV header-scan off-by-one dropping a boundary-filling record

### DIFF
--- a/packages/dart/lib/src/tlv.dart
+++ b/packages/dart/lib/src/tlv.dart
@@ -85,7 +85,7 @@ class Tlv {
     final containerTagsSet = tags ?? containerTags;
     final elements = <TlvNode>[];
     int pos = start;
-    while (pos < end - 6) {
+    while (pos <= end - 6) {
       final tagHex = _tagHex(data, pos);
       final size = readU32(data, pos + 2);
       if (pos + 6 + size > end) {
@@ -146,7 +146,7 @@ class Tlv {
   static List<(String, int, int)> _flatHeaders(Uint8List data, int start, int end) {
     final headers = <(String, int, int)>[];
     int pos = start;
-    while (pos < end - 6) {
+    while (pos <= end - 6) {
       final tagHex = _tagHex(data, pos);
       final size = readU32(data, pos + 2);
       if (pos + 6 + size > end) break;

--- a/packages/dart/test/tlv_test.dart
+++ b/packages/dart/test/tlv_test.dart
@@ -1,0 +1,47 @@
+import 'dart:typed_data';
+
+import 'package:openskp/src/tlv.dart';
+import 'package:test/test.dart';
+
+/// Regression coverage for a real bug: `Tlv.parseRecursive`'s and the
+/// private `_flatHeaders`' (exercised here via the public `iterTopLevelLazy`)
+/// "is there room for one more 6-byte header" loop guard used
+/// `pos < end - 6` instead of the correct `pos <= end - 6` (equivalently
+/// `pos + 6 <= end`) - a header occupying exactly the last 6 bytes of
+/// `[start, end)` is a real, valid record, not corrupt data, but the
+/// off-by-one silently dropped it with no error. `_flatHeaders` backs
+/// `iterTopLevelLazy`, the lazy scanner real 100k+-definition files depend
+/// on, so this could silently drop a trailing top-level definition, not
+/// just a nested child.
+
+Uint8List tlv(String tagHex, List<int> payload) {
+  final tag = [
+    int.parse(tagHex.substring(0, 2), radix: 16),
+    int.parse(tagHex.substring(2, 4), radix: 16),
+  ];
+  final size = ByteData(4)..setUint32(0, payload.length, Endian.little);
+  return Uint8List.fromList([...tag, ...size.buffer.asUint8List(), ...payload]);
+}
+
+void main() {
+  group('Tlv boundary', () {
+    test('parseRecursive keeps a header that exactly fills the range', () {
+      final data = tlv('0300', []);
+      expect(data.length, 6);
+      final nodes = Tlv.parseRecursive(data, 0, data.length);
+      expect(nodes.length, 1);
+      expect(nodes[0].tag, '0300');
+    });
+
+    test('iterTopLevelLazy keeps a top-level record that exactly fills the range', () {
+      final data = tlv('0300', []);
+      expect(data.length, 6);
+      final items = Tlv.iterTopLevelLazy(data, 0, data.length).toList();
+      expect(items.length, 1);
+      final (index, total, node) = items[0];
+      expect(index, 0);
+      expect(total, 1);
+      expect(node.tag, '0300');
+    });
+  });
+}

--- a/packages/dotnet/OpenSkp.Tests/TlvTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/TlvTests.cs
@@ -1,0 +1,60 @@
+using System.Linq;
+using OpenSkp;
+using Xunit;
+
+namespace OpenSkp.Tests
+{
+    /// <summary>Regression coverage for a real bug: Tlv.ParseRecursive's and
+    /// the private FlatHeaders' (exercised here via the public
+    /// IterTopLevelLazy) "is there room for one more 6-byte header" loop
+    /// guard used `pos &lt; end - 6` instead of the correct `pos &lt;= end - 6`
+    /// (equivalently `pos + 6 &lt;= end`) - a header occupying exactly the
+    /// last 6 bytes of [start, end) is a real, valid record, not corrupt
+    /// data, but the off-by-one silently dropped it with no error.
+    /// FlatHeaders backs IterTopLevelLazy, the lazy scanner real
+    /// 100k+-definition files depend on, so this could silently drop a
+    /// trailing top-level definition, not just a nested child.</summary>
+    public class TlvTests
+    {
+        private static byte[] Tlv(string tagHex, byte[] payload)
+        {
+            byte tag0 = (byte)System.Convert.ToInt32(tagHex.Substring(0, 2), 16);
+            byte tag1 = (byte)System.Convert.ToInt32(tagHex.Substring(2, 2), 16);
+            var size = System.BitConverter.GetBytes((uint)payload.Length);
+            var result = new byte[6 + payload.Length];
+            result[0] = tag0;
+            result[1] = tag1;
+            size.CopyTo(result, 2);
+            payload.CopyTo(result, 6);
+            return result;
+        }
+
+        [Fact]
+        public void ParseRecursiveKeepsAHeaderThatExactlyFillsTheRange()
+        {
+            var data = Tlv("0300", System.Array.Empty<byte>());
+            Assert.Equal(6, data.Length);
+            var buffer = ChunkedBuffer.FromArray(data);
+
+            var nodes = OpenSkp.Tlv.ParseRecursive(buffer, 0, buffer.Length);
+
+            Assert.Single(nodes);
+            Assert.Equal("0300", nodes[0].Tag);
+        }
+
+        [Fact]
+        public void IterTopLevelLazyKeepsATopLevelRecordThatExactlyFillsTheRange()
+        {
+            var data = Tlv("0300", System.Array.Empty<byte>());
+            Assert.Equal(6, data.Length);
+            var buffer = ChunkedBuffer.FromArray(data);
+
+            var items = OpenSkp.Tlv.IterTopLevelLazy(buffer, 0, buffer.Length).ToList();
+
+            Assert.Single(items);
+            Assert.Equal(0, items[0].Index);
+            Assert.Equal(1, items[0].Total);
+            Assert.Equal("0300", items[0].Node.Tag);
+        }
+    }
+}

--- a/packages/dotnet/OpenSkp/Tlv.cs
+++ b/packages/dotnet/OpenSkp/Tlv.cs
@@ -101,7 +101,7 @@ namespace OpenSkp
             containerTags ??= ContainerTags;
             var elements = new List<TlvNode>();
             long pos = start;
-            while (pos < end - 6)
+            while (pos <= end - 6)
             {
                 string tagHex = TagHex(data, pos);
                 uint size = data.ReadU32(pos + 2);
@@ -169,7 +169,7 @@ namespace OpenSkp
         {
             var headers = new List<(string, long, long)>();
             long pos = start;
-            while (pos < end - 6)
+            while (pos <= end - 6)
             {
                 string tagHex = TagHex(data, pos);
                 uint size = data.ReadU32(pos + 2);

--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -79,7 +79,7 @@ def parse_tlv_recursive(data, start, end, container_tags=None, depth=0):
         container_tags = CONTAINER_TAGS
     pos = start
     elements = []
-    while pos < end - 6:
+    while pos <= end - 6:
         tag_bytes = data[pos:pos+2]
         size = read_u32(data, pos+2)
         if pos + 6 + size > end:
@@ -108,7 +108,7 @@ def _flat_headers(data, start, end):
     once (real production files can have 100k+ top-level definitions)."""
     headers = []
     pos = start
-    while pos < end - 6:
+    while pos <= end - 6:
         tag_hex = data[pos:pos+2].hex().upper()
         size = read_u32(data, pos+2)
         if pos + 6 + size > end:

--- a/packages/python/src/openskp/parser.py
+++ b/packages/python/src/openskp/parser.py
@@ -124,7 +124,7 @@ def parse_tlv_recursive(
     pos: int = start
     elements: List[TlvNode] = []
 
-    while pos < end - 6:
+    while pos <= end - 6:
         tag_bytes = data[pos:pos + 2]
         size = read_u32(data, pos + 2)
 

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -100,12 +100,64 @@ class TestParseTlvRecursive:
     def test_empty_payload(self) -> None:
         from openskp.parser import parse_tlv_recursive
 
-        # Need a second element so buffer > 6 bytes (the while guard is `pos < end - 6`)
         data = self._make_tlv("0300", b'') + self._make_tlv("0100", b'\x01')
         nodes = parse_tlv_recursive(data, 0, len(data))
         assert len(nodes) == 2
         assert nodes[0].size == 0
         assert nodes[0].payload == b''
+
+    def test_single_element_whose_header_exactly_fills_the_range(self) -> None:
+        # Regression test for a real bug: the "is there room for one more
+        # header" loop guard used `pos < end - 6` instead of the correct
+        # `pos <= end - 6` (equivalently `pos + 6 <= end`), so a header
+        # occupying exactly the last 6 bytes of [start, end) - a real, valid
+        # record, not corrupt data - was silently dropped with no error.
+        # A zero-payload element is exactly 6 bytes, so a single one fills
+        # the whole range and exercises the boundary directly (unlike
+        # test_empty_payload above, which sidesteps it with a second
+        # element).
+        from openskp.parser import parse_tlv_recursive
+
+        data = self._make_tlv("0300", b'')
+        assert len(data) == 6
+        nodes = parse_tlv_recursive(data, 0, len(data))
+        assert len(nodes) == 1
+        assert nodes[0].tag == "0300"
+        assert nodes[0].size == 0
+
+
+class TestCoreTlvBoundary:
+    """Regression coverage for the same header-boundary off-by-one in
+    :mod:`openskp._core` - the actually-live production TLV walker
+    (:mod:`openskp.parser`'s own copy above is a separately-tested but
+    unused-in-production module; only :func:`openskp._core.read_u32`/
+    :func:`read_f64` are ever imported from it, by :mod:`openskp.metadata`).
+    """
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def test_parse_tlv_recursive_keeps_a_header_that_exactly_fills_the_range(self) -> None:
+        from openskp import _core
+
+        data = self._tlv("0300", b'')
+        assert len(data) == 6
+        nodes = _core.parse_tlv_recursive(data, 0, len(data))
+        assert len(nodes) == 1
+        assert nodes[0]['tag'] == "0300"
+
+    def test_flat_headers_keeps_a_header_that_exactly_fills_the_range(self) -> None:
+        # _flat_headers backs iter_top_level_lazy, the lazy scanner real
+        # 100k+-definition files depend on - this is the one that could
+        # silently drop a trailing TOP-LEVEL definition, not just a nested
+        # child.
+        from openskp import _core
+
+        data = self._tlv("0300", b'')
+        assert len(data) == 6
+        headers = _core._flat_headers(data, 0, len(data))
+        assert headers == [("0300", 0, 0)]
 
 
 # ── Data model tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Found during a full-repo audit ([published report](https://claude.ai/code/artifact/93c3a8a7-59bf-429a-b0c5-b8b6486919cd)): the TLV (tag-length-value) scanner's "is there room for one more 6-byte header" loop guard used `pos < end - 6` in Python, Dart, and .NET, instead of the correct `pos <= end - 6` (equivalently `pos + 6 <= end`). A header occupying exactly the last 6 bytes of the current range — a real, valid record, not corrupt data — fails the strict `<` check, so the loop exits one iteration early and silently drops that record with no error.
- Present in **both** the general recursive TLV walker and the flat top-level header scanner that backs lazy iteration over real production files with 100,000+ definitions — so this could silently drop a trailing **top-level definition**, not just a nested child node.
- TypeScript and C++ already had the correct comparison; this brings the other three ports in line.
- Also fixed a **third occurrence the original audit missed**: `packages/python/src/openskp/parser.py:127` has its own separate copy of `parse_tlv_recursive` — not called by any live production code path (only its `read_u32`/`read_f64` helpers are imported elsewhere), but publicly importable (`from openskp.parser import parse_tlv_recursive`) and covered by its own test file, so fixed for consistency. Found by grepping the whole codebase for the same `end - 6` pattern after fixing the two reported occurrences, rather than trusting the report was exhaustive.
- One existing Python test's own comment had literally documented working *around* this exact boundary case instead of catching it (`test_empty_payload`: *"Need a second element so buffer > 6 bytes (the while guard is `pos < end - 6`)"*) — removed now that the fix makes the workaround unnecessary.

## Test plan
- [x] New regression tests in all 3 fixed languages construct a single zero-payload TLV record whose 6-byte header exactly fills `[start, end)`, and confirm it's parsed, not dropped:
  - Python: `test_parser.py` — both the `openskp.parser` copy, and a new `TestCoreTlvBoundary` class covering the actually-live `openskp._core.parse_tlv_recursive` **and** `_flat_headers` (the one backing the lazy top-level scanner)
  - Dart: new `test/tlv_test.dart`
  - .NET: new `TlvTests.cs`, using the existing `InternalsVisibleTo` friend-assembly access to reach the `internal` `Tlv`/`ChunkedBuffer` classes
- [x] Python: 397 tests pass, `ruff==0.15.13` clean
- [x] Dart: 202 tests pass, `dart analyze --fatal-infos` clean
- [x] .NET: 176 tests pass, `dotnet format --verify-no-changes` clean
- [x] Repo-wide grep after the fix confirms no other `end - 6`/`end-6` occurrence remains in any of the 5 languages