### PR TITLE
create: port applied texture width and opacity to TS/.NET/Dart/C++

### DIFF
--- a/packages/cpp/include/openskp/create.hpp
+++ b/packages/cpp/include/openskp/create.hpp
@@ -373,21 +373,28 @@ class OPENSKP_EXPORT SkpBuilder {
   /// also come before any `add_layer` or `add_component_definition` call - materials are
   /// spliced in earlier in the file, so both of those sections' own slot numbering depends on
   /// the final material count too.
-  int add_material(const std::string& name, Color4 rgba);
+  int add_material(const std::string& name, Color4 rgba,
+                   std::optional<double> opacity = std::nullopt);
   /// Overload taking an opaque (alpha = 255) RGB color.
-  int add_material(const std::string& name, Color3 rgb);
+  int add_material(const std::string& name, Color3 rgb,
+                   std::optional<double> opacity = std::nullopt);
 
   /// Register an image-textured material from a local PNG or JPEG file and return a handle to
   /// pass as `FaceOptions::material`. The format is detected from the file's own magic bytes,
   /// not its extension. Same ordering rules as `add_material`.
   ///
-  /// `applied_height` defaults to 1.0 (matching applied width, always 1.0). Pass a different
-  /// value to make a default-projected face's texture repeat at a specific real-world size
-  /// instead of every 1 inch - see `write_textured_material`'s own note in create.cpp for why
-  /// this field matters even for `FaceOptions::front_uv`/`back_uv` pinning (a positioned mapping
-  /// still divides by it).
+  /// `applied_height`/`applied_width`, if given, are the applied size in INCHES - how much model
+  /// space one tile of the image covers. Both default to 1.0. A texture applied without
+  /// positioning carries no per-face UV record, so this pair IS its mapping - see
+  /// `write_textured_material`'s own note in create.cpp for why it matters even for
+  /// `FaceOptions::front_uv`/`back_uv` pinning (a positioned mapping still divides by it).
+  /// `applied_width` and `opacity` sit after `applied_height` (not alongside it) so an existing
+  /// positional call passing `applied_height` as the 3rd argument keeps meaning what it always
+  /// meant.
   int add_texture_material(const std::string& name, const std::filesystem::path& image_path,
-                           std::optional<double> applied_height = std::nullopt);
+                           std::optional<double> applied_height = std::nullopt,
+                           std::optional<double> applied_width = std::nullopt,
+                           std::optional<double> opacity = std::nullopt);
 
   /// Register a layer and return a handle to pass as `FaceOptions::layer`. Calling this again
   /// with a name already registered returns the same handle (`options` are ignored on a repeat

--- a/packages/cpp/src/create.cpp
+++ b/packages/cpp/src/create.cpp
@@ -758,7 +758,8 @@ class ArchiveWriter {
     }
   }
 
-  int write_material(const std::string& name, Color4 rgba) {
+  int write_material(const std::string& name, Color4 rgba,
+                     std::optional<double> opacity = std::nullopt) {
     int slot = new_of_known_class("CMaterial", kMaterialSchema);
     preamble();
     write_str(name);
@@ -766,24 +767,32 @@ class ArchiveWriter {
     buf.insert(buf.end(), rgba.begin(), rgba.end());
     write_str("");  // texture path (empty - no texture)
     buf.insert(buf.end(), 8, 0);
-    append_f64(buf, 1.0);  // opacity
-    buf.push_back(0);      // use_opacity = False
+    // Stored TRANSPARENCY (0 = opaque); see write_textured_material.
+    append_f64(buf, opacity.has_value() ? 1.0 - *opacity : 1.0);
+    buf.push_back(opacity.has_value() ? 1 : 0);  // use_opacity gates it
     return slot;
   }
 
   // `subtype` is CDib's image format tag (4 for PNG, 1 for JPEG - see detect_image_subtype).
   //
-  // `applied_height` defaults to 1.0, matching applied width (always 1.0, unconditionally). Pass
-  // a different value for a textured material used with default (unpositioned) projection, to
-  // make the texture repeat at a specific real-world size instead of every 1 inch - the reader's
-  // own ground-truth-derived UV formula divides a face's final UV by the material's applied
-  // width/height, for a default-projected face exactly as much as a positioned (front_uv/back_uv)
-  // one. Until 2026-08-28 this defaulted to a corrupted sentinel byte pattern instead (see
-  // kTextureHSentinel's own comment) - confirmed via real SketchUp screenshots to render as a
-  // streaky, vertically-smeared texture regardless of projection mode.
+  // `applied_width`/`applied_height` both default to 1.0. Pass the material's real-world tile
+  // size for a textured material used with default (unpositioned) projection, to make the
+  // texture repeat at a specific size instead of every 1 inch (real SketchUp writes the
+  // material's own size here - a file authored in SketchUp Web carries 8.0 x 16.0 for a brick) -
+  // the reader's own ground-truth-derived UV formula divides a face's final UV by the material's
+  // applied width/height, for a default-projected face exactly as much as a positioned
+  // (front_uv/back_uv) one. Until 2026-08-28 this defaulted to a corrupted sentinel byte pattern
+  // instead (see kTextureHSentinel's own comment) - confirmed via real SketchUp screenshots to
+  // render as a streaky, vertically-smeared texture regardless of projection mode.
+  //
+  // `applied_width` and `opacity` are appended after `applied_height` (rather than sitting next
+  // to it) so an existing positional call passing `applied_height` as the 5th argument keeps
+  // meaning what it always meant.
   int write_textured_material(const std::string& name, const ByteBuffer& image_bytes,
                               const std::string& texture_path, int subtype,
-                              std::optional<double> applied_height = std::nullopt) {
+                              std::optional<double> applied_height = std::nullopt,
+                              std::optional<double> applied_width = std::nullopt,
+                              std::optional<double> opacity = std::nullopt) {
     int slot = new_of_known_class("CMaterial", kMaterialSchema);
     preamble();
     write_str(name);
@@ -798,7 +807,11 @@ class ArchiveWriter {
       // encoded quality.
       append_u32(buf, 90);
     }
-    append_f64(buf, 1.0);  // applied width - ground truth default when unscaled
+    // Applied size: how much MODEL SPACE one tile of the image covers, in inches - two plain
+    // f64s. For a texture applied WITHOUT positioning it is the only thing that says how big the
+    // image is - such faces carry no per-face UV record at all, so a wrong size here is the whole
+    // mapping wrong.
+    append_f64(buf, applied_width.value_or(1.0));
     append_f64(buf, applied_height.value_or(1.0));
     write_str(texture_path);
     // avg color: neutral near-opaque white. Alpha is 254, not fully-opaque 255 - the reader
@@ -808,9 +821,14 @@ class ArchiveWriter {
     append_bytes(buf, avg, sizeof(avg));
     write_str("");  // second name field - empty in ground truth
     append_u32(buf, 1);
-    append_u32(buf, 0);    // blob (colorize-related, ground truth: 1, 0)
-    append_f64(buf, 1.0);  // opacity
-    buf.push_back(0);      // use_opacity = False
+    append_u32(buf, 0);  // blob (colorize-related, ground truth: 1, 0)
+    // Opacity, and the u8 that GATES it. The stored f64 is TRANSPARENCY (0 = opaque) - the reader
+    // turns it into the opacity factor exposed with `1.0 - stored`, and only when the flag is
+    // set - so an `opacity` argument here is written inverted and round-trips as itself.
+    // Hardcoding 1.0/false meant a translucent material came out solid: a pool's water at 0.6
+    // exported as an opaque slab.
+    append_f64(buf, opacity.has_value() ? 1.0 - *opacity : 1.0);
+    buf.push_back(opacity.has_value() ? 1 : 0);
     return slot;
   }
 
@@ -1671,7 +1689,7 @@ SkpBuilder::SkpBuilder() : impl_(std::make_unique<Impl>()) {}
 
 SkpBuilder::~SkpBuilder() = default;
 
-int SkpBuilder::add_material(const std::string& name, Color4 rgba) {
+int SkpBuilder::add_material(const std::string& name, Color4 rgba, std::optional<double> opacity) {
   if (impl_->geometry_writer)
     throw SkpWriteError("add_material must be called before any add_face calls");
   if (impl_->layer_writer)
@@ -1681,19 +1699,21 @@ int SkpBuilder::add_material(const std::string& name, Color4 rgba) {
   }
   auto it = materials_by_name.find(name);
   if (it != materials_by_name.end()) return it->second;
-  int slot = impl_->material_writer.write_material(name, rgba);
+  int slot = impl_->material_writer.write_material(name, rgba, opacity);
   materials_by_name[name] = slot;
   impl_->material_count += 1;
   return slot;
 }
 
-int SkpBuilder::add_material(const std::string& name, Color3 rgb) {
-  return add_material(name, Color4{rgb[0], rgb[1], rgb[2], 255});
+int SkpBuilder::add_material(const std::string& name, Color3 rgb, std::optional<double> opacity) {
+  return add_material(name, Color4{rgb[0], rgb[1], rgb[2], 255}, opacity);
 }
 
 int SkpBuilder::add_texture_material(const std::string& name,
                                      const std::filesystem::path& image_path,
-                                     std::optional<double> applied_height) {
+                                     std::optional<double> applied_height,
+                                     std::optional<double> applied_width,
+                                     std::optional<double> opacity) {
   if (impl_->geometry_writer)
     throw SkpWriteError("add_texture_material must be called before any add_face calls");
   if (impl_->layer_writer)
@@ -1708,8 +1728,8 @@ int SkpBuilder::add_texture_material(const std::string& name,
   if (!f) throw SkpWriteError("cannot open texture image file: " + image_path.string());
   ByteBuffer image_bytes((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
   int subtype = detail::detect_image_subtype(image_bytes);
-  int slot = impl_->material_writer.write_textured_material(name, image_bytes, image_path.string(),
-                                                            subtype, applied_height);
+  int slot = impl_->material_writer.write_textured_material(
+      name, image_bytes, image_path.string(), subtype, applied_height, applied_width, opacity);
   materials_by_name[name] = slot;
   impl_->material_count += 1;
   return slot;

--- a/packages/cpp/tests/create_test.cpp
+++ b/packages/cpp/tests/create_test.cpp
@@ -284,6 +284,80 @@ TEST(Create, TexturedMaterialExplicitAppliedHeightStillOverridable) {
   EXPECT_DOUBLE_EQ(model.materials[0].texture->height, 48.0);
 }
 
+// Real SketchUp writes the material's own tile size in BOTH axes (a file authored in SketchUp
+// Web carries 8.0 x 16.0 for a brick); a texture applied without positioning carries no per-face
+// UV record, so this pair IS its mapping (openskp#252).
+TEST(Create, TexturedMaterialAppliedSizeFullyOverridable) {
+  auto tmp_path = std::filesystem::temp_directory_path() / "openskp_create_test_texture_size.png";
+  {
+    std::ofstream f(tmp_path, std::ios::binary);
+    ByteBuffer png = fake_png_bytes();
+    f.write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+  }
+
+  auto builder = create();
+  int brick = builder->add_texture_material("Brick", tmp_path, 16.0, 8.0);
+  FaceOptions opts;
+  opts.material = brick;
+  builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, opts);
+
+  SkpModel model = round_trip(*builder);
+  std::filesystem::remove(tmp_path);
+
+  ASSERT_EQ(model.materials.size(), 1u);
+  ASSERT_TRUE(model.materials[0].texture.has_value());
+  EXPECT_DOUBLE_EQ(model.materials[0].texture->width, 8.0);
+  EXPECT_DOUBLE_EQ(model.materials[0].texture->height, 16.0);
+}
+
+TEST(Create, TexturedMaterialCarriesOpacity) {
+  auto tmp_path =
+      std::filesystem::temp_directory_path() / "openskp_create_test_texture_opacity.png";
+  {
+    std::ofstream f(tmp_path, std::ios::binary);
+    ByteBuffer png = fake_png_bytes();
+    f.write(reinterpret_cast<const char*>(png.data()), static_cast<std::streamsize>(png.size()));
+  }
+
+  auto builder = create();
+  int voile = builder->add_texture_material("Voile", tmp_path, std::nullopt, std::nullopt, 0.5);
+  FaceOptions opts;
+  opts.material = voile;
+  builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, opts);
+
+  SkpModel model = round_trip(*builder);
+  std::filesystem::remove(tmp_path);
+
+  ASSERT_EQ(model.materials.size(), 1u);
+  EXPECT_NEAR(model.materials[0].transparency, 0.5, 1e-9);
+}
+
+TEST(Create, SolidMaterialCarriesOpacity) {
+  auto builder = create();
+  int glass = builder->add_material("Glass", Color4{200, 220, 255, 255}, 0.35);
+  FaceOptions opts;
+  opts.material = glass;
+  builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, opts);
+
+  SkpModel model = round_trip(*builder);
+
+  ASSERT_EQ(model.materials.size(), 1u);
+  EXPECT_NEAR(model.materials[0].transparency, 0.35, 1e-9);
+}
+
+TEST(Create, OmittedOpacityStaysFullyOpaque) {
+  auto builder = create();
+  int red = builder->add_material("Red", Color3{255, 0, 0});
+  FaceOptions opts;
+  opts.material = red;
+  builder->add_face({{0, 0, 0}, {100, 0, 0}, {100, 100, 0}, {0, 100, 0}}, opts);
+
+  SkpModel model = round_trip(*builder);
+
+  ASSERT_EQ(model.materials.size(), 1u);
+  EXPECT_DOUBLE_EQ(model.materials[0].transparency, 1.0);
+}
+
 TEST(Create, AddImagePlacesARealImageEntityNotAPlainTexturedFace) {
   auto tmp_path = std::filesystem::temp_directory_path() / "openskp_create_test_image.png";
   {

--- a/packages/dart/lib/src/create.dart
+++ b/packages/dart/lib/src/create.dart
@@ -1018,7 +1018,7 @@ class _ArchiveWriter {
   }
 
   /// Write one solid-color `CMaterial` record and return its slot.
-  int writeMaterial(String name, (int, int, int, int) rgba) {
+  int writeMaterial(String name, (int, int, int, int) rgba, {double? opacity}) {
     final slot = _newOfKnownClass('CMaterial', schema: _materialSchema);
     _preamble();
     _writeStr(name);
@@ -1026,8 +1026,9 @@ class _ArchiveWriter {
     buf.addAll([rgba.$1, rgba.$2, rgba.$3, rgba.$4]);
     _writeStr(''); // texture path (empty - no texture)
     buf.addAll(List<int>.filled(8, 0)); // unknown/padding - ground truth is all-zero
-    buf.addAll(_f64(1.0)); // opacity
-    buf.add(0); // use_opacity = False (alpha carries transparency instead)
+    // Stored TRANSPARENCY (0 = opaque); see writeTexturedMaterial.
+    buf.addAll(_f64(opacity == null ? 1.0 : 1.0 - opacity));
+    buf.add(opacity == null ? 0 : 1); // use_opacity gates it
     return slot;
   }
 
@@ -1036,19 +1037,21 @@ class _ArchiveWriter {
   /// CDib's image format tag (4 for PNG, 1 for JPEG - see
   /// [_detectImageSubtype]).
   ///
-  /// [appliedHeight] defaults to 1.0, matching applied width (always 1.0,
-  /// unconditionally). Pass a different value for a textured material used
-  /// with default (unpositioned) projection, to make the texture repeat at
-  /// a specific real-world size instead of every 1 inch - the reader's own
-  /// ground-truth-derived UV formula divides a face's final UV by the
-  /// material's applied width/height, for a default-projected face exactly
-  /// as much as a positioned (`frontUv`/`backUv`) one. Until 2026-08-28
-  /// this defaulted to a corrupted sentinel byte pattern instead (see
+  /// [appliedWidth]/[appliedHeight] both default to 1.0. Pass the
+  /// material's real-world tile size for a textured material used with
+  /// default (unpositioned) projection, to make the texture repeat at a
+  /// specific size instead of every 1 inch (real SketchUp writes the
+  /// material's own size here - a file authored in SketchUp Web carries
+  /// 8.0 x 16.0 for a brick) - the reader's own ground-truth-derived UV
+  /// formula divides a face's final UV by the material's applied
+  /// width/height, for a default-projected face exactly as much as a
+  /// positioned (`frontUv`/`backUv`) one. Until 2026-08-28 this defaulted
+  /// to a corrupted sentinel byte pattern instead (see
   /// [_textureHSentinel]'s own comment) - confirmed via real SketchUp
   /// screenshots to render as a streaky, vertically-smeared texture
   /// regardless of projection mode.
   int writeTexturedMaterial(String name, Uint8List imageBytes, String texturePath, int subtype,
-      {double? appliedHeight}) {
+      {double? appliedHeight, double? appliedWidth, double? opacity}) {
     final slot = _newOfKnownClass('CMaterial', schema: _materialSchema);
     _preamble();
     _writeStr(name);
@@ -1064,7 +1067,12 @@ class _ArchiveWriter {
       // actual encoded quality.
       buf.addAll(_u32(90));
     }
-    buf.addAll(_f64(1.0)); // applied width - ground truth default when unscaled
+    // Applied size: how much MODEL SPACE one tile of the image covers, in
+    // inches - two plain f64s. For a texture applied WITHOUT positioning it
+    // is the only thing that says how big the image is - such faces carry
+    // no per-face UV record at all, so a wrong size here is the whole
+    // mapping wrong.
+    buf.addAll(_f64(appliedWidth ?? 1.0));
     buf.addAll(_f64(appliedHeight ?? 1.0));
     _writeStr(texturePath);
     // avg color (RGBA + pad + RGBA repeated) - neutral near-opaque white
@@ -1078,8 +1086,14 @@ class _ArchiveWriter {
     _writeStr(''); // second name field - empty in ground truth
     buf.addAll(_u32(1)); // blob (colorize-related, ground truth: 1, 0)
     buf.addAll(_u32(0));
-    buf.addAll(_f64(1.0)); // opacity
-    buf.add(0); // use_opacity = False
+    // Opacity, and the u8 that GATES it. The stored f64 is TRANSPARENCY
+    // (0 = opaque) - the reader turns it into the opacity factor exposed
+    // with `1.0 - stored`, and only when the flag is set - so an
+    // [opacity] argument here is written inverted and round-trips as
+    // itself. Hardcoding 1.0/false meant a translucent material came out
+    // solid: a pool's water at 0.6 exported as an opaque slab.
+    buf.addAll(_f64(opacity == null ? 1.0 : 1.0 - opacity));
+    buf.add(opacity == null ? 0 : 1);
     return slot;
   }
 
@@ -2116,7 +2130,7 @@ class SkpBuilder implements GeometryHost {
   /// before any [addLayer]/[addComponentDefinition] call - materials
   /// splice in earlier in the file, so those sections' own slot numbering
   /// depends on the final material count too.
-  int addMaterial(String name, List<int> rgba) {
+  int addMaterial(String name, List<int> rgba, {double? opacity}) {
     if (_geometryWriter != null) {
       throw SkpWriteError('addMaterial must be called before any addFace calls');
     }
@@ -2132,7 +2146,7 @@ class SkpBuilder implements GeometryHost {
     if (r.length != 4 || r.any((c) => c < 0 || c > 255)) {
       throw SkpWriteError('rgba must be 3 or 4 integers in 0-255');
     }
-    final slot = _materialWriter.writeMaterial(name, (r[0], r[1], r[2], r[3]));
+    final slot = _materialWriter.writeMaterial(name, (r[0], r[1], r[2], r[3]), opacity: opacity);
     materialsByName[name] = slot;
     _materialCount++;
     return slot;
@@ -2143,13 +2157,15 @@ class SkpBuilder implements GeometryHost {
   /// format is detected from the file's own magic bytes, not its
   /// extension. Same ordering rules as [addMaterial].
   ///
-  /// [appliedHeight] defaults to 1.0 (matching applied width, always 1.0).
-  /// Pass a different value to make a default-projected face's texture
-  /// repeat at a specific real-world size instead of every 1 inch - see
-  /// [_ArchiveWriter.writeTexturedMaterial]'s own comment for why this
-  /// field matters even for `addFace`'s `frontUv`/`backUv` pinning (a
-  /// positioned mapping still divides by it).
-  int addTextureMaterial(String name, String imagePath, {double? appliedHeight}) {
+  /// [appliedHeight]/[appliedWidth], if given, are the applied size in
+  /// INCHES - how much model space one tile of the image covers. Both
+  /// default to 1.0. A texture applied without positioning carries no
+  /// per-face UV record, so this pair IS its mapping - see
+  /// [_ArchiveWriter.writeTexturedMaterial]'s own comment for why it
+  /// matters even for `addFace`'s `frontUv`/`backUv` pinning (a positioned
+  /// mapping still divides by it).
+  int addTextureMaterial(String name, String imagePath,
+      {double? appliedHeight, double? appliedWidth, double? opacity}) {
     if (_geometryWriter != null) {
       throw SkpWriteError('addTextureMaterial must be called before any addFace calls');
     }
@@ -2162,8 +2178,8 @@ class SkpBuilder implements GeometryHost {
     if (materialsByName.containsKey(name)) return materialsByName[name]!;
     final imageBytes = File(imagePath).readAsBytesSync();
     final subtype = _detectImageSubtype(imageBytes);
-    final slot =
-        _materialWriter.writeTexturedMaterial(name, imageBytes, imagePath, subtype, appliedHeight: appliedHeight);
+    final slot = _materialWriter.writeTexturedMaterial(name, imageBytes, imagePath, subtype,
+        appliedHeight: appliedHeight, appliedWidth: appliedWidth, opacity: opacity);
     materialsByName[name] = slot;
     _materialCount++;
     return slot;

--- a/packages/dart/test/create_test.dart
+++ b/packages/dart/test/create_test.dart
@@ -347,6 +347,24 @@ void main() {
       expect(frontName, 'Red');
       expect(backName, 'Blue');
     });
+
+    test('carries opacity on a solid material (openskp#252)', () {
+      final builder = create();
+      final glass = builder.addMaterial('Glass', [200, 220, 255], opacity: 0.35);
+      builder.addFace(square, material: glass);
+      final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+      final mat = model.materials.single;
+      expect(mat.transparency, closeTo(0.35, 1e-9));
+    });
+
+    test('omitted opacity stays fully opaque', () {
+      final builder = create();
+      final red = builder.addMaterial('Red', [255, 0, 0]);
+      builder.addFace(square, material: red);
+      final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+      final mat = model.materials.single;
+      expect(mat.transparency, 1.0);
+    });
   });
 
   group('Textures', () {
@@ -407,6 +425,43 @@ void main() {
         final model = SkpFile.fromBuffer(builder.toBytes()).parse();
         final mat = model.materials.single;
         expect(mat.texture!.height, 48.0);
+      } finally {
+        tmpDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('applied width and height are both overridable (openskp#252)', () {
+      // Real SketchUp writes the material's own tile size in BOTH axes (a
+      // file authored in SketchUp Web carries 8.0 x 16.0 for a brick); a
+      // texture applied without positioning carries no per-face UV record,
+      // so this pair IS its mapping.
+      final tmpDir = Directory.systemTemp.createTempSync('openskp_tex_');
+      final pngPath = '${tmpDir.path}${Platform.pathSeparator}tex.png';
+      File(pngPath).writeAsBytesSync(makeFakePng());
+      try {
+        final builder = create();
+        final tex = builder.addTextureMaterial('Brick', pngPath, appliedHeight: 16.0, appliedWidth: 8.0);
+        builder.addFace(square, material: tex);
+        final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+        final mat = model.materials.single;
+        expect(mat.texture!.width, 8.0);
+        expect(mat.texture!.height, 16.0);
+      } finally {
+        tmpDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('carries opacity on a textured material (openskp#252)', () {
+      final tmpDir = Directory.systemTemp.createTempSync('openskp_tex_');
+      final pngPath = '${tmpDir.path}${Platform.pathSeparator}tex.png';
+      File(pngPath).writeAsBytesSync(makeFakePng());
+      try {
+        final builder = create();
+        final tex = builder.addTextureMaterial('Voile', pngPath, opacity: 0.5);
+        builder.addFace(square, material: tex);
+        final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+        final mat = model.materials.single;
+        expect(mat.transparency, closeTo(0.5, 1e-9));
       } finally {
         tmpDir.deleteSync(recursive: true);
       }

--- a/packages/dotnet/OpenSkp.Tests/CreateTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CreateTests.cs
@@ -320,6 +320,73 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
+        public void TexturedMaterialAppliedSizeFullyOverridable()
+        {
+            // Real SketchUp writes the material's own tile size in BOTH
+            // axes (a file authored in SketchUp Web carries 8.0 x 16.0 for
+            // a brick); a texture applied without positioning carries no
+            // per-face UV record, so this pair IS its mapping.
+            string pngPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+            File.WriteAllBytes(pngPath, TinyPng());
+            try
+            {
+                var builder = SkpCreate.NewFile();
+                int brick = builder.AddTextureMaterial("Brick", pngPath, appliedHeight: 16.0, appliedWidth: 8.0);
+                builder.AddFace(Square(), material: brick);
+                var model = SkpFile.Parse(builder.ToBytes());
+                var mat = model.Materials.Single();
+                Assert.Equal(8.0, mat.Texture!.Width);
+                Assert.Equal(16.0, mat.Texture.Height);
+            }
+            finally
+            {
+                File.Delete(pngPath);
+            }
+        }
+
+        [Fact]
+        public void TexturedMaterialCarriesOpacity()
+        {
+            string pngPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".png");
+            File.WriteAllBytes(pngPath, TinyPng());
+            try
+            {
+                var builder = SkpCreate.NewFile();
+                int voile = builder.AddTextureMaterial("Voile", pngPath, opacity: 0.5);
+                builder.AddFace(Square(), material: voile);
+                var model = SkpFile.Parse(builder.ToBytes());
+                var mat = model.Materials.Single();
+                Assert.Equal(0.5, mat.Transparency, 6);
+            }
+            finally
+            {
+                File.Delete(pngPath);
+            }
+        }
+
+        [Fact]
+        public void SolidMaterialCarriesOpacity()
+        {
+            var builder = SkpCreate.NewFile();
+            int glass = builder.AddMaterial("Glass", (200, 220, 255), opacity: 0.35);
+            builder.AddFace(Square(), material: glass);
+            var model = SkpFile.Parse(builder.ToBytes());
+            var mat = model.Materials.Single();
+            Assert.Equal(0.35, mat.Transparency, 6);
+        }
+
+        [Fact]
+        public void OmittedOpacityStaysFullyOpaque()
+        {
+            var builder = SkpCreate.NewFile();
+            int red = builder.AddMaterial("Red", (255, 0, 0));
+            builder.AddFace(Square(), material: red);
+            var model = SkpFile.Parse(builder.ToBytes());
+            var mat = model.Materials.Single();
+            Assert.Equal(1.0, mat.Transparency);
+        }
+
+        [Fact]
         public void UnrecognizedImageFormatThrows()
         {
             string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".bin");

--- a/packages/dotnet/OpenSkp/Create.cs
+++ b/packages/dotnet/OpenSkp/Create.cs
@@ -1058,7 +1058,7 @@ namespace OpenSkp
             AddRaw(encoded);
         }
 
-        internal int WriteMaterial(string name, (byte R, byte G, byte B, byte A) rgba)
+        internal int WriteMaterial(string name, (byte R, byte G, byte B, byte A) rgba, double? opacity = null)
         {
             int slot = NewOfKnownClass("CMaterial", CreateConstants.MaterialSchema);
             Preamble();
@@ -1067,8 +1067,9 @@ namespace OpenSkp
             Buf.Add(rgba.R); Buf.Add(rgba.G); Buf.Add(rgba.B); Buf.Add(rgba.A);
             WriteStr(""); // texture path (empty - no texture)
             AddZeros(8); // unknown/padding - ground truth is all-zero here
-            AddF64(1.0); // opacity
-            Buf.Add(0); // use_opacity = False (alpha carries transparency instead)
+            // Stored TRANSPARENCY (0 = opaque); see WriteTexturedMaterial.
+            AddF64(opacity.HasValue ? 1.0 - opacity.Value : 1.0);
+            Buf.Add(opacity.HasValue ? (byte)1 : (byte)0); // use_opacity gates it
             return slot;
         }
 
@@ -1077,20 +1078,28 @@ namespace OpenSkp
         /// slot. texturePath is stored as-is. subtype is CDib's image
         /// format tag (4 for PNG, 1 for JPEG).
         ///
-        /// appliedHeight defaults to 1.0, matching applied width (always
-        /// 1.0, unconditionally). Pass a different value for a textured
-        /// material used with default (unpositioned) projection, to make
-        /// the texture repeat at a specific real-world size instead of
-        /// every 1 inch - the reader's own ground-truth-derived UV formula
-        /// divides a face's final UV by the material's applied
-        /// width/height, for a default-projected face exactly as much as
-        /// a positioned (frontUv/backUv) one. Until 2026-08-28 this
-        /// defaulted to a corrupted sentinel byte pattern instead (see
-        /// CreateConstants.TextureHSentinel's own comment) - confirmed via
-        /// real SketchUp screenshots to render as a streaky,
-        /// vertically-smeared texture regardless of projection
-        /// mode.</summary>
-        internal int WriteTexturedMaterial(string name, byte[] imageBytes, string texturePath, int subtype, double? appliedHeight = null)
+        /// appliedWidth/appliedHeight both default to 1.0. Pass the
+        /// material's real-world tile size for a textured material used
+        /// with default (unpositioned) projection, to make the texture
+        /// repeat at a specific size instead of every 1 inch (real
+        /// SketchUp writes the material's own size here - a file authored
+        /// in SketchUp Web carries 8.0 x 16.0 for a brick) - the reader's
+        /// own ground-truth-derived UV formula divides a face's final UV
+        /// by the material's applied width/height, for a default-projected
+        /// face exactly as much as a positioned (frontUv/backUv) one.
+        /// Until 2026-08-28 this defaulted to a corrupted sentinel byte
+        /// pattern instead (see CreateConstants.TextureHSentinel's own
+        /// comment) - confirmed via real SketchUp screenshots to render as
+        /// a streaky, vertically-smeared texture regardless of projection
+        /// mode.
+        ///
+        /// appliedWidth and opacity are appended after appliedHeight
+        /// (rather than sitting next to it) so an existing positional call
+        /// passing appliedHeight as the 5th argument keeps meaning what it
+        /// always meant.</summary>
+        internal int WriteTexturedMaterial(
+            string name, byte[] imageBytes, string texturePath, int subtype,
+            double? appliedHeight = null, double? appliedWidth = null, double? opacity = null)
         {
             int slot = NewOfKnownClass("CMaterial", CreateConstants.MaterialSchema);
             Preamble();
@@ -1108,7 +1117,12 @@ namespace OpenSkp
                 // source JPEG's own actual encoded quality.
                 AddU32(90);
             }
-            AddF64(1.0); // applied width - ground truth default when unscaled
+            // Applied size: how much MODEL SPACE one tile of the image
+            // covers, in inches - two plain f64s. For a texture applied
+            // WITHOUT positioning it is the only thing that says how big
+            // the image is - such faces carry no per-face UV record at
+            // all, so a wrong size here is the whole mapping wrong.
+            AddF64(appliedWidth ?? 1.0);
             AddF64(appliedHeight ?? 1.0);
             WriteStr(texturePath);
             // avg color (RGBA + pad + RGBA repeated) - neutral near-opaque
@@ -1122,8 +1136,15 @@ namespace OpenSkp
             AddRaw(new byte[] { 255, 255, 255, 254, 0, 255, 255, 255, 254 });
             WriteStr(""); // second name field - empty in ground truth
             AddU32(1); AddU32(0); // blob (colorize-related, ground truth: 1, 0)
-            AddF64(1.0); // opacity
-            Buf.Add(0); // use_opacity = False
+            // Opacity, and the u8 that GATES it. The stored f64 is
+            // TRANSPARENCY (0 = opaque) - the reader turns it into the
+            // opacity factor exposed with 1.0 - stored, and only when the
+            // flag is set - so an opacity argument here is written
+            // inverted and round-trips as itself. Hardcoding 1.0/false
+            // meant a translucent material came out solid: a pool's water
+            // at 0.6 exported as an opaque slab.
+            AddF64(opacity.HasValue ? 1.0 - opacity.Value : 1.0);
+            Buf.Add(opacity.HasValue ? (byte)1 : (byte)0);
             return slot;
         }
 
@@ -2136,7 +2157,7 @@ namespace OpenSkp
         /// before any AddLayer or AddComponentDefinition call - materials
         /// are spliced in earlier in the file, so both of those sections'
         /// own slot numbering depends on the final material count too.</summary>
-        public int AddMaterial(string name, (int R, int G, int B, int A) rgba)
+        public int AddMaterial(string name, (int R, int G, int B, int A) rgba, double? opacity = null)
         {
             if (_geometryWriter != null)
             {
@@ -2155,14 +2176,14 @@ namespace OpenSkp
             ValidateByteRange(rgba.G, nameof(rgba.G));
             ValidateByteRange(rgba.B, nameof(rgba.B));
             ValidateByteRange(rgba.A, nameof(rgba.A));
-            int slot = _materialWriter.WriteMaterial(name, ((byte)rgba.R, (byte)rgba.G, (byte)rgba.B, (byte)rgba.A));
+            int slot = _materialWriter.WriteMaterial(name, ((byte)rgba.R, (byte)rgba.G, (byte)rgba.B, (byte)rgba.A), opacity);
             MaterialsByName[name] = slot;
             _materialCount += 1;
             return slot;
         }
 
         /// <summary>Convenience overload defaulting alpha to 255 (opaque).</summary>
-        public int AddMaterial(string name, (int R, int G, int B) rgb) => AddMaterial(name, (rgb.R, rgb.G, rgb.B, 255));
+        public int AddMaterial(string name, (int R, int G, int B) rgb, double? opacity = null) => AddMaterial(name, (rgb.R, rgb.G, rgb.B, 255), opacity);
 
         private static void ValidateByteRange(int v, string label)
         {
@@ -2179,13 +2200,18 @@ namespace OpenSkp
         /// project has confirmed the on-disk CDib subtype tag for via SDK
         /// ground truth. Same ordering rules as AddMaterial.
         ///
-        /// appliedHeight defaults to 1.0 (matching applied width, always
-        /// 1.0). Pass a different value to make a default-projected
-        /// face's texture repeat at a specific real-world size instead of
-        /// every 1 inch - see WriteTexturedMaterial's own note for why
-        /// this field matters even for AddFace's frontUv/backUv pinning
-        /// (a positioned mapping still divides by it).</summary>
-        public int AddTextureMaterial(string name, string imagePath, double? appliedHeight = null)
+        /// appliedHeight/appliedWidth, if given, are the applied size in
+        /// INCHES - how much model space one tile of the image covers.
+        /// Both default to 1.0. A texture applied without positioning
+        /// carries no per-face UV record, so this pair IS its mapping -
+        /// see WriteTexturedMaterial's own note for why it matters even
+        /// for AddFace's frontUv/backUv pinning (a positioned mapping
+        /// still divides by it). appliedWidth and opacity sit after
+        /// appliedHeight (not alongside it) so an existing positional call
+        /// passing appliedHeight as the 3rd argument keeps meaning what it
+        /// always meant.</summary>
+        public int AddTextureMaterial(
+            string name, string imagePath, double? appliedHeight = null, double? appliedWidth = null, double? opacity = null)
         {
             if (_geometryWriter != null)
             {
@@ -2202,7 +2228,7 @@ namespace OpenSkp
             if (MaterialsByName.TryGetValue(name, out int existing)) return existing;
             byte[] imageBytes = System.IO.File.ReadAllBytes(imagePath);
             int subtype = CreateMath.DetectImageSubtype(imageBytes);
-            int slot = _materialWriter.WriteTexturedMaterial(name, imageBytes, imagePath, subtype, appliedHeight);
+            int slot = _materialWriter.WriteTexturedMaterial(name, imageBytes, imagePath, subtype, appliedHeight, appliedWidth, opacity);
             MaterialsByName[name] = slot;
             _materialCount += 1;
             return slot;

--- a/packages/typescript/src/create.ts
+++ b/packages/typescript/src/create.ts
@@ -751,7 +751,9 @@ class ArchiveWriter {
   }
 
   /** Write one solid-color CMaterial record and return its slot. */
-  writeMaterial(name: string, rgba: readonly [number, number, number, number]): number {
+  writeMaterial(
+    name: string, rgba: readonly [number, number, number, number], opacity?: number
+  ): number {
     const slot = this.newOfKnownClass('CMaterial', MATERIAL_SCHEMA);
     this.preamble();
     this.writeStr(name);
@@ -759,8 +761,9 @@ class ArchiveWriter {
     this.pushBytes(rgba);
     this.writeStr(''); // texture path (empty - no texture)
     this.pushZeros(8); // unknown/padding - ground truth is all-zero here
-    this.pushF64(1.0); // opacity
-    this.pushU8(0); // use_opacity = False (alpha carries transparency instead)
+    // Stored TRANSPARENCY (0 = opaque); see writeTexturedMaterial.
+    this.pushF64(opacity === undefined ? 1.0 : 1.0 - opacity);
+    this.pushU8(opacity === undefined ? 0 : 1); // use_opacity gates it
     return slot;
   }
 
@@ -768,19 +771,27 @@ class ArchiveWriter {
    * verbatim inside a CDib sub-object) and return its slot. `subtype` is
    * CDib's image format tag (4 for PNG, 1 for JPEG).
    *
-   * `appliedHeight` defaults to 1.0, matching applied width (always 1.0,
-   * unconditionally). Pass a different value for a textured material used
-   * with default (unpositioned) projection, to make the texture repeat at
-   * a specific real-world size instead of every 1 inch - the reader's own
-   * ground-truth-derived UV formula divides a face's final UV by the
-   * material's applied width/height, for a default-projected face exactly
-   * as much as a positioned (`frontUv`/`backUv`) one. Until 2026-08-28
-   * this defaulted to a corrupted sentinel byte pattern instead (see
+   * `appliedWidth`/`appliedHeight` both default to 1.0. Pass the
+   * material's real-world tile size for a textured material used with
+   * default (unpositioned) projection, to make the texture repeat at a
+   * specific size instead of every 1 inch (real SketchUp writes the
+   * material's own size here - a file authored in SketchUp Web carries
+   * 8.0 x 16.0 for a brick) - the reader's own ground-truth-derived UV
+   * formula divides a face's final UV by the material's applied
+   * width/height, for a default-projected face exactly as much as a
+   * positioned (`frontUv`/`backUv`) one. Until 2026-08-28 this defaulted
+   * to a corrupted sentinel byte pattern instead (see
    * _TEXTURE_H_SENTINEL's own comment) - confirmed via real SketchUp
    * screenshots to render as a streaky, vertically-smeared texture
-   * regardless of projection mode. */
+   * regardless of projection mode.
+   *
+   * `appliedWidth` and `opacity` are appended after `appliedHeight`
+   * (rather than sitting next to it, matching Python's ordering) so an
+   * existing positional call passing `appliedHeight` as the 5th argument
+   * keeps meaning what it always meant. */
   writeTexturedMaterial(
-    name: string, imageBytes: Uint8Array, texturePath: string, subtype: number, appliedHeight?: number
+    name: string, imageBytes: Uint8Array, texturePath: string, subtype: number,
+    appliedHeight?: number, appliedWidth?: number, opacity?: number
   ): number {
     const slot = this.newOfKnownClass('CMaterial', MATERIAL_SCHEMA);
     this.preamble();
@@ -797,7 +808,12 @@ class ArchiveWriter {
       // JPEG's own actual encoded quality.
       this.pushU32(90);
     }
-    this.pushF64(1.0); // applied width - ground truth default when unscaled
+    // Applied size: how much MODEL SPACE one tile of the image covers, in
+    // inches - two plain f64s. For a texture applied WITHOUT positioning it
+    // is the only thing that says how big the image is - such faces carry
+    // no per-face UV record at all, so a wrong size here is the whole
+    // mapping wrong.
+    this.pushF64(appliedWidth !== undefined ? appliedWidth : 1.0);
     this.pushF64(appliedHeight !== undefined ? appliedHeight : 1.0);
     this.writeStr(texturePath);
     // avg color: neutral near-opaque white, alpha 254 not 255 - legacy.ts's
@@ -807,8 +823,14 @@ class ArchiveWriter {
     this.writeStr(''); // second name field - empty in ground truth
     this.pushU32(1);
     this.pushU32(0); // blob (colorize-related, ground truth: 1, 0)
-    this.pushF64(1.0); // opacity
-    this.pushU8(0); // use_opacity = False
+    // Opacity, and the u8 that GATES it. The stored f64 is TRANSPARENCY
+    // (0 = opaque) - the reader turns it into the opacity factor
+    // exposed with `1.0 - stored`, and only when the flag is set - so an
+    // `opacity` argument here is written inverted and round-trips as
+    // itself. Hardcoding 1.0/false meant a translucent material came out
+    // solid: a pool's water at 0.6 exported as an opaque slab.
+    this.pushF64(opacity === undefined ? 1.0 : 1.0 - opacity);
+    this.pushU8(opacity === undefined ? 0 : 1);
     return slot;
   }
 
@@ -1616,7 +1638,7 @@ export class SkpBuilder {
     this.materialWriter = new ArchiveWriter(this.base, {});
   }
 
-  addMaterial(name: string, rgba: readonly number[]): number {
+  addMaterial(name: string, rgba: readonly number[], opacity?: number): number {
     if (this.geometryWriter !== null) throw new SkpWriteError('addMaterial must be called before any addFace calls');
     if (this.layerWriter !== null) throw new SkpWriteError('addMaterial must be called before any addLayer calls');
     if (this.definitionWriterInstance !== null) {
@@ -1628,7 +1650,7 @@ export class SkpBuilder {
     if (full.length !== 4 || !full.every((c) => Number.isInteger(c) && c >= 0 && c <= 255)) {
       throw new SkpWriteError('rgba must be 3 or 4 integers in 0-255');
     }
-    const slot = this.materialWriter.writeMaterial(name, full as [number, number, number, number]);
+    const slot = this.materialWriter.writeMaterial(name, full as [number, number, number, number], opacity);
     this.materialsByName.set(name, slot);
     this.materialCount += 1;
     return slot;
@@ -1643,13 +1665,20 @@ export class SkpBuilder {
    * record (SketchUp shows it as the texture's original file path); it
    * has no effect on the embedded image bytes themselves.
    *
-   * `appliedHeight` defaults to 1.0 (matching applied width, always 1.0).
-   * Pass a different value to make a default-projected face's texture
-   * repeat at a specific real-world size instead of every 1 inch - see
-   * writeTexturedMaterial's own comment for why this field matters even
-   * for addFace's `frontUv`/`backUv` pinning (a positioned mapping still
-   * divides by it). */
-  addTextureMaterial(name: string, imageBytes: Uint8Array, texturePath = '', appliedHeight?: number): number {
+   * `appliedHeight`/`appliedWidth`, if given, are the applied size in
+   * INCHES - how much model space one tile of the image covers. Both
+   * default to 1.0. A texture applied without positioning carries no
+   * per-face UV record, so this pair IS its mapping - and see
+   * writeTexturedMaterial's own comment for why it matters even for
+   * addFace's `frontUv`/`backUv` pinning (a positioned mapping still
+   * divides by it). `appliedWidth` and `opacity` sit after `appliedHeight`
+   * (not alongside it) so an existing positional call passing
+   * `appliedHeight` as the 4th argument keeps meaning what it always
+   * meant. */
+  addTextureMaterial(
+    name: string, imageBytes: Uint8Array, texturePath = '',
+    appliedHeight?: number, appliedWidth?: number, opacity?: number
+  ): number {
     if (this.geometryWriter !== null) {
       throw new SkpWriteError('addTextureMaterial must be called before any addFace calls');
     }
@@ -1661,7 +1690,9 @@ export class SkpBuilder {
     }
     if (this.materialsByName.has(name)) return this.materialsByName.get(name)!;
     const subtype = detectImageSubtype(imageBytes);
-    const slot = this.materialWriter.writeTexturedMaterial(name, imageBytes, texturePath, subtype, appliedHeight);
+    const slot = this.materialWriter.writeTexturedMaterial(
+      name, imageBytes, texturePath, subtype, appliedHeight, appliedWidth, opacity
+    );
     this.materialsByName.set(name, slot);
     this.materialCount += 1;
     return slot;

--- a/packages/typescript/tests/create.test.ts
+++ b/packages/typescript/tests/create.test.ts
@@ -312,6 +312,24 @@ describe('Materials', () => {
     expect(glass.color.a).toBe(128);
     expect(solid.color).toEqual({ r: 10, g: 20, b: 30, a: 255 });
   });
+
+  it('carries opacity on a solid material (openskp#252)', () => {
+    const builder = create();
+    const glass = builder.addMaterial('Glass', [200, 220, 255], 0.35);
+    builder.addFace(SQUARE, { material: glass });
+    const model = parseSkp(toBuffer(builder.toBytes()));
+    const mat = model.materials.find((m) => m.name === 'Glass')!;
+    expect(mat.transparency).toBeCloseTo(0.35);
+  });
+
+  it('omitted opacity stays fully opaque', () => {
+    const builder = create();
+    const red = builder.addMaterial('Red', [255, 0, 0]);
+    builder.addFace(SQUARE, { material: red });
+    const model = parseSkp(toBuffer(builder.toBytes()));
+    const mat = model.materials.find((m) => m.name === 'Red')!;
+    expect(mat.transparency).toBe(1.0);
+  });
 });
 
 describe('Textures', () => {
@@ -386,6 +404,42 @@ describe('Textures', () => {
   it('an unrecognized image format throws', () => {
     const builder = create();
     expect(() => builder.addTextureMaterial('Bogus', Uint8Array.from([1, 2, 3, 4]))).toThrow(/unrecognized image format/);
+  });
+
+  it('carries the applied width and height on a textured material (openskp#252)', () => {
+    // Real SketchUp writes the material's own tile size in BOTH axes (a
+    // file authored in SketchUp Web carries 8.0 x 16.0 for a brick); a
+    // texture applied without positioning carries no per-face UV record,
+    // so this pair IS its mapping.
+    const builder = create();
+    const png = makeTestPng();
+    const brick = builder.addTextureMaterial('Brick', png, 'brick.png', 16.0, 8.0);
+    builder.addFace(SQUARE, { material: brick });
+    const model = parseSkp(toBuffer(builder.toBytes()));
+    const mat = model.materials.find((m) => m.name === 'Brick')!;
+    expect(mat.texture!.width).toBe(8.0);
+    expect(mat.texture!.height).toBe(16.0);
+  });
+
+  it('applied width and height both default to 1.0', () => {
+    const builder = create();
+    const png = makeTestPng();
+    const brick = builder.addTextureMaterial('Brick', png, 'brick.png');
+    builder.addFace(SQUARE, { material: brick });
+    const model = parseSkp(toBuffer(builder.toBytes()));
+    const mat = model.materials.find((m) => m.name === 'Brick')!;
+    expect(mat.texture!.width).toBe(1.0);
+    expect(mat.texture!.height).toBe(1.0);
+  });
+
+  it('carries opacity on a textured material (openskp#252)', () => {
+    const builder = create();
+    const png = makeTestPng();
+    const voile = builder.addTextureMaterial('Voile', png, 'voile.png', undefined, undefined, 0.5);
+    builder.addFace(SQUARE, { material: voile });
+    const model = parseSkp(toBuffer(builder.toBytes()));
+    const mat = model.materials.find((m) => m.name === 'Voile')!;
+    expect(mat.transparency).toBeCloseTo(0.5);
   });
 
   it('addImage places a real Image entity, not a plain textured face', () => {


### PR DESCRIPTION
## Summary

- Follow-up to #252, which added `applied_width` and `opacity` to the Python writer only (materials' real-world texture tile size and stored transparency). Every other language still hardcoded `opacity=1.0`/`use_opacity=false` and had no `applied_width` parameter at all.
- Ports both parameters identically to TypeScript, .NET, Dart, and C++, verified against each language's own public reader (`transparency`/`Transparency`, `Texture.width`/`height`/`Width`/`Height` - all already wired from the raw on-disk fields, so no reader changes were needed).
- TS and C++ append `applied_width`/`opacity` *after* `applied_height` rather than sitting next to it (unlike Python's own parameter order) because each has a real positional caller passing `applied_height` unnamed (`edit.ts`, `edit.cpp`, `create_test.cpp`) - inserting ahead of it would have silently reinterpreted that caller's value. .NET and Dart use named/optional parameters throughout, so no such risk there.

## Test plan

- [x] TypeScript: 366 tests pass, `eslint` clean
- [x] .NET: 197 tests pass (`dotnet test`); `dotnet format --verify-no-changes` flags only pre-existing CRLF/ENDOFLINE drift on this checkout (confirmed present in untouched files and already true on `main`)
- [x] Dart: 90 tests pass, `dart analyze --fatal-infos` clean
- [x] C++: 193 tests pass, `clang-format --dry-run -Werror` clean
- [x] Every new test confirmed to fail against the pre-fix code (compile error in .NET/Dart since the parameters didn't exist; runtime assertion failure in TS)