### PR TITLE
Fix empty component/group definition name fabricated on replay/codegen

### DIFF
--- a/packages/cpp/src/codegen.cpp
+++ b/packages/cpp/src/codegen.cpp
@@ -463,7 +463,15 @@ std::string to_cpp_code(const SkpModel& model) {
     }
 
     std::string var_name = "def" + std::to_string(def_counter++);
-    std::string def_name = defn.name.empty() ? ("Def" + std::to_string(def_id)) : defn.name;
+    // defn.name unconditionally, not `defn.name.empty() ? ... :
+    // defn.name` - an explicit empty string is a real, valid definition
+    // name, and this same value also feeds instance_opts_lines's
+    // comparison below, which needs the TRUE definition name to
+    // correctly decide whether an instance's own name differs from it -
+    // a fabricated fallback here would corrupt that comparison, not just
+    // the written name. var_name (the emitted identifier, e.g. "def0")
+    // is unrelated and always safe.
+    std::string def_name = defn.name;
     def_var[def_id] = var_name;
 
     push("");

--- a/packages/cpp/src/edit.cpp
+++ b/packages/cpp/src/edit.cpp
@@ -474,13 +474,21 @@ OpenExistingResult open_existing(const std::filesystem::path& path) {
     auto it = model.definitions.find(def_id);
     if (it == model.definitions.end()) continue;
     const Definition& defn = it->second;
-    std::string dname = defn.name.empty() ? ("Definition" + std::to_string(def_id)) : defn.name;
-    std::string context = "definition '" + dname + "'";
+    std::string context_name =
+        defn.name.empty() ? ("Definition" + std::to_string(def_id)) : defn.name;
+    std::string context = "definition '" + context_name + "'";
     if (!definition_has_content(defn, def_builders)) {
       result.warnings.push_back(context + ": skipped (no replayable geometry)");
       continue;
     }
-    ComponentDefinitionBuilder& db = builder.add_component_definition(dname);
+    // defn.name unconditionally, not the context_name fallback above - an
+    // explicit empty string is a real, valid definition name. SketchUp
+    // Groups are internally just unnamed component definitions (unlike
+    // Components, which SketchUp auto-names), so an empty name is common
+    // in real files - same reasoning as replay_instance's own name
+    // handling below. context_name stays fallback-safe since it's only
+    // ever used for a human-readable warning message.
+    ComponentDefinitionBuilder& db = builder.add_component_definition(defn.name);
     replay_body(db, defn, by_id, material_slots, layer_slots, result.warnings, context,
                 def_builders);
     db.close();

--- a/packages/cpp/tests/codegen_test.cpp
+++ b/packages/cpp/tests/codegen_test.cpp
@@ -111,6 +111,32 @@ TEST(Codegen, PreservesGenuinelyEmptyInstanceNameAndInstancePaint) {
   EXPECT_NE(code.find("inst_opts1.material = mat0;"), std::string::npos);
 }
 
+TEST(Codegen, PreservesGenuinelyEmptyDefinitionName) {
+  // Found via cross-language analysis (2026-08-28), same bug class as the empty instance name
+  // case above: `defn.name.empty() ? ("Def" + std::to_string(def_id)) : defn.name` silently
+  // replaced a genuinely empty definition name with a fabricated one. SketchUp Groups are
+  // internally just unnamed component definitions (unlike Components, which SketchUp
+  // auto-names), so an empty name is common in real files.
+  auto builder = create();
+  auto& def = builder->add_component_definition("");
+  def.add_face({{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}});
+  def.close();
+  builder->add_instance(def, {});
+
+  SkpModel model = roundtrip(builder);
+  ASSERT_EQ(model.definitions.size(), 1u);
+  EXPECT_EQ(model.definitions.begin()->second.name, "");
+
+  std::string code = to_cpp_code(model);
+
+  // add_component_definition("") - not a fabricated "Def123" name - and the def-vs-instance
+  // name comparison must still use the real (empty) name, not the fabricated fallback, or a
+  // root instance whose own name is also genuinely empty would incorrectly get an explicit
+  // `.name = ""` line instead of being correctly recognized as matching its definition.
+  EXPECT_NE(code.find("add_component_definition(\"\")"), std::string::npos);
+  EXPECT_EQ(code.find("add_component_definition(\"Def"), std::string::npos);
+}
+
 TEST(Codegen, UsesDotForDefinitionBuildersAndArrowForRootBuilder) {
   auto builder = create();
   auto& inner = builder->add_component_definition("Inner");

--- a/packages/cpp/tests/edit_test.cpp
+++ b/packages/cpp/tests/edit_test.cpp
@@ -145,6 +145,36 @@ TEST(Edit, GenuinelyEmptyInstanceNameIsPreservedNotReplaced) {
   EXPECT_EQ(rebuilt.root().instances[0].name, "");
 }
 
+TEST(Edit, GenuinelyEmptyDefinitionNameIsPreservedNotReplaced) {
+  // Found via cross-language analysis (2026-08-28), same bug class as the empty instance name
+  // case above: `defn.name.empty() ? ("Definition" + std::to_string(def_id)) : defn.name` silently
+  // replaced a genuinely empty definition name with a fabricated one. SketchUp Groups are
+  // internally just unnamed component definitions (unlike Components, which SketchUp
+  // auto-names), so an empty name is common in real files.
+  auto path = temp_skp("empty_definition_name");
+  {
+    auto builder = create();
+    auto& box = builder->add_component_definition("");
+    box.add_face({{0, 0, 0}, {10, 0, 0}, {10, 10, 0}, {0, 10, 0}});
+    box.close();
+    builder->add_instance(box, {});
+    builder->save(path);
+  }
+
+  SkpModel source = SkpFile::open(path).parse();
+  ASSERT_EQ(source.definitions.size(), 1u);
+  EXPECT_EQ(source.definitions.begin()->second.name, "");
+
+  OpenExistingResult result = open_existing(path);
+  ASSERT_NE(result.builder, nullptr);
+  ByteBuffer rebuilt_bytes = result.builder->to_bytes();
+  SkpModel rebuilt = SkpFile::from_buffer(rebuilt_bytes).parse();
+  std::filesystem::remove(path);
+
+  ASSERT_EQ(rebuilt.definitions.size(), 1u);
+  EXPECT_EQ(rebuilt.definitions.begin()->second.name, "");
+}
+
 TEST(Edit, ReturnedBuilderCanAddMoreGeometryAndCannotRegisterNewSections) {
   auto path = temp_skp("addmore");
   {

--- a/packages/dart/lib/src/codegen.dart
+++ b/packages/dart/lib/src/codegen.dart
@@ -317,7 +317,15 @@ String toDartCode(SkpModel model) {
     }
 
     final varName = 'def${defCounter++}';
-    final defName = defn.name.isNotEmpty ? defn.name : 'Def$defId';
+    // defn.name unconditionally, not `defn.name.isNotEmpty ? defn.name :
+    // 'Def$defId'` - an explicit empty string is a real, valid definition
+    // name, and this same value also feeds instanceOptsStr's comparison
+    // below, which needs the TRUE definition name to correctly decide
+    // whether an instance's own name differs from it - a fabricated
+    // fallback here would corrupt that comparison, not just the written
+    // name. varName (the emitted identifier, e.g. "def0") is unrelated
+    // and always safe.
+    final defName = defn.name;
     defVar[defId] = varName;
 
     push('');

--- a/packages/dart/lib/src/edit.dart
+++ b/packages/dart/lib/src/edit.dart
@@ -128,8 +128,13 @@ OpenExistingResult openExisting(String path) {
       warnings.add('$context: skipped (no replayable geometry)');
       continue;
     }
-    final defName = defn.name.isNotEmpty ? defn.name : 'Definition$defId';
-    final db = builder.addComponentDefinition(defName, (b) {
+    // defn.name unconditionally, not `defn.name.isNotEmpty ? defn.name :
+    // 'Definition$defId'` - an explicit empty string is a real, valid
+    // definition name. SketchUp Groups are internally just unnamed
+    // component definitions (unlike Components, which SketchUp
+    // auto-names), so an empty name is common in real files - same
+    // reasoning as _replayInstance's own name handling below.
+    final db = builder.addComponentDefinition(defn.name, (b) {
       _replayBody(b, defn, model, materialSlots, layerSlots, warnings, context, defBuilders);
     });
     defBuilders[defId] = db;

--- a/packages/dart/test/codegen_test.dart
+++ b/packages/dart/test/codegen_test.dart
@@ -92,6 +92,36 @@ void main() {
       }
     });
 
+    test('reproduces a genuinely empty definition name', () {
+      // Found via cross-language analysis (2026-08-28), same bug class as
+      // the empty-instance-name case above: `defn.name.isNotEmpty ?
+      // defn.name : 'Def$defId'` silently replaced a genuinely empty
+      // definition name with a fabricated one. SketchUp Groups are
+      // internally just unnamed component definitions (unlike
+      // Components, which SketchUp auto-names), so an empty name is
+      // common in real files.
+      final b = create();
+      final box = b.addComponentDefinition('', (d) {
+        d.addFace([(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)]);
+      });
+      b.addInstance(box, translation: (0.0, 0.0, 0.0));
+
+      final original = SkpFile.fromBuffer(Uint8List.fromList(b.toBytes())).parse();
+      expect(original.definitions.values.first.name, '');
+      final code = toDartCode(original);
+
+      final tmpOut = '$packageRoot/.tmp_codegen_out_${DateTime.now().microsecondsSinceEpoch}.skp';
+      try {
+        final regenBytes = runGeneratedCode(code, tmpOut);
+        final regen = SkpFile.fromBuffer(Uint8List.fromList(regenBytes)).parse();
+
+        expect(regen.definitions.values.first.name, '');
+      } finally {
+        final f = File(tmpOut);
+        if (f.existsSync()) f.deleteSync();
+      }
+    });
+
     test('reproduces a textured material with default projection', () {
       final tmpDir = Directory.systemTemp.createTempSync('openskp_codegen_tex_');
       final pngPath = '${tmpDir.path}${Platform.pathSeparator}brick.png';

--- a/packages/dart/test/edit_test.dart
+++ b/packages/dart/test/edit_test.dart
@@ -68,6 +68,63 @@ void main() {
       }
     });
 
+    test('a genuinely empty instance name is preserved, not replaced', () {
+      // Found via cross-language analysis (2026-08-28): addInstance's own
+      // name-defaults-to-definition-name fallback and _replayInstance's
+      // own `inst.name.isNotEmpty ? inst.name : null` both silently
+      // replaced a genuinely empty instance name with its definition's
+      // name - a real difference, not cosmetic (a later rename of the
+      // definition would no longer show through). No dedicated
+      // regression test for this existed for Dart specifically, unlike
+      // Python/TypeScript.
+      final tmpDir = Directory.systemTemp.createTempSync('openskp_edit_test_');
+      try {
+        final builder = create();
+        final box = builder.addComponentDefinition('Box', (def) {
+          def.addFace([(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)]);
+        });
+        builder.addInstance(box, name: '', translation: (0.0, 0.0, 0.0));
+        final src = saveToTempFile(builder, tmpDir);
+
+        final source = SkpFile.fromBuffer(File(src).readAsBytesSync()).parse();
+        expect(source.root.instances[0].name, '');
+
+        final result = openExisting(src);
+        final rebuilt = SkpFile.fromBuffer(result.builder.toBytes()).parse();
+        expect(rebuilt.root.instances[0].name, '');
+      } finally {
+        tmpDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('a genuinely empty definition name is preserved, not replaced', () {
+      // Found via cross-language analysis (2026-08-28), same bug class as
+      // the empty instance name case above: `defn.name.isNotEmpty ?
+      // defn.name : 'Definition$defId'` silently replaced a genuinely
+      // empty definition name with a fabricated one. SketchUp Groups are
+      // internally just unnamed component definitions (unlike
+      // Components, which SketchUp auto-names), so an empty name is
+      // common in real files.
+      final tmpDir = Directory.systemTemp.createTempSync('openskp_edit_test_');
+      try {
+        final builder = create();
+        final box = builder.addComponentDefinition('', (def) {
+          def.addFace([(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)]);
+        });
+        builder.addInstance(box, translation: (0.0, 0.0, 0.0));
+        final src = saveToTempFile(builder, tmpDir);
+
+        final source = SkpFile.fromBuffer(File(src).readAsBytesSync()).parse();
+        expect(source.definitions.values.first.name, '');
+
+        final result = openExisting(src);
+        final rebuilt = SkpFile.fromBuffer(result.builder.toBytes()).parse();
+        expect(rebuilt.definitions.values.first.name, '');
+      } finally {
+        tmpDir.deleteSync(recursive: true);
+      }
+    });
+
     test('preserves instance translation', () {
       final tmpDir = Directory.systemTemp.createTempSync('openskp_edit_test_');
       try {

--- a/packages/dotnet/OpenSkp.Tests/CodegenTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CodegenTests.cs
@@ -53,6 +53,34 @@ namespace OpenSkp.Tests
             Assert.Null(byName["PlainBox"].MaterialId);
         }
 
+        [Fact]
+        public void ReproducesAGenuinelyEmptyDefinitionName()
+        {
+            // Found via cross-language analysis (2026-08-28), same bug
+            // class as the empty instance name case above:
+            // `!IsNullOrEmpty(defn.Name) ? defn.Name : $"Def{defId}"`
+            // silently replaced a genuinely empty definition name with a
+            // fabricated one. SketchUp Groups are internally just unnamed
+            // component definitions (unlike Components, which SketchUp
+            // auto-names), so an empty name is common in real files.
+            var builder = SkpCreate.NewFile();
+            var box = builder.AddComponentDefinition("");
+            using (box)
+            {
+                box.AddFace(new (double, double, double)[] { (0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0) });
+            }
+            builder.AddInstance(box, translation: (0, 0, 0));
+
+            var original = SkpFile.Parse(builder.ToBytes());
+            Assert.Equal("", original.Definitions.Values.First().Name);
+
+            string code = Codegen.ToCSharpCode(original);
+            byte[] regenBytes = CompileAndRun(code);
+            var regen = SkpFile.Parse(regenBytes);
+
+            Assert.Equal("", regen.Definitions.Values.First().Name);
+        }
+
         public static System.Collections.Generic.IEnumerable<object[]> RealFixtures()
         {
             // single_material_v17.skp is deliberately excluded: it

--- a/packages/dotnet/OpenSkp.Tests/EditTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/EditTests.cs
@@ -100,6 +100,77 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
+        public void GenuinelyEmptyInstanceNameIsPreservedNotReplaced()
+        {
+            // Found via cross-language analysis (2026-08-28): AddInstance's
+            // own name-defaults-to-definition-name fallback and
+            // ReplayInstance's own `IsNullOrEmpty(...) ? null : inst.Name`
+            // both silently replaced a genuinely empty instance name with
+            // its definition's name - a real difference, not cosmetic (a
+            // later rename of the definition would no longer show
+            // through). No dedicated regression test for this existed for
+            // .NET specifically, unlike Python/TypeScript/Dart/C++.
+            var original = SkpCreate.NewFile();
+            ComponentDefinitionBuilder box;
+            using (box = original.AddComponentDefinition("Box"))
+            {
+                box.AddFace(new (double, double, double)[] { (0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0) });
+            }
+            original.AddInstance(box, name: "", translation: (0, 0, 0));
+
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".skp");
+            original.Save(path);
+            try
+            {
+                var source = SkpFile.Parse(File.ReadAllBytes(path));
+                Assert.Equal("", source.Root.Instances[0].Name);
+
+                var result = SkpEdit.OpenExisting(path);
+                var rebuilt = SkpFile.Parse(result.Builder.ToBytes());
+                Assert.Equal("", rebuilt.Root.Instances[0].Name);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
+        public void GenuinelyEmptyDefinitionNameIsPreservedNotReplaced()
+        {
+            // Found via cross-language analysis (2026-08-28), same bug
+            // class as the empty instance name case above:
+            // `IsNullOrEmpty(defn.Name) ? $"Definition{defId}" : defn.Name`
+            // silently replaced a genuinely empty definition name with a
+            // fabricated one. SketchUp Groups are internally just unnamed
+            // component definitions (unlike Components, which SketchUp
+            // auto-names), so an empty name is common in real files.
+            var original = SkpCreate.NewFile();
+            ComponentDefinitionBuilder box;
+            using (box = original.AddComponentDefinition(""))
+            {
+                box.AddFace(new (double, double, double)[] { (0, 0, 0), (10, 0, 0), (10, 10, 0), (0, 10, 0) });
+            }
+            original.AddInstance(box, translation: (0, 0, 0));
+
+            string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".skp");
+            original.Save(path);
+            try
+            {
+                var source = SkpFile.Parse(File.ReadAllBytes(path));
+                Assert.Equal("", source.Definitions.Values.First().Name);
+
+                var result = SkpEdit.OpenExisting(path);
+                var rebuilt = SkpFile.Parse(result.Builder.ToBytes());
+                Assert.Equal("", rebuilt.Definitions.Values.First().Name);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
         public void NewMaterialAfterOpenExistingThrows()
         {
             var original = SkpCreate.NewFile();

--- a/packages/dotnet/OpenSkp/Codegen.cs
+++ b/packages/dotnet/OpenSkp/Codegen.cs
@@ -234,7 +234,16 @@ namespace OpenSkp
                 }
 
                 string varName = $"def{defCounter++}";
-                string defName = !string.IsNullOrEmpty(defn.Name) ? defn.Name : $"Def{defId}";
+                // defn.Name unconditionally, not `IsNullOrEmpty(...) ? ... :
+                // $"Def{defId}"` - an explicit empty string is a real,
+                // valid definition name, and this same value also feeds
+                // InstanceOptsStr's comparison below, which needs the TRUE
+                // definition name to correctly decide whether an
+                // instance's own name differs from it - a fabricated
+                // fallback here would corrupt that comparison, not just
+                // the written name. varName (the emitted identifier, e.g.
+                // "def0") is unrelated and always safe.
+                string defName = defn.Name;
                 defVar[defId] = varName;
 
                 Push("");

--- a/packages/dotnet/OpenSkp/Edit.cs
+++ b/packages/dotnet/OpenSkp/Edit.cs
@@ -134,7 +134,14 @@ namespace OpenSkp
                     warnings.Add($"{context}: skipped (no replayable geometry)");
                     continue;
                 }
-                var db = builder.AddComponentDefinition(string.IsNullOrEmpty(defn.Name) ? $"Definition{defId}" : defn.Name);
+                // defn.Name unconditionally, not `IsNullOrEmpty(...) ? ... :
+                // defn.Name` - an explicit empty string is a real, valid
+                // definition name. SketchUp Groups are internally just
+                // unnamed component definitions (unlike Components, which
+                // SketchUp auto-names), so an empty name is common in real
+                // files - same reasoning as ReplayInstance's own name
+                // handling below.
+                var db = builder.AddComponentDefinition(defn.Name);
                 ReplayBody(db, defn, model, materialSlots, layerSlots, warnings, context, defBuilders);
                 db.Dispose();
                 defBuilders[defId] = db;

--- a/packages/python/src/openskp/codegen.py
+++ b/packages/python/src/openskp/codegen.py
@@ -282,7 +282,16 @@ def to_python_code(model: SkpModel) -> str:
 
         var_name = f"def{def_counter}"
         def_counter += 1
-        def_name = defn.name or f"Def{def_id}"
+        # defn.name unconditionally, not `defn.name or f"Def{def_id}"` - an
+        # explicit empty string is a real, valid definition name (SketchUp
+        # Groups are internally unnamed definitions), and this same value
+        # also feeds instance_opts_str's comparison below, which needs the
+        # TRUE definition name to correctly decide whether an instance's
+        # own name differs from it - a fabricated fallback here would
+        # corrupt that comparison, not just the written name. var_name
+        # (the emitted Python variable, e.g. "def0") is unrelated and
+        # always safe regardless of defn.name.
+        def_name = defn.name
         def_var[def_id] = var_name
 
         push("")

--- a/packages/python/src/openskp/edit.py
+++ b/packages/python/src/openskp/edit.py
@@ -148,7 +148,13 @@ def open_existing(
         if not _definition_has_content(defn, def_builders):
             warnings.append(f"{context}: skipped (no replayable geometry)")
             continue
-        with builder.add_component_definition(defn.name or f"Definition{def_id}") as db:
+        # defn.name unconditionally, not `defn.name or f"Definition{def_id}"`
+        # - an explicit empty string is a real, valid definition name.
+        # SketchUp Groups are internally just unnamed component
+        # definitions (unlike Components, which SketchUp auto-names), so
+        # an empty name is common in real files - the same reasoning as
+        # _replay_instance's own name handling below.
+        with builder.add_component_definition(defn.name) as db:
             _replay_body(db, defn, model, material_slots, layer_slots, warnings, context, def_builders)
         def_builders[def_id] = db
 

--- a/packages/python/tests/test_codegen.py
+++ b/packages/python/tests/test_codegen.py
@@ -70,6 +70,31 @@ class TestToPythonCode:
         assert by_name["PaintedBox"].material_id is not None
         assert by_name["PlainBox"].material_id is None
 
+    def test_reproduces_a_genuinely_empty_definition_name(self, tmp_path):
+        # Found via cross-language analysis (2026-08-28), same bug class as
+        # the empty INSTANCE name case above: `defn.name or f"Def{def_id}"`
+        # silently replaced a genuinely empty definition name with a
+        # fabricated one. SketchUp Groups are internally just unnamed
+        # component definitions (unlike Components, which SketchUp
+        # auto-names), so an empty name is common in real files.
+        b = create()
+        with b.add_component_definition("") as box:
+            box.add_face([(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)])
+        b.add_instance(box, translation=(0.0, 0.0, 0.0))
+
+        out = tmp_path / "orig.skp"
+        out.write_bytes(b.to_bytes())
+        original = SkpFile.open(str(out)).parse()
+        assert next(iter(original.definitions.values())).name == ""
+
+        code = to_python_code(original)
+        regen_bytes = _run_generated_code(code)
+        regen_out = tmp_path / "regen.skp"
+        regen_out.write_bytes(regen_bytes)
+        regen = SkpFile.open(str(regen_out)).parse()
+
+        assert next(iter(regen.definitions.values())).name == ""
+
     def test_reproduces_textured_material_with_default_projection(self, tmp_path):
         png_path = tmp_path / "brick.png"
         png_path.write_bytes(_make_test_png())

--- a/packages/python/tests/test_edit.py
+++ b/packages/python/tests/test_edit.py
@@ -282,6 +282,30 @@ class TestOpenExisting:
         rebuilt = SkpFile.open(str(out)).parse()
         assert rebuilt.root.instances[0].name == ""
 
+    def test_empty_definition_name_is_preserved_not_replaced(self, tmp_path):
+        # Found via cross-language analysis (2026-08-28), same bug class as
+        # the empty INSTANCE name case just above: `defn.name or
+        # f"Definition{def_id}"` silently replaced a genuinely empty
+        # definition name with a fabricated one. SketchUp Groups are
+        # internally just unnamed component definitions (unlike
+        # Components, which SketchUp auto-names), so an empty name is
+        # common in real files, not an edge case.
+        builder = create()
+        with builder.add_component_definition("") as box:
+            box.add_face([(0.0, 0.0, 0.0), (10.0, 0.0, 0.0), (10.0, 10.0, 0.0), (0.0, 10.0, 0.0)])
+        builder.add_instance(box, translation=(0.0, 0.0, 0.0))
+        src = tmp_path / "source.skp"
+        builder.save(str(src))
+
+        source = SkpFile.open(str(src)).parse()
+        assert next(iter(source.definitions.values())).name == ""
+
+        new_builder, warnings, definitions = edit.open_existing(str(src))
+        out = tmp_path / "rebuilt.skp"
+        out.write_bytes(new_builder.to_bytes())
+        rebuilt = SkpFile.open(str(out)).parse()
+        assert next(iter(rebuilt.definitions.values())).name == ""
+
     def test_face_with_hole_round_trips(self, tmp_path):
         # add_face's holes= support (added alongside this module) means a
         # multi-loop face is now faithfully replayed, not skipped.

--- a/packages/typescript/src/codegen.ts
+++ b/packages/typescript/src/codegen.ts
@@ -332,7 +332,14 @@ export function toTypeScriptCode(model: SkpModel): string {
     for (const inst of def.instances) getOrBuildDef(inst.refIdx as number, visiting);
 
     const varName = `def${defCounter++}`;
-    const defName = def.name || `Def${defId}`;
+    // def.name unconditionally, not `def.name || \`Def${defId}\`` - an
+    // explicit empty string is a real, valid definition name, and this
+    // same value also feeds instanceOptsStr's comparison below, which
+    // needs the TRUE definition name to correctly decide whether an
+    // instance's own name differs from it - a fabricated fallback here
+    // would corrupt that comparison, not just the written name. varName
+    // (the emitted identifier, e.g. "def0") is unrelated and always safe.
+    const defName = def.name;
     defVar.set(defId, varName);
 
     push(``);

--- a/packages/typescript/src/edit.ts
+++ b/packages/typescript/src/edit.ts
@@ -185,7 +185,13 @@ export function openExisting(
       warnings.push(`${context}: skipped (no replayable geometry)`);
       continue;
     }
-    const db = builder.addComponentDefinition(defn.name || `Definition${defId}`, (d) => {
+    // defn.name unconditionally, not `defn.name || \`Definition${defId}\`` -
+    // an explicit empty string is a real, valid definition name. SketchUp
+    // Groups are internally just unnamed component definitions (unlike
+    // Components, which SketchUp auto-names), so an empty name is common
+    // in real files - same reasoning as replayInstance's own name
+    // handling below.
+    const db = builder.addComponentDefinition(defn.name, (d) => {
       replayBody(d, defn, model, materialSlots, layerSlots, warnings, context, defBuilders);
     });
     defBuilders.set(defId, db);

--- a/packages/typescript/tests/codegen.test.ts
+++ b/packages/typescript/tests/codegen.test.ts
@@ -122,6 +122,34 @@ describe('toTypeScriptCode', () => {
     expect(byName.get('PlainBox')?.materialId).toBeNull();
   });
 
+  it('reproduces a genuinely empty definition name', () => {
+    // Found via cross-language analysis (2026-08-28), same bug class as
+    // the empty-instance-name case above: `def.name || \`Def${defId}\`
+    // silently replaced a genuinely empty definition name with a
+    // fabricated one. SketchUp Groups are internally just unnamed
+    // component definitions (unlike Components, which SketchUp
+    // auto-names), so an empty name is common in real files.
+    const b = create();
+    const def = b.addComponentDefinition('', (d) => {
+      d.addFace([
+        [0, 0, 0],
+        [10, 0, 0],
+        [10, 10, 0],
+        [0, 10, 0],
+      ]);
+    });
+    b.addInstance(def, { translation: [0, 0, 0] });
+
+    const original = parseSkp(toBuffer(b.toBytes()));
+    expect(Array.from(original.definitions.values())[0].name).toBe('');
+
+    const code = toTypeScriptCode(original);
+    const regenBytes = runGeneratedCode(code);
+    const regen = parseSkp(toBuffer(regenBytes));
+
+    expect(Array.from(regen.definitions.values())[0].name).toBe('');
+  });
+
   it('reproduces a textured material with default projection', () => {
     const png = makeTestPng();
     const b = create();

--- a/packages/typescript/tests/edit.test.ts
+++ b/packages/typescript/tests/edit.test.ts
@@ -316,6 +316,27 @@ describe('openExisting', () => {
     const rebuilt = parseSkp(toBuffer(newBuilder.toBytes()));
     expect(rebuilt.root.instances[0].name).toBe('');
   });
+
+  it('a genuinely empty definition name is preserved, not replaced', () => {
+    // Found via cross-language analysis (2026-08-28), same bug class as
+    // the empty instance name case above: `defn.name || \`Definition${defId}\`
+    // silently replaced a genuinely empty definition name with a
+    // fabricated one. SketchUp Groups are internally just unnamed
+    // component definitions (unlike Components, which SketchUp
+    // auto-names), so an empty name is common in real files.
+    const builder = create();
+    const box = builder.addComponentDefinition('', (def) => {
+      def.addFace([[0, 0, 0], [10, 0, 0], [10, 10, 0], [0, 10, 0]]);
+    });
+    builder.addInstance(box, { translation: [0, 0, 0] });
+
+    const source = parseSkp(toBuffer(builder.toBytes()));
+    expect(Array.from(source.definitions.values())[0].name).toBe('');
+
+    const { builder: newBuilder } = openExisting(toBuffer(builder.toBytes()));
+    const rebuilt = parseSkp(toBuffer(newBuilder.toBytes()));
+    expect(Array.from(rebuilt.definitions.values())[0].name).toBe('');
+  });
 });
 
 describe('Real-world fixtures (non-writer-authored)', () => {


### PR DESCRIPTION
## Summary
- Found during a full-repo audit ([published report](https://claude.ai/code/artifact/93c3a8a7-59bf-429a-b0c5-b8b6486919cd)): the empty-instance-name fix from an earlier PR this session (pass `inst.name` through unconditionally, not `inst.name or None`) was never applied to the sibling case - a **definition's own name**. All 5 languages' `open_existing`/`edit.*` and `to_*_code`/`codegen.*` still had `defn.name or f"Definition{def_id}"` (or the equivalent per-language falsy-empty-string fallback: `||`, `IsNullOrEmpty(...) ? ... :`, `.isNotEmpty ? ... :`, `.empty() ? ... :`).
- SketchUp Groups are internally just unnamed component definitions (unlike Components, which SketchUp auto-names), so an empty definition name is common in real files, not an edge case. Every unnamed Group silently got a fabricated visible name (`"Definition123"`/`"Def123"`) after a round-trip through `open_existing()`, or in the emitted source from `to_*_code()`.
- In `codegen.*` specifically, the same fallback-bearing value also fed the instance-vs-definition name **comparison** that decides whether an instance needs an explicit name option in the generated code - a fabricated fallback there would have corrupted that comparison independently of the written-name bug. The emitted variable/identifier (`def0`, `def1`, ...) turned out to be a separate counter-based value in every language, unrelated to the name fallback at all, so no extra handling was needed for it despite initially looking like it might be (see the CHECKLIST correction noted in the commit).
- C++'s `edit.cpp` needed one extra step the other 4 languages didn't: its fallback-bearing variable was also reused for a human-readable warning message, so it's now split into a fallback-safe warning-only variable (`context_name`) and the real, unconditional `defn.name` used for the actual `add_component_definition` call.

## Test plan
- [x] New regression tests in all 5 languages' `edit.*` **and** `codegen.*` suites confirm a genuinely-unnamed definition's name survives `open_existing()`/`to_*_code()` unchanged
- [x] .NET and Dart had never gotten a dedicated regression test for the *original* empty-instance-name fix either (unlike Python/TypeScript/C++) - added those too while in the area, for parity
- [x] Python: 400 tests pass, `ruff==0.15.13` clean
- [x] TypeScript: 347 tests pass, `tsc --noEmit`/`eslint` clean
- [x] .NET: 179 tests pass, `dotnet format --verify-no-changes` clean
- [x] Dart: 205 tests pass, `dart analyze --fatal-infos` clean
- [x] C++: 175 tests pass (Release config), `clang-format-18 --dry-run --Werror` clean
- [x] Repo-wide grep after the fix confirms no remaining unfixed occurrence of this pattern in any of the 5 languages (only intentional, cosmetic-only fallbacks used for human-readable warning-message text remain, which are correct as-is)