### PR TITLE
fix: IFC classify_element() falls back to layer name, add custom classifier override

### DIFF
--- a/packages/cpp/include/openskp/ifc_export.hpp
+++ b/packages/cpp/include/openskp/ifc_export.hpp
@@ -2,6 +2,7 @@
 #define OPENSKP_IFC_EXPORT_HPP
 
 #include <filesystem>
+#include <functional>
 #include <string>
 
 #include "model.hpp"
@@ -12,15 +13,27 @@ namespace openskp {
 // 1 metre = 39.37007874015748 inches (SketchUp native unit)
 constexpr double METRES_TO_INCHES = 39.37007874015748;
 
+/// A (STEP_ENTITY_TYPE, IFC_CLASS_NAME) classification, and the signature
+/// a custom classifier passed to to_ifc()/export_ifc() must match.
+using IfcClassifier =
+    std::function<std::pair<std::string, std::string>(const std::string&, const std::string&)>;
+
 /**
  * Generate a standard 22-character IFC base64 compressed GUID.
  */
 std::string generate_ifc_guid();
 
 /**
- * Classify a geometry name to an IFC entity type (STEP_TYPE, CLASS_NAME).
+ * Classify a geometry/component name to an IFC entity type (STEP_TYPE, CLASS_NAME).
+ *
+ * Tries geom_name first, then falls back to layer_name (many
+ * SketchUp-for-BIM workflows organize by tag/layer - "Walls", "Doors" -
+ * even when individual components are never renamed away from
+ * SketchUp's own defaults like "Component#109415"), then falls back to a
+ * generic, untyped element if neither matches.
  */
-std::pair<std::string, std::string> classify_element(const std::string& geom_name);
+std::pair<std::string, std::string> classify_element(const std::string& geom_name,
+                                                     const std::string& layer_name = "");
 
 /**
  * Serialize a baked Scene into ISO-10303-21 STEP ASCII IFC4 format.
@@ -28,10 +41,13 @@ std::pair<std::string, std::string> classify_element(const std::string& geom_nam
  * @param scene The baked scene returned by SkpFile::build_scene()
  * @param scale Scale factor for vertex coordinates (default: METRES_TO_INCHES)
  * @param schema IFC schema version (default: "IFC4")
+ * @param classifier Optional override for classify_element() - supply your
+ *   own naming convention or metadata-driven typing instead of the
+ *   built-in keyword/layer heuristic.
  * @return Formatted ASCII IFC text string.
  */
 std::string to_ifc(const Scene& scene, double scale = METRES_TO_INCHES,
-                   const std::string& schema = "IFC4");
+                   const std::string& schema = "IFC4", const IfcClassifier& classifier = nullptr);
 
 /**
  * Export a baked Scene directly to an ISO-10303-21 STEP ASCII IFC4 file.
@@ -40,9 +56,11 @@ std::string to_ifc(const Scene& scene, double scale = METRES_TO_INCHES,
  * @param path Destination file path (.ifc)
  * @param scale Scale factor for vertex coordinates (default: METRES_TO_INCHES)
  * @param schema IFC schema version (default: "IFC4")
+ * @param classifier Optional override for classify_element() - see to_ifc().
  */
 void export_ifc(const Scene& scene, const std::filesystem::path& path,
-                double scale = METRES_TO_INCHES, const std::string& schema = "IFC4");
+                double scale = METRES_TO_INCHES, const std::string& schema = "IFC4",
+                const IfcClassifier& classifier = nullptr);
 
 }  // namespace openskp
 

--- a/packages/cpp/src/ifc_export.cpp
+++ b/packages/cpp/src/ifc_export.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <iomanip>
 #include <map>
+#include <optional>
 #include <random>
 #include <sstream>
 
@@ -61,23 +62,38 @@ std::string generate_ifc_guid() {
   return result;
 }
 
-std::pair<std::string, std::string> classify_element(const std::string& geom_name) {
-  std::string l = geom_name;
+namespace {
+
+std::optional<std::pair<std::string, std::string>> classify_by_keyword(const std::string& name) {
+  std::string l = name;
   std::transform(l.begin(), l.end(), l.begin(), [](unsigned char c) { return std::tolower(c); });
-  if (l.find("wall") != std::string::npos) return {"IFCWALL", "IfcWall"};
-  if (l.find("door") != std::string::npos) return {"IFCDOOR", "IfcDoor"};
-  if (l.find("window") != std::string::npos) return {"IFCWINDOW", "IfcWindow"};
+  if (l.find("wall") != std::string::npos) return std::pair{"IFCWALL", "IfcWall"};
+  if (l.find("door") != std::string::npos) return std::pair{"IFCDOOR", "IfcDoor"};
+  if (l.find("window") != std::string::npos) return std::pair{"IFCWINDOW", "IfcWindow"};
   if (l.find("slab") != std::string::npos || l.find("floor") != std::string::npos)
-    return {"IFCSLAB", "IfcSlab"};
+    return std::pair{"IFCSLAB", "IfcSlab"};
   if (l.find("column") != std::string::npos || l.find("pillar") != std::string::npos)
-    return {"IFCCOLUMN", "IfcColumn"};
+    return std::pair{"IFCCOLUMN", "IfcColumn"};
   if (l.find("beam") != std::string::npos || l.find("joist") != std::string::npos)
-    return {"IFCBEAM", "IfcBeam"};
-  if (l.find("roof") != std::string::npos) return {"IFCROOF", "IfcRoof"};
+    return std::pair{"IFCBEAM", "IfcBeam"};
+  if (l.find("roof") != std::string::npos) return std::pair{"IFCROOF", "IfcRoof"};
+  return std::nullopt;
+}
+
+}  // namespace
+
+std::pair<std::string, std::string> classify_element(const std::string& geom_name,
+                                                     const std::string& layer_name) {
+  if (auto by_name = classify_by_keyword(geom_name)) return *by_name;
+  if (!layer_name.empty()) {
+    if (auto by_layer = classify_by_keyword(layer_name)) return *by_layer;
+  }
   return {"IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy"};
 }
 
-std::string to_ifc(const Scene& scene, double scale, const std::string& schema) {
+std::string to_ifc(const Scene& scene, double scale, const std::string& schema,
+                   const IfcClassifier& classifier) {
+  IfcClassifier classify = classifier ? classifier : IfcClassifier(classify_element);
   std::string schema_str = schema.empty() ? "IFC4" : schema;
   std::transform(schema_str.begin(), schema_str.end(), schema_str.begin(),
                  [](unsigned char c) { return std::toupper(c); });
@@ -203,7 +219,7 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
       layer_name = sanitize_name(meta_it->second.layer);
     }
 
-    auto [step_type, _] = classify_element(geom_name);
+    auto [step_type, _] = classify(geom_name, layer_name);
 
     std::ostringstream pt_ss;
     pt_ss.imbue(std::locale::classic());
@@ -341,7 +357,7 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema) 
 }
 
 void export_ifc(const Scene& scene, const std::filesystem::path& path, double scale,
-                const std::string& schema) {
+                const std::string& schema, const IfcClassifier& classifier) {
   if (path.has_parent_path()) {
     std::filesystem::create_directories(path.parent_path());
   }
@@ -349,7 +365,7 @@ void export_ifc(const Scene& scene, const std::filesystem::path& path, double sc
   if (!file.is_open()) {
     throw std::runtime_error("Failed to open file for writing: " + path.string());
   }
-  std::string text = to_ifc(scene, scale, schema);
+  std::string text = to_ifc(scene, scale, schema, classifier);
   file.write(text.data(), text.size());
 }
 

--- a/packages/cpp/tests/ifc_export_test.cpp
+++ b/packages/cpp/tests/ifc_export_test.cpp
@@ -18,6 +18,66 @@ TEST(IfcExport, ClassifiesElementNames) {
   EXPECT_EQ(classify_element("Steel Beam").first, "IFCBEAM");
 }
 
+TEST(IfcExport, ClassifyElementFallsBackToLayerNameWhenComponentNameHasNoKeyword) {
+  // SketchUp default names carry no signal, but a BIM-style layer/tag
+  // often does (openskp#238).
+  EXPECT_EQ(classify_element("Component#109415", "Walls").first, "IFCWALL");
+  EXPECT_EQ(classify_element("Group#3", "Doors").first, "IFCDOOR");
+}
+
+TEST(IfcExport, ClassifyElementPrefersComponentNameOverLayerName) {
+  EXPECT_EQ(classify_element("Interior Door", "Walls").first, "IFCDOOR");
+}
+
+TEST(IfcExport, ClassifyElementFallsBackToGenericProxyWhenNeitherMatches) {
+  EXPECT_EQ(classify_element("Component#109415", "Layer0").first, "IFCBUILDINGELEMENTPROXY");
+  EXPECT_EQ(classify_element("Component#109415").first, "IFCBUILDINGELEMENTPROXY");
+}
+
+TEST(IfcExport, ToIfcUsesLayerNameFallbackForUnnamedComponents) {
+  Scene scene;
+  GlbPrimitive prim;
+  prim.geom_name = "Component#109415";
+  prim.material_index = 0;
+  prim.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  scene.glb_primitives.push_back(prim);
+
+  MeshMetadata meta;
+  meta.name = "Component#109415";
+  meta.layer = "Walls";
+  scene.mesh_index["Component#109415"] = meta;
+
+  std::string ifc_text = to_ifc(scene);
+  EXPECT_NE(ifc_text.find("IFCWALL("), std::string::npos);
+  EXPECT_EQ(ifc_text.find("IFCBUILDINGELEMENTPROXY"), std::string::npos);
+}
+
+TEST(IfcExport, ToIfcAcceptsCustomClassifierOverride) {
+  Scene scene;
+  GlbPrimitive prim;
+  prim.geom_name = "Outer Wall";
+  prim.material_index = 0;
+  prim.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  scene.glb_primitives.push_back(prim);
+
+  MeshMetadata meta;
+  meta.name = "Outer Wall";
+  scene.mesh_index["Outer Wall"] = meta;
+
+  IfcClassifier always_column = [](const std::string&, const std::string&) {
+    return std::pair<std::string, std::string>{"IFCCOLUMN", "IfcColumn"};
+  };
+  std::string ifc_text = to_ifc(scene, METRES_TO_INCHES, "IFC4", always_column);
+  EXPECT_EQ(ifc_text.find("IFCWALL("), std::string::npos);
+  EXPECT_NE(ifc_text.find("IFCCOLUMN("), std::string::npos);
+}
+
 TEST(IfcExport, SerializesSceneToIfc4StepText) {
   Scene scene;
   GlbPrimitive prim;

--- a/packages/dart/lib/src/ifc_export.dart
+++ b/packages/dart/lib/src/ifc_export.dart
@@ -3,7 +3,8 @@ import 'dart:math' as math;
 import 'scene.dart';
 
 const double metresToInches = 39.37007874015748;
-const _ifcBase64 = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_\$';
+const _ifcBase64 =
+    '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_\$';
 
 String generateIfcGuid() {
   final rand = math.Random();
@@ -20,15 +21,33 @@ String sanitizeName(String? name) {
   return clean.isEmpty ? 'Unnamed' : clean;
 }
 
-List<String> classifyElement(String geomName) {
-  final l = geomName.toLowerCase();
+List<String>? _classifyByKeyword(String name) {
+  final l = name.toLowerCase();
   if (l.contains('wall')) return ['IFCWALL', 'IfcWall'];
   if (l.contains('door')) return ['IFCDOOR', 'IfcDoor'];
   if (l.contains('window')) return ['IFCWINDOW', 'IfcWindow'];
   if (l.contains('slab') || l.contains('floor')) return ['IFCSLAB', 'IfcSlab'];
-  if (l.contains('column') || l.contains('pillar')) return ['IFCCOLUMN', 'IfcColumn'];
+  if (l.contains('column') || l.contains('pillar'))
+    return ['IFCCOLUMN', 'IfcColumn'];
   if (l.contains('beam') || l.contains('joist')) return ['IFCBEAM', 'IfcBeam'];
   if (l.contains('roof')) return ['IFCROOF', 'IfcRoof'];
+  return null;
+}
+
+/// Maps a geometry/component name to an IFC4 entity type and constructor.
+///
+/// Tries [geomName] first, then falls back to [layerName] (many
+/// SketchUp-for-BIM workflows organize by tag/layer - "Walls", "Doors" -
+/// even when individual components are never renamed away from
+/// SketchUp's own defaults like "Component#109415"), then falls back to
+/// a generic, untyped element if neither matches.
+List<String> classifyElement(String geomName, [String layerName = '']) {
+  final byName = _classifyByKeyword(geomName);
+  if (byName != null) return byName;
+  if (layerName.isNotEmpty) {
+    final byLayer = _classifyByKeyword(layerName);
+    if (byLayer != null) return byLayer;
+  }
   return ['IFCBUILDINGELEMENTPROXY', 'IfcBuildingElementProxy'];
 }
 
@@ -61,7 +80,9 @@ String toIfc(
   Scene scene, {
   double scale = metresToInches,
   String schema = 'IFC4',
+  List<String> Function(String geomName, String layerName)? classifier,
 }) {
+  final classify = classifier ?? classifyElement;
   final schemaStr = schema.toUpperCase();
   final nowIso = DateTime.now().toUtc().toIso8601String().split('.').first;
   final timestampEpoch = DateTime.now().toUtc().millisecondsSinceEpoch ~/ 1000;
@@ -89,12 +110,12 @@ String toIfc(
   lines.add('#$personOrgId=IFCPERSONANDORGANIZATION(#$personId,#$orgId,\$);');
 
   final appId = nextId();
-  lines.add('#$appId=IFCAPPLICATION(#$orgId,\'0.3.1\',\'OpenSKP Exporter\',\'OpenSKP\');');
+  lines.add(
+      '#$appId=IFCAPPLICATION(#$orgId,\'0.3.1\',\'OpenSKP Exporter\',\'OpenSKP\');');
 
   final ownerHistId = nextId();
   lines.add(
-    '#$ownerHistId=IFCOWNERHISTORY(#$personOrgId,#$appId,\$,.READWRITE.,\$,\$,\$,$timestampEpoch);'
-  );
+      '#$ownerHistId=IFCOWNERHISTORY(#$personOrgId,#$appId,\$,.READWRITE.,\$,\$,\$,$timestampEpoch);');
 
   final lengthUnitId = nextId();
   lines.add('#$lengthUnitId=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);');
@@ -107,8 +128,7 @@ String toIfc(
 
   final unitAssignId = nextId();
   lines.add(
-    '#$unitAssignId=IFCUNITASSIGNMENT((#$lengthUnitId,#$angleUnitId,#$solidUnitId));'
-  );
+      '#$unitAssignId=IFCUNITASSIGNMENT((#$lengthUnitId,#$angleUnitId,#$solidUnitId));');
 
   final ptZeroId = nextId();
   lines.add('#$ptZeroId=IFCCARTESIANPOINT((0.0,0.0,0.0));');
@@ -118,47 +138,41 @@ String toIfc(
 
   final geomCtxId = nextId();
   lines.add(
-    '#$geomCtxId=IFCGEOMETRICREPRESENTATIONCONTEXT(\$,\'Model\',3,1.0E-5,#$axisPlacementId,\$);'
-  );
+      '#$geomCtxId=IFCGEOMETRICREPRESENTATIONCONTEXT(\$,\'Model\',3,1.0E-5,#$axisPlacementId,\$);');
 
   final projId = nextId();
   lines.add(
-    '#$projId=IFCPROJECT(\'${generateIfcGuid()}\',#$ownerHistId,\'OpenSKP Project\',\$,\$,\$,\$,(#$geomCtxId),#$unitAssignId);'
-  );
+      '#$projId=IFCPROJECT(\'${generateIfcGuid()}\',#$ownerHistId,\'OpenSKP Project\',\$,\$,\$,\$,(#$geomCtxId),#$unitAssignId);');
 
   final sitePlacementId = nextId();
   lines.add('#$sitePlacementId=IFCLOCALPLACEMENT(\$,#$axisPlacementId);');
 
   final siteId = nextId();
   lines.add(
-    '#$siteId=IFCSITE(\'${generateIfcGuid()}\',#$ownerHistId,\'Site\',\$,\$,#$sitePlacementId,\$,\$,.ELEMENT.,\$,\$,\$,\$,\$);'
-  );
+      '#$siteId=IFCSITE(\'${generateIfcGuid()}\',#$ownerHistId,\'Site\',\$,\$,#$sitePlacementId,\$,\$,.ELEMENT.,\$,\$,\$,\$,\$);');
 
   final bldgPlacementId = nextId();
-  lines.add('#$bldgPlacementId=IFCLOCALPLACEMENT(#$sitePlacementId,#$axisPlacementId);');
+  lines.add(
+      '#$bldgPlacementId=IFCLOCALPLACEMENT(#$sitePlacementId,#$axisPlacementId);');
 
   final bldgId = nextId();
   lines.add(
-    '#$bldgId=IFCBUILDING(\'${generateIfcGuid()}\',#$ownerHistId,\'Building\',\$,\$,#$bldgPlacementId,\$,\$,.ELEMENT.,\$,\$,\$);'
-  );
+      '#$bldgId=IFCBUILDING(\'${generateIfcGuid()}\',#$ownerHistId,\'Building\',\$,\$,#$bldgPlacementId,\$,\$,.ELEMENT.,\$,\$,\$);');
 
   final storeyPlacementId = nextId();
-  lines.add('#$storeyPlacementId=IFCLOCALPLACEMENT(#$bldgPlacementId,#$axisPlacementId);');
+  lines.add(
+      '#$storeyPlacementId=IFCLOCALPLACEMENT(#$bldgPlacementId,#$axisPlacementId);');
 
   final storeyId = nextId();
   lines.add(
-    '#$storeyId=IFCBUILDINGSTOREY(\'${generateIfcGuid()}\',#$ownerHistId,\'Level 0\',\$,\$,#$storeyPlacementId,\$,\$,.ELEMENT.,0.0);'
-  );
+      '#$storeyId=IFCBUILDINGSTOREY(\'${generateIfcGuid()}\',#$ownerHistId,\'Level 0\',\$,\$,#$storeyPlacementId,\$,\$,.ELEMENT.,0.0);');
 
   lines.add(
-    '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$projId,(#$siteId));'
-  );
+      '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$projId,(#$siteId));');
   lines.add(
-    '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$siteId,(#$bldgId));'
-  );
+      '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$siteId,(#$bldgId));');
   lines.add(
-    '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$bldgId,(#$storeyId));'
-  );
+      '#${nextId()}=IFCRELAGGREGATES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,#$bldgId,(#$storeyId));');
 
   final productIds = <int>[];
   final layerItems = <String, List<int>>{};
@@ -172,7 +186,7 @@ String toIfc(
     final geomName = sanitizeName(prim.geomName);
     final meta = scene.meshIndex[prim.geomName];
     final layerName = sanitizeName(meta?.layer ?? 'Layer0');
-    final classification = classifyElement(geomName);
+    final classification = classify(geomName, layerName);
     final stepType = classification[0];
 
     final ptCoords = <String>[];
@@ -196,28 +210,29 @@ String toIfc(
 
     final faceSetId = nextId();
     lines.add(
-      '#$faceSetId=IFCTRIANGULATEDFACESET(#$ptListId,\$,.TRUE.,(${faceIndices.join(',')}),\$);'
-    );
+        '#$faceSetId=IFCTRIANGULATEDFACESET(#$ptListId,\$,.TRUE.,(${faceIndices.join(',')}),\$);');
 
     layerItems.putIfAbsent(layerName, () => []).add(faceSetId);
 
     final rgba = getPrimRgb(scene, prim.materialIndex);
     final r = rgba[0], g = rgba[1], b = rgba[2], a = rgba[3];
-    final rgbaKey = '${r.toStringAsFixed(4)},${g.toStringAsFixed(4)},${b.toStringAsFixed(4)},${a.toStringAsFixed(4)}';
+    final rgbaKey =
+        '${r.toStringAsFixed(4)},${g.toStringAsFixed(4)},${b.toStringAsFixed(4)},${a.toStringAsFixed(4)}';
     int styleAssignId;
 
     if (!matStyleCache.containsKey(rgbaKey)) {
       final colId = nextId();
-      lines.add('#$colId=IFCCOLOURRGB(\$,${r.toStringAsFixed(4)},${g.toStringAsFixed(4)},${b.toStringAsFixed(4)});');
+      lines.add(
+          '#$colId=IFCCOLOURRGB(\$,${r.toStringAsFixed(4)},${g.toStringAsFixed(4)},${b.toStringAsFixed(4)});');
 
       final transparency = (1.0 - a).toStringAsFixed(4);
       final renderingId = nextId();
       lines.add(
-        '#$renderingId=IFCSURFACESTYLERENDERING(#$colId,$transparency,\$,\$,\$,\$,\$,\$,.FLAT.);'
-      );
+          '#$renderingId=IFCSURFACESTYLERENDERING(#$colId,$transparency,\$,\$,\$,\$,\$,\$,.FLAT.);');
 
       final styleId = nextId();
-      lines.add('#$styleId=IFCSURFACESTYLE(\'${geomName}_Material\',.BOTH.,(#$renderingId));');
+      lines.add(
+          '#$styleId=IFCSURFACESTYLE(\'${geomName}_Material\',.BOTH.,(#$renderingId));');
 
       styleAssignId = nextId();
       lines.add('#$styleAssignId=IFCPRESENTATIONSTYLEASSIGNMENT((#$styleId));');
@@ -227,29 +242,28 @@ String toIfc(
     }
 
     final styledItemId = nextId();
-    lines.add('#$styledItemId=IFCSTYLEDITEM(#$faceSetId,(#$styleAssignId),\$);');
+    lines
+        .add('#$styledItemId=IFCSTYLEDITEM(#$faceSetId,(#$styleAssignId),\$);');
 
     final shapeRepId = nextId();
     lines.add(
-      '#$shapeRepId=IFCSHAPEREPRESENTATION(#$geomCtxId,\'Body\',\'Tessellation\',(#$faceSetId));'
-    );
+        '#$shapeRepId=IFCSHAPEREPRESENTATION(#$geomCtxId,\'Body\',\'Tessellation\',(#$faceSetId));');
 
     final prodShapeId = nextId();
     lines.add('#$prodShapeId=IFCPRODUCTDEFINITIONSHAPE(\$,\$,(#$shapeRepId));');
 
     final prodPlacementId = nextId();
-    lines.add('#$prodPlacementId=IFCLOCALPLACEMENT(#$storeyPlacementId,#$axisPlacementId);');
+    lines.add(
+        '#$prodPlacementId=IFCLOCALPLACEMENT(#$storeyPlacementId,#$axisPlacementId);');
 
     final productId = nextId();
     final prodGuid = generateIfcGuid();
     if (stepType == 'IFCBUILDINGELEMENTPROXY') {
       lines.add(
-        '#$productId=$stepType(\'$prodGuid\',#$ownerHistId,\'$geomName\',\$,\$,#$prodPlacementId,#$prodShapeId,\$,.NOTDEFINED.);'
-      );
+          '#$productId=$stepType(\'$prodGuid\',#$ownerHistId,\'$geomName\',\$,\$,#$prodPlacementId,#$prodShapeId,\$,.NOTDEFINED.);');
     } else {
       lines.add(
-        '#$productId=$stepType(\'$prodGuid\',#$ownerHistId,\'$geomName\',\$,\$,#$prodPlacementId,#$prodShapeId,\$,\$);'
-      );
+          '#$productId=$stepType(\'$prodGuid\',#$ownerHistId,\'$geomName\',\$,\$,#$prodPlacementId,#$prodShapeId,\$,\$);');
     }
     productIds.add(productId);
 
@@ -259,7 +273,8 @@ String toIfc(
         final cleanK = sanitizeName(entry.key);
         final cleanV = sanitizeName(entry.value);
         final propId = nextId();
-        lines.add('#$propId=IFCPROPERTYSINGLEVALUE(\'$cleanK\',\$,IFCTEXT(\'$cleanV\'),\$);');
+        lines.add(
+            '#$propId=IFCPROPERTYSINGLEVALUE(\'$cleanK\',\$,IFCTEXT(\'$cleanV\'),\$);');
         propValIds.add(propId);
       }
 
@@ -267,12 +282,10 @@ String toIfc(
         final psetId = nextId();
         final propRefs = propValIds.map((pid) => '#$pid').join(',');
         lines.add(
-          '#$psetId=IFCPROPERTYSET(\'${generateIfcGuid()}\',#$ownerHistId,\'Pset_CustomProperties\',\$,($propRefs));'
-        );
+            '#$psetId=IFCPROPERTYSET(\'${generateIfcGuid()}\',#$ownerHistId,\'Pset_CustomProperties\',\$,($propRefs));');
 
         lines.add(
-          '#${nextId()}=IFCRELDEFINESBYPROPERTIES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,(#$productId),#$psetId);'
-        );
+            '#${nextId()}=IFCRELDEFINESBYPROPERTIES(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,(#$productId),#$psetId);');
       }
     }
   }
@@ -283,16 +296,14 @@ String toIfc(
     if (itemIds.isNotEmpty) {
       final itemRefs = itemIds.map((iid) => '#$iid').join(',');
       lines.add(
-        '#${nextId()}=IFCPRESENTATIONLAYERASSIGNMENT(\'$lName\',\$,($itemRefs),\$);'
-      );
+          '#${nextId()}=IFCPRESENTATIONLAYERASSIGNMENT(\'$lName\',\$,($itemRefs),\$);');
     }
   }
 
   if (productIds.isNotEmpty) {
     final prodRefs = productIds.map((pid) => '#$pid').join(',');
     lines.add(
-      '#${nextId()}=IFCRELCONTAINEDINSPATIALSTRUCTURE(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,($prodRefs),#$storeyId);'
-    );
+        '#${nextId()}=IFCRELCONTAINEDINSPATIALSTRUCTURE(\'${generateIfcGuid()}\',#$ownerHistId,\$,\$,($prodRefs),#$storeyId);');
   }
 
   lines.add('ENDSEC;');
@@ -305,9 +316,11 @@ void exportIfc(
   String outputPath, {
   double scale = metresToInches,
   String schema = 'IFC4',
+  List<String> Function(String geomName, String layerName)? classifier,
 }) {
   final file = File(outputPath);
   file.parent.createSync(recursive: true);
-  final text = toIfc(scene, scale: scale, schema: schema);
+  final text =
+      toIfc(scene, scale: scale, schema: schema, classifier: classifier);
   file.writeAsStringSync(text);
 }

--- a/packages/dart/test/ifc_export_test.dart
+++ b/packages/dart/test/ifc_export_test.dart
@@ -17,6 +17,105 @@ void main() {
       expect(classifyElement('Steel Beam')[0], equals('IFCBEAM'));
     });
 
+    test('falls back to the layer name when the component name has no keyword',
+        () {
+      // SketchUp default names carry no signal, but a BIM-style layer/tag
+      // often does (openskp#238).
+      expect(
+          classifyElement('Component#109415', 'Walls')[0], equals('IFCWALL'));
+      expect(classifyElement('Group#3', 'Doors')[0], equals('IFCDOOR'));
+    });
+
+    test('prefers the component name over the layer name when both match', () {
+      expect(classifyElement('Interior Door', 'Walls')[0], equals('IFCDOOR'));
+    });
+
+    test('falls back to the generic proxy when neither name matches', () {
+      expect(classifyElement('Component#109415', 'Layer0')[0],
+          equals('IFCBUILDINGELEMENTPROXY'));
+      expect(classifyElement('Component#109415')[0],
+          equals('IFCBUILDINGELEMENTPROXY'));
+    });
+
+    test('uses the layer name fallback in toIfc for unnamed components', () {
+      final scene = Scene(
+        sceneHierarchy: InstanceNode(
+          name: 'Root',
+          definitionName: 'RootDef',
+          layer: 'Layer0',
+          positionMm: (0.0, 0.0, 0.0),
+          properties: {},
+          children: [],
+        ),
+        meshIndex: {
+          'Component#109415': MeshMetadata(
+            name: 'Component#109415',
+            definitionName: 'CompDef',
+            layer: 'Walls',
+            positionMm: (0.0, 0.0, 0.0),
+            properties: {},
+            path: 'Root/Component#109415',
+          ),
+        },
+        glbPrimitives: [
+          GlbPrimitive(
+            geomName: 'Component#109415',
+            materialIndex: 0,
+            positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+            normals: Float32List.fromList([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+            uvs: Float32List.fromList([0, 0, 1, 0, 0, 1]),
+            indices: Uint32List.fromList([0, 1, 2]),
+          ),
+        ],
+        gltfMaterials: [{}],
+      );
+
+      final ifcText = toIfc(scene);
+      expect(ifcText, contains('IFCWALL('));
+      expect(ifcText, isNot(contains('IFCBUILDINGELEMENTPROXY')));
+    });
+
+    test('accepts a custom classifier override in toIfc', () {
+      final scene = Scene(
+        sceneHierarchy: InstanceNode(
+          name: 'Root',
+          definitionName: 'RootDef',
+          layer: 'Layer0',
+          positionMm: (0.0, 0.0, 0.0),
+          properties: {},
+          children: [],
+        ),
+        meshIndex: {
+          'Outer Wall': MeshMetadata(
+            name: 'Outer Wall',
+            definitionName: 'WallDef',
+            layer: 'Layer0',
+            positionMm: (0.0, 0.0, 0.0),
+            properties: {},
+            path: 'Root/Outer Wall',
+          ),
+        },
+        glbPrimitives: [
+          GlbPrimitive(
+            geomName: 'Outer Wall',
+            materialIndex: 0,
+            positions: Float32List.fromList([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+            normals: Float32List.fromList([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+            uvs: Float32List.fromList([0, 0, 1, 0, 0, 1]),
+            indices: Uint32List.fromList([0, 1, 2]),
+          ),
+        ],
+        gltfMaterials: [{}],
+      );
+
+      final ifcText = toIfc(
+        scene,
+        classifier: (geomName, layerName) => ['IFCCOLUMN', 'IfcColumn'],
+      );
+      expect(ifcText, isNot(contains('IFCWALL(')));
+      expect(ifcText, contains('IFCCOLUMN('));
+    });
+
     test('serializes Scene to IFC4 STEP text format', () {
       final scene = Scene(
         sceneHierarchy: InstanceNode(

--- a/packages/dotnet/OpenSkp.Tests/IfcExportTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/IfcExportTests.cs
@@ -25,6 +25,90 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
+        public void ClassifyElement_FallsBackToLayerNameWhenComponentNameHasNoKeyword()
+        {
+            // SketchUp default names carry no signal, but a BIM-style
+            // layer/tag often does (openskp#238).
+            Assert.Equal("IFCWALL", IfcExport.ClassifyElement("Component#109415", "Walls").StepType);
+            Assert.Equal("IFCDOOR", IfcExport.ClassifyElement("Group#3", "Doors").StepType);
+        }
+
+        [Fact]
+        public void ClassifyElement_PrefersComponentNameOverLayerName()
+        {
+            Assert.Equal("IFCDOOR", IfcExport.ClassifyElement("Interior Door", "Walls").StepType);
+        }
+
+        [Fact]
+        public void ClassifyElement_FallsBackToGenericProxyWhenNeitherMatches()
+        {
+            Assert.Equal("IFCBUILDINGELEMENTPROXY", IfcExport.ClassifyElement("Component#109415", "Layer0").StepType);
+            Assert.Equal("IFCBUILDINGELEMENTPROXY", IfcExport.ClassifyElement("Component#109415").StepType);
+        }
+
+        [Fact]
+        public void ToIfc_UsesLayerNameFallbackForUnnamedComponents()
+        {
+            var scene = new Scene
+            {
+                SceneHierarchy = new InstanceNode { Name = "Root", DefinitionName = "RootDef" },
+                MeshIndex = new Dictionary<string, MeshMetadata>
+                {
+                    ["Component#109415"] = new MeshMetadata
+                    {
+                        Name = "Component#109415",
+                        Layer = "Walls"
+                    }
+                },
+                GlbPrimitives = new List<GlbPrimitive>
+                {
+                    new GlbPrimitive
+                    {
+                        GeomName = "Component#109415",
+                        MaterialIndex = 0,
+                        Positions = new float[] { 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f, 0f },
+                        Normals = new float[] { 0f, 0f, 1f, 0f, 0f, 1f, 0f, 0f, 1f },
+                        Uvs = new float[] { 0f, 0f, 1f, 0f, 0f, 1f },
+                        Indices = new uint[] { 0, 1, 2 }
+                    }
+                }
+            };
+
+            string ifcText = IfcExport.ToIfc(scene);
+            Assert.Contains("IFCWALL(", ifcText);
+            Assert.DoesNotContain("IFCBUILDINGELEMENTPROXY", ifcText);
+        }
+
+        [Fact]
+        public void ToIfc_AcceptsCustomClassifierOverride()
+        {
+            var scene = new Scene
+            {
+                SceneHierarchy = new InstanceNode { Name = "Root", DefinitionName = "RootDef" },
+                MeshIndex = new Dictionary<string, MeshMetadata>
+                {
+                    ["Outer Wall"] = new MeshMetadata { Name = "Outer Wall" }
+                },
+                GlbPrimitives = new List<GlbPrimitive>
+                {
+                    new GlbPrimitive
+                    {
+                        GeomName = "Outer Wall",
+                        MaterialIndex = 0,
+                        Positions = new float[] { 0f, 0f, 0f, 1f, 0f, 0f, 0f, 1f, 0f },
+                        Normals = new float[] { 0f, 0f, 1f, 0f, 0f, 1f, 0f, 0f, 1f },
+                        Uvs = new float[] { 0f, 0f, 1f, 0f, 0f, 1f },
+                        Indices = new uint[] { 0, 1, 2 }
+                    }
+                }
+            };
+
+            string ifcText = IfcExport.ToIfc(scene, IfcExport.MetresToInches, "IFC4", (geomName, layerName) => ("IFCCOLUMN", "IfcColumn"));
+            Assert.DoesNotContain("IFCWALL(", ifcText);
+            Assert.Contains("IFCCOLUMN(", ifcText);
+        }
+
+        [Fact]
         public void ToIfc_SerializesSceneToIfc4StepText()
         {
             var scene = new Scene

--- a/packages/dotnet/OpenSkp/IfcExport.cs
+++ b/packages/dotnet/OpenSkp/IfcExport.cs
@@ -39,13 +39,10 @@ namespace OpenSkp
             return string.IsNullOrEmpty(clean) ? "Unnamed" : clean;
         }
 
-        /// <summary>
-        /// Classifies geometry/component name into an IFC entity type.
-        /// </summary>
-        public static (string StepType, string ClassName) ClassifyElement(string geomName)
+        private static (string StepType, string ClassName)? ClassifyByKeyword(string name)
         {
-            if (string.IsNullOrEmpty(geomName)) return ("IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy");
-            string l = geomName.ToLowerInvariant();
+            if (string.IsNullOrEmpty(name)) return null;
+            string l = name.ToLowerInvariant();
             if (l.Contains("wall")) return ("IFCWALL", "IfcWall");
             if (l.Contains("door")) return ("IFCDOOR", "IfcDoor");
             if (l.Contains("window")) return ("IFCWINDOW", "IfcWindow");
@@ -53,6 +50,27 @@ namespace OpenSkp
             if (l.Contains("column") || l.Contains("pillar")) return ("IFCCOLUMN", "IfcColumn");
             if (l.Contains("beam") || l.Contains("joist")) return ("IFCBEAM", "IfcBeam");
             if (l.Contains("roof")) return ("IFCROOF", "IfcRoof");
+            return null;
+        }
+
+        /// <summary>
+        /// Classifies geometry/component name into an IFC entity type.
+        /// Tries <paramref name="geomName"/> first, then falls back to
+        /// <paramref name="layerName"/> (many SketchUp-for-BIM workflows
+        /// organize by tag/layer - "Walls", "Doors" - even when individual
+        /// components are never renamed away from SketchUp's own defaults
+        /// like "Component#109415"), then falls back to a generic, untyped
+        /// element if neither matches.
+        /// </summary>
+        public static (string StepType, string ClassName) ClassifyElement(string geomName, string layerName = "")
+        {
+            var byName = ClassifyByKeyword(geomName);
+            if (byName.HasValue) return byName.Value;
+            if (!string.IsNullOrEmpty(layerName))
+            {
+                var byLayer = ClassifyByKeyword(layerName);
+                if (byLayer.HasValue) return byLayer.Value;
+            }
             return ("IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy");
         }
 
@@ -82,12 +100,17 @@ namespace OpenSkp
         /// <summary>
         /// Serializes a baked <see cref="Scene"/> to ISO-10303-21 STEP ASCII IFC4 format.
         /// </summary>
-        public static string ToIfc(Scene scene, double scale = MetresToInches, string schema = "IFC4")
+        /// <param name="classifier">Optional override for <see cref="ClassifyElement"/> -
+        /// use this to supply your own naming convention or metadata-driven typing
+        /// instead of the built-in keyword/layer heuristic.</param>
+        public static string ToIfc(Scene scene, double scale = MetresToInches, string schema = "IFC4", Func<string, string, (string StepType, string ClassName)>? classifier = null)
         {
             if (scene == null || scene.GlbPrimitives == null)
             {
                 throw new ArgumentNullException(nameof(scene), "ToIfc requires a valid Scene instance");
             }
+
+            var classify = classifier ?? ClassifyElement;
 
             string schemaStr = string.IsNullOrWhiteSpace(schema) ? "IFC4" : schema.ToUpperInvariant();
             string nowIso = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss", CultureInfo.InvariantCulture);
@@ -189,7 +212,7 @@ namespace OpenSkp
                     }
                 }
 
-                var (stepType, _) = ClassifyElement(geomName);
+                var (stepType, _) = classify(geomName, layerName);
 
                 var ptCoords = new List<string>();
                 for (int i = 0; i < vCount; i++)
@@ -315,7 +338,7 @@ namespace OpenSkp
         /// <summary>
         /// Exports a baked <see cref="Scene"/> directly to an ISO-10303-21 STEP ASCII IFC4 file using UTF-8 without BOM.
         /// </summary>
-        public static void ExportIfc(Scene scene, string outputPath, double scale = MetresToInches, string schema = "IFC4")
+        public static void ExportIfc(Scene scene, string outputPath, double scale = MetresToInches, string schema = "IFC4", Func<string, string, (string StepType, string ClassName)>? classifier = null)
         {
             if (scene == null)
             {
@@ -332,7 +355,7 @@ namespace OpenSkp
                 Directory.CreateDirectory(dir);
             }
 
-            string text = ToIfc(scene, scale, schema);
+            string text = ToIfc(scene, scale, schema, classifier);
             File.WriteAllText(outputPath, text, new UTF8Encoding(false));
         }
     }

--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import datetime
 import pathlib
 import uuid
-from typing import Dict, List, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from ..scene import Scene
 
@@ -40,13 +40,9 @@ def sanitize_name(name: str) -> str:
     return clean if clean else "Unnamed"
 
 
-def classify_element(geom_name: str) -> Tuple[str, str]:
-    """Map a geometry/component name to an IFC4 entity type and constructor.
-
-    Returns:
-        Tuple of (STEP_ENTITY_TYPE, IFC_CLASS_NAME)
-    """
-    name_lower = geom_name.lower()
+def _classify_by_keyword(name: str) -> Union[Tuple[str, str], None]:
+    """Match a single name string against the keyword vocabulary, or None."""
+    name_lower = name.lower()
     if "wall" in name_lower:
         return "IFCWALL", "IfcWall"
     if "door" in name_lower:
@@ -61,6 +57,31 @@ def classify_element(geom_name: str) -> Tuple[str, str]:
         return "IFCBEAM", "IfcBeam"
     if "roof" in name_lower:
         return "IFCROOF", "IfcRoof"
+    return None
+
+
+def classify_element(geom_name: str, layer_name: str = "") -> Tuple[str, str]:
+    """Map a geometry/component name to an IFC4 entity type and constructor.
+
+    Tries the component's own name first - if a modeler bothered to name a
+    part "Wall_A", that's the most specific signal available. Most
+    real-world files never get that far (SketchUp's own default names like
+    "Component#109415" carry no semantic info), so this falls back to
+    ``layer_name`` next: many SketchUp-for-BIM workflows organize by
+    tag/layer ("Walls", "Doors") even when individual components are never
+    renamed. Only if neither matches does this fall back to a generic,
+    untyped element.
+
+    Returns:
+        Tuple of (STEP_ENTITY_TYPE, IFC_CLASS_NAME)
+    """
+    result = _classify_by_keyword(geom_name)
+    if result is not None:
+        return result
+    if layer_name:
+        result = _classify_by_keyword(layer_name)
+        if result is not None:
+            return result
     return "IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy"
 
 
@@ -86,6 +107,7 @@ def to_ifc(
     scene: Scene,
     scale: float = METRES_TO_INCHES,
     schema: str = "IFC4",
+    classifier: Optional[Callable[[str, str], Tuple[str, str]]] = None,
 ) -> str:
     """Serialize a baked Scene into ISO-10303-21 STEP ASCII IFC4 format.
 
@@ -94,12 +116,19 @@ def to_ifc(
         scene: The baked scene returned by :meth:`SkpFile.build_scene`.
         scale: Coordinate scale factor (default: METRES_TO_INCHES).
         schema: IFC schema version (default: "IFC4").
+        classifier: Optional override for :func:`classify_element`, called
+            as ``classifier(geom_name, layer_name)`` and expected to return
+            the same ``(STEP_ENTITY_TYPE, IFC_CLASS_NAME)`` tuple - use this
+            to supply your own naming convention or metadata-driven typing
+            instead of the built-in keyword/layer heuristic.
 
     Returns:
         Formatted ASCII IFC text string.
     """
     if not isinstance(scene, Scene):
         raise TypeError("to_ifc requires a valid Scene instance")
+
+    classify = classifier or classify_element
 
     schema_str = schema.upper() if schema else "IFC4"
     now_iso = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S")
@@ -131,10 +160,14 @@ def to_ifc(
     lines.append(f"#{org_id}=IFCORGANIZATION($,'OpenSKP',$,$,$);")
 
     person_org_id = next_id()
-    lines.append(f"#{person_org_id}=IFCPERSONANDORGANIZATION(#{person_id},#{org_id},$);")
+    lines.append(
+        f"#{person_org_id}=IFCPERSONANDORGANIZATION(#{person_id},#{org_id},$);"
+    )
 
     app_id = next_id()
-    lines.append(f"#{app_id}=IFCAPPLICATION(#{org_id},'0.3.1','OpenSKP Exporter','OpenSKP');")
+    lines.append(
+        f"#{app_id}=IFCAPPLICATION(#{org_id},'0.3.1','OpenSKP Exporter','OpenSKP');"
+    )
 
     owner_hist_id = next_id()
     lines.append(
@@ -184,7 +217,9 @@ def to_ifc(
     )
 
     bldg_placement_id = next_id()
-    lines.append(f"#{bldg_placement_id}=IFCLOCALPLACEMENT(#{site_placement_id},#{axis_placement_id});")
+    lines.append(
+        f"#{bldg_placement_id}=IFCLOCALPLACEMENT(#{site_placement_id},#{axis_placement_id});"
+    )
 
     bldg_id = next_id()
     bldg_guid = generate_ifc_guid()
@@ -193,7 +228,9 @@ def to_ifc(
     )
 
     storey_placement_id = next_id()
-    lines.append(f"#{storey_placement_id}=IFCLOCALPLACEMENT(#{bldg_placement_id},#{axis_placement_id});")
+    lines.append(
+        f"#{storey_placement_id}=IFCLOCALPLACEMENT(#{bldg_placement_id},#{axis_placement_id});"
+    )
 
     storey_id = next_id()
     storey_guid = generate_ifc_guid()
@@ -233,7 +270,7 @@ def to_ifc(
         if meta and getattr(meta, "layer", None):
             layer_name = sanitize_name(meta.layer)
 
-        step_type, ifc_class = classify_element(geom_name)
+        step_type, ifc_class = classify(geom_name, layer_name)
 
         # 1. Coordinate Point List 3D
         pt_coords: List[str] = []
@@ -280,13 +317,17 @@ def to_ifc(
             )
 
             style_assign_id = next_id()
-            lines.append(f"#{style_assign_id}=IFCPRESENTATIONSTYLEASSIGNMENT((#{style_id}));")
+            lines.append(
+                f"#{style_assign_id}=IFCPRESENTATIONSTYLEASSIGNMENT((#{style_id}));"
+            )
             mat_style_cache[rgba_key] = style_assign_id
         else:
             style_assign_id = mat_style_cache[rgba_key]
 
         styled_item_id = next_id()
-        lines.append(f"#{styled_item_id}=IFCSTYLEDITEM(#{face_set_id},(#{style_assign_id}),$);")
+        lines.append(
+            f"#{styled_item_id}=IFCSTYLEDITEM(#{face_set_id},(#{style_assign_id}),$);"
+        )
 
         # 4. Shape Representation & Product Definition Shape
         shape_rep_id = next_id()
@@ -295,10 +336,14 @@ def to_ifc(
         )
 
         prod_shape_id = next_id()
-        lines.append(f"#{prod_shape_id}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{shape_rep_id}));")
+        lines.append(
+            f"#{prod_shape_id}=IFCPRODUCTDEFINITIONSHAPE($,$,(#{shape_rep_id}));"
+        )
 
         prod_placement_id = next_id()
-        lines.append(f"#{prod_placement_id}=IFCLOCALPLACEMENT(#{storey_placement_id},#{axis_placement_id});")
+        lines.append(
+            f"#{prod_placement_id}=IFCLOCALPLACEMENT(#{storey_placement_id},#{axis_placement_id});"
+        )
 
         prod_guid = generate_ifc_guid()
         product_id = next_id()
@@ -314,7 +359,12 @@ def to_ifc(
         product_ids.append(product_id)
 
         # 5. Property Sets (if scene metadata contains dynamic properties)
-        if meta and hasattr(meta, "properties") and isinstance(meta.properties, dict) and meta.properties:
+        if (
+            meta
+            and hasattr(meta, "properties")
+            and isinstance(meta.properties, dict)
+            and meta.properties
+        ):
             prop_val_ids: List[int] = []
             for p_key, p_val in meta.properties.items():
                 clean_k = sanitize_name(str(p_key))
@@ -365,6 +415,7 @@ def export(
     output_path: Union[str, pathlib.Path],
     scale: float = METRES_TO_INCHES,
     schema: str = "IFC4",
+    classifier: Optional[Callable[[str, str], Tuple[str, str]]] = None,
 ) -> None:
     """Export a baked scene to an ISO-10303-21 STEP ASCII IFC4 file.
 
@@ -373,8 +424,10 @@ def export(
         output_path: Destination path (.ifc).
         scale: Coordinate scale factor (default: METRES_TO_INCHES).
         schema: IFC schema version (default: "IFC4").
+        classifier: Optional override for :func:`classify_element` - see
+            :func:`to_ifc` for the calling convention.
     """
     path = pathlib.Path(output_path)
     path.parent.mkdir(parents=True, exist_ok=True)
-    text = to_ifc(scene, scale=scale, schema=schema)
+    text = to_ifc(scene, scale=scale, schema=schema, classifier=classifier)
     path.write_bytes(text.encode("utf-8"))

--- a/packages/python/tests/test_ifc.py
+++ b/packages/python/tests/test_ifc.py
@@ -28,7 +28,9 @@ def create_mock_scene() -> Scene:
         {"pbrMetallicRoughness": {"baseColorFactor": [0.2, 0.8, 0.2, 0.9]}},
     ]
     mesh_index = {
-        "Outer Wall": MeshMetadata(name="Outer Wall", properties={"Thickness": "200mm", "LoadBearing": "True"}),
+        "Outer Wall": MeshMetadata(
+            name="Outer Wall", properties={"Thickness": "200mm", "LoadBearing": "True"}
+        ),
         "Front Door": MeshMetadata(name="Front Door", properties={"Material": "Wood"}),
     }
     return Scene(
@@ -54,6 +56,58 @@ class TestIfcExporter:
         assert classify_element("Steel Beam")[0] == "IFCBEAM"
         assert classify_element("Roof Tile")[0] == "IFCROOF"
         assert classify_element("Random Object")[0] == "IFCBUILDINGELEMENTPROXY"
+
+    def test_classify_element_falls_back_to_layer_name(self):
+        # A SketchUp default component name carries no keyword, but a
+        # BIM-style layer/tag name often does - this is the real-world
+        # case openskp#238 reported (components never renamed, but
+        # organized onto layers like "Walls").
+        assert classify_element("Component#109415", "Walls")[0] == "IFCWALL"
+        assert classify_element("Group#3", "Doors")[0] == "IFCDOOR"
+
+    def test_classify_element_prefers_component_name_over_layer(self):
+        # The component's own name is a more specific signal than the
+        # layer it happens to sit on, so it must win when both match.
+        assert classify_element("Interior Door", "Walls")[0] == "IFCDOOR"
+
+    def test_classify_element_generic_when_neither_matches(self):
+        assert (
+            classify_element("Component#109415", "Layer0")[0]
+            == "IFCBUILDINGELEMENTPROXY"
+        )
+        assert classify_element("Component#109415")[0] == "IFCBUILDINGELEMENTPROXY"
+
+    def test_to_ifc_uses_layer_name_fallback_for_unnamed_components(self):
+        prim = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="Component#109415",
+        )
+        scene = Scene(
+            scene_hierarchy=InstanceNode(name="Root"),
+            mesh_index={
+                "Component#109415": MeshMetadata(name="Component#109415", layer="Walls")
+            },
+            glb_primitives=[prim],
+            gltf_materials=[{}],
+        )
+        ifc_text = to_ifc(scene)
+        assert "IFCWALL(" in ifc_text
+        assert "IFCBUILDINGELEMENTPROXY" not in ifc_text
+
+    def test_to_ifc_accepts_a_custom_classifier(self):
+        scene = create_mock_scene()
+
+        def always_column(geom_name, layer_name):
+            return "IFCCOLUMN", "IfcColumn"
+
+        ifc_text = to_ifc(scene, classifier=always_column)
+        assert "IFCWALL(" not in ifc_text
+        assert "IFCDOOR(" not in ifc_text
+        assert ifc_text.count("IFCCOLUMN(") == 2
 
     def test_to_ifc_structure(self):
         scene = create_mock_scene()

--- a/packages/typescript/src/ifc.ts
+++ b/packages/typescript/src/ifc.ts
@@ -22,8 +22,8 @@ export function sanitizeName(name: string | null | undefined): string {
   return clean.length > 0 ? clean : 'Unnamed';
 }
 
-export function classifyElement(geomName: string): [string, string] {
-  const l = geomName.toLowerCase();
+function classifyByKeyword(name: string): [string, string] | null {
+  const l = name.toLowerCase();
   if (l.includes('wall')) return ['IFCWALL', 'IfcWall'];
   if (l.includes('door')) return ['IFCDOOR', 'IfcDoor'];
   if (l.includes('window')) return ['IFCWINDOW', 'IfcWindow'];
@@ -31,6 +31,25 @@ export function classifyElement(geomName: string): [string, string] {
   if (l.includes('column') || l.includes('pillar')) return ['IFCCOLUMN', 'IfcColumn'];
   if (l.includes('beam') || l.includes('joist')) return ['IFCBEAM', 'IfcBeam'];
   if (l.includes('roof')) return ['IFCROOF', 'IfcRoof'];
+  return null;
+}
+
+/**
+ * Map a geometry/component name to an IFC4 entity type and constructor.
+ *
+ * Tries the component's own name first, then falls back to `layerName`
+ * (many SketchUp-for-BIM workflows organize by tag/layer - "Walls",
+ * "Doors" - even when individual components are never renamed away from
+ * SketchUp's own defaults like "Component#109415"), then falls back to a
+ * generic, untyped element if neither matches.
+ */
+export function classifyElement(geomName: string, layerName = ''): [string, string] {
+  const byName = classifyByKeyword(geomName);
+  if (byName) return byName;
+  if (layerName) {
+    const byLayer = classifyByKeyword(layerName);
+    if (byLayer) return byLayer;
+  }
   return ['IFCBUILDINGELEMENTPROXY', 'IfcBuildingElementProxy'];
 }
 
@@ -55,15 +74,24 @@ function getPrimRgb(scene: SkpScene, primMatIdx: number): [number, number, numbe
 
 /**
  * Serialize a baked SkpScene to ISO-10303-21 STEP ASCII IFC4 format.
+ *
+ * @param classifier - Optional override for {@link classifyElement}, called
+ * as `classifier(geomName, layerName)` and expected to return the same
+ * `[STEP_ENTITY_TYPE, IFC_CLASS_NAME]` tuple - use this to supply your own
+ * naming convention or metadata-driven typing instead of the built-in
+ * keyword/layer heuristic.
  */
 export function toIFC(
   scene: SkpScene,
   scale: number = METRES_TO_INCHES,
-  schema: string = 'IFC4'
+  schema: string = 'IFC4',
+  classifier?: (geomName: string, layerName: string) => [string, string]
 ): string {
   if (!scene || !scene.glbPrimitives) {
     throw new Error('toIFC requires a valid SkpScene instance');
   }
+
+  const classify = classifier || classifyElement;
 
   const schemaStr = (schema || 'IFC4').toUpperCase();
   const nowIso = new Date().toISOString().replace(/\.\d{3}Z$/, '');
@@ -175,7 +203,7 @@ export function toIFC(
     const geomName = sanitizeName(prim.geomName);
     const meta = scene.meshIndex ? scene.meshIndex[prim.geomName] : undefined;
     const layerName = sanitizeName(meta && meta.layer ? meta.layer : 'Layer0');
-    const [stepType] = classifyElement(geomName);
+    const [stepType] = classify(geomName, layerName);
 
     const ptCoords: string[] = [];
     for (let i = 0; i < vCount; i++) {
@@ -309,7 +337,8 @@ export function exportIFC(
   scene: SkpScene,
   outputPath: string,
   scale: number = METRES_TO_INCHES,
-  schema: string = 'IFC4'
+  schema: string = 'IFC4',
+  classifier?: (geomName: string, layerName: string) => [string, string]
 ): void {
   if (typeof process !== 'undefined' && process.versions && process.versions.node) {
     const fs = require('fs');
@@ -318,7 +347,7 @@ export function exportIFC(
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
     }
-    const text = toIFC(scene, scale, schema);
+    const text = toIFC(scene, scale, schema, classifier);
     fs.writeFileSync(outputPath, text, 'utf8');
   } else {
     throw new Error('exportIFC is only supported in Node.js environment');

--- a/packages/typescript/tests/ifc.test.ts
+++ b/packages/typescript/tests/ifc.test.ts
@@ -54,6 +54,67 @@ describe('IFC4 3D Exporter', () => {
     expect(classifyElement('Steel Beam')[0]).toBe('IFCBEAM');
   });
 
+  it('falls back to the layer name when the component name has no keyword', () => {
+    // SketchUp default names carry no signal, but a BIM-style layer/tag
+    // often does (openskp#238).
+    expect(classifyElement('Component#109415', 'Walls')[0]).toBe('IFCWALL');
+    expect(classifyElement('Group#3', 'Doors')[0]).toBe('IFCDOOR');
+  });
+
+  it('prefers the component name over the layer name when both match', () => {
+    expect(classifyElement('Interior Door', 'Walls')[0]).toBe('IFCDOOR');
+  });
+
+  it('falls back to the generic proxy when neither name matches', () => {
+    expect(classifyElement('Component#109415', 'Layer0')[0]).toBe('IFCBUILDINGELEMENTPROXY');
+    expect(classifyElement('Component#109415')[0]).toBe('IFCBUILDINGELEMENTPROXY');
+  });
+
+  it('uses the layer name fallback in toIFC for unnamed components', () => {
+    const scene: SkpScene = {
+      sceneHierarchy: {
+        name: 'Root',
+        definitionName: 'RootDef',
+        layer: 'Layer0',
+        positionMm: [0, 0, 0],
+        properties: {},
+        children: [],
+      },
+      meshIndex: {
+        'Component#109415': {
+          name: 'Component#109415',
+          definitionName: 'CompDef',
+          layer: 'Walls',
+          positionMm: [0, 0, 0],
+          properties: {},
+          path: 'Root/Component#109415',
+        },
+      },
+      glbPrimitives: [
+        {
+          geomName: 'Component#109415',
+          materialIndex: 0,
+          positions: new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]),
+          normals: new Float32Array([0, 0, 1, 0, 0, 1, 0, 0, 1]),
+          uvs: new Float32Array([0, 0, 1, 0, 0, 1]),
+          indices: new Uint32Array([0, 1, 2]),
+        },
+      ],
+      gltfMaterials: [{}],
+    };
+    const ifcText = toIFC(scene);
+    expect(ifcText).toContain('IFCWALL(');
+    expect(ifcText).not.toContain('IFCBUILDINGELEMENTPROXY');
+  });
+
+  it('accepts a custom classifier override in toIFC', () => {
+    const scene = createMockScene();
+    const alwaysColumn = (): [string, string] => ['IFCCOLUMN', 'IfcColumn'];
+    const ifcText = toIFC(scene, METRES_TO_INCHES, 'IFC4', alwaysColumn);
+    expect(ifcText).not.toContain('IFCWALL(');
+    expect(ifcText).toContain('IFCCOLUMN(');
+  });
+
   it('serializes SkpScene to IFC4 STEP format', () => {
     const scene = createMockScene();
     const ifcText = toIFC(scene);


### PR DESCRIPTION
## Summary

Fixes #238, filed by @nooraliqureshi.

`classify_element()` in the IFC exporter only matched keywords ("wall", "door", "window", "slab"/"floor", "column"/"pillar", "beam"/"joist", "roof") against a component's own *name*. Real-world files that keep SketchUp's own default component names (`Component#109415`, `Group#3`) instead of renaming every object therefore exported as almost entirely generic `IfcBuildingElementProxy`, losing all semantic IFC typing.

**Fix:** `classify_element(geom_name, layer_name)` now cascades:
1. Component's own name (most specific signal, if a modeler bothered to name it)
2. Layer/tag name (many SketchUp-for-BIM workflows organize by tag — "Walls", "Doors" — even without renaming individual components)
3. Generic `IfcBuildingElementProxy` fallback (unchanged from today)

The layer name was already being extracted right next to the classification call site in every language's exporter — this just wires it in. This is purely additive: it only changes behavior in cases that would previously have fallen through to the generic proxy, so it can't produce a worse classification than today.

**Also added:** an optional `classifier` override parameter to `to_ifc()`/`export()` (and each language's equivalent — `toIFC`/`exportIFC`, `ToIfc`/`ExportIfc`, `toIfc`/`exportIfc`, `to_ifc`/`export_ifc`), called as `classifier(geomName, layerName)`. This lets an app built on OpenSKP fully override the heuristic with its own naming convention or metadata-driven typing (e.g. Dynamic Component attributes) without forking the library.

Implemented identically across all 5 languages: Python, TypeScript, .NET, Dart, C++.

## Test plan

- [x] New regression tests in every language's IFC export suite: layer-name fallback, name-over-layer precedence, generic-proxy-when-neither-matches, an end-to-end unnamed-component-on-a-named-layer test, and a custom-classifier-override test
- [x] Python: 405 tests pass, `ruff check`/`ruff format --check` clean
- [x] TypeScript: 352 tests pass, `eslint`/`tsc --noEmit` clean
- [x] .NET: 184 tests pass, `dotnet format --verify-no-changes` clean
- [x] Dart: 210 tests pass, `dart analyze --fatal-infos` clean
- [x] C++: 180 tests pass (Release build), `clang-format --dry-run --Werror` clean