### PR TITLE
docs: add revolve/extrude lathe example, credit IngeTrazo's AI tooling

### DIFF
--- a/docs/AI_MODELING.md
+++ b/docs/AI_MODELING.md
@@ -116,6 +116,17 @@ Point your AI coding agent at:
   legs and a curved backrest" works better than asking for SketchUp API
   calls directly, since the agent already knows how to turn a shape
   description into geometry once it has the writer's API in context.
+- [`examples/python/lathe_and_extrude.py`](../examples/python/lathe_and_extrude.py)
+  for turned/revolved shapes specifically (columns, vases, balusters,
+  fountain tiers) — a `revolve()`/`extrude()` pair built entirely on the
+  raw `add_face()`/`add_group()` API above, not a new writer capability.
+  It exists because agents kept hand-rolling the same ~40-line
+  ring-of-quads math per turned part; one call now does it. This is a
+  narrow, deliberate exception to "no object-specific helpers" — it's a
+  geometric primitive (a lathe), not a domain-specific one (`add_chair`
+  is still out of scope) — contributed as a CC0 gift by
+  [IngeTrazo](https://github.com/iamahsanmehmood) after the same pattern
+  showed up repeatedly in their own AI Assistant's generated code.
 
 The workflow that produced every showcase model above: describe the
 object, let the agent write and run `openskp.create()` code, open the
@@ -134,21 +145,31 @@ rather than an opaque `.skp` binary. See
 ## What's next — help build this out
 
 This page documents what already works today: a generic, AI-legible
-writer API, proven on real generated models. What doesn't exist yet, and
-is a genuinely open direction:
+writer API, proven on real generated models. Two directions listed here
+as open now have a real reference implementation, built by a downstream
+project rather than in this repo:
 
 - **A render/validate feedback loop.** The biggest gap in "AI generates
-  a `.skp` file" today is that the agent has no way to *see* what it
-  built without a human opening SketchUp. A tool (MCP or otherwise) that
-  renders a built file to an image, or runs it through the real SDK for
-  validation, would close that loop directly.
-- **An MCP server**, if it turns out to add real value beyond what a
-  coding agent can already do by writing and running code directly
-  against the library — worth prototyping and comparing rather than
-  assuming either direction up front.
+  a `.skp` file" is that the agent has no way to *see* what it built
+  without a human opening SketchUp — closing that loop needs an actual
+  3D viewport, which is out of scope for a library that only reads and
+  writes files. [IngeTrazo](https://github.com/iamahsanmehmood), a
+  desktop `.skp` editor built on this project's reader and writer, has
+  shipped exactly this: an in-app AI Assistant that runs an agent's
+  recipe against the live scene, screenshots the viewport, and feeds the
+  image back for the next turn — closing the loop this page describes,
+  just one layer up from OpenSKP itself.
+- **An MCP server.** IngeTrazo also ships one (`docs/ai-bridge.md` in
+  their repo) exposing the same recipe-execution engine to an external
+  MCP client. Worth a look before building a second one from scratch.
 - **More showcase models** — different shapes, different levels of
   geometric complexity, ideally with the prompt that produced them
-  alongside the code and a real screenshot.
+  alongside the code and a real screenshot. IngeTrazo's own AI Assistant
+  reproduced a real three-tier garden fountain from a single reference
+  photo this way — 7 component definitions, 1,104 faces, correct
+  real-world dimensions, using the `revolve()`/`extrude()` helpers above
+  — a strong independent proof point for the writer API under real,
+  unsupervised AI use.
 
 Contributions and ideas on any of the above are welcome — see
 [CONTRIBUTING.md](../CONTRIBUTING.md), or open a discussion on the

--- a/examples/python/lathe_and_extrude.py
+++ b/examples/python/lathe_and_extrude.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""
+OpenSKP — Lathe (Revolve) and Extrude Helpers
+
+Two small, dependency-free helpers on top of openskp.create()'s raw
+add_face() API: revolve() builds a solid of revolution around Z from a
+2D (radius, z) profile (columns, vases, balusters, fountain tiers),
+and extrude() sweeps a 2D outline into a straight prism.
+
+Why these exist: an AI agent (or a human) writing openskp.create() code
+by hand for a turned/revolved shape ends up hand-rolling ~40 lines of
+ring-of-quads math per part, with no shared, tested code path — easy to
+get wrong (degenerate faces, missing end caps, faceted/unsmoothed
+shading) and expensive to redo for every similar part. These two
+functions collapse that to one call, e.g.:
+
+    revolve(target, [(0.3, 0.0), (0.2, 0.5), (0.35, 0.8)])   # a baluster
+
+This does not change OpenSKP's own writer API — it is example code
+built entirely on the existing public add_face()/add_group() surface,
+included here as a starting point for anyone (agent or human) modeling
+turned/extruded shapes. See docs/AI_MODELING.md for the broader context.
+
+Originally written by IngeTrazo (github.com/iamahsanmehmood — the
+downstream .skp-editing app that uses this project's writer) as a CC0
+gift after finding the same ring-of-quads pattern recurring across
+AI-generated recipes in their own AI Assistant; adapted here as an
+OpenSKP example.
+
+Profiles are (radius, z) in METERS, bottom to top, converted to the
+inches openskp.create() expects. Run this file directly to produce
+fountain.skp — a three-tier garden fountain in seven revolve()/extrude()
+calls, modeled after a real reference photo.
+"""
+
+import math
+
+import openskp
+
+INCH_PER_METER = 39.3701
+
+
+def revolve(target, profile, segments=32, scallop=None, closed=False, material=None):
+    """Build a solid of revolution around Z on ``target`` (an SkpBuilder
+    or a group/component-definition builder — anything with add_face()).
+
+    ``profile`` is a list of (radius, z) points in meters, bottom to top.
+    An open profile (the common case) gets flat end caps at its first
+    and last ring, unless that ring's radius is ~0 (a point, needing no
+    cap). ``closed=True`` instead revolves the profile as a closed
+    cross-section ring with no caps at all — for a shape like a basin
+    wall, whose profile already returns to its own start.
+
+    ``scallop=(depth, lobes)`` carves festoons into the rim: each ring's
+    radius is perturbed by a cosine wave with ``lobes`` repetitions and
+    ``depth`` meters of amplitude, scaled by that ring's own radius
+    relative to the profile's largest radius — so the effect is
+    strongest at the widest ring and fades toward the axis, rather than
+    displacing every ring by the same amount regardless of size.
+
+    Side faces are marked soft+smooth so the curved surface shades
+    smoothly in SketchUp instead of showing each individual segment.
+    """
+    amp, lobes = scallop or (0.0, 0)
+    r_max = max(r for r, _z in profile) or 1.0
+    rings = []
+    for r, z in profile:
+        ring = []
+        for i in range(segments):
+            theta = 2.0 * math.pi * i / segments
+            rr = r
+            if lobes:
+                rr += amp * 0.5 * (math.cos(lobes * theta) - 1.0) * (r / r_max)
+            ring.append((
+                rr * math.cos(theta) * INCH_PER_METER,
+                rr * math.sin(theta) * INCH_PER_METER,
+                z * INCH_PER_METER,
+            ))
+        rings.append(ring)
+
+    row_count = len(rings)
+    for j in range(row_count if closed else row_count - 1):
+        lower, upper = rings[j], rings[(j + 1) % row_count]
+        for i in range(segments):
+            i2 = (i + 1) % segments
+            quad = [lower[i], lower[i2], upper[i2], upper[i]]
+            if _is_degenerate(quad):
+                continue
+            target.add_face(quad, material=material, soft_edges=True, smooth_edges=True)
+
+    if not closed:
+        if profile[0][0] > 1e-6:
+            target.add_face(list(reversed(rings[0])), material=material)
+        if profile[-1][0] > 1e-6:
+            target.add_face(rings[-1], material=material)
+
+
+def extrude(target, outline, z0, z1, material=None):
+    """Build a straight prism on ``target`` by sweeping a 2D (x, y)
+    ``outline`` (meters) from height ``z0`` up to ``z1`` (also meters)."""
+    lower = [(x * INCH_PER_METER, y * INCH_PER_METER, z0 * INCH_PER_METER) for x, y in outline]
+    upper = [(x * INCH_PER_METER, y * INCH_PER_METER, z1 * INCH_PER_METER) for x, y in outline]
+    n = len(lower)
+    for i in range(n):
+        j = (i + 1) % n
+        target.add_face([lower[i], lower[j], upper[j], upper[i]], material=material)
+    target.add_face(list(reversed(lower)), material=material)
+    target.add_face(upper, material=material)
+
+
+def _is_degenerate(quad):
+    def close(p, q):
+        return abs(p[0] - q[0]) + abs(p[1] - q[1]) + abs(p[2] - q[2]) < 1e-6
+    return close(quad[0], quad[3]) and close(quad[1], quad[2])
+
+
+if __name__ == "__main__":
+    builder = openskp.create()
+    stone = builder.add_material("Stone", (140, 138, 133))
+
+    octagon = [
+        (0.39 * math.cos(a), 0.39 * math.sin(a))
+        for a in (math.pi / 8 + i * math.pi / 4 for i in range(8))
+    ]
+    with builder.add_group("Pedestal") as g:
+        extrude(g, octagon, 0.0, 0.45, material=stone)
+    with builder.add_group("Baluster") as g:
+        revolve(g, [(0.34, 0.45), (0.26, 0.52), (0.29, 0.62), (0.19, 0.86),
+                    (0.21, 1.00), (0.15, 1.05)], material=stone)
+    with builder.add_group("Big plate") as g:
+        revolve(g, [(0.12, 1.05), (0.66, 1.20), (0.75, 1.25), (0.75, 1.30),
+                    (0.45, 1.24), (0.12, 1.18)],
+                closed=True, scallop=(0.03, 12), material=stone)
+    with builder.add_group("Upper shaft") as g:
+        revolve(g, [(0.16, 1.17), (0.13, 1.24), (0.15, 1.34), (0.10, 1.58),
+                    (0.13, 1.64), (0.09, 1.72)], material=stone)
+    with builder.add_group("Small plate") as g:
+        revolve(g, [(0.09, 1.72), (0.44, 1.83), (0.50, 1.865), (0.50, 1.90),
+                    (0.28, 1.85), (0.09, 1.81)],
+                closed=True, scallop=(0.02, 10), material=stone)
+    with builder.add_group("Finial") as g:
+        revolve(g, [(0.09, 1.80), (0.16, 1.98), (0.17, 2.08), (0.14, 2.18),
+                    (0.025, 2.30)], scallop=(0.015, 8), material=stone)
+    with builder.add_group("Basin") as g:
+        revolve(g, [(1.50, 0.00), (1.80, 0.00), (1.88, 0.16), (1.82, 0.44),
+                    (1.94, 0.53), (1.96, 0.60), (1.88, 0.64), (1.50, 0.64)],
+                closed=True, scallop=(0.025, 16), material=stone)
+
+    builder.save("fountain.skp")
+    print("wrote fountain.skp")


### PR DESCRIPTION
## Summary

- Adds `examples/python/lathe_and_extrude.py` — a `revolve()`/`extrude()` helper pair built entirely on the existing `add_face()`/`add_group()` writer API (no new writer capability). Solves a recurring pattern: an AI agent writing `openskp.create()` code by hand for a turned/revolved shape (columns, vases, fountain tiers) hand-rolls ~40 lines of ring-of-quads math per part.
- Originally a CC0 gift from [IngeTrazo](https://github.com/iamahsanmehmood) (a downstream `.skp` editor built on this project's reader/writer), after the same pattern showed up repeatedly in their own AI Assistant's generated code.
- Verified: running the example's `__main__` block reproduces the exact fountain IngeTrazo's own AI Assistant modeled from a real reference photo — 7 definitions, 1,104 faces, matching their reported numbers exactly.
- Updates `docs/AI_MODELING.md`'s "What's next" section: two items listed as open (a render/validate feedback loop, an MCP server) now have a real reference implementation — IngeTrazo's in-app AI Assistant and MCP bridge, built one layer up from a file-only library (a viewport/screenshot loop is out of scope for OpenSKP itself). Linked instead of duplicated.

## Test plan

- [x] `python examples/python/lathe_and_extrude.py` runs and writes `fountain.skp`
- [x] Round-tripped the output through `SkpFile.parse()`: 7 definitions, 1104 faces — matches IngeTrazo's own numbers for the same model
- [x] `ruff check` clean (not CI-enforced for `examples/`, checked anyway)