### PR TITLE
fix: mesh_index name/properties no longer cascade from an ancestor instance

### DIFF
--- a/packages/cpp/tests/create_test.cpp
+++ b/packages/cpp/tests/create_test.cpp
@@ -6,6 +6,7 @@
 // and assert on the resulting SkpModel - the same "read your own output back with the
 // already-trusted reader" validation strategy this project already uses on the read side.
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
 #include <gtest/gtest.h>
@@ -449,6 +450,42 @@ TEST(Create, NestedDefinitionInstanceAndNestedGroupInstance) {
   ASSERT_NE(car_def, nullptr);
   EXPECT_EQ(car_def->faces.size(), 1u);
   EXPECT_EQ(car_def->instances.size(), 2u);  // the wheel instance + the engine group instance
+}
+
+TEST(Create, EachNestedLevelKeepsItsOwnInstanceNameInMeshIndex) {
+  // Cross-language parity check for openskp#240: Python, TypeScript, .NET,
+  // and Dart all had a bug where a shallow instance's own name overwrote
+  // every mesh beneath it in scene.mesh_index, since a shallow instance's
+  // path is always a string prefix of every deeper descendant's path too.
+  // C++ never had that bug - each mesh's name is set once, correctly, at
+  // creation time from its own path, with no later backfill/cascading
+  // pass at all - but this test locks that in so it can't regress toward
+  // the same bug the other four languages had.
+  auto builder = create();
+  auto& leaf = builder->add_component_definition("Leaf");
+  leaf.add_face({{0, 0, 0}, {1, 0, 0}, {1, 1, 0}, {0, 1, 0}});
+  leaf.close();
+  auto& middle = builder->add_component_definition("Middle");
+  middle.add_face({{0, 0, 10}, {1, 0, 10}, {1, 1, 10}, {0, 1, 10}});
+  InstanceOptions leaf_inst;
+  leaf_inst.name = "LeafInstance";
+  middle.add_instance(leaf, leaf_inst);
+  middle.close();
+  auto& outer = builder->add_component_definition("Outer");
+  outer.add_face({{0, 0, 20}, {1, 0, 20}, {1, 1, 20}, {0, 1, 20}});
+  InstanceOptions middle_inst;
+  middle_inst.name = "MiddleInstance";
+  outer.add_instance(middle, middle_inst);
+  outer.close();
+  InstanceOptions outer_inst;
+  outer_inst.name = "OuterInstance";
+  builder->add_instance(outer, outer_inst);
+
+  Scene scene = SkpFile::from_buffer(builder->to_bytes()).build_scene();
+  std::vector<std::string> names;
+  for (const auto& [geom_name, meta] : scene.mesh_index) names.push_back(meta.name);
+  std::sort(names.begin(), names.end());
+  EXPECT_EQ(names, (std::vector<std::string>{"LeafInstance", "MiddleInstance", "OuterInstance"}));
 }
 
 TEST(Create, DefinitionCannotNestAnInstanceOfItself) {

--- a/packages/dart/lib/src/scene.dart
+++ b/packages/dart/lib/src/scene.dart
@@ -165,6 +165,16 @@ class SceneBuilder {
     final meshIndex = <String, MeshMetadata>{};
     final glbPrimitives = <GlbPrimitive>[];
 
+    // Instance path -> (properties, name) updates, recorded in O(1) per
+    // instance and applied once after instantiation completes (see the
+    // lookup pass below), instead of scanning the entire meshIndex per
+    // placed instance - an O(instances x meshes) substring scan that both
+    // dominated build_scene on models with many placed instances and
+    // could match the wrong meshes (a shallow instance's path is always a
+    // string prefix of every deeper descendant's path too, so `contains`
+    // matched far more than intended - see openskp#240).
+    final pathUpdates = <String, (Map<String, String>, String)>{};
+
     // Textures deduplicated by bytes: the same image routinely backs
     // several materials, and re-embedding it per material would multiply
     // the export size for nothing.
@@ -462,14 +472,7 @@ class SceneBuilder {
         );
         childInstancesInfo.add(instInfo);
 
-        var safeChildPath = fullPathName.replaceAll(' / ', '__').replaceAll(' ', '_');
-        if (safeChildPath.length > 80) safeChildPath = safeChildPath.substring(0, 80);
-        for (final entry in meshIndex.entries) {
-          if (entry.key.contains(safeChildPath)) {
-            entry.value.properties = properties;
-            entry.value.name = inst.name ?? '';
-          }
-        }
+        pathUpdates[fullPathName] = (properties, inst.name ?? '');
       }
 
       return childInstancesInfo;
@@ -477,6 +480,22 @@ class SceneBuilder {
 
     final identityMat = <double>[1.0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0];
     final rootChildren = instantiateBuilder(parsed.root.builder, 'ROOT_MODEL', null, identityMat, 'Layer0', 'ROOT', null);
+
+    // Deferred mesh backfill: each mesh's own path was recorded verbatim
+    // as a pathUpdates key by the exact instance that placed the
+    // definition that mesh's own faces belong to (never an ancestor's),
+    // so a direct O(1) lookup per mesh is enough - no cascading from an
+    // ancestor down to its descendants' own meshes. Properties/name are
+    // per-instance, not inherited by nested sub-parts, matching how the
+    // instance tree above already builds each InstanceNode from that
+    // same instance's own `inst.name`/`properties` directly.
+    for (final entry in meshIndex.entries) {
+      final update = pathUpdates[entry.value.path];
+      if (update != null) {
+        entry.value.properties = update.$1;
+        entry.value.name = update.$2;
+      }
+    }
 
     for (final entry in meshIndex.entries) {
       final existing = entry.value;

--- a/packages/dart/test/scene_test.dart
+++ b/packages/dart/test/scene_test.dart
@@ -140,6 +140,41 @@ void main() {
     }
   });
 
+  test('each nested level keeps its own instance name in meshIndex (openskp#240)', () {
+    // Regression: each mesh's own name must reflect the specific instance
+    // that placed its OWN definition, not an ancestor's - matching how
+    // sceneHierarchy already builds each InstanceNode from that same
+    // instance directly. A prior bug backfilled meshIndex by a substring
+    // match on the sanitized path string; since a shallow instance's path
+    // is always a string prefix of every deeper descendant's path too,
+    // the shallowest instance's own name silently overwrote every mesh
+    // beneath it as recursion unwound.
+    final builder = create();
+    final leaf = builder.addComponentDefinition('Leaf', (def) {
+      def.addFace([(0.0, 0.0, 0.0), (1.0, 0.0, 0.0), (1.0, 1.0, 0.0), (0.0, 1.0, 0.0)]);
+    });
+    final middle = builder.addComponentDefinition('Middle', (def) {
+      def.addFace([(0.0, 0.0, 10.0), (1.0, 0.0, 10.0), (1.0, 1.0, 10.0), (0.0, 1.0, 10.0)]);
+      def.addInstance(leaf, name: 'LeafInstance');
+    });
+    final outer = builder.addComponentDefinition('Outer', (def) {
+      def.addFace([(0.0, 0.0, 20.0), (1.0, 0.0, 20.0), (1.0, 1.0, 20.0), (0.0, 1.0, 20.0)]);
+      def.addInstance(middle, name: 'MiddleInstance');
+    });
+    builder.addInstance(outer, name: 'OuterInstance');
+    final bytes = builder.toBytes();
+
+    final path = '${Directory.systemTemp.path}/openskp_dart_nested_metadata_test.skp';
+    File(path).writeAsBytesSync(bytes);
+    try {
+      final scene = SkpFile.open(path).buildScene();
+      final names = scene.meshIndex.values.map((m) => m.name).toList()..sort();
+      expect(names, ['LeafInstance', 'MiddleInstance', 'OuterInstance']);
+    } finally {
+      File(path).deleteSync();
+    }
+  });
+
   test('textured materials get MASK or BLEND, never left OPAQUE', () {
     // capilla_quiroz_v17.skp has four textured materials: two ordinary
     // opaque ones (MASK - a safe no-op, nothing in their JPEGs to cut out)

--- a/packages/dotnet/OpenSkp.Tests/SceneInstancePropagationTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/SceneInstancePropagationTests.cs
@@ -17,8 +17,20 @@ namespace OpenSkp.Tests
     /// that single loop took tens of minutes (measured: 323,856 instances x
     /// 321,683 meshes -> ~73 minutes in BuildScene, ~98% of the total
     /// conversion time). The replacement records one dictionary entry per
-    /// instance during instantiation and applies updates once afterwards by
-    /// walking each mesh's Path to its shallowest recorded ancestor.
+    /// instance during instantiation and applies updates once afterwards.
+    ///
+    /// An earlier version of that deferred pass walked each mesh's Path up
+    /// toward the root and applied the shallowest ancestor with a recorded
+    /// update ("outermost wins"), deliberately matching what the old O(n^2)
+    /// scan produced. That matched the old scan, but the old scan itself
+    /// was wrong: for a genuinely nested structure, every mesh under an
+    /// assembly ended up with that assembly's own name/properties instead
+    /// of its own (openskp#240 - the same bug, independently found via
+    /// Python's port). Each mesh's own Path is always recorded verbatim in
+    /// pathUpdates by the exact instance that placed the definition its own
+    /// faces belong to, so a direct O(1) lookup - no walking, no cascading
+    /// to descendants - is both correct and simpler than the walk it
+    /// replaced.
     ///
     /// These tests build synthetic RawParsed models directly (internals are
     /// visible to the test assembly) so the semantics and the linear-time
@@ -60,7 +72,7 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
-        public void MeshBackfill_OutermostAncestorWins()
+        public void MeshBackfill_EachInstanceKeepsItsOwnNameAndProperties()
         {
             // ROOT (one direct face)
             //  |- A (def1: one face + child instance C -> def3, dynamic props)
@@ -99,17 +111,18 @@ namespace OpenSkp.Tests
             Assert.Equal("ROOT", rootMesh.Name);
             Assert.Empty(rootMesh.Properties);
 
-            // Mesh directly under instance A: gets A's properties/name.
+            // Mesh directly under instance A: gets A's own properties/name.
             var meshA = Assert.Single(scene.MeshIndex.Values, m => m.Path == "ROOT / A");
             Assert.Equal("A", meshA.Name);
             Assert.Equal("10", meshA.Properties["width"]);
 
-            // Mesh under A's child C: the OUTERMOST ancestor (A) wins, exactly
-            // like the old scan (A wrote last, after C).
+            // Mesh under A's child C: gets C's OWN properties/name, not A's -
+            // properties/name are per-instance, never inherited from an
+            // ancestor (openskp#240).
             var meshAC = Assert.Single(scene.MeshIndex.Values, m => m.Path == "ROOT / A / C");
-            Assert.Equal("A", meshAC.Name);
-            Assert.Equal("10", meshAC.Properties["width"]);
-            Assert.False(meshAC.Properties.ContainsKey("height"));
+            Assert.Equal("C", meshAC.Name);
+            Assert.Equal("5", meshAC.Properties["height"]);
+            Assert.False(meshAC.Properties.ContainsKey("width"));
 
             // Mesh under B: B has no dynamic props; still records (empty, "B").
             var meshB = Assert.Single(scene.MeshIndex.Values, m => m.Path == "ROOT / B");

--- a/packages/dotnet/OpenSkp.Tests/SceneTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/SceneTests.cs
@@ -101,6 +101,46 @@ namespace OpenSkp.Tests
                 ((System.Collections.Generic.IDictionary<string, object>)mat)["pbrMetallicRoughness"];
 
         [Fact]
+        public void EachNestedLevelKeepsItsOwnInstanceNameInMeshIndex()
+        {
+            // Regression for openskp#240: each mesh's own name must reflect
+            // the specific instance that placed its OWN definition, not an
+            // ancestor's - matching how the instance tree already builds
+            // each InstanceNode from that same instance directly. A prior
+            // bug backfilled MeshIndex by a substring/path-prefix-walk
+            // match; since a shallow instance's path is always a prefix of
+            // every deeper descendant's path too, the shallowest instance's
+            // own name silently overwrote every mesh beneath it.
+            var builder = SkpCreate.NewFile();
+            var leaf = builder.AddComponentDefinition("Leaf");
+            leaf.AddFace(new (double, double, double)[] { (0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0) });
+            leaf.Dispose();
+            var middle = builder.AddComponentDefinition("Middle");
+            middle.AddFace(new (double, double, double)[] { (0, 0, 10), (1, 0, 10), (1, 1, 10), (0, 1, 10) });
+            middle.AddInstance(leaf, name: "LeafInstance");
+            middle.Dispose();
+            var outer = builder.AddComponentDefinition("Outer");
+            outer.AddFace(new (double, double, double)[] { (0, 0, 20), (1, 0, 20), (1, 1, 20), (0, 1, 20) });
+            outer.AddInstance(middle, name: "MiddleInstance");
+            outer.Dispose();
+            builder.AddInstance(outer, name: "OuterInstance");
+            byte[] bytes = builder.ToBytes();
+
+            string path = Path.Combine(Path.GetTempPath(), $"openskp_dotnet_nested_metadata_{Guid.NewGuid():N}.skp");
+            File.WriteAllBytes(path, bytes);
+            try
+            {
+                var scene = SkpFile.BuildScene(path);
+                var names = scene.MeshIndex.Values.Select(m => m.Name).OrderBy(n => n).ToList();
+                Assert.Equal(new[] { "LeafInstance", "MiddleInstance", "OuterInstance" }, names);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Fact]
         public void TranslucentMaterialGetsBlendAlpha()
         {
             // Round-tripped through the real writer and reader rather than

--- a/packages/dotnet/OpenSkp/Scene.cs
+++ b/packages/dotnet/OpenSkp/Scene.cs
@@ -473,30 +473,26 @@ namespace OpenSkp
             var identityMat = new List<double> { 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0 };
             var rootChildren = InstantiateRoot(parsed.Root.Builder, identityMat);
 
-            // Deferred mesh back-fill: for each mesh, walk its Path from the
-            // leaf up to the root and apply the shallowest recorded ancestor
-            // update. Equivalent to the old scan's final state (the outermost
-            // ancestor wrote last and won), O(meshes x path_depth) instead of
-            // O(instances x meshes). This also fixes a latent over-match in the
-            // old substring test: "ROOT / A_B" would previously match a mesh
-            // whose GeomName merely contained the substring "A_B" (e.g. inside
-            // "A_BC"), wrongly propagating the update to non-descendants.
+            // Deferred mesh back-fill: each mesh's own Path was recorded
+            // verbatim as a pathUpdates key by the exact instance that placed
+            // the definition that mesh's own faces belong to (never an
+            // ancestor's), so a direct O(1) lookup per mesh is enough - no
+            // cascading from an ancestor down to its descendants' own meshes.
+            // Properties/Name are per-instance, not inherited by nested
+            // sub-parts, matching how the instance tree above already builds
+            // each InstanceNode from that same instance's own Name/properties
+            // directly. An earlier version of this loop walked from each
+            // mesh's Path up toward the root and let the outermost ancestor
+            // with a recorded update win - which, for a genuinely nested
+            // structure, meant every mesh under an assembly ended up with
+            // that assembly's own name instead of its own (openskp#240).
             foreach (var meshKv2 in meshIndex)
             {
                 var mesh = meshKv2.Value;
-                var meshPath = mesh.Path ?? "";
-                (Dictionary<string, string> Props, string Name)? found = null;
-                string p = meshPath;
-                while (p.Length > 0)
+                if (pathUpdates.TryGetValue(mesh.Path ?? "", out var u))
                 {
-                    if (pathUpdates.TryGetValue(p, out var u)) found = u;
-                    int sep = p.LastIndexOf(" / ");
-                    p = sep >= 0 ? p.Substring(0, sep) : "";
-                }
-                if (found.HasValue)
-                {
-                    mesh.Properties = found.Value.Props;
-                    mesh.Name = found.Value.Name;
+                    mesh.Properties = u.Props;
+                    mesh.Name = u.Name;
                 }
             }
 

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -176,6 +176,16 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
     mesh_index: Dict[str, MeshMetadata] = {}
     glb_primitives: List[GlbPrimitive] = []
 
+    # Instance path -> (properties, name) updates, collected in O(1) per
+    # instance and applied once after instantiation completes (see the
+    # path-walk loop below), instead of scanning the entire mesh_index per
+    # placed instance - an O(instances x meshes) substring scan that both
+    # dominated build_scene on models with many placed instances and could
+    # match the wrong meshes (a shallow instance's path is always a string
+    # prefix of every deeper descendant's path too, so "in" matched far
+    # more than intended - see openskp#240).
+    path_updates: Dict[str, Tuple[Dict[str, str], str]] = {}
+
     # Textures deduplicated by bytes: the same image routinely backs
     # several materials, and re-embedding it per material would multiply
     # the export size for nothing.
@@ -451,16 +461,27 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             )
             child_instances_info.append(inst_info)
 
-            safe_child_path = full_path_name.replace(" / ", "__").replace(" ", "_")[:80]
-            for geom_name, existing in mesh_index.items():
-                if safe_child_path in geom_name:
-                    existing.properties = properties
-                    existing.name = inst["name"] or ""
+            path_updates[full_path_name] = (properties, inst["name"] or "")
 
         return child_instances_info
 
     identity_mat = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0]
     root_children = instantiate("ROOT", identity_mat)
+
+    # Deferred mesh backfill: each mesh's own path was recorded verbatim as
+    # a path_updates key by the exact instance that placed the definition
+    # that mesh's own faces belong to (never an ancestor's), so a direct
+    # O(1) lookup per mesh is enough - no cascading from an ancestor down
+    # to its descendants' own meshes. Properties/name are per-instance
+    # (each definition's own Dynamic Component attributes and placement
+    # name), not inherited by nested sub-parts, matching how
+    # scene_hierarchy already builds each InstanceNode from that same
+    # instance's own `inst["name"]`/`properties` directly above - a mesh
+    # ending up with some ancestor's name/properties instead of its own
+    # was exactly this bug (openskp#240).
+    for existing in mesh_index.values():
+        if existing.path in path_updates:
+            existing.properties, existing.name = path_updates[existing.path]
 
     for geom_name, existing in mesh_index.items():
         if existing.path == "ROOT":

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2298,6 +2298,40 @@ class TestBuildSceneRecursionGuard:
         assert len(scene.scene_hierarchy.children) == 2
 
 
+class TestBuildSceneMeshIndexPerInstanceMetadata:
+    """Regression for openskp#240: each mesh's own ``name`` must reflect
+    the specific instance that placed its OWN definition, not an
+    ancestor's - matching how ``scene_hierarchy`` already builds each
+    ``InstanceNode`` directly from that same instance. A prior bug
+    backfilled ``mesh_index`` by a substring match on the sanitized path
+    string; since a shallow instance's path is always a string prefix of
+    every deeper descendant's path too, the shallowest instance's own
+    name silently overwrote every mesh beneath it as recursion unwound.
+    """
+
+    def test_each_nested_level_keeps_its_own_instance_name(self, tmp_path) -> None:
+        from openskp import SkpFile
+        from openskp.create import create
+
+        builder = create()
+        with builder.add_component_definition("Leaf") as leaf:
+            leaf.add_face([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)])
+        with builder.add_component_definition("Middle") as middle:
+            middle.add_face([(0, 0, 10), (1, 0, 10), (1, 1, 10), (0, 1, 10)])
+            middle.add_instance(leaf, name="LeafInstance")
+        with builder.add_component_definition("Outer") as outer:
+            outer.add_face([(0, 0, 20), (1, 0, 20), (1, 1, 20), (0, 1, 20)])
+            outer.add_instance(middle, name="MiddleInstance")
+        builder.add_instance(outer, name="OuterInstance")
+
+        out = tmp_path / "nested_metadata.skp"
+        out.write_bytes(builder.to_bytes())
+        scene = SkpFile.open(str(out)).build_scene()
+
+        names = sorted(m.name for m in scene.mesh_index.values())
+        assert names == ["LeafInstance", "MiddleInstance", "OuterInstance"]
+
+
 class TestGlbExport:
     """``export.glb.export()`` bakes via ``scene.build_scene()`` (the same
     step ``SkpFile.build_scene()`` exposes directly) and hands the

--- a/packages/typescript/src/model.ts
+++ b/packages/typescript/src/model.ts
@@ -693,6 +693,16 @@ export function buildSceneFromParsed(
   const meshIndex: Record<string, MeshMetadata> = {};
   const glbPrimitives: any[] = [];
 
+  // Instance path -> (properties, name) updates, recorded in O(1) per
+  // instance and applied once after instantiation completes (see the
+  // lookup pass below), instead of scanning the entire meshIndex per
+  // placed instance - an O(instances x meshes) substring scan that both
+  // dominated build_scene on models with many placed instances and could
+  // match the wrong meshes (a shallow instance's path is always a string
+  // prefix of every deeper descendant's path too, so `includes()` matched
+  // far more than intended - see openskp#240).
+  const pathUpdates = new Map<string, { properties: Record<string, string>; name: string }>();
+
   const getLayerColor = (name: string) => {
     const c = layerColors.get(name) || [136, 136, 136];
     return { r: c[0], g: c[1], b: c[2] };
@@ -1008,18 +1018,7 @@ export function buildSceneFromParsed(
       };
       childInstancesInfo.push(instInfo);
 
-      let safeChildPath = fullPathName.replace(/ \/ /g, '__').replace(/ /g, '_');
-      if (safeChildPath.length > 80) safeChildPath = safeChildPath.slice(0, 80);
-
-      for (const geomName of Object.keys(meshIndex)) {
-        if (geomName.includes(safeChildPath)) {
-          const existing = meshIndex[geomName];
-          if (existing) {
-            existing.properties = properties;
-            existing.name = inst.name || '';
-          }
-        }
-      }
+      pathUpdates.set(fullPathName, { properties, name: inst.name || '' });
     }
 
     return childInstancesInfo;
@@ -1027,6 +1026,23 @@ export function buildSceneFromParsed(
 
   const identityMat = [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0];
   const rootChildren = instantiate('ROOT', identityMat);
+
+  // Deferred mesh backfill: each mesh's own path was recorded verbatim as
+  // a pathUpdates key by the exact instance that placed the definition
+  // that mesh's own faces belong to (never an ancestor's), so a direct
+  // O(1) lookup per mesh is enough - no cascading from an ancestor down
+  // to its descendants' own meshes. Properties/name are per-instance,
+  // not inherited by nested sub-parts, matching how sceneHierarchy
+  // already builds each InstanceNode from that same instance's own
+  // `inst.name`/`properties` directly above.
+  for (const geomName of Object.keys(meshIndex)) {
+    const existing = meshIndex[geomName];
+    const update = existing ? pathUpdates.get(existing.path) : undefined;
+    if (existing && update) {
+      existing.properties = update.properties;
+      existing.name = update.name;
+    }
+  }
 
   // Fill in missing root meshes
   for (const geomName of Object.keys(meshIndex)) {

--- a/packages/typescript/tests/create.test.ts
+++ b/packages/typescript/tests/create.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { create, SkpWriteError, _internal, Point3 } from '../src/create';
-import { parseSkp } from '../src/index';
+import { parseSkp, buildScene } from '../src/index';
 
 /**
  * Tests for create.ts - the from-scratch legacy (v17) .skp writer, ported
@@ -729,6 +729,34 @@ describe('Nested definitions and groups', () => {
     const carDefinition = [...model.definitions.values()].find((d) => d.name === 'Car')!;
     expect(carDefinition.instances.length).toBe(1);
     expect(carDefinition.faces.length).toBe(1);
+  });
+
+  it('buildScene keeps each nested level\'s own instance name in meshIndex (openskp#240)', () => {
+    // Regression: each mesh's own name must reflect the specific instance
+    // that placed its OWN definition, not an ancestor's - matching how
+    // sceneHierarchy already builds each InstanceNode from that same
+    // instance directly. A prior bug backfilled meshIndex by a substring
+    // match on the sanitized path string; since a shallow instance's path
+    // is always a string prefix of every deeper descendant's path too,
+    // the shallowest instance's own name silently overwrote every mesh
+    // beneath it as recursion unwound.
+    const builder = create();
+    const leaf = builder.addComponentDefinition('Leaf', (def) =>
+      def.addFace([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]])
+    );
+    const middle = builder.addComponentDefinition('Middle', (def) => {
+      def.addFace([[0, 0, 10], [1, 0, 10], [1, 1, 10], [0, 1, 10]]);
+      def.addInstance(leaf, { name: 'LeafInstance' });
+    });
+    const outer = builder.addComponentDefinition('Outer', (def) => {
+      def.addFace([[0, 0, 20], [1, 0, 20], [1, 1, 20], [0, 1, 20]]);
+      def.addInstance(middle, { name: 'MiddleInstance' });
+    });
+    builder.addInstance(outer, { name: 'OuterInstance' });
+
+    const scene = buildScene(toBuffer(builder.toBytes()));
+    const names = Object.values(scene.meshIndex).map((m) => m.name).sort();
+    expect(names).toEqual(['LeafInstance', 'MiddleInstance', 'OuterInstance']);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #240, filed by @nooraliqureshi. On a real production file, every entry in `Scene.mesh_index` had the identical, wrong `.name` — the top-level ancestor's own name — while `scene_hierarchy` (built from the same underlying data) had the correct, distinct, properly-nested name per element.

**Root cause (Python, TypeScript, Dart):** a post-hoc backfill loop attaching each instance's own dynamic properties/name onto `mesh_index` matched by `geom_name.includes/contains(sanitizedInstancePath)` — a **substring** check, not an exact match. Since a shallow instance's path is always a string *prefix* of every deeper descendant's path too, the shallowest instance's own update matched (and overwrote) every mesh beneath it as recursion unwound bottom-up, with the outermost ancestor's write happening last and winning for the entire subtree.

**.NET had a subtler version of the same bug.** It had already been "fixed" for a real, measured performance problem (an O(instances × meshes) substring scan that took ~73 minutes on a 323,856-instance / 321,683-mesh production file) via an O(1)-per-instance dict plus a path-prefix-walk-to-root pass. That walk correctly eliminated *false-positive* substring collisions between *unrelated* paths, but deliberately preserved "outermost ancestor wins, cascading to every descendant" as intentional, documented behavior — not realizing that behavior was itself #240, just harder to trigger (needs genuine nesting, not a coincidental substring collision). An existing test (`SceneInstancePropagationTests.MeshBackfill_OutermostAncestorWins`) explicitly locked this in as correct; I've updated it (renamed to `..._EachInstanceKeepsItsOwnNameAndProperties`) to assert each instance's own data instead.

**The fix, in all 4 languages that had it:** replace the per-instance full-index scan/walk with an O(1)-per-instance dict recording `{path -> (properties, name)}`, then a single O(meshes) pass where each mesh does a **direct, exact lookup by its own path** — no substring matching, no ancestor walking, no cascading to descendants. This is strictly simpler *and* faster than every version it replaced (O(instances) + O(meshes) instead of O(instances × meshes) or O(meshes × path_depth)), while also being correct. Properties/name are per-instance metadata — never inherited by nested sub-parts, matching how `scene_hierarchy` already builds each node from that same instance's own data directly.

**C++ never had this bug** — its mesh name is set once, correctly, at creation time from its own path, with no backfill/cascading pass at all. I added a same-shape regression test there too, to lock in correct behavior and guard against future regression toward what the other 4 languages had (no source change needed there). Separately noted: C++'s `mesh_index[...].properties` is never populated at all (always empty) — a real, smaller feature gap compared to the other 4 languages, not this bug, not fixed here.

## Test plan

- [x] New cross-language regression test in each language: 3-level nested component definitions, each with its own face, each instanced under a distinct name — asserts all three mesh names come back distinct, not collapsed
- [x] Each regression test independently confirmed to **fail** against the pre-fix code (verified via `git stash` for Python and .NET) before the fix landed, not just trusted on inspection
- [x] Python: 414 tests pass, `ruff check` clean
- [x] TypeScript: 361 tests pass, `eslint`/`tsc --noEmit` clean
- [x] .NET: 193 tests pass (including the pre-existing 100k-instance linear-time perf test, still green), `dotnet format --verify-no-changes` clean
- [x] Dart: 219 tests pass, `dart analyze --fatal-infos` clean
- [x] C++: 189 tests pass (Release build), `clang-format --dry-run --Werror` clean