### PR TITLE
create: applied size (width+height) and opacity on materials

### DIFF
--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -917,6 +917,7 @@ class _ArchiveWriter:
 
     def write_textured_material(
         self, name: str, image_bytes: bytes, texture_path: str, subtype: int,
+        applied_width: Optional[float] = None,
         applied_height: Optional[float] = None,
     ) -> int:
         """Write one image-textured ``CMaterial`` record (embedding
@@ -926,11 +927,13 @@ class _ArchiveWriter:
         string round-trips fine structurally. ``subtype`` is CDib's image
         format tag (4 for PNG, 1 for JPEG - see :func:`_detect_image_subtype`).
 
-        ``applied_height`` defaults to 1.0, matching applied width (always
-        1.0, unconditionally). Pass a different value for a textured
-        material used with default (unpositioned) projection, to make the
-        texture repeat at a specific real-world size instead of every 1
-        inch - `_face_groups.compute_face_uv`, this project's own
+        ``applied_width``/``applied_height`` both default to 1.0. Pass the
+        material's real-world tile size for a textured material used with
+        default (unpositioned) projection, to make the texture repeat at a
+        specific size instead of every 1 inch (real SketchUp writes the
+        material's own size here - a file authored in SketchUp Web carries
+        8.0 x 16.0 for a brick) - `_face_groups.compute_face_uv`, this
+        project's own
         reverse-engineered read-side formula, divides a face's final UV by
         the material's applied width/height, for a default-projected face
         exactly as much as a `front_uv`/`back_uv`-positioned one. Until
@@ -956,8 +959,14 @@ class _ArchiveWriter:
             # qualities, same value both times), so not something this
             # project computes from the image; PNG has no such field.
             self.buf += _u32(90)
-        self.buf += _f64(1.0)  # applied width - ground truth default when unscaled
-        self.buf += _f64(applied_height if applied_height is not None else 1.0)
+        # Applied size: how much MODEL SPACE one tile of the image covers, in
+        # inches - two plain f64s, which is what legacy.py's
+        # ``_texture_block`` reads back as ``tex_w``/``tex_h``. For a texture
+        # applied WITHOUT positioning it is the only thing that says how big
+        # the image is - such faces carry no per-face UV record at all, so a
+        # wrong size here is the whole mapping wrong.
+        self.buf += _f64(1.0 if applied_width is None else float(applied_width))
+        self.buf += _f64(1.0 if applied_height is None else float(applied_height))
         self._write_str(texture_path)
         # avg color (RGBA + pad + RGBA repeated, per legacy.py's _read_material
         # comment) - neutral near-opaque white rather than a real image
@@ -2081,24 +2090,27 @@ class SkpBuilder:
         return slot
 
     def add_texture_material(
-        self, name: str, image_path: str, applied_height: Optional[float] = None,
+        self, name: str, image_path: str,
+        applied_width: Optional[float] = None,
+        applied_height: Optional[float] = None,
     ) -> int:
         """Register an image-textured material from a local PNG or JPEG
         file and return a handle to pass as `add_face`'s ``material``
         argument.
+
+        ``applied_width``/``applied_height``, if given, are the applied
+        size in INCHES - how much model space one tile of the image
+        covers. Both default to 1.0. A texture applied without positioning
+        carries no per-face UV record, so this size IS its mapping - and
+        see `write_textured_material`'s own docstring for why it matters
+        even for `add_face`'s ``front_uv``/``back_uv`` pinning (a
+        positioned mapping still divides by it).
 
         The format is detected from the file's own magic bytes, not its
         extension - PNG and JPEG are the only two this project has
         confirmed the on-disk ``CDib`` subtype tag for via SDK ground
         truth (4 and 1 respectively; see :meth:`_ArchiveWriter.
         write_textured_material`).
-
-        ``applied_height`` defaults to 1.0 (matching applied width, always
-        1.0). Pass a different value to make a default-projected face's
-        texture repeat at a specific real-world size instead of every 1
-        inch - see `write_textured_material`'s own docstring for why this
-        field matters even for `add_face`'s ``front_uv``/``back_uv``
-        pinning (a positioned mapping still divides by it).
 
         Same ordering rules as `add_material` - must be called before any
         `add_layer`, `add_component_definition`, or `add_face` call.
@@ -2115,7 +2127,8 @@ class SkpBuilder:
             image_bytes = f.read()
         subtype = _detect_image_subtype(image_bytes)
         slot = self._material_writer.write_textured_material(
-            name, image_bytes, image_path, subtype=subtype, applied_height=applied_height,
+            name, image_bytes, image_path, subtype=subtype,
+            applied_width=applied_width, applied_height=applied_height,
         )
         self.materials_by_name[name] = slot
         self._material_count += 1

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -902,7 +902,8 @@ class _ArchiveWriter:
             raise SkpWriteError("string too long to encode (255 char limit)")
         self.buf += b"\xff\xfe\xff" + struct.pack("<B", n) + encoded
 
-    def write_material(self, name: str, rgba: Tuple[int, int, int, int]) -> int:
+    def write_material(self, name: str, rgba: Tuple[int, int, int, int],
+                       opacity: Optional[float] = None) -> int:
         """Write one solid-color ``CMaterial`` record and return its slot."""
         slot = self._new_of_known_class("CMaterial", schema=_MATERIAL_SCHEMA)
         self._preamble()
@@ -911,14 +912,16 @@ class _ArchiveWriter:
         self.buf += bytes(rgba)
         self._write_str("")  # texture path (empty - no texture)
         self.buf += bytes(8)  # unknown/padding - ground truth is all-zero here
-        self.buf += _f64(1.0)  # opacity
-        self.buf.append(0)  # use_opacity = False (alpha carries transparency instead)
+        # Stored TRANSPARENCY (0 = opaque); see write_textured_material.
+        self.buf += _f64(1.0 if opacity is None else 1.0 - float(opacity))
+        self.buf.append(0 if opacity is None else 1)  # use_opacity gates it
         return slot
 
     def write_textured_material(
         self, name: str, image_bytes: bytes, texture_path: str, subtype: int,
         applied_width: Optional[float] = None,
         applied_height: Optional[float] = None,
+        opacity: Optional[float] = None,
     ) -> int:
         """Write one image-textured ``CMaterial`` record (embedding
         ``image_bytes`` verbatim inside a ``CDib`` sub-object) and return
@@ -983,8 +986,15 @@ class _ArchiveWriter:
         self.buf += bytes([255, 255, 255, 254, 0, 255, 255, 255, 254])
         self._write_str("")  # second name field - empty in ground truth
         self.buf += struct.pack("<I", 1) + struct.pack("<I", 0)  # blob (colorize-related, ground truth: 1, 0)
-        self.buf += _f64(1.0)  # opacity
-        self.buf.append(0)  # use_opacity = False
+        # Opacity, and the u8 that GATES it. The stored f64 is TRANSPARENCY
+        # (0 = opaque) - legacy.py turns it into the opacity factor
+        # ``Material.transparency`` exposes with ``1.0 - stored``, and only
+        # when the flag is set - so an ``opacity`` argument is written
+        # inverted and round-trips as itself. Hardcoding 1.0/False meant a
+        # translucent material came out solid: a pool's water, 0.6 in the
+        # source, exported as an opaque slab.
+        self.buf += _f64(1.0 if opacity is None else 1.0 - float(opacity))
+        self.buf.append(0 if opacity is None else 1)
         return slot
 
     def write_layer(
@@ -2057,7 +2067,8 @@ class SkpBuilder:
         self._face_count = 0
         self._dim_font_slot: Optional[int] = None
 
-    def add_material(self, name: str, rgba: Sequence[int]) -> int:
+    def add_material(self, name: str, rgba: Sequence[int],
+                     opacity: Optional[float] = None) -> int:
         """Register a solid-color material and return a handle to pass as
         `add_face`'s ``material`` argument. ``rgba`` is ``(r, g, b)`` or
         ``(r, g, b, a)``, each 0-255; alpha defaults to 255 (opaque).
@@ -2084,7 +2095,7 @@ class SkpBuilder:
             rgba = (*rgba, 255)
         if len(rgba) != 4 or not all(isinstance(c, int) and 0 <= c <= 255 for c in rgba):
             raise SkpWriteError("rgba must be 3 or 4 integers in 0-255")
-        slot = self._material_writer.write_material(name, tuple(rgba))
+        slot = self._material_writer.write_material(name, tuple(rgba), opacity=opacity)
         self.materials_by_name[name] = slot
         self._material_count += 1
         return slot
@@ -2093,6 +2104,7 @@ class SkpBuilder:
         self, name: str, image_path: str,
         applied_width: Optional[float] = None,
         applied_height: Optional[float] = None,
+        opacity: Optional[float] = None,
     ) -> int:
         """Register an image-textured material from a local PNG or JPEG
         file and return a handle to pass as `add_face`'s ``material``
@@ -2129,6 +2141,7 @@ class SkpBuilder:
         slot = self._material_writer.write_textured_material(
             name, image_bytes, image_path, subtype=subtype,
             applied_width=applied_width, applied_height=applied_height,
+            opacity=opacity,
         )
         self.materials_by_name[name] = slot
         self._material_count += 1

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1176,10 +1176,9 @@ class TestTextures:
         # applied_height wrote a corrupted internal sentinel byte pattern
         # (~1.29e-231) instead of a real number - confirmed via real
         # SketchUp screenshots to render as a streaky, vertically-smeared
-        # texture. add_texture_material's applied WIDTH is unconditionally
-        # 1.0 (a deliberate ground-truth value); height should match it by
-        # default now, not silently corrupt every caller who doesn't know
-        # to pass applied_height=1.0 explicitly.
+        # texture. add_texture_material's applied width and height both
+        # default to 1.0 now (each overridable), not silently corrupt every
+        # caller who doesn't know to pass applied_height=1.0 explicitly.
         png_path = tmp_path / "tex.png"
         png_path.write_bytes(_make_test_png(size=4, rgb=(200, 50, 50)))
 
@@ -1205,6 +1204,25 @@ class TestTextures:
         ar, root, layers, materials = legacy._walk(data)
         mat_by_slot = {s: v for s, v in materials}
         assert mat_by_slot[tex]["tex_h"] == 48.0
+
+    def test_texture_material_applied_size_fully_overridable(self, tmp_path):
+        # Real SketchUp writes the material's own tile size in BOTH axes (a
+        # file authored in SketchUp Web carries 8.0 x 16.0 for a brick); a
+        # texture applied without positioning carries no per-face UV record,
+        # so this pair IS its mapping.
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png(size=4, rgb=(200, 50, 50)))
+
+        builder = create()
+        tex = builder.add_texture_material(
+            "Brick", str(png_path), applied_width=8.0, applied_height=16.0)
+        builder.add_face(SQUARE, material=tex)
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        mat_by_slot = {s: v for s, v in materials}
+        assert mat_by_slot[tex]["tex_w"] == 8.0
+        assert mat_by_slot[tex]["tex_h"] == 16.0
 
     def test_jpeg_texture_material_self_parses(self, tmp_path):
         jpg_path = tmp_path / "tex.jpg"
@@ -3698,3 +3716,40 @@ class TestRealSketchUpOracle:
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()
+
+
+class TestMaterialOpacity:
+    def test_solid_material_carries_opacity(self):
+        builder = create()
+        glass = builder.add_material("Glass", (200, 220, 255), opacity=0.35)
+        builder.add_face(SQUARE, material=glass)
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        mat = {s: v for s, v in materials}[glass]
+        # Stored as TRANSPARENCY gated by use_opacity - the exact solid-tail
+        # shape legacy.py documents (and VFF's useTrans semantics).
+        assert mat["use_opacity"] == 1
+        assert mat["opacity"] == pytest.approx(0.65)
+
+    def test_omitted_opacity_stays_ungated(self):
+        builder = create()
+        red = builder.add_material("Red", (255, 0, 0))
+        builder.add_face(SQUARE, material=red)
+        data = builder.to_bytes()
+
+        mat = {s: v for s, v in legacy._walk(data)[3]}[red]
+        assert mat["use_opacity"] == 0
+
+    def test_texture_material_carries_opacity(self, tmp_path):
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png(size=4, rgb=(200, 50, 50)))
+
+        builder = create()
+        tex = builder.add_texture_material("Voile", str(png_path), opacity=0.5)
+        builder.add_face(SQUARE, material=tex)
+        data = builder.to_bytes()
+
+        mat = {s: v for s, v in legacy._walk(data)[3]}[tex]
+        assert mat["use_opacity"] == 1
+        assert mat["opacity"] == pytest.approx(0.5)


### PR DESCRIPTION
Two writer additions IngeTrazo's native `.skp` export has been running on locally since August, now rebased onto current `main` — plus round-trip tests.

**`applied_width` on `add_texture_material` / `write_textured_material`** — completing what #-2026-08-28's applied-height fix started: real SketchUp writes the material's own tile size in BOTH axes (a file authored in SketchUp Web carries 8.0 × 16.0 for a brick), and for a texture applied without positioning that pair IS the mapping — such faces carry no per-face UV record at all. The public kwarg follows the `applied_height` naming already on main, and both now default to a plain 1.0 (no sentinel).

**`opacity` on `add_material` / `add_texture_material`** — stored as TRANSPARENCY gated by the trailing `use_opacity` byte, the exact solid-tail shape `legacy.py` documents (VFF `useTrans` semantics). Omitted, the record is byte-identical to before (gate 0).

Tests walk the written bytes back with `legacy._walk` and assert `tex_w`/`tex_h` and the gated opacity; the stale comment claiming applied width was "unconditionally 1.0" is refreshed. Full `packages/python` suite: 386 passed (the 2 glTF texture-embed failures are pre-existing on main in my env, unrelated).

Context: without these, IngeTrazo's exporter degrades (its capability guard falls back to 1-inch tiles and opaque glass), so packaged builds were writing worse `.skp` files than dev machines — this closes that gap at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjT1HnRCNu1kEqHz1y99j9