### PR TITLE
Fix legacy v20 filler-recovery ignoring caller's plausibility limit

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -257,7 +257,7 @@ def _plausible_list_tag(ar, data, at) -> bool:
     return t < ar.next_slot
 
 
-def _retry_count_after_v20_filler(r: _R, count_pos: int, ar=None) -> Optional[int]:
+def _retry_count_after_v20_filler(r: _R, count_pos: int, limit: int, ar=None) -> Optional[int]:
     """SketchUp 2020 (v20) writes an extra, undocumented record ahead of some
     counts that v17 does not have, which leaves the reader a few bytes early
     and makes it read garbage as the count. The filler is an empty UTF-16
@@ -276,6 +276,18 @@ def _retry_count_after_v20_filler(r: _R, count_pos: int, ar=None) -> Optional[in
     files that were already parsing (v17, and the VFF path) never reach it.
 
     *count_pos* is the offset the count was read FROM (i.e. ``r.pos - 4``).
+
+    *limit* is the caller's own plausibility ceiling for whatever count this
+    is (e.g. 100,000 for a relationship count, 1,000,000 for a definition
+    count) - required, not a shared internal default, since a candidate this
+    function accepts is returned directly with no further check at most call
+    sites. A single hardcoded ceiling here previously let a byte-garbage
+    candidate between a tighter caller's real limit and that hardcoded value
+    win the search over a better/correct candidate at a different offset,
+    causing the caller's own downstream check to fail on an otherwise-valid
+    file (found 2026-08-28, cross-language audit against TypeScript/.NET/
+    Dart/C++, which always passed their own caller-specific limit through).
+
     Returns the corrected count, or ``None`` when this is not the v20 layout.
     """
     data = r.data
@@ -303,7 +315,7 @@ def _retry_count_after_v20_filler(r: _R, count_pos: int, ar=None) -> Optional[in
         if at2 < marker_at + 4 or at2 + 4 > len(data):
             continue
         count = struct.unpack_from('<I', data, at2)[0]
-        if not (0 < count <= 5_000_000):
+        if not (0 < count <= limit):
             continue
         if ar is not None and not _plausible_list_tag(ar, data, at2 + 4):
             continue
@@ -964,7 +976,7 @@ def _read_definition(ar, r):
     # the first non-zero u32 after its padding.
     count = None
     if ar.ver >= 20:
-        count = _retry_count_after_v20_filler(r, r.pos, ar)
+        count = _retry_count_after_v20_filler(r, r.pos, 5_000_000, ar)
     if count is None:
         r.u32()
         count = r.u32()
@@ -973,7 +985,7 @@ def _read_definition(ar, r):
     # instead of the count. A genuinely empty definition reads zero with no
     # filler ahead, and _retry_count_after_v20_filler leaves those alone.
     if count > 5_000_000 or count == 0:
-        retry = _retry_count_after_v20_filler(r, r.pos - 4, ar)
+        retry = _retry_count_after_v20_filler(r, r.pos - 4, 5_000_000, ar)
         if retry is not None:
             count = retry
     if count > 5_000_000:
@@ -981,7 +993,7 @@ def _read_definition(ar, r):
     ents = _read_entity_list(ar, r, count, 'def')
     nrel = r.u32()
     if nrel > 100000:
-        retry = _retry_count_after_v20_filler(r, r.pos - 4, ar)
+        retry = _retry_count_after_v20_filler(r, r.pos - 4, 100_000, ar)
         if retry is not None:
             nrel = retry
     if nrel > 100000:
@@ -1238,7 +1250,7 @@ def _walk_model(data: bytes, ver: int, start: int, mat_count: int,
         raise LegacyParseError(f"definition-list anchor is {dn}, not a layer")
     def_count = r.u32()
     if def_count > 1_000_000:
-        retry = _retry_count_after_v20_filler(r, r.pos - 4, ar)
+        retry = _retry_count_after_v20_filler(r, r.pos - 4, 1_000_000, ar)
         if retry is not None:
             def_count = retry
     if def_count > 1_000_000:
@@ -1261,7 +1273,7 @@ def _walk_model(data: bytes, ver: int, start: int, mat_count: int,
     # root entity list
     root_count = r.u32()
     if root_count > 5_000_000:
-        retry = _retry_count_after_v20_filler(r, r.pos - 4, ar)
+        retry = _retry_count_after_v20_filler(r, r.pos - 4, 5_000_000, ar)
         if retry is not None:
             root_count = retry
     if root_count > 5_000_000:

--- a/packages/python/tests/test_legacy_v20_filler.py
+++ b/packages/python/tests/test_legacy_v20_filler.py
@@ -31,8 +31,8 @@ def _filler(count: int, pad: int) -> bytes:
     return bytes(b)
 
 
-def _retry(data: bytes) -> int | None:
-    return _retry_count_after_v20_filler(_R(data, 0), 0, ar=None)
+def _retry(data: bytes, limit: int = 5_000_000) -> int | None:
+    return _retry_count_after_v20_filler(_R(data, 0), 0, limit, ar=None)
 
 
 class TestRetryCountAfterV20Filler:
@@ -61,3 +61,20 @@ class TestRetryCountAfterV20Filler:
     def test_does_not_run_past_the_end_of_the_buffer(self):
         data = bytes([0xff, 0xfe, 0xff, 0x00, 0, 0])
         assert _retry(data) is None
+
+    def test_rejects_a_candidate_above_the_callers_own_limit(self):
+        # Regression test for a real bug (found 2026-08-28, cross-language
+        # audit): this function used to hardcode a single 5,000,000
+        # ceiling internally regardless of which caller invoked it, even
+        # though most call sites in legacy.py enforce a much tighter limit
+        # right after (e.g. 100,000 for a relationship count, 1,000,000
+        # for a definition count). A byte-garbage candidate between the
+        # caller's real limit and 5,000,000 could win the search here and
+        # get returned, when a better/correct candidate at a different
+        # offset would have been found by continuing to search - the
+        # caller's own downstream check then raised a spurious parse
+        # error on an otherwise-valid file. limit is now a required
+        # parameter, not a shared internal default.
+        count = 200_000  # plausible for a def/root count, NOT for nrel (>100_000)
+        assert _retry(_filler(count, 9), limit=5_000_000) == count
+        assert _retry(_filler(count, 9), limit=100_000) is None


### PR DESCRIPTION
## Summary
- Found during a full-repo audit ([published report](https://claude.ai/code/artifact/93c3a8a7-59bf-429a-b0c5-b8b6486919cd)): SketchUp 2020's legacy format sometimes writes an undocumented filler record ahead of a count field, leaving the reader a few bytes early. Python's `_retry_count_after_v20_filler` recovery helper scans up to 4 nearby offsets for a plausible replacement count, but had no `limit` parameter - it always accepted any candidate up to a hardcoded `5_000_000`, regardless of which of its 5 call sites invoked it.
- Every other language's equivalent (`retryCountAfterV20Filler`/`RetryCountAfterV20Filler`/`retry_count_after_v20_filler`) takes an explicit `limit` matched to what the calling code will actually accept right after - e.g. `100_000` for a relationship count, `1_000_000` for a definition count - verified directly against TypeScript's exact per-call-site values (`legacy.ts:109,1168,1179,1188,1518,1543`).
- A byte-garbage candidate between a tighter caller's real limit and 5,000,000 could win the search over a better/correct candidate at a different offset, so the caller's own downstream check (`if nrel > 100000: raise`) would then fail on a real v20 file the other four languages parse successfully.
- `limit` is now a required parameter (matching TypeScript's design, not defaulted). All 5 call sites updated to the exact same limits TypeScript uses - including a **second mismatch found while fixing this**, beyond the one originally reported: `def_count` was also using the wrong hardcoded 5,000,000 instead of its own 1,000,000 ceiling.

## Test plan
- [x] New regression test constructs a filler-recovery candidate (200,000) that's plausible under the old hardcoded default but above a tighter caller's real limit, and confirms it's now correctly rejected (falls through to `None` instead of being returned) while still being accepted under a looser limit
- [x] Python: 398 tests pass, `ruff==0.15.13` clean
- [x] Real `gondola_v20.skp` fixture (an actual SketchUp-2020-saved file) still parses correctly end to end - all 6 tests in `test_legacy_v20.py` green