### PR TITLE
create/legacy/_core: full attribute dictionary read+write support

### DIFF
--- a/packages/python/src/openskp/_core.py
+++ b/packages/python/src/openskp/_core.py
@@ -826,7 +826,7 @@ def _extract_geometry_from_nodes(elements, builder):
             # knowable once the scene graph is actually flattened (see
             # SkpFile.build_scene()'s InstanceNode.layer for that).
             inst_layer_id = None
-            inst_properties = {}
+            inst_attribute_dicts = {}
             d007 = next((c for c in el['children'] if c['tag'] == 'D007'),
                         None)
             if d007:
@@ -840,7 +840,7 @@ def _extract_geometry_from_nodes(elements, builder):
                 if d207 and d207['payload']:
                     inst_layer_id = parse_var_int(
                         d207['payload'], 0, len(d207['payload']))
-                inst_properties = extract_dynamic_properties(d007)
+                inst_attribute_dicts = extract_attribute_dictionaries(d007)
                 # D307 = display flags, same record edges/faces already
                 # read (base 0x06, +0x01 hidden).
                 d307 = next((c for c in d007['children']
@@ -848,6 +848,7 @@ def _extract_geometry_from_nodes(elements, builder):
                 if d307 is not None and d307['payload']:
                     inst_hidden = bool(d307['payload'][0] & 0x01)
 
+            dynamic = inst_attribute_dicts.get('dynamic_attributes', {})
             builder.instances.append({
                 'offset': el['offset'],
                 'ref_guid': guid,
@@ -857,7 +858,11 @@ def _extract_geometry_from_nodes(elements, builder):
                 'material_id': inst_mat_id,
                 'hidden': inst_hidden,
                 'layer_id': inst_layer_id,
-                'properties': inst_properties,
+                # Backward-compatible view: stringified dynamic_attributes
+                # dict only. attribute_dictionaries carries every
+                # dictionary by name, real (non-stringified) types.
+                'properties': {k: _stringify_vff_attr_value(v) for k, v in dynamic.items()},
+                'attribute_dictionaries': inst_attribute_dicts,
                 'children': el['children']
             })
 
@@ -909,37 +914,124 @@ def multiply_matrices(parent, child):
 
 # ── Dynamic properties ───────────────────────────────────────────────────
 
-def extract_dynamic_properties(d007):
-    """Extract Dynamic Component attribute key-value pairs from a D007 container node.
+# TLV container tags nesting the dynamic property key/value nodes. A438
+# wraps one attribute value (its own type tag lives inside it, or no
+# children at all for null); AE38 wraps an array's own elements (each
+# itself an A438-wrapped value, concatenated with no count prefix - the
+# array's own declared byte size is what bounds how many there are). Both
+# must be descended into for real content to appear instead of an opaque
+# leaf payload - confirmed byte-for-byte against real FrameBuilder-
+# authored production files (openskp#254/#255), cross-checked against
+# SketchUp's own Ruby API reading the identical file live.
+_PROP_CONTAINER_TAGS = ['DD05', 'B536', 'B136', 'B236', 'B336', 'B036', 'A438', 'AE38']
 
-    Dynamic properties are stored in a nested TLV hierarchy under the DC05 tag:
-    - Container tags (DD05, B536, B136, B236, B336, B036, A438) wrap property sub-trees.
-    - Tag B636 contains the attribute key name (UTF-8 string).
-    - Tag AD38 contains the attribute value (UTF-8 string).
+# Attribute value type tags found inside an A438 wrapper - the VFF-format
+# counterpart of legacy._read_attr_named's own type table, verified the
+# same way (real bytes, not guessed): AD38 string, AF38 Length, A938
+# plain double - SketchUp genuinely uses two different tags for the same
+# 8-byte float64 encoding depending on whether the value is a Length or a
+# plain Float - A738 int32, B438 Point3d, B538 Vector3d (each 3 x f64,
+# 24 bytes flat, no per-component tags). No native bool/time_t tag has
+# been observed in real data yet -
+# FrameBuilder itself stores booleans as the literal strings "true"/
+# "false" - so those two of legacy's 9 types are not yet decoded here;
+# left safely unrecognized (see _decode_vff_attr_value) rather than
+# guessed at.
+_VFF_ATTR_DOUBLE_TAGS = ('AF38', 'A938')
+
+
+def _decode_vff_attr_value(a438_node):
+    """Decode one A438-wrapped attribute value node into a native Python
+    value. A438 with no children is null; otherwise it has exactly one
+    child holding the value's own type tag. An unrecognized type tag (or
+    a payload of the wrong size for its tag) is left undecoded (returns
+    None) rather than guessed at - matching this project's standing rule
+    to never assume an unverified binary layout."""
+    children = a438_node['children']
+    if not children:
+        return None
+    child = children[0]
+    tag = child['tag']
+    payload = child['payload']
+    if tag == 'AD38':
+        return payload.decode('utf-8', errors='replace')
+    if tag in _VFF_ATTR_DOUBLE_TAGS and len(payload) == 8:
+        return struct.unpack('<d', payload)[0]
+    if tag == 'A738' and len(payload) == 4:
+        return struct.unpack('<i', payload)[0]
+    if tag in ('B438', 'B538') and len(payload) == 24:
+        return struct.unpack('<3d', payload)
+    if tag == 'AE38':
+        return [_decode_vff_attr_value(elem) for elem in child['children']]
+    return None
+
+
+def extract_attribute_dictionaries(d007):
+    """Extract EVERY attribute dictionary attached to a D007 container
+    node, keyed by the dictionary's own declared name (tag B436) rather
+    than merged into one flat dict (openskp#254), decoding every value
+    type the format carries rather than only strings (openskp#255).
+
+    Dynamic properties are stored in a nested TLV hierarchy under the
+    DC05 tag. Each dictionary is a B436 (name) node immediately followed
+    by a sibling entries container (typically B536) holding that
+    dictionary's own B636 (key name) / A438 (type-tagged value) pairs.
+    Returns {} when the entity carries no DC05 subtree at all.
     """
     dc05 = next((c for c in d007['children'] if c['tag'] == 'DC05'), None)
     if not dc05:
         return {}
-    # TLV container tags nesting the dynamic property key/value nodes
-    prop_container_tags = ['DD05', 'B536', 'B136', 'B236', 'B336', 'B036', 'A438']
-    prop_elements = parse_tlv_recursive(dc05['payload'], 0, len(dc05['payload']), prop_container_tags)
-    properties = {}
-    current_key = None
-    def extract_props(nodes):
-        nonlocal current_key
+    prop_elements = parse_tlv_recursive(dc05['payload'], 0, len(dc05['payload']), _PROP_CONTAINER_TAGS)
+
+    dictionaries: Dict[str, Dict[str, Any]] = {}
+
+    def extract_entries(nodes, entries):
+        current_key = None
         for n in nodes:
             tag = n['tag']
             if tag == 'B636':
-                # Property key name (UTF-8 string)
                 current_key = n['payload'].decode('utf-8', errors='replace')
-            elif tag == 'AD38' and current_key:
-                # Property value (UTF-8 string) matching preceding key
-                val = n['payload'].decode('utf-8', errors='replace')
-                properties[current_key] = val
+            elif tag == 'A438' and current_key is not None:
+                entries[current_key] = _decode_vff_attr_value(n)
                 current_key = None
-            extract_props(n['children'])
-    extract_props(prop_elements)
-    return properties
+            else:
+                extract_entries(n['children'], entries)
+
+    def walk(nodes):
+        for i, n in enumerate(nodes):
+            if n['tag'] == 'B436':
+                name = n['payload'].decode('utf-8', errors='replace')
+                entries: Dict[str, Any] = {}
+                if i + 1 < len(nodes):
+                    extract_entries(nodes[i + 1]['children'], entries)
+                dictionaries[name] = entries
+            else:
+                walk(n['children'])
+
+    walk(prop_elements)
+    return dictionaries
+
+
+def _stringify_vff_attr_value(value):
+    """Render an already-typed VFF attribute value as a string, matching
+    extract_dynamic_properties' pre-existing Dict[str, str] contract -
+    mirrors legacy._stringify_attr_value exactly."""
+    if value is None:
+        return ''
+    if isinstance(value, (list, tuple)):
+        return ','.join(_stringify_vff_attr_value(v) for v in value)
+    return str(value)
+
+
+def extract_dynamic_properties(d007):
+    """Extract Dynamic Component attribute key-value pairs from a D007
+    container node - a backward-compatible view of just the one
+    dictionary SketchUp's own Dynamic Components extension uses
+    (``dynamic_attributes``), values stringified. See
+    extract_attribute_dictionaries for every dictionary by name, with
+    real (non-stringified) types."""
+    dynamic = extract_attribute_dictionaries(d007).get('dynamic_attributes', {})
+    return {k: _stringify_vff_attr_value(v) for k, v in dynamic.items()}
 
 
 # ── ZIP entry size validation ────────────────────────────────────────────

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -93,6 +93,7 @@ happens at import time, write time, or any other runtime path.
 """
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import math
 import re
@@ -100,17 +101,83 @@ import struct
 import time
 import uuid
 from importlib import resources
-from typing import Dict, FrozenSet, List, Optional, Sequence, Tuple
+from typing import Dict, FrozenSet, Iterator, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 from . import legacy
 
-__all__ = ["SkpWriteError", "SkpBuilder", "ComponentDefinitionBuilder", "create"]
+__all__ = [
+    "SkpWriteError", "SkpBuilder", "ComponentDefinitionBuilder", "create",
+    "Point3d", "Vector3d", "Length", "Timestamp",
+]
 
 Point3 = Tuple[float, float, float]
 
 
+class Point3d(NamedTuple):
+    """An attribute value written as SketchUp's ``Geom::Point3d`` type
+    (tag ``0x11``) - a position in inches. Disambiguates from
+    :class:`Vector3d` and from a plain 3-element array (tag ``0x0B``),
+    which share the same on-the-wire shape (3 floats) but a different
+    type tag - see :meth:`_ArchiveWriter.write_attribute_dict`."""
+    x: float
+    y: float
+    z: float
+
+
+class Vector3d(NamedTuple):
+    """An attribute value written as SketchUp's ``Geom::Vector3d`` type
+    (tag ``0x12``) - a direction, not a position. See :class:`Point3d`."""
+    x: float
+    y: float
+    z: float
+
+
+class Length(float):
+    """An attribute value written as SketchUp's ``Length`` type
+    (tag ``0x0C``, a double in inches) instead of a plain double
+    (``0x06``). Behaves exactly like a ``float`` otherwise."""
+    __slots__ = ()
+
+
+class Timestamp(int):
+    """An attribute value written as a ``time_t``-style unsigned 32-bit
+    integer (tag ``0x09``) instead of a plain 32-bit signed int
+    (``0x04``). Behaves exactly like an ``int`` otherwise; must be in
+    ``[0, 2**32)``."""
+    __slots__ = ()
+
+
+#: The full set of value types :meth:`_ArchiveWriter.write_attribute_dict`
+#: accepts, mirroring every type ``legacy._read_attr_named`` decodes.
+AttributeValue = Union[
+    None, bool, int, float, str, Point3d, Vector3d, Length, Timestamp,
+    List["AttributeValue"],
+]
+
+
 class SkpWriteError(Exception):
     """Raised when a ``.skp`` file cannot be constructed."""
+
+
+def _resolve_attribute_dicts(
+    attributes: Optional[Dict[str, object]],
+    attribute_dict_name: str,
+    attribute_dicts: Sequence[Tuple[str, Dict[str, object]]],
+) -> List[Tuple[str, Dict[str, object]]]:
+    """Resolve the two ways to attach custom attribute dictionaries to an
+    entity into a single ordered list: the ``attributes``/
+    ``attribute_dict_name`` shorthand for exactly one dictionary, or
+    ``attribute_dicts`` for several at once (real SketchUp entities
+    routinely carry more than one - e.g. a FrameBuilder-authored instance
+    typically has three). Passing both is an error rather than a silent
+    merge, to keep the resulting ordering unambiguous (openskp#256)."""
+    if attributes and attribute_dicts:
+        raise SkpWriteError(
+            "pass either attributes/attribute_dict_name or attribute_dicts, not both"
+        )
+    if attributes:
+        return [(attribute_dict_name, attributes)]
+    return list(attribute_dicts)
 
 
 _SCAFFOLD_FILE = "blank_v17.skp"
@@ -240,13 +307,19 @@ _ATTR_CONTAINER_SLOT = 3
 # reading back where its class-ref pointed.
 _ATTRIBUTE_NAMED_SLOT = 5
 
-# CAttributeNamed's own value-type tags, ground-truth-and-reader-confirmed
-# (legacy.py's _read_attr_named documents the full set this format
-# supports; only the 3 most commonly useful ones for custom metadata are
-# exposed by this writer for now - see write_attribute_dict).
+# CAttributeNamed's own value-type tags - the full set legacy.py's
+# _read_attr_named already decodes; write_attribute_dict below inverts
+# every one of them.
+_ATTR_TYPE_NULL = 0x00
 _ATTR_TYPE_INT32 = 0x04
 _ATTR_TYPE_DOUBLE = 0x06
+_ATTR_TYPE_BOOL = 0x07
+_ATTR_TYPE_TIME = 0x09       # uint32, time_t
 _ATTR_TYPE_STRING = 0x0A
+_ATTR_TYPE_ARRAY = 0x0B      # u32 count + that many (type-tag, value) pairs
+_ATTR_TYPE_LENGTH = 0x0C     # double, inches
+_ATTR_TYPE_POINT3D = 0x11    # 3 x f64
+_ATTR_TYPE_VECTOR3D = 0x12   # 3 x f64
 
 # The 176 bytes (everything after CCamera's 2-byte class-ref tag) real
 # SketchUp writes for a definition's default thumbnail camera - copied
@@ -718,39 +791,96 @@ class _ArchiveWriter:
     def _validate_attribute_entries(self, entries: Dict[str, object]) -> None:
         """Raise ``SkpWriteError`` for the first unsupported key/value in
         ``entries``, without writing anything - shares
-        `write_attribute_dict`'s own exact validation rules so a caller
-        can check every attribute dict a multi-part write will need
-        BEFORE that write starts mutating ``self.buf`` (and any shared
+        `_write_attr_value`'s own exact type dispatch so a caller can
+        check every attribute dict a multi-part write will need BEFORE
+        that write starts mutating ``self.buf`` (and any shared
         vertex/edge-sharing dicts a caller passes in), see `write_face`'s
         own upfront-validation comment for why that ordering matters.
         """
         for key, value in entries.items():
-            if isinstance(value, str):
-                continue
-            if isinstance(value, bool):
-                raise SkpWriteError(
-                    f"attribute {key!r}: bool is not a supported value type - "
-                    "use an int (0/1) if you need a boolean-like flag"
-                )
-            if isinstance(value, int):
-                if not (-(2**31) <= value < 2**31):
-                    raise SkpWriteError(f"attribute {key!r}: int value {value} out of signed 32-bit range")
-                continue
-            if isinstance(value, float):
-                continue
-            raise SkpWriteError(
-                f"attribute {key!r}: unsupported value type {type(value).__name__} "
-                "(only str, int, and float are supported for now)"
-            )
+            self._check_attribute_value(key, value)
+
+    def _check_attribute_value(self, key: str, value: object) -> None:
+        """Recursively validate one attribute value (array elements are
+        each checked in turn, so a bad value nested inside an array is
+        still caught before any writing starts)."""
+        if value is None or isinstance(value, bool):
+            return
+        if isinstance(value, (Point3d, Vector3d)):
+            if len(value) != 3 or not all(isinstance(c, (int, float)) and not isinstance(c, bool) for c in value):
+                raise SkpWriteError(f"attribute {key!r}: {type(value).__name__} needs exactly 3 numeric components")
+            return
+        if isinstance(value, Timestamp):
+            if not (0 <= int(value) < 2**32):
+                raise SkpWriteError(f"attribute {key!r}: Timestamp value {int(value)} out of unsigned 32-bit range")
+            return
+        if isinstance(value, (Length, str, float)):
+            return
+        if isinstance(value, int):
+            if not (-(2**31) <= value < 2**31):
+                raise SkpWriteError(f"attribute {key!r}: int value {value} out of signed 32-bit range")
+            return
+        if isinstance(value, (list, tuple)):
+            for i, item in enumerate(value):
+                self._check_attribute_value(f"{key}[{i}]", item)
+            return
+        raise SkpWriteError(
+            f"attribute {key!r}: unsupported value type {type(value).__name__} "
+            "(supported: None, bool, int, float, str, Point3d, Vector3d, Length, "
+            "Timestamp, or a list of these)"
+        )
+
+    def _write_attr_value(self, value: object) -> None:
+        """Write one type-tagged attribute value - the recursive core
+        both a top-level entry and each element of an array (tag
+        ``0x0B``) go through, since an array element is itself just
+        another type-tagged value."""
+        if value is None:
+            self.buf.append(_ATTR_TYPE_NULL)
+        elif isinstance(value, bool):
+            self.buf.append(_ATTR_TYPE_BOOL)
+            self.buf.append(1 if value else 0)
+        elif isinstance(value, Point3d):
+            self.buf.append(_ATTR_TYPE_POINT3D)
+            self.buf += b"".join(_f64(float(c)) for c in value)
+        elif isinstance(value, Vector3d):
+            self.buf.append(_ATTR_TYPE_VECTOR3D)
+            self.buf += b"".join(_f64(float(c)) for c in value)
+        elif isinstance(value, Length):
+            self.buf.append(_ATTR_TYPE_LENGTH)
+            self.buf += _f64(float(value))
+        elif isinstance(value, Timestamp):
+            self.buf.append(_ATTR_TYPE_TIME)
+            self.buf += _u32(int(value))
+        elif isinstance(value, str):
+            self.buf.append(_ATTR_TYPE_STRING)
+            self._write_str(value)
+        elif isinstance(value, int):
+            self.buf.append(_ATTR_TYPE_INT32)
+            self.buf += struct.pack("<i", value)
+        elif isinstance(value, float):
+            self.buf.append(_ATTR_TYPE_DOUBLE)
+            self.buf += _f64(value)
+        elif isinstance(value, (list, tuple)):
+            self.buf.append(_ATTR_TYPE_ARRAY)
+            self.buf += _u32(len(value))
+            for item in value:
+                self._write_attr_value(item)
+        else:
+            raise SkpWriteError(f"unsupported attribute value type {type(value).__name__}")
 
     def write_attribute_dict(self, dict_name: str, entries: Dict[str, object]) -> None:
         """Write one ``CAttributeNamed`` record - a named dictionary of
         custom key/value metadata attached to an entity's real attribute
         container (the same mechanism SketchUp's own "dynamic component"
         attributes use). Inverts ``legacy._read_attr_named`` field-for-
-        field; see that function's docstring for the full set of value
-        types this format supports - only ``str``, ``int`` (32-bit
-        signed), and ``float`` are exposed by this writer for now.
+        field, covering every value type that reader decodes: ``None``,
+        ``bool``, ``int`` (32-bit signed), ``float``, ``str``,
+        :class:`Point3d`, :class:`Vector3d`, :class:`Length`,
+        :class:`Timestamp`, and a ``list``/``tuple`` of any of these
+        (nestable, tag ``0x0B``) - see those classes' own docstrings for
+        when to reach for a wrapper type instead of a plain ``int``/
+        ``float``/3-tuple.
 
         Unlike every other class this project declares, ``CAttributeNamed``
         is already pre-declared in the scaffold's own prefix (ground
@@ -767,15 +897,7 @@ class _ArchiveWriter:
         self._write_str(dict_name)
         for key, value in entries.items():
             self._write_str(key)
-            if isinstance(value, str):
-                self.buf.append(_ATTR_TYPE_STRING)
-                self._write_str(value)
-            elif isinstance(value, int):
-                self.buf.append(_ATTR_TYPE_INT32)
-                self.buf += struct.pack("<i", value)
-            else:
-                self.buf.append(_ATTR_TYPE_DOUBLE)
-                self.buf += _f64(value)
+            self._write_attr_value(value)
         self._write_str("")  # empty-key terminator
         self.buf += _u32(0)  # ground truth: read and discarded by legacy.py's reader too
 
@@ -1715,6 +1837,7 @@ class ComponentDefinitionBuilder:
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
         auto_triangulate: bool = False,
         holes: Sequence[Sequence[Point3]] = (),
     ) -> None:
@@ -1730,12 +1853,12 @@ class ComponentDefinitionBuilder:
         if len(points) < 3:
             raise SkpWriteError("a face needs at least 3 points")
         holes = [[(float(p[0]), float(p[1]), float(p[2])) for p in hole] for hole in holes]
-        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
+        resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
         self._new_entity_count += _write_face_or_triangulate(
             self._skp._definition_writer, points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
-            front_uv, back_uv, attribute_dicts, auto_triangulate,
+            front_uv, back_uv, resolved_attribute_dicts, auto_triangulate,
             holes=holes,
         )
 
@@ -1753,6 +1876,7 @@ class ComponentDefinitionBuilder:
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> None:
         """Add one circular face to this definition - same signature and
         behavior as :meth:`SkpBuilder.add_circle`, except vertices/edges
@@ -1771,12 +1895,12 @@ class ComponentDefinitionBuilder:
         xaxis = (radius * u[0], radius * u[1], radius * u[2])
         curve_params = (center, normal, xaxis, 0.0, 2.0 * math.pi, radius, num_segments)
         points = _circle_points(center, normal, radius, num_segments, u, w)
-        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
+        resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
         self._new_entity_count += writer.write_face(
             points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, False, False, False,
-            front_uv, back_uv, attribute_dicts,
+            front_uv, back_uv, resolved_attribute_dicts,
             curve_params=curve_params,
         )
 
@@ -1844,6 +1968,7 @@ class ComponentDefinitionBuilder:
         layer: Optional[int] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
         hidden: bool = False,
     ) -> None:
         """Place one instance of another, already-closed component
@@ -1886,13 +2011,13 @@ class ComponentDefinitionBuilder:
         if definition is self:
             raise SkpWriteError(f"component definition {self.name!r} cannot nest an instance of itself")
         matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
-        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
+        resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
         # See SkpBuilder.add_instance's own comment on `name if name is not
         # None else ...` vs `name or ...` - an explicit empty string must
         # round-trip as empty, not silently become the definition's name.
         self._new_entity_count += self._skp._definition_writer.write_instance(
             definition.slot, name if name is not None else definition.name, translation, matrix3x3,
-            material or 0, layer or 0, attribute_dicts, hidden,
+            material or 0, layer or 0, resolved_attribute_dicts, hidden,
         )
 
     def add_group_instance(
@@ -2066,6 +2191,45 @@ class SkpBuilder:
         self._new_entity_count = 0
         self._face_count = 0
         self._dim_font_slot: Optional[int] = None
+
+    @contextlib.contextmanager
+    def definitions(self) -> Iterator["SkpBuilder"]:
+        """Context manager marking this builder's "definitions phase" -
+        purely organizational, a place to visibly group every
+        `add_material`/`add_texture_material`/`add_layer`/
+        `add_component_definition` call together (openskp#257). It does
+        not itself relax or add to the underlying rule that all of those
+        must happen before the first `add_face`/`add_instance` call -
+        see `instances()`, which is the half that actually enforces
+        anything, for why a plain call to any of those methods (with or
+        without wrapping them in this block) already raises
+        `SkpWriteError` immediately if the ordering is wrong.
+
+        >>> with builder.definitions():
+        ...     chair = builder.add_component_definition("Chair")
+        ...     with chair:
+        ...         chair.add_face([(0, 0, 0), (20, 0, 0), (20, 20, 0), (0, 20, 0)])
+        >>> with builder.instances():
+        ...     builder.add_instance(chair)
+        """
+        yield self
+
+    @contextlib.contextmanager
+    def instances(self) -> Iterator["SkpBuilder"]:
+        """Context manager marking the start of this builder's "instance
+        phase" (openskp#257) - see `definitions()`'s own docstring for
+        the pair's full intent. Entering this block immediately locks in
+        this builder's geometry-section slot numbering, the same
+        irreversible step the first `add_face`/`add_instance` call would
+        trigger anyway - so a `add_material`/`add_layer`/
+        `add_component_definition` call misplaced inside (or after) this
+        block raises `SkpWriteError` right there, at the top of the
+        block, instead of only whenever the first real geometry call
+        happens to occur deep inside a long build. Safe to enter more
+        than once (a second `with builder.instances():` is a no-op, same
+        as calling `add_face` again already is)."""
+        self._ensure_geometry_writer()
+        yield self
 
     def add_material(self, name: str, rgba: Sequence[int],
                      opacity: Optional[float] = None) -> int:
@@ -2258,7 +2422,11 @@ class SkpBuilder:
         attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> "ComponentDefinitionBuilder":
         if self._geometry_writer is not None:
-            raise SkpWriteError(f"{caller} must be called before any add_face/add_instance calls")
+            raise SkpWriteError(
+                f"{caller} must be called before any add_face/add_instance calls "
+                f"({self._face_count} already written). Collect all definitions first, "
+                "then place instances - see SkpBuilder.definitions()/instances()."
+            )
         if self._open_definition is not None:
             raise SkpWriteError(
                 f"component definition {self._open_definition.name!r} is still open - "
@@ -2281,6 +2449,7 @@ class SkpBuilder:
         self, name: str,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> "ComponentDefinitionBuilder":
         """Start a new reusable component definition. Use the returned
         object as a context manager, adding its geometry via `.add_face`
@@ -2296,13 +2465,16 @@ class SkpBuilder:
         and layers, before root-level geometry, so their slot numbering
         depends on the final material and layer counts.
 
-        ``attributes``, if given, is custom key/value metadata (values
-        may be ``str``, ``int``, or ``float``) attached to the definition
-        itself, under a dictionary named ``attribute_dict_name`` - the
-        same mechanism SketchUp's own "dynamic component" attributes use.
+        ``attributes``, if given, is custom key/value metadata attached
+        to the definition itself, under a dictionary named
+        ``attribute_dict_name`` - the same mechanism SketchUp's own
+        "dynamic component" attributes use. Pass ``attribute_dicts``
+        instead (a sequence of ``(dict_name, entries)`` pairs) to attach
+        several dictionaries at once - real SketchUp entities routinely
+        carry more than one. Passing both raises.
         """
-        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
-        return self._start_definition(name, "add_component_definition", attribute_dicts=attribute_dicts)
+        resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
+        return self._start_definition(name, "add_component_definition", attribute_dicts=resolved_attribute_dicts)
 
     def add_group(
         self,
@@ -2362,6 +2534,7 @@ class SkpBuilder:
         layer: Optional[int] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
         hidden: bool = False,
     ) -> None:
         """Place one instance of ``definition`` (from
@@ -2405,7 +2578,7 @@ class SkpBuilder:
             )
         matrix3x3 = _resolve_matrix3x3(matrix3x3, rotation)
         self._ensure_geometry_writer()
-        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
+        resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
         # `name if name is not None else definition.name`, not `name or
         # definition.name` - an explicit empty string is a real, valid
         # instance name (SketchUp itself stores it that way when a
@@ -2418,7 +2591,7 @@ class SkpBuilder:
         # an empty stored name.
         self._new_entity_count += self._geometry_writer.write_instance(
             definition.slot, name if name is not None else definition.name, translation, matrix3x3,
-            material or 0, layer or 0, attribute_dicts, hidden,
+            material or 0, layer or 0, resolved_attribute_dicts, hidden,
         )
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 
@@ -2549,6 +2722,7 @@ class SkpBuilder:
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
         auto_triangulate: bool = False,
         holes: Sequence[Sequence[Point3]] = (),
     ) -> None:
@@ -2627,12 +2801,12 @@ class SkpBuilder:
             raise SkpWriteError("a face needs at least 3 points")
         holes = [[(float(p[0]), float(p[1]), float(p[2])) for p in hole] for hole in holes]
         self._ensure_geometry_writer()
-        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
+        resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
         self._new_entity_count += _write_face_or_triangulate(
             self._geometry_writer, points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, soft_edges, smooth_edges, hidden_edges,
-            front_uv, back_uv, attribute_dicts, auto_triangulate,
+            front_uv, back_uv, resolved_attribute_dicts, auto_triangulate,
             holes=holes,
         )
         self._face_count += 1
@@ -2651,6 +2825,7 @@ class SkpBuilder:
         back_uv: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]] = None,
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
+        attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
     ) -> None:
         """Add one circular face - a true SketchUp circle (editable by
         radius, re-tessellatable, selectable as a single "Curve" entity),
@@ -2682,12 +2857,12 @@ class SkpBuilder:
         xaxis = (radius * u[0], radius * u[1], radius * u[2])
         curve_params = (center, normal, xaxis, 0.0, 2.0 * math.pi, radius, num_segments)
         points = _circle_points(center, normal, radius, num_segments, u, w)
-        attribute_dicts = [(attribute_dict_name, attributes)] if attributes else []
+        resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
         self._new_entity_count += self._geometry_writer.write_face(
             points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
             hidden, False, False, False,
-            front_uv, back_uv, attribute_dicts,
+            front_uv, back_uv, resolved_attribute_dicts,
             curve_params=curve_params,
         )
         self._face_count += 1

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -1309,21 +1309,33 @@ def _stringify_attr_value(value):
     return str(value)
 
 
-def _extract_legacy_dynamic_properties(attrs):
-    """Extract Dynamic Component attribute key/value pairs from a legacy
-    entity's already-parsed CAttributeContainer (see _DYNAMIC_ATTRIBUTES_
-    DICT_NAME above), or {} when the entity carries no attribute
-    container or no dynamic_attributes dictionary."""
+def _extract_legacy_attribute_dictionaries(attrs):
+    """Extract EVERY attribute dictionary attached to a legacy entity's
+    already-parsed CAttributeContainer, keyed by the dictionary's own
+    declared name - not just the one named _DYNAMIC_ATTRIBUTES_DICT_NAME
+    (openskp#254). Real entities routinely carry several at once (a
+    SketchUp extension's own dictionary alongside SketchUp's own
+    'dynamic_attributes' one, or several of the extension's own, e.g.
+    FrameBuilder's 'fbd-einfo'/'fbd-profile'/'fbd-profile-cords') -
+    filtering down to one hardcoded name silently discarded the rest.
+    Values keep their real, already-typed shape (int/float/str/None/a
+    3-tuple/a possibly-nested list) - see _stringify_attr_value for the
+    separate, backward-compatible stringified view. Returns {} when the
+    entity carries no attribute container at all."""
     if not isinstance(attrs, dict):
         return {}
+    out = {}
     for _class_name, value in attrs.get('children', []):
         # _class_name is the entity class name (always 'CAttributeNamed'
         # here, from ar.read_object) - the dictionary's own declared name
         # lives inside the value, as value['name'].
-        if isinstance(value, dict) and value.get('name') == _DYNAMIC_ATTRIBUTES_DICT_NAME:
-            entries = value.get('entries', {})
-            return {k: _stringify_attr_value(v) for k, v in entries.items()}
-    return {}
+        if not isinstance(value, dict):
+            continue
+        name = value.get('name')
+        if not name:
+            continue
+        out[name] = dict(value.get('entries', {}))
+    return out
 
 
 # ── adapter to the full_parse dict shape ────────────────────────────────
@@ -1378,6 +1390,8 @@ def _fill_builder(builder, ents, slots):
                         face['uv_projected_back'] = cv.get('back_projected', False)
             builder.faces[s] = face
         elif k == 'instance':
+            attr_dicts = _extract_legacy_attribute_dictionaries(v.get('attrs'))
+            dynamic = attr_dicts.get(_DYNAMIC_ATTRIBUTES_DICT_NAME, {})
             builder.instances.append({
                 'name': v['name'], 'ref_idx': v['def'],
                 'ref_guid': '', 'matrix': list(v['xf']),
@@ -1385,7 +1399,12 @@ def _fill_builder(builder, ents, slots):
                 'layer_id': v['db']['layer'] or None,
                 'hidden': bool(v['db']['hidden']),
                 'children': [],
-                'properties': _extract_legacy_dynamic_properties(v.get('attrs'))})
+                'attribute_dictionaries': attr_dicts,
+                # Backward-compatible view: the one dictionary SketchUp's
+                # own Dynamic Components extension uses, stringified (or
+                # {} if this entity carries no dictionary by that exact
+                # name) - matching this field's pre-existing contract.
+                'properties': {dk: _stringify_attr_value(dv) for dk, dv in dynamic.items()}})
         elif k == 'image':
             # Placed exactly like an ordinary component instance - same
             # transform/definition-reference shape - the only difference is

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -279,7 +279,22 @@ class Instance:
             :meth:`SkpFile.build_scene`'s ``InstanceNode.layer`` for that
             resolved value.
         properties: Arbitrary key/value dynamic attributes attached
-            directly to this instance (SketchUp's Dynamic Components).
+            directly to this instance (SketchUp's Dynamic Components) -
+            a backward-compatible view of
+            ``attribute_dictionaries.get("dynamic_attributes", {})``.
+        attribute_dictionaries: Every custom attribute dictionary
+            attached to this instance, keyed by the dictionary's own
+            declared name - not just the one SketchUp's own Dynamic
+            Components extension uses. A real instance routinely carries
+            several at once (a SketchUp extension's own dictionary
+            alongside SketchUp's, or several of the extension's own).
+            Unlike :attr:`properties`, values here keep their real type
+            (``str``/``int``/``float``/``None``/a 3-tuple for a Point3d
+            or Vector3d/a possibly-nested ``list``) rather than being
+            stringified - an extension is free to store a value as a
+            genuine array or as its own string-encoded convention (both
+            are observed in real files), and this preserves whichever
+            one it chose.
         material_id: Numeric material ID painted onto the instance itself
             (SketchUp's "paint the component"), or ``None``.  Faces inside
             the placed definition whose own :attr:`Face.material_id` is
@@ -301,6 +316,7 @@ class Instance:
     ])
     layer: str = ""
     properties: Dict[str, str] = field(default_factory=dict)
+    attribute_dictionaries: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     material_id: Optional[int] = None
     hidden: bool = False
 
@@ -602,6 +618,7 @@ class SkpFile:
                     hidden=inst.get("hidden", False),
                     layer=layer_id_to_name.get(layer_id, "") if layer_id is not None else "",
                     properties=inst.get("properties", {}),
+                    attribute_dictionaries=inst.get("attribute_dictionaries", {}),
                 ))
             # Populate section planes
             for sp in getattr(builder, "section_planes", []):

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -21,7 +21,9 @@ import struct
 
 import pytest
 
-from openskp.create import SkpBuilder, SkpWriteError, create
+from openskp.create import (
+    Length, Point3d, SkpBuilder, SkpWriteError, Timestamp, Vector3d, create,
+)
 from openskp import legacy
 from openskp import SkpFile
 
@@ -1061,6 +1063,93 @@ class TestPreExistingOrderingGap:
             builder.add_instance(wheel)
 
 
+class TestDefinitionsInstancesPhaseApi:
+    # openskp#257: an explicit with builder.definitions()/instances()
+    # phase API, documenting the definitions-before-instances ordering
+    # rule and catching a misplaced call at the point it's made.
+
+    def test_happy_path_round_trips(self):
+        builder = create()
+        with builder.definitions():
+            with builder.add_component_definition("Chair") as chair:
+                chair.add_face(SQUARE)
+        with builder.instances():
+            builder.add_instance(chair)
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        assert root[0][1] == "CComponentInstance"
+
+    def test_definitions_block_is_a_pure_marker_no_new_restriction(self):
+        # definitions() itself adds no new checks - the SAME material/
+        # layer/definition calls that work unwrapped still work inside
+        # it, in any order relative to each other.
+        builder = create()
+        with builder.definitions():
+            red = builder.add_material("Red", (255, 0, 0))
+            layer = builder.add_layer("L")
+            with builder.add_component_definition("Chair") as chair:
+                chair.add_face(SQUARE, material=red, layer=layer)
+        builder.add_instance(chair)
+        assert builder.to_bytes()
+
+    def test_add_component_definition_inside_instances_raises_immediately(self):
+        # The exact scenario openskp#257 asks for: the error arrives
+        # right when the definition is opened inside the instance phase,
+        # not only whenever the first real geometry call happens to
+        # occur - here that's immediately on entering instances(), since
+        # no add_face/add_instance was ever called before it.
+        builder = create()
+        with pytest.raises(SkpWriteError, match="before any add_face/add_instance"):
+            with builder.instances():
+                builder.add_component_definition("TooLate")
+
+    def test_add_material_inside_instances_raises_immediately(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="before any add_face calls"):
+            with builder.instances():
+                builder.add_material("TooLate", (0, 0, 0))
+
+    def test_add_layer_inside_instances_raises_immediately(self):
+        builder = create()
+        with pytest.raises(SkpWriteError, match="before any add_face calls"):
+            with builder.instances():
+                builder.add_layer("TooLate")
+
+    def test_instances_entered_twice_is_a_no_op(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with builder.instances():
+            with builder.instances():
+                builder.add_instance(chair)
+        assert builder.to_bytes()
+
+    def test_error_message_reports_entities_already_written(self):
+        builder = create()
+        builder.add_face(SQUARE)
+        builder.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match=r"\(2 already written\)"):
+            builder.add_component_definition("TooLate")
+
+    def test_two_definitions_blocks_compose_like_two_independent_modules(self):
+        # The issue's "composing two independent modules" case: two
+        # separate definitions() blocks (standing in for e.g. walls.emit()
+        # and roof.emit() each declaring their own definitions) both
+        # still work, since definitions() is a pure marker with no
+        # exclusive-entry restriction of its own.
+        builder = create()
+        with builder.definitions():
+            with builder.add_component_definition("Wall") as wall:
+                wall.add_face(SQUARE)
+        with builder.definitions():
+            with builder.add_component_definition("Roof") as roof:
+                roof.add_face(SQUARE)
+        with builder.instances():
+            builder.add_instance(wall)
+            builder.add_instance(roof)
+        assert builder.to_bytes()
+
+
 class TestMaterials:
     def test_material_assigned_to_face_front(self):
         builder = create()
@@ -1611,6 +1700,44 @@ class TestAttributeDicts:
         ar, root, layers, materials = legacy._walk(data)
         assert root[0][2]["attrs"]["children"][0][1]["name"] == "dynamic_attributes"
 
+    def test_attribute_dictionaries_exposed_by_name_through_the_public_reader(self, tmp_path):
+        # openskp#254: every dictionary reachable by name through the
+        # public reader, not just a flat merge - and `properties` stays
+        # a backward-compatible view of the 'dynamic_attributes' one
+        # specifically.
+        builder = create()
+        with builder.add_component_definition("Stud") as stud:
+            stud.add_face(SQUARE)
+        builder.add_instance(stud, attribute_dicts=[
+            ("dynamic_attributes", {"width": 10.0, "count": 4}),
+            ("fbd-profile", {"guide": 1}),
+        ])
+        out = tmp_path / "attrs.skp"
+        builder.save(str(out))
+
+        model = SkpFile.open(str(out)).parse()
+        inst = model.root.instances[0]
+        # properties (backward-compatible) stringifies; attribute_dictionaries
+        # keeps each value's real type.
+        assert inst.properties == {"width": "10.0", "count": "4"}
+        assert inst.attribute_dictionaries == {
+            "dynamic_attributes": {"width": 10.0, "count": 4},
+            "fbd-profile": {"guide": 1},
+        }
+
+    def test_no_dynamic_attributes_dict_leaves_properties_empty_but_others_visible(self, tmp_path):
+        builder = create()
+        with builder.add_component_definition("Stud") as stud:
+            stud.add_face(SQUARE)
+        builder.add_instance(stud, attribute_dicts=[("fbd-profile", {"guide": 1})])
+        out = tmp_path / "attrs.skp"
+        builder.save(str(out))
+
+        model = SkpFile.open(str(out)).parse()
+        inst = model.root.instances[0]
+        assert inst.properties == {}
+        assert inst.attribute_dictionaries == {"fbd-profile": {"guide": 1}}
+
     def test_face_with_no_attributes_has_no_attr_container(self):
         # A face with no attributes (and no UV positioning) shouldn't pay
         # for (or emit) an attribute container at all - same discipline as
@@ -1638,19 +1765,24 @@ class TestAttributeDicts:
         ar, root, layers, materials = legacy._walk(data)
         assert root[0][2]["attrs"] == {"k": "attrs", "children": []}
 
-    def test_bool_value_raises(self):
+    def test_bool_value_round_trips(self):
+        # openskp#253: bool (tag 0x07) is a real, distinct type the reader
+        # already decodes - no longer rejected in favor of int(0/1).
         builder = create()
         with builder.add_component_definition("Chair") as chair:
             chair.add_face(SQUARE)
-        with pytest.raises(SkpWriteError, match="bool is not a supported"):
-            builder.add_instance(chair, attributes={"flag": True})
+        builder.add_instance(chair, attributes={"flag": True, "off": False})
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        entries = root[0][2]["attrs"]["children"][0][1]["entries"]
+        assert entries == {"flag": 1, "off": 0}
 
     def test_unsupported_type_raises(self):
         builder = create()
         with builder.add_component_definition("Chair") as chair:
             chair.add_face(SQUARE)
         with pytest.raises(SkpWriteError, match="unsupported value type"):
-            builder.add_instance(chair, attributes={"bad": [1, 2, 3]})
+            builder.add_instance(chair, attributes={"bad": object()})
 
     def test_int32_out_of_range_raises(self):
         builder = create()
@@ -1658,6 +1790,185 @@ class TestAttributeDicts:
             chair.add_face(SQUARE)
         with pytest.raises(SkpWriteError, match="out of signed 32-bit range"):
             builder.add_instance(chair, attributes={"huge": 2**40})
+
+    # openskp#253: write_attribute_dict now covers all 9 value types
+    # legacy._read_attr_named already decodes, not just str/int/float.
+
+    def test_none_value_round_trips(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={"empty": None})
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        entries = root[0][2]["attrs"]["children"][0][1]["entries"]
+        assert entries == {"empty": None}
+
+    def test_point3d_and_vector3d_round_trip(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={
+            "pt": Point3d(1.0, 2.0, 3.0),
+            "vec": Vector3d(0.0, 0.0, 1.0),
+        })
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        entries = root[0][2]["attrs"]["children"][0][1]["entries"]
+        assert entries == {"pt": (1.0, 2.0, 3.0), "vec": (0.0, 0.0, 1.0)}
+
+    def test_length_round_trips_as_double_not_int32(self):
+        # Length is a float subclass - must be written as tag 0x0C, not
+        # accidentally caught by the plain-float branch's tag 0x06 (both
+        # decode to the same Python float, so this only distinguishes at
+        # the raw byte level - covered indirectly by every other test
+        # already using legacy._walk's own type-agnostic decode; this
+        # test exists to pin the *value*, which would still be wrong if
+        # Length silently fell through to the int32 branch instead).
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={"depth": Length(94.92125984251969)})
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        entries = root[0][2]["attrs"]["children"][0][1]["entries"]
+        assert entries == {"depth": 94.92125984251969}
+
+    def test_timestamp_round_trips_as_uint32(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={"saved": Timestamp(1234567890)})
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        entries = root[0][2]["attrs"]["children"][0][1]["entries"]
+        assert entries == {"saved": 1234567890}
+
+    def test_timestamp_out_of_range_raises(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="out of unsigned 32-bit range"):
+            builder.add_instance(chair, attributes={"bad": Timestamp(-1)})
+
+    def test_array_round_trips_with_mixed_element_types(self):
+        # openskp#253's motivating case: fbd-profile's guide-geometry keys
+        # are entirely arrays of Point3d (34,979 values across the
+        # reporter's 3 production files) - previously unwritable at all.
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={
+            "guide": [Point3d(1.0, 2.0, 3.0), Point3d(4.0, 5.0, 6.0)],
+            "mixed": [1, "two", 3.0, None, True],
+        }, attribute_dict_name="fbd-profile")
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        entries = root[0][2]["attrs"]["children"][0][1]["entries"]
+        assert entries == {
+            "guide": [(1.0, 2.0, 3.0), (4.0, 5.0, 6.0)],
+            "mixed": [1, "two", 3.0, None, 1],
+        }
+
+    def test_nested_array_round_trips(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={"nested": [[1, 2], [3, 4]]})
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        entries = root[0][2]["attrs"]["children"][0][1]["entries"]
+        assert entries == {"nested": [[1, 2], [3, 4]]}
+
+    def test_bad_value_inside_array_raises_before_any_write(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match=r"attribute 'bad\[1\]'"):
+            builder.add_instance(chair, attributes={"bad": [1, object(), 3]})
+
+    def test_point3d_non_numeric_component_raises(self):
+        # Point3d's own NamedTuple constructor enforces arity (exactly 3
+        # positional args) before validation ever runs - what
+        # _check_attribute_value's "numeric components" check actually
+        # catches is a non-numeric element smuggled into one of those 3
+        # slots.
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="needs exactly 3 numeric components"):
+            builder.add_instance(chair, attributes={"pt": Point3d(1.0, 2.0, "bad")})
+
+    # openskp#256: the public API can attach several attribute
+    # dictionaries to one entity, not just the attributes/
+    # attribute_dict_name shorthand's single dictionary.
+
+    def test_multiple_attribute_dicts_on_instance(self):
+        # The FrameBuilder shape from the issue: three dictionaries on
+        # one instance, previously only the first was ever reachable.
+        builder = create()
+        with builder.add_component_definition("Stud") as stud:
+            stud.add_face(SQUARE)
+        builder.add_instance(stud, attribute_dicts=[
+            ("fbd-einfo", {"part": "Stud", "depth": 94.92}),
+            ("fbd-profile", {"guide": 1}),
+            ("fbd-profile-cords", {"x": 1.0, "y": 2.0}),
+        ])
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        children = root[0][2]["attrs"]["children"]
+        names = [v["name"] for _, v in children]
+        assert names == ["fbd-einfo", "fbd-profile", "fbd-profile-cords"]
+        assert children[0][1]["entries"] == {"part": "Stud", "depth": 94.92}
+        assert children[2][1]["entries"] == {"x": 1.0, "y": 2.0}
+
+    def test_multiple_attribute_dicts_on_face(self):
+        builder = create()
+        builder.add_face(SQUARE, attribute_dicts=[("a", {"x": 1}), ("b", {"y": 2})])
+        data = builder.to_bytes()
+        assert "x".encode("utf-16-le") in data and "y".encode("utf-16-le") in data
+
+    def test_multiple_attribute_dicts_on_component_definition(self):
+        builder = create()
+        with builder.add_component_definition(
+            "Chair", attribute_dicts=[("a", {"x": 1}), ("b", {"y": 2})],
+        ) as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair)
+        data = builder.to_bytes()
+        assert "x".encode("utf-16-le") in data and "y".encode("utf-16-le") in data
+
+    def test_multiple_attribute_dicts_on_definition_scoped_instance(self):
+        # A nested definition-scoped add_instance (placing an already-
+        # closed sub-part definition inside another definition's own
+        # body) - built in the order this format requires: the part
+        # closed and ready before the assembly that nests it opens.
+        builder = create()
+        with builder.add_component_definition("Part") as part:
+            part.add_face(SQUARE)
+        with builder.add_component_definition("Assembly") as assembly:
+            assembly.add_instance(part, attribute_dicts=[("a", {"x": 1}), ("b", {"y": 2})])
+        builder.add_instance(assembly)
+        data = builder.to_bytes()
+        assert "x".encode("utf-16-le") in data and "y".encode("utf-16-le") in data
+
+    def test_attributes_and_attribute_dicts_together_raises(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        with pytest.raises(SkpWriteError, match="not both"):
+            builder.add_instance(
+                chair, attributes={"a": 1}, attribute_dicts=[("b", {"c": 2})],
+            )
+
+    def test_empty_attribute_dicts_behaves_like_no_attributes(self):
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attribute_dicts=[])
+        data = builder.to_bytes()
+        ar, root, layers, materials = legacy._walk(data)
+        assert root[0][2]["attrs"] == {"k": "attrs", "children": []}
 
     def test_face_attributes_in_component_definition(self):
         builder = create()
@@ -2528,6 +2839,90 @@ class TestRealSketchUpOracle:
                 assert dll.SUMaterialGetColor(mat, ctypes.byref(color)) == 0
                 colors.append((color.red, color.green, color.blue))
             assert set(colors) == {(255, 0, 0), (0, 0, 255)}
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_bool_time_and_array_attribute_values_round_trip_through_real_sketchup(self, tmp_path):
+        # openskp#253: bool/Timestamp/array were previously unwritable at
+        # all. Point3d/Vector3d/Length are covered instead by the
+        # legacy._walk byte-level tests in TestAttributeDicts - the
+        # public C SDK's SUTypedValue surface has no
+        # SUTypedValueGetPoint3D/GetVector3D/GetLength accessor (confirmed
+        # by probing this DLL's exports directly), only
+        # GetBool/GetTime/GetArrayItems for the newly-added types.
+        import ctypes
+
+        builder = create()
+        with builder.add_component_definition("Chair") as chair:
+            chair.add_face(SQUARE)
+        builder.add_instance(chair, attributes={
+            "flag": True, "ts": Timestamp(1700000000), "arr": [1, 2, 3],
+        })
+        out = tmp_path / "bool_time_array.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetInstances.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUEntityGetAttributeDictionary.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUAttributeDictionaryGetValue.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUTypedValueCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUTypedValueGetBool.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_bool)]
+        dll.SUTypedValueGetTime.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int64)]
+        dll.SUTypedValueGetNumArrayItems.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_size_t)]
+        dll.SUTypedValueGetArrayItems.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUTypedValueGetInt32.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int32)]
+
+        def get_value(dict_ref, key):
+            tv = ctypes.c_void_p()
+            dll.SUTypedValueCreate(ctypes.byref(tv))
+            err = dll.SUAttributeDictionaryGetValue(dict_ref, key.encode(), ctypes.byref(tv))
+            assert err == 0, f"key {key!r} not found (error {err})"
+            return tv
+
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            insts = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetInstances(entities, 1, insts, ctypes.byref(got))
+            attr_dict = ctypes.c_void_p()
+            err = dll.SUEntityGetAttributeDictionary(insts[0], b"attributes", ctypes.byref(attr_dict))
+            assert err == 0
+
+            flag_tv = get_value(attr_dict, "flag")
+            flag = ctypes.c_bool()
+            assert dll.SUTypedValueGetBool(flag_tv, ctypes.byref(flag)) == 0
+            assert flag.value is True
+
+            ts_tv = get_value(attr_dict, "ts")
+            ts = ctypes.c_int64()
+            assert dll.SUTypedValueGetTime(ts_tv, ctypes.byref(ts)) == 0
+            assert ts.value == 1700000000
+
+            arr_tv = get_value(attr_dict, "arr")
+            n = ctypes.c_size_t()
+            assert dll.SUTypedValueGetNumArrayItems(arr_tv, ctypes.byref(n)) == 0
+            assert n.value == 3
+            items = (ctypes.c_void_p * n.value)()
+            got_items = ctypes.c_size_t()
+            assert dll.SUTypedValueGetArrayItems(arr_tv, n.value, items, ctypes.byref(got_items)) == 0
+            values = []
+            for i in range(got_items.value):
+                v = ctypes.c_int32()
+                assert dll.SUTypedValueGetInt32(items[i], ctypes.byref(v)) == 0
+                values.append(v.value)
+            assert values == [1, 2, 3]
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2010,8 +2010,16 @@ class TestModernRealFile:
         assert battens[0].layer == "Hat Sections"
         w1 = [i for i in model.root.instances if i.name == "W1"]
         assert w1
-        assert w1[0].properties["generator"] == "SteelFramer::Engine::PanelGenerator"
-        assert w1[0].properties["profile"] == "362S200-43"
+        # "generator"/"profile" live under this SteelFramer-authored
+        # file's own "steelframer-dict" dictionary, not SketchUp's
+        # "dynamic_attributes" - properties (the backward-compatible
+        # dynamic_attributes-only view) is correctly empty for this
+        # instance; attribute_dictionaries exposes every dictionary by
+        # its own name (openskp#254).
+        assert w1[0].properties == {}
+        steelframer = w1[0].attribute_dictionaries["steelframer-dict"]
+        assert steelframer["generator"] == "SteelFramer::Engine::PanelGenerator"
+        assert steelframer["profile"] == "362S200-43"
 
         # 4. Definitions
         assert len(model.definitions) == 46
@@ -2134,8 +2142,10 @@ class TestLegacyDynamicProperties:
         assert _stringify_attr_value([1, 2, 3]) == "1,2,3"
         assert _stringify_attr_value((1.0, 2.0, 3.0)) == "1.0,2.0,3.0"
 
-    def test_extracts_dynamic_attributes_dict_by_name(self) -> None:
-        from openskp.legacy import _extract_legacy_dynamic_properties
+    def test_extracts_every_attribute_dictionary_by_name(self) -> None:
+        # openskp#254: every dictionary is returned, keyed by its own
+        # declared name - not just the one named 'dynamic_attributes'.
+        from openskp.legacy import _extract_legacy_attribute_dictionaries
         # Real shape from _read_attr_container/_read_attr_named: each
         # child tuple's first element is the ENTITY CLASS NAME (always
         # 'CAttributeNamed', from ar.read_object) - never the dictionary's
@@ -2148,21 +2158,27 @@ class TestLegacyDynamicProperties:
                     "k": "dict", "name": "dynamic_attributes",
                     "entries": {"width": 10.0, "_width_label": "Width", "count": 4},
                 }),
+                ("CAttributeNamed", {"k": "dict", "name": "fbd-profile", "entries": {"guide": (1.0, 2.0, 3.0)}}),
             ],
         }
-        props = _extract_legacy_dynamic_properties(attrs)
-        assert props == {"width": "10.0", "_width_label": "Width", "count": "4"}
+        dicts = _extract_legacy_attribute_dictionaries(attrs)
+        # Real, already-typed values - not stringified (see
+        # _stringify_attr_value for the separate stringified view
+        # `properties` uses).
+        assert dicts == {
+            "SU_DefinitionSet": {"unrelated": 1},
+            "dynamic_attributes": {"width": 10.0, "_width_label": "Width", "count": 4},
+            "fbd-profile": {"guide": (1.0, 2.0, 3.0)},
+        }
 
-    def test_returns_empty_dict_when_no_dynamic_attributes_dict(self) -> None:
-        from openskp.legacy import _extract_legacy_dynamic_properties
-        attrs = {"k": "attrs", "children": [
-            ("CAttributeNamed", {"k": "dict", "name": "SU_DefinitionSet", "entries": {"a": 1}}),
-        ]}
-        assert _extract_legacy_dynamic_properties(attrs) == {}
+    def test_returns_empty_dict_for_no_children(self) -> None:
+        from openskp.legacy import _extract_legacy_attribute_dictionaries
+        attrs = {"k": "attrs", "children": []}
+        assert _extract_legacy_attribute_dictionaries(attrs) == {}
 
     def test_returns_empty_dict_for_no_attribute_container(self) -> None:
-        from openskp.legacy import _extract_legacy_dynamic_properties
-        assert _extract_legacy_dynamic_properties(None) == {}
+        from openskp.legacy import _extract_legacy_attribute_dictionaries
+        assert _extract_legacy_attribute_dictionaries(None) == {}
 
     import pathlib as _pathlib
 
@@ -2185,6 +2201,150 @@ class TestLegacyDynamicProperties:
                 walk(child)
 
         walk(scene.scene_hierarchy)
+
+
+class TestVffAttributeDictionaries:
+    """Tests for _core.extract_attribute_dictionaries/extract_dynamic_
+    properties (openskp#254/#255) - the VFF-format counterpart of
+    TestLegacyDynamicProperties above.
+
+    The TLV shape asserted here (B436 dictionary-name node immediately
+    followed by a B536 entries sibling; each entry a B636 key followed by
+    an A438 value wrapper; A438 with no children is null, otherwise wraps
+    exactly one type-tagged child; AE38 wraps an array's own elements,
+    each itself A438-wrapped, concatenated with no count prefix) was
+    confirmed byte-for-byte against a real FrameBuilder-authored
+    production file, cross-checked against SketchUp's own Ruby API
+    reading the identical file live - not guessed at. See CHECKLIST.md's
+    entry on this fix for how that verification was done.
+    """
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    def _value(self, inner: bytes = b"") -> bytes:
+        """One A438-wrapped value: empty payload (no children) is null,
+        otherwise `inner` is exactly one type-tagged TLV element."""
+        return self._tlv('A438', inner)
+
+    def _entry(self, key: str, value_bytes: bytes) -> bytes:
+        return self._tlv('B636', key.encode('utf-8')) + value_bytes
+
+    def _dict(self, name: str, entries: bytes) -> bytes:
+        return self._tlv('B436', name.encode('utf-8')) + self._tlv('B536', entries)
+
+    def _d007(self, dc05_payload: bytes):
+        from openskp import _core
+        d007_bytes = self._tlv('D007', self._tlv('DC05', dc05_payload))
+        elements = _core.parse_tlv_recursive(d007_bytes, 0, len(d007_bytes))
+        return elements[0]
+
+    def test_string_value_round_trips(self) -> None:
+        from openskp import _core
+        entries = self._entry('code', self._value(self._tlv('AD38', b'Ks')))
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        assert _core.extract_attribute_dictionaries(d007) == {'fbd-einfo': {'code': 'Ks'}}
+
+    def test_length_and_float_are_distinct_tags_both_f64(self) -> None:
+        # AF38 (Length) and A938 (plain Float) both encode as a flat
+        # 8-byte float64 but are genuinely different tags - real
+        # SketchUp/FrameBuilder data uses both for different keys.
+        from openskp import _core
+        entries = (
+            self._entry('depth', self._value(self._tlv('AF38', struct.pack('<d', 15.5))))
+            + self._entry('price', self._value(self._tlv('A938', struct.pack('<d', 120.0))))
+        )
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        result = _core.extract_attribute_dictionaries(d007)['fbd-einfo']
+        assert result == {'depth': 15.5, 'price': 120.0}
+        assert isinstance(result['depth'], float) and isinstance(result['price'], float)
+
+    def test_integer_value_round_trips(self) -> None:
+        from openskp import _core
+        entries = self._entry('angle', self._value(self._tlv('A738', struct.pack('<i', -7))))
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        assert _core.extract_attribute_dictionaries(d007) == {'fbd-einfo': {'angle': -7}}
+
+    def test_null_value_round_trips(self) -> None:
+        from openskp import _core
+        entries = self._entry('child_thickness', self._value())  # A438 with no children
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        assert _core.extract_attribute_dictionaries(d007) == {'fbd-einfo': {'child_thickness': None}}
+
+    def test_point3d_and_vector3d_round_trip(self) -> None:
+        from openskp import _core
+        point_bytes = self._tlv('B438', struct.pack('<3d', 0.0, 0.807085, 14.6551))
+        vector_bytes = self._tlv('B538', struct.pack('<3d', 1.0, 0.0, 0.0))
+        entries = (
+            self._entry('end_pos', self._value(point_bytes))
+            + self._entry('vector_new', self._value(vector_bytes))
+        )
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        result = _core.extract_attribute_dictionaries(d007)['fbd-einfo']
+        assert result == {'end_pos': (0.0, 0.807085, 14.6551), 'vector_new': (1.0, 0.0, 0.0)}
+
+    def test_empty_array_round_trips(self) -> None:
+        from openskp import _core
+        entries = self._entry('added_bolt_holes', self._value(self._tlv('AE38', b'')))
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        assert _core.extract_attribute_dictionaries(d007) == {'fbd-einfo': {'added_bolt_holes': []}}
+
+    def test_array_of_floats_round_trips(self) -> None:
+        from openskp import _core
+        elems = b''.join(self._value(self._tlv('A938', struct.pack('<d', v))) for v in (0.728, 11.358, 14.655))
+        entries = self._entry('flangeholes', self._value(self._tlv('AE38', elems)))
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        assert _core.extract_attribute_dictionaries(d007) == {'fbd-einfo': {'flangeholes': [0.728, 11.358, 14.655]}}
+
+    def test_nested_array_round_trips(self) -> None:
+        # openskp#253's motivating case mirrored on the read side:
+        # fbd-profile-cords style [[x, y], [x, y]] - an array whose
+        # elements are themselves arrays.
+        from openskp import _core
+        inner1 = b''.join(self._value(self._tlv('A938', struct.pack('<d', v))) for v in (25.17, 0.07))
+        inner2 = b''.join(self._value(self._tlv('A938', struct.pack('<d', v))) for v in (25.17, 15.35))
+        outer = self._value(self._tlv('AE38', inner1)) + self._value(self._tlv('AE38', inner2))
+        entries = self._entry('lip_side1_cords', self._value(self._tlv('AE38', outer)))
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        result = _core.extract_attribute_dictionaries(d007)['fbd-einfo']
+        assert result == {'lip_side1_cords': [[25.17, 0.07], [25.17, 15.35]]}
+
+    def test_multiple_dictionaries_kept_separate_by_name(self) -> None:
+        # openskp#254: dictionaries no longer merged into one flat blob.
+        from openskp import _core
+        d1 = self._dict('fbd-einfo', self._entry('code', self._value(self._tlv('AD38', b'Ks'))))
+        d2 = self._dict('fbd-profile', self._entry('guide', self._value(self._tlv('A738', struct.pack('<i', 1)))))
+        d007 = self._d007(d1 + d2)
+        assert _core.extract_attribute_dictionaries(d007) == {
+            'fbd-einfo': {'code': 'Ks'},
+            'fbd-profile': {'guide': 1},
+        }
+
+    def test_unrecognized_value_tag_is_skipped_not_guessed(self) -> None:
+        # A type tag this decoder doesn't (yet) know is left as None
+        # rather than misinterpreted - safer than a wrong guess.
+        from openskp import _core
+        entries = self._entry('mystery', self._value(self._tlv('EE99', b'\x01\x02')))
+        d007 = self._d007(self._dict('fbd-einfo', entries))
+        assert _core.extract_attribute_dictionaries(d007) == {'fbd-einfo': {'mystery': None}}
+
+    def test_backward_compatible_properties_view(self) -> None:
+        # extract_dynamic_properties stays the stringified,
+        # dynamic_attributes-only view for existing callers.
+        from openskp import _core
+        d1 = self._dict('dynamic_attributes', self._entry(
+            'width', self._value(self._tlv('AF38', struct.pack('<d', 10.0)))))
+        d2 = self._dict('fbd-profile', self._entry('guide', self._value(self._tlv('A738', struct.pack('<i', 1)))))
+        d007 = self._d007(d1 + d2)
+        assert _core.extract_dynamic_properties(d007) == {'width': '10.0'}
+
+    def test_no_dc05_returns_empty(self) -> None:
+        from openskp import _core
+        d007_bytes = self._tlv('D007', b'')
+        elements = _core.parse_tlv_recursive(d007_bytes, 0, len(d007_bytes))
+        assert _core.extract_attribute_dictionaries(elements[0]) == {}
+        assert _core.extract_dynamic_properties(elements[0]) == {}
 
 
 # ── Scene baking (opt-in build_scene(), separate from parse()) ──────────


### PR DESCRIPTION
## Summary

Combined fix for #253, #254, #255, #256, #257 — all from the same real-world FrameBuilder LGS-framing workflow.

- **#253** — writer now covers all 9 attribute value types the reader (`legacy._read_attr_named`) already decoded, not just str/int/float: `None`, `bool`, `int`, `float`, `str`, new `Point3d`/`Vector3d`/`Length`/`Timestamp` wrapper types, and nestable arrays of any of these.
- **#254** — dictionary names no longer discarded on either read path. New `Instance.attribute_dictionaries: Dict[str, Dict[str, Any]]` exposes every dictionary by name (real, non-stringified values); `Instance.properties` stays as the backward-compatible `dynamic_attributes`-only stringified view.
- **#255** — the VFF reader now decodes every attribute value type, not just strings — previously dropped the majority of real FrameBuilder data silently (170 of 268 keys missing on a real wall panel, per the issue).
- **#256** — `add_face`/`add_instance`/`add_component_definition` accept `attribute_dicts=[(name, entries), ...]` for multiple dictionaries per entity, matching what the writer already supported internally.
- **#257** — explicit `with builder.definitions():`/`with builder.instances():` phase API. Entering `instances()` locks in slot numbering immediately, so a misplaced definition/material/layer call raises right there instead of only whenever the first real geometry call happens to occur.

### How #255's VFF byte layout was verified

This project never guesses at an undocumented binary format. The user had a real production file (`Ariane IFC01.skp`, FrameBuilder-authored, 3,142 component definitions) open live in SketchUp with a local automation bridge exposing `ops.execute_ruby` over WebSocket JSON-RPC. Used it to dump one instance's three FrameBuilder dictionaries live via Ruby (120 real key/value pairs spanning every relevant type SketchUp's own API reports — `Integer`, `Float`, `String`, `nil`, `Length`, `Point3d`, `Vector3d`, nested arrays). Separately reverse-engineered the same region's raw TLV bytes from first principles and implemented a decoder, then ran it against those exact bytes — **every one of the 120 values matched the Ruby dump exactly**, including two tags (`AF38`/`A938`) that turned out to be distinct despite an identical 8-byte float64 encoding (Length vs. plain Float), and an array encoding (`AE38`) that's size-bounded rather than count-prefixed, neither of which could have been safely guessed from the issue's own description alone.

## Test plan

- [x] `pytest` full suite: 460 passed (up from ~420)
- [x] `ruff check` clean
- [x] New regression tests for every value type (#253 writer, including a real SketchUp SDK round-trip for bool/Timestamp/array), dictionary-name grouping on both read paths (#254), full VFF byte-layout coverage incl. nested arrays (#255), multi-dict public API (#256), and the phase API (#257)
- [x] Stashed all 4 touched source files at once and confirmed the new tests fail without the fix — `test_create.py` fails to even *collect* (`Length` doesn't exist in pre-fix `create.py`), a stronger guard than a runtime assertion failure
- [x] One pre-existing test that had baked in the old flat-merge behavior as correct updated to assert the corrected, intentional split instead