### PR TITLE
fix: validate material/layer handles at every writer call site (all 5 languages)

### DIFF
--- a/packages/cpp/src/create.cpp
+++ b/packages/cpp/src/create.cpp
@@ -1262,6 +1262,40 @@ int do_add_polyline(ArchiveWriter& writer, std::map<Point3, int>& vertex_slots,
                                options.hidden_edges, options.soft_edges, options.smooth_edges);
 }
 
+// Reject a material/back_material option that isn't a handle `skp`'s own add_material()/
+// add_texture_material() actually returned. Without this, a stray value - most commonly a layer
+// handle passed to the wrong option by mistake - gets written straight into the file as a
+// material reference: this project's own reader tolerates the dangling reference silently, but
+// real SketchUp rejects the whole file as corrupt on open, with no indication of which call
+// caused it.
+void check_material_handle(const SkpBuilder& skp, const std::optional<int>& value,
+                           const std::string& param) {
+  if (!value || *value == 0) return;
+  for (const auto& [name, slot] : skp.materials_by_name) {
+    if (slot == *value) return;
+  }
+  throw SkpWriteError(
+      param + "=" + std::to_string(*value) +
+      " is not a handle this builder's add_material()/add_texture_material() returned - "
+      "passing an unrelated value (e.g. a layer handle by mistake) would silently write an "
+      "invalid material reference that real SketchUp rejects on open");
+}
+
+// Reject a layer option that isn't a handle `skp`'s own add_layer() actually returned - see
+// check_material_handle for why this matters.
+void check_layer_handle(const SkpBuilder& skp, const std::optional<int>& value,
+                        const std::string& param = "layer") {
+  if (!value || *value == 0) return;
+  for (const auto& [name, slot] : skp.layers_by_name) {
+    if (slot == *value) return;
+  }
+  throw SkpWriteError(
+      param + "=" + std::to_string(*value) +
+      " is not a handle this builder's add_layer() returned - passing an unrelated value "
+      "(e.g. a material handle by mistake) would silently write an invalid layer reference "
+      "that real SketchUp rejects on open");
+}
+
 }  // namespace
 }  // namespace detail
 
@@ -1523,6 +1557,9 @@ void ComponentDefinitionBuilder::check_writable(const std::string& action) const
 void ComponentDefinitionBuilder::add_face(const std::vector<Point3>& points,
                                           const FaceOptions& options) {
   check_writable("faces");
+  detail::check_material_handle(*impl_->skp, options.material, "material");
+  detail::check_material_handle(*impl_->skp, options.back_material, "back_material");
+  detail::check_layer_handle(*impl_->skp, options.layer);
   if (points.size() < 3) throw SkpWriteError("a face needs at least 3 points");
   detail::AttributeDictList dicts;
   if (!options.attributes.empty())
@@ -1537,6 +1574,9 @@ void ComponentDefinitionBuilder::add_face(const std::vector<Point3>& points,
 void ComponentDefinitionBuilder::add_circle(Point3 center, Point3 normal, double radius,
                                             const CircleOptions& options) {
   check_writable("faces");
+  detail::check_material_handle(*impl_->skp, options.material, "material");
+  detail::check_material_handle(*impl_->skp, options.back_material, "back_material");
+  detail::check_layer_handle(*impl_->skp, options.layer);
   impl_->new_entity_count += detail::do_add_circle(
       *impl_->writer, impl_->vertex_slots, impl_->edge_registry, center, normal, radius, options);
 }
@@ -1560,6 +1600,8 @@ void ComponentDefinitionBuilder::add_polyline(const std::vector<Point3>& points,
 void ComponentDefinitionBuilder::add_instance(const ComponentDefinitionBuilder& definition,
                                               const InstanceOptions& options) {
   check_writable("instances");
+  detail::check_material_handle(*impl_->skp, options.material, "material");
+  detail::check_layer_handle(*impl_->skp, options.layer);
   if (definition.impl_->skp != impl_->skp) {
     throw SkpWriteError("component definition '" + definition.name() +
                         "' belongs to a different builder (a different create() call) - "
@@ -1581,6 +1623,8 @@ void ComponentDefinitionBuilder::add_instance(const ComponentDefinitionBuilder& 
 void ComponentDefinitionBuilder::add_group_instance(const ComponentDefinitionBuilder& definition,
                                                     const GroupInstanceOptions& options) {
   check_writable("groups");
+  detail::check_material_handle(*impl_->skp, options.material, "material");
+  detail::check_layer_handle(*impl_->skp, options.layer);
   if (definition.impl_->skp != impl_->skp) {
     throw SkpWriteError("component definition '" + definition.name() +
                         "' belongs to a different builder (a different create() call) - "
@@ -1717,6 +1761,8 @@ ComponentDefinitionBuilder& SkpBuilder::add_component_definition(const std::stri
 }
 
 ComponentDefinitionBuilder& SkpBuilder::add_group(const GroupOptions& options) {
+  detail::check_material_handle(*this, options.material, "material");
+  detail::check_layer_handle(*this, options.layer);
   auto matrix = detail::resolve_matrix3x3(options.matrix3x3, options.rotation);
   auto [slot, count_patch_pos] = impl_->begin_definition_header("add_group", {});
   auto cdb_impl = std::make_unique<ComponentDefinitionBuilder::Impl>();
@@ -1737,6 +1783,8 @@ ComponentDefinitionBuilder& SkpBuilder::add_group(const GroupOptions& options) {
 
 void SkpBuilder::add_instance(const ComponentDefinitionBuilder& definition,
                               const InstanceOptions& options) {
+  detail::check_material_handle(*this, options.material, "material");
+  detail::check_layer_handle(*this, options.layer);
   if (definition.impl_->skp != this) {
     throw SkpWriteError("component definition '" + definition.name() +
                         "' belongs to a different builder (a different create() call) - "
@@ -1759,6 +1807,7 @@ void SkpBuilder::add_instance(const ComponentDefinitionBuilder& definition,
 
 void SkpBuilder::add_image(const std::filesystem::path& image_path, double width, double height,
                            const ImageOptions& options) {
+  detail::check_layer_handle(*this, options.layer);
   int mat =
       add_texture_material("__openskp_image_" + std::to_string(impl_->material_count), image_path);
   auto& image_def = add_component_definition("Image" + std::to_string(impl_->definition_count));
@@ -1784,6 +1833,9 @@ void SkpBuilder::add_image(const std::filesystem::path& image_path, double width
 }
 
 void SkpBuilder::add_face(const std::vector<Point3>& points, const FaceOptions& options) {
+  detail::check_material_handle(*this, options.material, "material");
+  detail::check_material_handle(*this, options.back_material, "back_material");
+  detail::check_layer_handle(*this, options.layer);
   if (points.size() < 3) throw SkpWriteError("a face needs at least 3 points");
   impl_->ensure_geometry_writer();
   detail::AttributeDictList dicts;
@@ -1799,6 +1851,9 @@ void SkpBuilder::add_face(const std::vector<Point3>& points, const FaceOptions& 
 
 void SkpBuilder::add_circle(Point3 center, Point3 normal, double radius,
                             const CircleOptions& options) {
+  detail::check_material_handle(*this, options.material, "material");
+  detail::check_material_handle(*this, options.back_material, "back_material");
+  detail::check_layer_handle(*this, options.layer);
   impl_->ensure_geometry_writer();
   impl_->new_entity_count +=
       detail::do_add_circle(*impl_->geometry_writer, impl_->vertex_slots, impl_->edge_registry,

--- a/packages/cpp/tests/create_test.cpp
+++ b/packages/cpp/tests/create_test.cpp
@@ -85,6 +85,92 @@ TEST(Create, NonCoplanarFaceRaisesWithoutAutoTriangulate) {
 }
 
 // ---------------------------------------------------------------------------------------------
+// Material/layer handle validation.
+// ---------------------------------------------------------------------------------------------
+
+std::vector<Point3> square_pts() { return {{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}; }
+
+TEST(Create, AddFaceRejectsALayerHandlePassedAsMaterial) {
+  // The exact real-world mistake this guards against: a caller accidentally passes a layer
+  // handle into FaceOptions::material (e.g. via a field mix-up in a wrapper function around
+  // add_face). Before this check, the layer's slot silently became a dangling material
+  // reference - openskp's own reader tolerated it, but real SketchUp rejected the resulting
+  // file outright.
+  auto builder = create();
+  int layer = builder->add_layer("Layer0");
+  FaceOptions opts;
+  opts.material = layer;
+  EXPECT_THROW(builder->add_face(square_pts(), opts), SkpWriteError);
+}
+
+TEST(Create, AddFaceRejectsAMaterialHandlePassedAsLayer) {
+  auto builder = create();
+  int mat = builder->add_material("Red", Color3{255, 0, 0});
+  FaceOptions opts;
+  opts.layer = mat;
+  EXPECT_THROW(builder->add_face(square_pts(), opts), SkpWriteError);
+}
+
+TEST(Create, AddFaceRejectsAnUnrelatedBackMaterialHandle) {
+  auto builder = create();
+  int layer = builder->add_layer("Layer0");
+  FaceOptions opts;
+  opts.back_material = layer;
+  EXPECT_THROW(builder->add_face(square_pts(), opts), SkpWriteError);
+}
+
+TEST(Create, AddFaceRejectsAHandleFromADifferentBuilder) {
+  auto other_builder = create();
+  int stray_material = other_builder->add_material("Blue", Color3{0, 0, 255});
+  auto builder = create();
+  FaceOptions opts;
+  opts.material = stray_material;
+  EXPECT_THROW(builder->add_face(square_pts(), opts), SkpWriteError);
+}
+
+TEST(Create, AddInstanceRejectsALayerHandlePassedAsMaterial) {
+  auto builder = create();
+  int layer = builder->add_layer("Layer0");
+  auto& chair = builder->add_component_definition("Chair");
+  chair.add_face(square_pts());
+  chair.close();
+  InstanceOptions opts;
+  opts.material = layer;
+  EXPECT_THROW(builder->add_instance(chair, opts), SkpWriteError);
+}
+
+TEST(Create, AddGroupRejectsAnUnrelatedLayerHandle) {
+  auto builder = create();
+  int mat = builder->add_material("Red", Color3{255, 0, 0});
+  GroupOptions opts;
+  opts.name = "Table";
+  opts.layer = mat;
+  EXPECT_THROW(builder->add_group(opts), SkpWriteError);
+}
+
+TEST(Create, ComponentScopeAddFaceRejectsAnUnrelatedHandle) {
+  auto builder = create();
+  int layer = builder->add_layer("Layer0");
+  auto& chair = builder->add_component_definition("Chair");
+  FaceOptions opts;
+  opts.material = layer;
+  EXPECT_THROW(chair.add_face(square_pts(), opts), SkpWriteError);
+  // the definition must still be usable after a rejected call
+  chair.add_face(square_pts());
+}
+
+TEST(Create, AddFaceAcceptsARealMaterialAndLayer) {
+  auto builder = create();
+  int mat = builder->add_material("Red", Color3{255, 0, 0});
+  int layer = builder->add_layer("MyLayer");
+  FaceOptions opts;
+  opts.material = mat;
+  opts.layer = layer;
+  builder->add_face(square_pts(), opts);
+  EXPECT_GT(builder->to_bytes().size(), 0u);
+}
+
+// ---------------------------------------------------------------------------------------------
 // Materials.
 // ---------------------------------------------------------------------------------------------
 

--- a/packages/dart/lib/src/create.dart
+++ b/packages/dart/lib/src/create.dart
@@ -1744,6 +1744,9 @@ class ComponentDefinitionBuilder implements GeometryHost {
     List<List<Point3>> holes = const [],
   }) {
     _checkWritable('faces');
+    _skp._checkMaterialHandle(material, 'material');
+    _skp._checkMaterialHandle(backMaterial, 'backMaterial');
+    _skp._checkLayerHandle(layer);
     if (points.length < 3) {
       throw SkpWriteError('a face needs at least 3 points');
     }
@@ -1786,6 +1789,9 @@ class ComponentDefinitionBuilder implements GeometryHost {
     String attributeDictName = 'attributes',
   }) {
     _checkWritable('faces');
+    _skp._checkMaterialHandle(material, 'material');
+    _skp._checkMaterialHandle(backMaterial, 'backMaterial');
+    _skp._checkLayerHandle(layer);
     if (numSegments < 3 || numSegments > 255) {
       throw SkpWriteError('numSegments must be between 3 and 255, got $numSegments');
     }
@@ -1894,6 +1900,8 @@ class ComponentDefinitionBuilder implements GeometryHost {
     bool hidden = false,
   }) {
     _checkWritable('instances');
+    _skp._checkMaterialHandle(material, 'material');
+    _skp._checkLayerHandle(layer);
     if (!identical(definition._skp, _skp)) {
       throw SkpWriteError(
         "component definition '${definition.name}' belongs to a different builder "
@@ -1935,6 +1943,8 @@ class ComponentDefinitionBuilder implements GeometryHost {
     bool hidden = false,
   }) {
     _checkWritable('groups');
+    _skp._checkMaterialHandle(material, 'material');
+    _skp._checkLayerHandle(layer);
     if (!identical(definition._skp, _skp)) {
       throw SkpWriteError(
         "component definition '${definition.name}' belongs to a different builder "
@@ -2197,6 +2207,36 @@ class SkpBuilder implements GeometryHost {
     return slot;
   }
 
+  /// Reject a material/backMaterial argument that isn't a handle this
+  /// builder's own [addMaterial]/[addTextureMaterial] actually returned.
+  /// Without this, a stray value - most commonly a layer handle passed to
+  /// the wrong parameter by mistake - gets written straight into the file
+  /// as a material reference: this project's own reader tolerates the
+  /// dangling reference silently, but real SketchUp rejects the whole
+  /// file as corrupt on open, with no indication of which call caused it.
+  void _checkMaterialHandle(int? value, String param) {
+    if (value != null && value != 0 && !materialsByName.values.contains(value)) {
+      throw SkpWriteError(
+        "$param=$value is not a handle this builder's addMaterial()/addTextureMaterial() "
+        'returned - passing an unrelated value (e.g. a layer handle by mistake) would '
+        'silently write an invalid material reference that real SketchUp rejects on open',
+      );
+    }
+  }
+
+  /// Reject a layer argument that isn't a handle this builder's own
+  /// [addLayer] actually returned - see [_checkMaterialHandle] for why
+  /// this matters.
+  void _checkLayerHandle(int? value, [String param = 'layer']) {
+    if (value != null && value != 0 && !layersByName.values.contains(value)) {
+      throw SkpWriteError(
+        "$param=$value is not a handle this builder's addLayer() returned - passing an "
+        'unrelated value (e.g. a material handle by mistake) would silently write an '
+        'invalid layer reference that real SketchUp rejects on open',
+      );
+    }
+  }
+
   Map<String, int> _materialShiftedClassSlot() {
     final materialShift = _materialWriter.nextSlot - _base;
     return {for (final e in _scaffoldClassSlot.entries) e.key: e.value + materialShift};
@@ -2296,6 +2336,8 @@ class SkpBuilder implements GeometryHost {
     int? layer,
     bool hidden = false,
   }) {
+    _checkMaterialHandle(material, 'material');
+    _checkLayerHandle(layer);
     final resolved = _resolveMatrix3x3(matrix3x3, rotation);
     final comp = _startDefinition(
       name ?? 'Group',
@@ -2344,6 +2386,8 @@ class SkpBuilder implements GeometryHost {
     String attributeDictName = 'attributes',
     bool hidden = false,
   }) {
+    _checkMaterialHandle(material, 'material');
+    _checkLayerHandle(layer);
     if (!identical(definition._skp, this)) {
       throw SkpWriteError(
         "component definition '${definition.name}' belongs to a different builder "
@@ -2421,6 +2465,7 @@ class SkpBuilder implements GeometryHost {
     int? layer,
     bool hidden = false,
   }) {
+    _checkLayerHandle(layer);
     final mat = addTextureMaterial('__openskp_image_$_materialCount', imagePath);
     late final ComponentDefinitionBuilder imageDef;
     imageDef = addComponentDefinition('Image$_definitionCount', (def) {
@@ -2512,6 +2557,9 @@ class SkpBuilder implements GeometryHost {
     bool autoTriangulate = false,
     List<List<Point3>> holes = const [],
   }) {
+    _checkMaterialHandle(material, 'material');
+    _checkMaterialHandle(backMaterial, 'backMaterial');
+    _checkLayerHandle(layer);
     if (points.length < 3) {
       throw SkpWriteError('a face needs at least 3 points');
     }
@@ -2560,6 +2608,9 @@ class SkpBuilder implements GeometryHost {
     Map<String, Object>? attributes,
     String attributeDictName = 'attributes',
   }) {
+    _checkMaterialHandle(material, 'material');
+    _checkMaterialHandle(backMaterial, 'backMaterial');
+    _checkLayerHandle(layer);
     if (numSegments < 3 || numSegments > 255) {
       throw SkpWriteError('numSegments must be between 3 and 255, got $numSegments');
     }

--- a/packages/dart/test/create_test.dart
+++ b/packages/dart/test/create_test.dart
@@ -1015,6 +1015,91 @@ void main() {
         throwsA(isA<SkpWriteError>().having((e) => e.message, 'message', contains('not coplanar'))),
       );
     });
+
+    final square = [
+      (0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (100.0, 100.0, 0.0), (0.0, 100.0, 0.0),
+    ];
+
+    test('addFace rejects a layer handle passed as material', () {
+      // The exact real-world mistake this guards against: a caller
+      // accidentally passes a layer handle into the material parameter
+      // (e.g. via an argument-order slip in a wrapper function around
+      // addFace). Before this check, the layer's slot silently became a
+      // dangling material reference - openskp's own reader tolerated it,
+      // but real SketchUp rejected the resulting file outright.
+      final builder = create();
+      final layer = builder.addLayer('Layer0');
+      expect(
+        () => builder.addFace(square, material: layer),
+        throwsA(isA<SkpWriteError>().having((e) => e.message, 'message', contains('material'))),
+      );
+    });
+
+    test('addFace rejects a material handle passed as layer', () {
+      final builder = create();
+      final mat = builder.addMaterial('Red', [255, 0, 0]);
+      expect(
+        () => builder.addFace(square, layer: mat),
+        throwsA(isA<SkpWriteError>().having((e) => e.message, 'message', contains('layer'))),
+      );
+    });
+
+    test('addFace rejects an unrelated backMaterial handle', () {
+      final builder = create();
+      final layer = builder.addLayer('Layer0');
+      expect(
+        () => builder.addFace(square, backMaterial: layer),
+        throwsA(isA<SkpWriteError>().having((e) => e.message, 'message', contains('backMaterial'))),
+      );
+    });
+
+    test('addFace rejects a handle from a different builder', () {
+      final otherBuilder = create();
+      final strayMaterial = otherBuilder.addMaterial('Blue', [0, 0, 255]);
+      final builder = create();
+      expect(
+        () => builder.addFace(square, material: strayMaterial),
+        throwsA(isA<SkpWriteError>()),
+      );
+    });
+
+    test('addInstance rejects a layer handle passed as material', () {
+      final builder = create();
+      final layer = builder.addLayer('Layer0');
+      final chair = builder.addComponentDefinition('Chair', (def) => def.addFace(square));
+      expect(
+        () => builder.addInstance(chair, material: layer),
+        throwsA(isA<SkpWriteError>().having((e) => e.message, 'message', contains('material'))),
+      );
+    });
+
+    test('addGroup rejects an unrelated layer handle', () {
+      final builder = create();
+      final mat = builder.addMaterial('Red', [255, 0, 0]);
+      expect(
+        () => builder.addGroup((def) => def.addFace(square), name: 'Table', layer: mat),
+        throwsA(isA<SkpWriteError>().having((e) => e.message, 'message', contains('layer'))),
+      );
+    });
+
+    test('a component-scope addFace rejects an unrelated handle', () {
+      final builder = create();
+      final layer = builder.addLayer('Layer0');
+      expect(
+        () => builder.addComponentDefinition('Chair', (def) {
+          def.addFace(square, material: layer);
+        }),
+        throwsA(isA<SkpWriteError>().having((e) => e.message, 'message', contains('material'))),
+      );
+    });
+
+    test('addFace accepts a real material and layer', () {
+      final builder = create();
+      final mat = builder.addMaterial('Red', [255, 0, 0]);
+      final layer = builder.addLayer('MyLayer');
+      builder.addFace(square, material: mat, layer: layer);
+      expect(builder.toBytes().length, greaterThan(0));
+    });
   });
 
   group('SlotBoundary', () {

--- a/packages/dotnet/OpenSkp.Tests/CreateTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CreateTests.cs
@@ -74,6 +74,89 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
+        public void AddFaceRejectsALayerHandlePassedAsMaterial()
+        {
+            // The exact real-world mistake this guards against: a caller
+            // accidentally passes a layer handle into the material
+            // parameter (e.g. via an argument-order slip in a wrapper
+            // function around AddFace). Before this check, the layer's
+            // slot silently became a dangling material reference -
+            // openskp's own reader tolerated it, but real SketchUp
+            // rejected the resulting file outright.
+            var builder = SkpCreate.NewFile();
+            int layer = builder.AddLayer("Layer0");
+            var ex = Assert.Throws<SkpWriteException>(() => builder.AddFace(Square(), material: layer));
+            Assert.Contains("material", ex.Message);
+        }
+
+        [Fact]
+        public void AddFaceRejectsAMaterialHandlePassedAsLayer()
+        {
+            var builder = SkpCreate.NewFile();
+            int mat = builder.AddMaterial("Red", (255, 0, 0));
+            var ex = Assert.Throws<SkpWriteException>(() => builder.AddFace(Square(), layer: mat));
+            Assert.Contains("layer", ex.Message);
+        }
+
+        [Fact]
+        public void AddFaceRejectsAnUnrelatedBackMaterialHandle()
+        {
+            var builder = SkpCreate.NewFile();
+            int layer = builder.AddLayer("Layer0");
+            var ex = Assert.Throws<SkpWriteException>(() => builder.AddFace(Square(), backMaterial: layer));
+            Assert.Contains("backMaterial", ex.Message);
+        }
+
+        [Fact]
+        public void AddFaceRejectsAHandleFromADifferentBuilder()
+        {
+            var otherBuilder = SkpCreate.NewFile();
+            int strayMaterial = otherBuilder.AddMaterial("Blue", (0, 0, 255));
+            var builder = SkpCreate.NewFile();
+            Assert.Throws<SkpWriteException>(() => builder.AddFace(Square(), material: strayMaterial));
+        }
+
+        [Fact]
+        public void AddInstanceRejectsALayerHandlePassedAsMaterial()
+        {
+            var builder = SkpCreate.NewFile();
+            int layer = builder.AddLayer("Layer0");
+            var chair = builder.AddComponentDefinition("Chair");
+            chair.AddFace(Square());
+            chair.Dispose();
+            Assert.Throws<SkpWriteException>(() => builder.AddInstance(chair, material: layer));
+        }
+
+        [Fact]
+        public void AddGroupRejectsAnUnrelatedLayerHandle()
+        {
+            var builder = SkpCreate.NewFile();
+            int mat = builder.AddMaterial("Red", (255, 0, 0));
+            Assert.Throws<SkpWriteException>(() => builder.AddGroup("Table", layer: mat));
+        }
+
+        [Fact]
+        public void ComponentScopeAddFaceRejectsAnUnrelatedHandle()
+        {
+            var builder = SkpCreate.NewFile();
+            int layer = builder.AddLayer("Layer0");
+            using var chair = builder.AddComponentDefinition("Chair");
+            Assert.Throws<SkpWriteException>(() => chair.AddFace(Square(), material: layer));
+            // the definition must still be usable after a rejected call
+            chair.AddFace(Square());
+        }
+
+        [Fact]
+        public void AddFaceAcceptsARealMaterialAndLayer()
+        {
+            var builder = SkpCreate.NewFile();
+            int mat = builder.AddMaterial("Red", (255, 0, 0));
+            int layer = builder.AddLayer("MyLayer");
+            builder.AddFace(Square(), material: mat, layer: layer);
+            Assert.True(builder.ToBytes().Length > 0);
+        }
+
+        [Fact]
         public void AutoTriangulateSplitsNonPlanarQuad()
         {
             var builder = SkpCreate.NewFile();

--- a/packages/dotnet/OpenSkp/Create.cs
+++ b/packages/dotnet/OpenSkp/Create.cs
@@ -1747,6 +1747,9 @@ namespace OpenSkp
             IReadOnlyList<IReadOnlyList<(double X, double Y, double Z)>>? holes = null)
         {
             CheckWritable("faces");
+            Skp.CheckMaterialHandle(material, "material");
+            Skp.CheckMaterialHandle(backMaterial, "backMaterial");
+            Skp.CheckLayerHandle(layer);
             if (points.Count < 3)
             {
                 throw new SkpWriteException("a face needs at least 3 points");
@@ -1772,6 +1775,9 @@ namespace OpenSkp
             IReadOnlyDictionary<string, object>? attributes = null, string attributeDictName = "attributes")
         {
             CheckWritable("faces");
+            Skp.CheckMaterialHandle(material, "material");
+            Skp.CheckMaterialHandle(backMaterial, "backMaterial");
+            Skp.CheckLayerHandle(layer);
             if (numSegments < 3 || numSegments > 255)
             {
                 throw new SkpWriteException($"num_segments must be between 3 and 255, got {numSegments}");
@@ -1852,6 +1858,8 @@ namespace OpenSkp
             bool hidden = false)
         {
             CheckWritable("instances");
+            Skp.CheckMaterialHandle(material, "material");
+            Skp.CheckLayerHandle(layer);
             if (!ReferenceEquals(definition.Skp, Skp))
             {
                 throw new SkpWriteException(
@@ -1887,6 +1895,8 @@ namespace OpenSkp
             bool hidden = false)
         {
             CheckWritable("groups");
+            Skp.CheckMaterialHandle(material, "material");
+            Skp.CheckLayerHandle(layer);
             if (!ReferenceEquals(definition.Skp, Skp))
             {
                 throw new SkpWriteException(
@@ -2249,6 +2259,40 @@ namespace OpenSkp
         public int AddLayer(string name, (int R, int G, int B) color, bool hidden = false) =>
             AddLayer(name, (color.R, color.G, color.B, 255), hidden);
 
+        /// <summary>Reject a material/backMaterial argument that isn't a
+        /// handle this builder's own AddMaterial()/AddTextureMaterial()
+        /// actually returned. Without this, a stray value - most commonly
+        /// a layer handle passed to the wrong parameter by mistake - gets
+        /// written straight into the file as a material reference: this
+        /// project's own reader tolerates the dangling reference silently,
+        /// but real SketchUp rejects the whole file as corrupt on open,
+        /// with no indication of which call caused it.</summary>
+        internal void CheckMaterialHandle(int? value, string param)
+        {
+            if (value.HasValue && value.Value != 0 && !MaterialsByName.ContainsValue(value.Value))
+            {
+                throw new SkpWriteException(
+                    $"{param}={value.Value} is not a handle this builder's AddMaterial()/" +
+                    "AddTextureMaterial() returned - passing an unrelated value (e.g. a layer " +
+                    "handle by mistake) would silently write an invalid material reference that " +
+                    "real SketchUp rejects on open");
+            }
+        }
+
+        /// <summary>Reject a layer argument that isn't a handle this
+        /// builder's own AddLayer() actually returned - see
+        /// CheckMaterialHandle for why this matters.</summary>
+        internal void CheckLayerHandle(int? value, string param = "layer")
+        {
+            if (value.HasValue && value.Value != 0 && !LayersByName.ContainsValue(value.Value))
+            {
+                throw new SkpWriteException(
+                    $"{param}={value.Value} is not a handle this builder's AddLayer() returned - " +
+                    "passing an unrelated value (e.g. a material handle by mistake) would silently " +
+                    "write an invalid layer reference that real SketchUp rejects on open");
+            }
+        }
+
         private Dictionary<string, int> MaterialShiftedClassSlot()
         {
             int materialShift = _materialWriter.NextSlot - _base;
@@ -2342,6 +2386,8 @@ namespace OpenSkp
             int? material = null, int? layer = null,
             bool hidden = false)
         {
+            CheckMaterialHandle(material, "material");
+            CheckLayerHandle(layer);
             var resolved = CreateMath.ResolveMatrix3x3(matrix3x3, rotation);
             var placement = new GroupPlacement(translation, resolved, material ?? 0, layer ?? 0, hidden);
             return StartDefinition(name ?? "Group", "AddGroup", placement, null);
@@ -2382,6 +2428,8 @@ namespace OpenSkp
             IReadOnlyDictionary<string, object>? attributes = null, string attributeDictName = "attributes",
             bool hidden = false)
         {
+            CheckMaterialHandle(material, "material");
+            CheckLayerHandle(layer);
             if (!ReferenceEquals(definition.Skp, this))
             {
                 throw new SkpWriteException(
@@ -2453,6 +2501,7 @@ namespace OpenSkp
             int? layer = null,
             bool hidden = false)
         {
+            CheckLayerHandle(layer);
             int mat = AddTextureMaterial($"__openskp_image_{_materialCount}", imagePath);
             ComponentDefinitionBuilder imageDef;
             using (imageDef = AddComponentDefinition($"Image{_definitionCount}"))
@@ -2566,6 +2615,9 @@ namespace OpenSkp
             bool autoTriangulate = false,
             IReadOnlyList<IReadOnlyList<(double X, double Y, double Z)>>? holes = null)
         {
+            CheckMaterialHandle(material, "material");
+            CheckMaterialHandle(backMaterial, "backMaterial");
+            CheckLayerHandle(layer);
             if (points.Count < 3)
             {
                 throw new SkpWriteException("a face needs at least 3 points");
@@ -2601,6 +2653,9 @@ namespace OpenSkp
             IReadOnlyList<UvCorrespondence>? frontUv = null, IReadOnlyList<UvCorrespondence>? backUv = null,
             IReadOnlyDictionary<string, object>? attributes = null, string attributeDictName = "attributes")
         {
+            CheckMaterialHandle(material, "material");
+            CheckMaterialHandle(backMaterial, "backMaterial");
+            CheckLayerHandle(layer);
             if (numSegments < 3 || numSegments > 255)
             {
                 throw new SkpWriteException($"num_segments must be between 3 and 255, got {numSegments}");

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -1704,6 +1704,9 @@ class ComponentDefinitionBuilder:
         shared only within this definition, never with the root model or
         other definitions."""
         self._check_writable("faces")
+        self._skp._check_material_handle(material, "material")
+        self._skp._check_material_handle(back_material, "back_material")
+        self._skp._check_layer_handle(layer)
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
@@ -1736,6 +1739,9 @@ class ComponentDefinitionBuilder:
         behavior as :meth:`SkpBuilder.add_circle`, except vertices/edges
         are shared only within this definition."""
         self._check_writable("faces")
+        self._skp._check_material_handle(material, "material")
+        self._skp._check_material_handle(back_material, "back_material")
+        self._skp._check_layer_handle(layer)
         if not (3 <= num_segments <= 255):
             raise SkpWriteError(f"num_segments must be between 3 and 255, got {num_segments}")
         center = (float(center[0]), float(center[1]), float(center[2]))
@@ -1851,6 +1857,8 @@ class ComponentDefinitionBuilder:
         this specific placement (SketchUp's "Hide" on the instance).
         """
         self._check_writable("instances")
+        self._skp._check_material_handle(material, "material")
+        self._skp._check_layer_handle(layer)
         if definition._skp is not self._skp:
             raise SkpWriteError(
                 f"component definition {definition.name!r} belongs to a different "
@@ -1905,6 +1913,8 @@ class ComponentDefinitionBuilder:
         this specific placement.
         """
         self._check_writable("groups")
+        self._skp._check_material_handle(material, "material")
+        self._skp._check_layer_handle(layer)
         if definition._skp is not self._skp:
             raise SkpWriteError(
                 f"component definition {definition.name!r} belongs to a different "
@@ -2167,6 +2177,38 @@ class SkpBuilder:
         self._layer_count += 1
         return slot
 
+    def _check_material_handle(self, value: Optional[int], param: str) -> None:
+        """Reject a material/back_material argument that isn't a handle
+        this builder's own add_material()/add_texture_material() actually
+        returned. Without this, a stray value - most commonly a layer
+        handle passed to the wrong parameter by mistake - gets written
+        straight into the file as a material reference: this project's own
+        reader tolerates the dangling reference silently, but real
+        SketchUp rejects the whole file as corrupt on open, with no
+        indication of which call caused it."""
+        # `value` rather than `value is not None`: every call site already
+        # treats `material or 0` as its own "no material" sentinel, so an
+        # explicit falsy 0 is just as much "not given" as None is.
+        if value and value not in self.materials_by_name.values():
+            raise SkpWriteError(
+                f"{param}={value!r} is not a handle this builder's add_material()/"
+                "add_texture_material() returned - passing an unrelated value "
+                "(e.g. a layer handle by mistake) would silently write an "
+                "invalid material reference that real SketchUp rejects on open"
+            )
+
+    def _check_layer_handle(self, value: Optional[int], param: str = "layer") -> None:
+        """Reject a layer argument that isn't a handle this builder's own
+        add_layer() actually returned - see `_check_material_handle` for
+        why this matters."""
+        if value and value not in self.layers_by_name.values():
+            raise SkpWriteError(
+                f"{param}={value!r} is not a handle this builder's add_layer() "
+                "returned - passing an unrelated value (e.g. a material handle "
+                "by mistake) would silently write an invalid layer reference "
+                "that real SketchUp rejects on open"
+            )
+
     def _material_shifted_class_slot(self) -> Dict[str, int]:
         material_shift = self._material_writer.next_slot - self._base
         return {n: s + material_shift for n, s in self._scaffold_class_slot.items()}
@@ -2265,6 +2307,8 @@ class SkpBuilder:
         a pure rotation; pass at most one of the two. ``hidden`` hides
         this group once placed.
         """
+        self._check_material_handle(material, "material")
+        self._check_layer_handle(layer)
         matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
         return self._start_definition(
             name or "Group", "add_group",
@@ -2321,6 +2365,8 @@ class SkpBuilder:
         the instance) - its contents still exist in the file, just not
         shown by default.
         """
+        self._check_material_handle(material, "material")
+        self._check_layer_handle(layer)
         if definition._skp is not self:
             raise SkpWriteError(
                 f"component definition {definition.name!r} belongs to a different "
@@ -2403,6 +2449,7 @@ class SkpBuilder:
         unverified - open the output in real SketchUp before relying on
         this, and please report back what you find either way.
         """
+        self._check_layer_handle(layer)
         mat = self.add_texture_material(f"__openskp_image_{self._material_count}", image_path)
         with self.add_component_definition(f"Image{self._definition_count}") as image_def:
             # Standard (0,0)-at-bottom-left, V increasing upward - no
@@ -2546,6 +2593,9 @@ class SkpBuilder:
         itself. Not combined with ``auto_triangulate`` - see that
         parameter's own note.
         """
+        self._check_material_handle(material, "material")
+        self._check_material_handle(back_material, "back_material")
+        self._check_layer_handle(layer)
         points = [(float(p[0]), float(p[1]), float(p[2])) for p in points]
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
@@ -2593,6 +2643,9 @@ class SkpBuilder:
 
         >>> builder.add_circle((50, 50, 0), (0, 0, 1), radius=40)
         """
+        self._check_material_handle(material, "material")
+        self._check_material_handle(back_material, "back_material")
+        self._check_layer_handle(layer)
         if not (3 <= num_segments <= 255):
             raise SkpWriteError(f"num_segments must be between 3 and 255, got {num_segments}")
         center = (float(center[0]), float(center[1]), float(center[2]))

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -134,6 +134,67 @@ class TestBuilderErrors:
         with pytest.raises(SkpWriteError, match="not coplanar"):
             builder.add_face([(0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (100.0, 100.0, 0.0), (0.0, 100.0, 50.0)])
 
+    def test_add_face_rejects_a_layer_handle_passed_as_material(self):
+        # The exact real-world mistake this guards against: a caller
+        # accidentally passes a layer handle into `material=` (e.g. via a
+        # positional-argument slip in a wrapper function around add_face).
+        # Before this check, the layer's slot silently became a dangling
+        # material reference - openskp's own reader tolerated it, but real
+        # SketchUp rejected the resulting file outright.
+        builder = create()
+        layer = builder.add_layer("Layer0")
+        with pytest.raises(SkpWriteError, match="material"):
+            builder.add_face(SQUARE, material=layer)
+
+    def test_add_face_rejects_a_material_handle_passed_as_layer(self):
+        builder = create()
+        mat = builder.add_material("Red", (255, 0, 0))
+        with pytest.raises(SkpWriteError, match="layer"):
+            builder.add_face(SQUARE, layer=mat)
+
+    def test_add_face_rejects_an_unrelated_back_material_handle(self):
+        builder = create()
+        layer = builder.add_layer("Layer0")
+        with pytest.raises(SkpWriteError, match="back_material"):
+            builder.add_face(SQUARE, back_material=layer)
+
+    def test_add_face_rejects_a_handle_from_a_different_builder(self):
+        other_builder = create()
+        stray_material = other_builder.add_material("Blue", (0, 0, 255))
+        builder = create()
+        with pytest.raises(SkpWriteError, match="material"):
+            builder.add_face(SQUARE, material=stray_material)
+
+    def test_add_instance_rejects_a_layer_handle_passed_as_material(self):
+        builder = create()
+        layer = builder.add_layer("Layer0")
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="material"):
+            builder.add_instance(chair, material=layer)
+
+    def test_add_group_rejects_an_unrelated_layer_handle(self):
+        builder = create()
+        mat = builder.add_material("Red", (255, 0, 0))
+        with pytest.raises(SkpWriteError, match="layer"):
+            builder.add_group("Table", layer=mat)
+
+    def test_component_scope_add_face_rejects_an_unrelated_handle(self):
+        builder = create()
+        layer = builder.add_layer("Layer0")
+        with builder.add_component_definition("Chair") as chair:
+            with pytest.raises(SkpWriteError, match="material"):
+                chair.add_face(SQUARE, material=layer)
+            # the definition must still be usable after a rejected call
+            chair.add_face(SQUARE)
+
+    def test_add_face_accepts_a_real_material_and_layer(self):
+        builder = create()
+        mat = builder.add_material("Red", (255, 0, 0))
+        layer = builder.add_layer("MyLayer")
+        builder.add_face(SQUARE, material=mat, layer=layer)
+        assert len(builder.to_bytes()) > 0
+
 
 class TestSingleFace:
     def test_matches_ground_truth_byte_size(self):

--- a/packages/typescript/src/create.ts
+++ b/packages/typescript/src/create.ts
@@ -1428,6 +1428,9 @@ export class ComponentDefinitionBuilder {
 
   addFace(points: readonly Point3[], options: AddFaceOptions = {}): void {
     this.checkWritable('faces');
+    this._skp._checkMaterialHandle(options.material, 'material');
+    this._skp._checkMaterialHandle(options.backMaterial, 'backMaterial');
+    this._skp._checkLayerHandle(options.layer);
     const pts = points.map(toPoint3);
     if (pts.length < 3) throw new SkpWriteError('a face needs at least 3 points');
     const holes = (options.holes ?? []).map((h) => h.map(toPoint3));
@@ -1444,6 +1447,9 @@ export class ComponentDefinitionBuilder {
 
   addCircle(center: Point3, normal: Point3, radius: number, options: AddCircleOptions = {}): void {
     this.checkWritable('faces');
+    this._skp._checkMaterialHandle(options.material, 'material');
+    this._skp._checkMaterialHandle(options.backMaterial, 'backMaterial');
+    this._skp._checkLayerHandle(options.layer);
     const numSegments = options.numSegments ?? 24;
     if (!(numSegments >= 3 && numSegments <= 255)) {
       throw new SkpWriteError(`num_segments must be between 3 and 255, got ${numSegments}`);
@@ -1500,6 +1506,8 @@ export class ComponentDefinitionBuilder {
    * already-closed definition (never `this`). */
   addInstance(definition: ComponentDefinitionBuilder, options: AddInstanceOptions = {}): void {
     this.checkWritable('instances');
+    this._skp._checkMaterialHandle(options.material, 'material');
+    this._skp._checkLayerHandle(options.layer);
     if (definition._skp !== this._skp) {
       throw new SkpWriteError(
         `component definition ${JSON.stringify(definition.name)} belongs to a different builder (a different create() call) - its slot number is meaningless here`
@@ -1522,6 +1530,8 @@ export class ComponentDefinitionBuilder {
    * `addComponentDefinition` first, then place it here. */
   addGroupInstance(definition: ComponentDefinitionBuilder, options: AddGroupInstanceOptions = {}): void {
     this.checkWritable('groups');
+    this._skp._checkMaterialHandle(options.material, 'material');
+    this._skp._checkLayerHandle(options.layer);
     if (definition._skp !== this._skp) {
       throw new SkpWriteError(
         `component definition ${JSON.stringify(definition.name)} belongs to a different builder (a different create() call) - its slot number is meaningless here`
@@ -1683,6 +1693,36 @@ export class SkpBuilder {
     return slot;
   }
 
+  /** @internal Reject a material/backMaterial option that isn't a handle
+   * this builder's own addMaterial()/addTextureMaterial() actually
+   * returned. Without this, a stray value - most commonly a layer handle
+   * passed to the wrong option by mistake - gets written straight into
+   * the file as a material reference: this project's own reader tolerates
+   * the dangling reference silently, but real SketchUp rejects the whole
+   * file as corrupt on open, with no indication of which call caused it. */
+  _checkMaterialHandle(value: number | undefined, param: string): void {
+    if (value && ![...this.materialsByName.values()].includes(value)) {
+      throw new SkpWriteError(
+        `${param}=${value} is not a handle this builder's addMaterial()/addTextureMaterial() ` +
+          'returned - passing an unrelated value (e.g. a layer handle by mistake) would silently ' +
+          'write an invalid material reference that real SketchUp rejects on open'
+      );
+    }
+  }
+
+  /** @internal Reject a layer option that isn't a handle this builder's
+   * own addLayer() actually returned - see `_checkMaterialHandle` for why
+   * this matters. */
+  _checkLayerHandle(value: number | undefined, param = 'layer'): void {
+    if (value && ![...this.layersByName.values()].includes(value)) {
+      throw new SkpWriteError(
+        `${param}=${value} is not a handle this builder's addLayer() returned - passing an ` +
+          'unrelated value (e.g. a material handle by mistake) would silently write an invalid ' +
+          'layer reference that real SketchUp rejects on open'
+      );
+    }
+  }
+
   private materialShiftedClassSlot(): Record<string, number> {
     const materialShift = this.materialWriter.nextSlot - this.base;
     const out: Record<string, number> = {};
@@ -1760,6 +1800,8 @@ export class SkpBuilder {
    * }, { name: 'Table', translation: [50, 0, 0] });
    * ``` */
   addGroup(build: (def: ComponentDefinitionBuilder) => void, options: AddGroupOptions = {}): ComponentDefinitionBuilder {
+    this._checkMaterialHandle(options.material, 'material');
+    this._checkLayerHandle(options.layer);
     const matrix3x3 = resolveMatrix3x3(options.matrix3x3, options.rotation);
     const placement: GroupPlacement = [
       options.translation ?? [0, 0, 0], matrix3x3, options.material ?? 0, options.layer ?? 0, options.hidden ?? false,
@@ -1784,6 +1826,8 @@ export class SkpBuilder {
    * already closed) in the model. `rotation`, if given, is an
    * alternative to `matrix3x3` for the common case of a pure rotation. */
   addInstance(definition: ComponentDefinitionBuilder, options: AddInstanceOptions = {}): void {
+    this._checkMaterialHandle(options.material, 'material');
+    this._checkLayerHandle(options.layer);
     if (definition._skp !== this) {
       throw new SkpWriteError(
         `component definition ${JSON.stringify(definition.name)} belongs to a different builder (a different create() call) - its slot number is meaningless here`
@@ -1838,6 +1882,7 @@ export class SkpBuilder {
    * beyond the Python port's own real-SketchUp test (placement/
    * orientation/texture all confirmed correct there - see CHECKLIST.md). */
   addImage(imageBytes: Uint8Array, width: number, height: number, options: AddImageOptions = {}): void {
+    this._checkLayerHandle(options.layer);
     const mat = this.addTextureMaterial(`__openskp_image_${this.materialCount}`, imageBytes, options.texturePath ?? '');
     const imageDef = this.addComponentDefinition(`Image${this.definitionCount}`, (def) => {
       // Standard (0,0)-at-bottom-left, V increasing upward - no vertical
@@ -1897,6 +1942,9 @@ export class SkpBuilder {
    * and edges are automatically shared with previously-added faces
    * wherever a point's coordinates match exactly. */
   addFace(points: readonly Point3[], options: AddFaceOptions = {}): void {
+    this._checkMaterialHandle(options.material, 'material');
+    this._checkMaterialHandle(options.backMaterial, 'backMaterial');
+    this._checkLayerHandle(options.layer);
     const pts = points.map(toPoint3);
     if (pts.length < 3) throw new SkpWriteError('a face needs at least 3 points');
     const holes = (options.holes ?? []).map((h) => h.map(toPoint3));
@@ -1916,6 +1964,9 @@ export class SkpBuilder {
   /** Add one circular face - a true SketchUp circle (editable by radius,
    * re-tessellatable), not `numSegments` disconnected straight edges. */
   addCircle(center: Point3, normal: Point3, radius: number, options: AddCircleOptions = {}): void {
+    this._checkMaterialHandle(options.material, 'material');
+    this._checkMaterialHandle(options.backMaterial, 'backMaterial');
+    this._checkLayerHandle(options.layer);
     const numSegments = options.numSegments ?? 24;
     if (!(numSegments >= 3 && numSegments <= 255)) {
       throw new SkpWriteError(`num_segments must be between 3 and 255, got ${numSegments}`);

--- a/packages/typescript/tests/create.test.ts
+++ b/packages/typescript/tests/create.test.ts
@@ -45,6 +45,70 @@ describe('Builder errors', () => {
       builder.addFace([[0, 0, 0], [100, 0, 0], [100, 100, 0], [0, 100, 50]])
     ).toThrow(/not coplanar/);
   });
+
+  it('addFace rejects a layer handle passed as material', () => {
+    // The exact real-world mistake this guards against: a caller
+    // accidentally passes a layer handle into the `material` option (e.g.
+    // via an argument-order slip in a wrapper function around addFace).
+    // Before this check, the layer's slot silently became a dangling
+    // material reference - openskp's own reader tolerated it, but real
+    // SketchUp rejected the resulting file outright.
+    const builder = create();
+    const layer = builder.addLayer('Layer0');
+    expect(() => builder.addFace(SQUARE, { material: layer })).toThrow(/material/);
+  });
+
+  it('addFace rejects a material handle passed as layer', () => {
+    const builder = create();
+    const mat = builder.addMaterial('Red', [255, 0, 0]);
+    expect(() => builder.addFace(SQUARE, { layer: mat })).toThrow(/layer/);
+  });
+
+  it('addFace rejects an unrelated backMaterial handle', () => {
+    const builder = create();
+    const layer = builder.addLayer('Layer0');
+    expect(() => builder.addFace(SQUARE, { backMaterial: layer })).toThrow(/backMaterial/);
+  });
+
+  it('addFace rejects a handle from a different builder', () => {
+    const otherBuilder = create();
+    const strayMaterial = otherBuilder.addMaterial('Blue', [0, 0, 255]);
+    const builder = create();
+    expect(() => builder.addFace(SQUARE, { material: strayMaterial })).toThrow(/material/);
+  });
+
+  it('addInstance rejects a layer handle passed as material', () => {
+    const builder = create();
+    const layer = builder.addLayer('Layer0');
+    const chair = builder.addComponentDefinition('Chair', (def) => def.addFace(SQUARE));
+    expect(() => builder.addInstance(chair, { material: layer })).toThrow(/material/);
+  });
+
+  it('addGroup rejects an unrelated layer handle', () => {
+    const builder = create();
+    const mat = builder.addMaterial('Red', [255, 0, 0]);
+    expect(() =>
+      builder.addGroup((def) => def.addFace(SQUARE), { name: 'Table', layer: mat })
+    ).toThrow(/layer/);
+  });
+
+  it('a component-scope addFace rejects an unrelated handle', () => {
+    const builder = create();
+    const layer = builder.addLayer('Layer0');
+    expect(() =>
+      builder.addComponentDefinition('Chair', (def) => {
+        def.addFace(SQUARE, { material: layer });
+      })
+    ).toThrow(/material/);
+  });
+
+  it('addFace accepts a real material and layer', () => {
+    const builder = create();
+    const mat = builder.addMaterial('Red', [255, 0, 0]);
+    const layer = builder.addLayer('MyLayer');
+    builder.addFace(SQUARE, { material: mat, layer });
+    expect(builder.toBytes().length).toBeGreaterThan(0);
+  });
 });
 
 describe('Single face', () => {


### PR DESCRIPTION
## Summary

Found via a real user bug report, not an audit: a contributor's own LGS-house-generator project produced `.skp` files that failed to open in real SketchUp ("unexpected file, click OK to create a new one") despite round-tripping fine through OpenSKP's own reader.

Bisected the failure down to one call site in their own `wall_panels.py`: `add_wall_horizontal_track(s_start, s_end, z_val, layer_bottom_track)` passed a **layer** handle as the 4th *positional* argument, which bound to the function's `custom_mat` parameter instead of `custom_layer` — a plain Python argument-order slip, entirely in the user's own code, not OpenSKP's. That layer's internal slot number then got written straight into the file as a face's material reference. OpenSKP's own reader tolerates a dangling/wrong material reference silently; real SketchUp's stricter parser rejects the whole file as corrupt.

**The actual OpenSKP-side fix:** `add_face()`/`add_circle()`/`add_instance()`/`add_group()`/`add_group_instance()`/`add_image()` now validate every `material`/`back_material`/`layer` argument against the handles that *same builder's* `add_material()`/`add_texture_material()`/`add_layer()` have actually returned, and raise immediately if a caller passes an unrelated value — a stray handle from the wrong parameter, a handle from a *different* builder instance, or any other garbage int. Before this, the writer accepted any integer and silently produced exactly the class of corrupt-but-plausible-looking file that took real trial-and-error bisection to track down.

`0`/`null`/`None`/unset continues to mean "no material/layer" everywhere, matching every language's existing `material ?? 0`-style fallback convention — only a truthy, unrecognized value is rejected. So this is purely additive: it can only reject calls that were already producing corrupt output, never a previously-valid call.

Implemented identically across Python, TypeScript, .NET, Dart, and C++, covering every material/layer-accepting entry point on both the root `SkpBuilder` and the nested `ComponentDefinitionBuilder`.

## Test plan

- [x] New regression tests in every language's create-test suite: layer-as-material, material-as-layer, an unrelated `back_material`, a handle from a different builder instance, instance-level rejection, group-level rejection, a rejected call inside a component definition leaving the definition still usable afterward, and a real material+layer pair still succeeding normally
- [x] Python: 413 tests pass, `ruff check` clean
- [x] TypeScript: 360 tests pass, `eslint`/`tsc --noEmit` clean
- [x] .NET: 192 tests pass, `dotnet format --verify-no-changes` clean
- [x] Dart: 218 tests pass, `dart analyze --fatal-infos` clean
- [x] C++: 188 tests pass (Release build), `clang-format --dry-run --Werror` clean
- [x] Verified against the real reported failure: the reporter's own generated file, which previously failed to open in real SketchUp, now opens correctly after fixing their argument-order bug — this PR ensures the same class of mistake fails loudly at the API call site instead of silently corrupting output