### PR TITLE
create: port group attribute dictionaries to TS/.NET/Dart/C++ (#261)

### DIFF
--- a/packages/cpp/include/openskp/create.hpp
+++ b/packages/cpp/include/openskp/create.hpp
@@ -20,9 +20,10 @@
 /// add_group` is at the root level, since this format has no way to embed one definition's
 /// declaration inside another's); per-instance rotation (axis+angle convenience) and hidden
 /// state; explicit per-side texture positioning (`FaceOptions::front_uv`/`back_uv`) on a face of
-/// any orientation; custom attribute dictionaries on definitions/instances/faces (the same
-/// mechanism SketchUp's own "dynamic component" attributes use; not yet supported on groups -
-/// ground truth shows a group's own attribute pointer is always null); real, editable-by-radius
+/// any orientation; custom attribute dictionaries on definitions/instances/faces/groups (the same
+/// mechanism SketchUp's own "dynamic component" attributes use - a group only pays for a real
+/// attribute container when it actually has one, unlike a component instance, which always
+/// carries a real, if often empty, one); real, editable-by-radius
 /// `CArcCurve` circles/arcs (`add_circle`/`add_arc`) and freeform `CCurve` polylines
 /// (`add_polyline`); faces with one or more holes; `auto_triangulate` fan-splitting a
 /// non-coplanar polygon into real, always-planar triangles instead of raising (mirrors real
@@ -236,12 +237,15 @@ struct GroupOptions {
   std::optional<Rotation> rotation;
   std::optional<int> material;
   std::optional<int> layer;
+  /// Custom key/value metadata attached to this group, under a dictionary named
+  /// `attribute_dict_name`. A group only gets a real attribute container when this is
+  /// non-empty - matching `FaceOptions::attributes`' own conditional pattern (openskp#261).
+  AttributeDict attributes;
+  std::string attribute_dict_name = "attributes";
   bool hidden = false;
 };
 
-/// Options for `ComponentDefinitionBuilder::add_group_instance`. Same shape as `GroupOptions`
-/// (a group's attribute pointer is always null in ground truth, unlike a component instance's -
-/// hence no `attributes` here, unlike `InstanceOptions`).
+/// Options for `ComponentDefinitionBuilder::add_group_instance`. Same shape as `GroupOptions`.
 struct GroupInstanceOptions {
   std::optional<std::string> name;
   Point3 translation{0.0, 0.0, 0.0};
@@ -249,6 +253,8 @@ struct GroupInstanceOptions {
   std::optional<Rotation> rotation;
   std::optional<int> material;
   std::optional<int> layer;
+  AttributeDict attributes;
+  std::string attribute_dict_name = "attributes";
   bool hidden = false;
 };
 

--- a/packages/cpp/src/create.cpp
+++ b/packages/cpp/src/create.cpp
@@ -945,12 +945,18 @@ class ArchiveWriter {
   }
 
   // A group is structurally almost identical to a component instance - the two real differences
-  // are its class name/schema and that it uses a plain null attribute pointer.
+  // are its class name/schema and its attribute pointer: unlike CComponentInstance (which always
+  // carries a real, if often empty, CAttributeContainer regardless of whether attributes are
+  // given), a group only gets one when attribute_dicts is actually given - matching write_face's
+  // conditional pattern instead. A real production Group WITH attributes (SketchUp 2020 export,
+  // ground truth) carries a genuine CAttributeContainer at this exact schema; a never-attributed
+  // group still correctly gets a null pointer either way (openskp#261).
   int write_group(int definition_slot, const std::string& name, Point3 translation,
                   std::optional<Matrix3x3> matrix3x3, int group_material, int group_layer,
-                  bool hidden) {
-    write_instance_like("CGroup", kGroupSchema, false, definition_slot, name, translation,
-                        matrix3x3, group_material, group_layer, {}, hidden);
+                  const AttributeDictList& attribute_dicts, bool hidden) {
+    write_instance_like("CGroup", kGroupSchema, !attribute_dicts.empty(), definition_slot, name,
+                        translation, matrix3x3, group_material, group_layer, attribute_dicts,
+                        hidden);
     return 1;
   }
 
@@ -1342,6 +1348,7 @@ struct ComponentDefinitionBuilder::Impl {
     std::optional<Matrix3x3> matrix3x3;
     int material;
     int layer;
+    detail::AttributeDictList attribute_dicts;
     bool hidden;
   };
 
@@ -1423,7 +1430,7 @@ struct SkpBuilder::Impl {
     for (auto& [comp, gp] : pending_groups) {
       new_entity_count +=
           geometry_writer->write_group(comp->slot(), comp->name(), gp.translation, gp.matrix3x3,
-                                       gp.material, gp.layer, gp.hidden);
+                                       gp.material, gp.layer, gp.attribute_dicts, gp.hidden);
       face_count += 1;
     }
     pending_groups.clear();
@@ -1653,9 +1660,12 @@ void ComponentDefinitionBuilder::add_group_instance(const ComponentDefinitionBui
                         "' cannot nest a group instance of itself");
   }
   auto matrix = detail::resolve_matrix3x3(options.matrix3x3, options.rotation);
+  detail::AttributeDictList dicts;
+  if (!options.attributes.empty())
+    dicts.emplace_back(options.attribute_dict_name, options.attributes);
   impl_->new_entity_count += impl_->writer->write_group(
       definition.slot(), options.name.value_or(definition.name()), options.translation, matrix,
-      options.material.value_or(0), options.layer.value_or(0), options.hidden);
+      options.material.value_or(0), options.layer.value_or(0), dicts, options.hidden);
 }
 
 int ComponentDefinitionBuilder::slot() const noexcept { return impl_->slot; }
@@ -1791,9 +1801,12 @@ ComponentDefinitionBuilder& SkpBuilder::add_group(const GroupOptions& options) {
   cdb_impl->name = options.name.value_or("Group");
   cdb_impl->count_patch_pos = count_patch_pos;
   cdb_impl->writer = &*impl_->definition_writer;
+  detail::AttributeDictList group_dicts;
+  if (!options.attributes.empty())
+    group_dicts.emplace_back(options.attribute_dict_name, options.attributes);
   cdb_impl->group_placement = ComponentDefinitionBuilder::Impl::GroupPlacement{
-      options.translation, matrix, options.material.value_or(0), options.layer.value_or(0),
-      options.hidden};
+      options.translation,       matrix,      options.material.value_or(0),
+      options.layer.value_or(0), group_dicts, options.hidden};
   impl_->definitions.push_back(std::unique_ptr<ComponentDefinitionBuilder>(
       new ComponentDefinitionBuilder(std::move(cdb_impl))));
   ComponentDefinitionBuilder* raw = impl_->definitions.back().get();

--- a/packages/cpp/tests/create_test.cpp
+++ b/packages/cpp/tests/create_test.cpp
@@ -493,6 +493,25 @@ TEST(Create, GroupSelfPlaces) {
   EXPECT_NEAR(inst.matrix[9], 50.0, 1e-9);
 }
 
+TEST(Create, GroupAttributesRoundTrip) {
+  // Groups used to hardcode a null attribute pointer on the belief that a CGroup never carries a
+  // CAttributeContainer - real production files (SketchUp 2020-legacy export, ground truth)
+  // contradicted this (openskp#261). Smoke test only, matching InstanceAttributesRoundTrip above:
+  // model.root().instances[].properties isn't wired to custom CAttributeNamed dictionaries in
+  // this port.
+  auto builder = create();
+  GroupOptions opts;
+  opts.name = "Table";
+  opts.attributes["sku"] = std::string{"TBL-1"};
+  opts.attributes["qty"] = std::int32_t{2};
+  auto& table = builder->add_group(opts);
+  table.add_face({{0, 0, 0}, {30, 0, 0}, {30, 30, 0}, {0, 30, 0}});
+  table.close();
+
+  SkpModel model = round_trip(*builder);
+  ASSERT_EQ(model.root().instances.size(), 1u);
+}
+
 TEST(Create, NestedDefinitionInstanceAndNestedGroupInstance) {
   auto builder = create();
   auto& wheel = builder->add_component_definition("Wheel");
@@ -524,6 +543,31 @@ TEST(Create, NestedDefinitionInstanceAndNestedGroupInstance) {
   ASSERT_NE(car_def, nullptr);
   EXPECT_EQ(car_def->faces.size(), 1u);
   EXPECT_EQ(car_def->instances.size(), 2u);  // the wheel instance + the engine group instance
+}
+
+TEST(Create, NestedGroupInstanceCarriesItsOwnAttributesToo) {
+  auto builder = create();
+  auto& engine = builder->add_component_definition("Engine");
+  engine.add_face({{0, 0, 0}, {30, 0, 0}, {30, 30, 0}, {0, 30, 0}});
+  engine.close();
+
+  auto& car = builder->add_component_definition("Car");
+  car.add_face({{0, 0, 0}, {150, 0, 0}, {150, 60, 0}, {0, 60, 0}});
+  GroupInstanceOptions engine_group;
+  engine_group.translation = {50, 0, 10};
+  engine_group.attributes["part"] = std::string{"V6"};
+  car.add_group_instance(engine, engine_group);
+  car.close();
+
+  builder->add_instance(car);
+
+  SkpModel model = round_trip(*builder);
+  const Definition* car_def = nullptr;
+  for (const auto& [id, defn] : model.definitions) {
+    if (defn.name == "Car") car_def = &defn;
+  }
+  ASSERT_NE(car_def, nullptr);
+  EXPECT_EQ(car_def->instances.size(), 1u);
 }
 
 TEST(Create, EachNestedLevelKeepsItsOwnInstanceNameInMeshIndex) {

--- a/packages/dart/lib/src/create.dart
+++ b/packages/dart/lib/src/create.dart
@@ -89,11 +89,12 @@ typedef Rotation = (Point3, double);
 /// xaxis, startAngle, endAngle, radius, numSegments)`.
 typedef CurveParams = (Point3, Point3, Point3, double, double, double, int);
 
-/// `(translation, matrix3x3, materialSlot, layerSlot, hidden)` - a group's
-/// deferred self-placement, recorded when [SkpBuilder.addGroup]'s body
-/// closes and flushed the first time anything actually needs the root
-/// geometry writer (see [SkpBuilder._ensureGeometryWriter]).
-typedef GroupPlacement = (Point3, Matrix3x3?, int, int, bool);
+/// `(translation, matrix3x3, materialSlot, layerSlot, attributeDicts,
+/// hidden)` - a group's deferred self-placement, recorded when
+/// [SkpBuilder.addGroup]'s body closes and flushed the first time anything
+/// actually needs the root geometry writer (see
+/// [SkpBuilder._ensureGeometryWriter]).
+typedef GroupPlacement = (Point3, Matrix3x3?, int, int, List<(String, Map<String, Object>)>, bool);
 
 /// Raised when a `.skp` file cannot be constructed.
 class SkpWriteError implements Exception {
@@ -1253,27 +1254,35 @@ class _ArchiveWriter {
   ///
   /// A group is structurally almost identical to a component instance -
   /// the two real differences are its class name/schema (CGroup, schema 1)
-  /// and that it uses a plain null attribute pointer rather than the real
-  /// (empty) CAttributeContainer instances need.
+  /// and its attribute pointer: unlike `CComponentInstance` (which always
+  /// carries a real, if often empty, `CAttributeContainer` regardless of
+  /// whether attributes are given), a group only gets one when
+  /// [attributeDicts] is actually given - matching `writeFace`'s
+  /// conditional pattern instead. A real production Group WITH attributes
+  /// (SketchUp 2020 export, ground truth) carries a genuine
+  /// `CAttributeContainer` at this exact schema; a never-attributed group
+  /// still correctly gets a null pointer either way (openskp#261).
   int writeGroup(
     int definitionSlot,
     String name,
     Point3 translation,
     Matrix3x3? matrix3x3,
     int groupMaterial,
-    int groupLayer, [
+    int groupLayer, {
+    List<(String, Map<String, Object>)> attributeDicts = const [],
     bool hidden = false,
-  ]) {
+  }) {
     _writeInstanceLike(
       className: 'CGroup',
       schema: _groupSchema,
-      realAttrs: false,
+      realAttrs: attributeDicts.isNotEmpty,
       definitionSlot: definitionSlot,
       name: name,
       translation: translation,
       matrix3x3: matrix3x3,
       mat: groupMaterial,
       layer: groupLayer,
+      attributeDicts: attributeDicts,
       hidden: hidden,
     );
     return 1;
@@ -1954,6 +1963,8 @@ class ComponentDefinitionBuilder implements GeometryHost {
     Rotation? rotation,
     int? material,
     int? layer,
+    Map<String, Object>? attributes,
+    String attributeDictName = 'attributes',
     bool hidden = false,
   }) {
     _checkWritable('groups');
@@ -1969,6 +1980,7 @@ class ComponentDefinitionBuilder implements GeometryHost {
       throw SkpWriteError("component definition '$name' cannot nest a group instance of itself");
     }
     final resolved = _resolveMatrix3x3(matrix3x3, rotation);
+    final attributeDicts = _attrDicts(attributes, attributeDictName);
     _newEntityCount += _skp._definitionWriter!.writeGroup(
       definition.slot,
       name ?? definition.name,
@@ -1976,7 +1988,8 @@ class ComponentDefinitionBuilder implements GeometryHost {
       resolved,
       material ?? 0,
       layer ?? 0,
-      hidden,
+      attributeDicts: attributeDicts,
+      hidden: hidden,
     );
   }
 
@@ -2350,15 +2363,18 @@ class SkpBuilder implements GeometryHost {
     Rotation? rotation,
     int? material,
     int? layer,
+    Map<String, Object>? attributes,
+    String attributeDictName = 'attributes',
     bool hidden = false,
   }) {
     _checkMaterialHandle(material, 'material');
     _checkLayerHandle(layer);
     final resolved = _resolveMatrix3x3(matrix3x3, rotation);
+    final attributeDicts = _attrDicts(attributes, attributeDictName);
     final comp = _startDefinition(
       name ?? 'Group',
       'addGroup',
-      groupPlacement: (translation, resolved, material ?? 0, layer ?? 0, hidden),
+      groupPlacement: (translation, resolved, material ?? 0, layer ?? 0, attributeDicts, hidden),
     );
     body(comp);
     comp._close();
@@ -2530,8 +2546,11 @@ class SkpBuilder implements GeometryHost {
     // slot numbering before a later addGroup/addComponentDefinition call
     // has had a chance to run.
     for (final (comp, placement) in _pendingGroups) {
-      final (translation, matrix3x3, mat, layer, hidden) = placement;
-      _newEntityCount += _geometryWriter!.writeGroup(comp.slot, comp.name, translation, matrix3x3, mat, layer, hidden);
+      final (translation, matrix3x3, mat, layer, attributeDicts, hidden) = placement;
+      _newEntityCount += _geometryWriter!.writeGroup(
+        comp.slot, comp.name, translation, matrix3x3, mat, layer,
+        attributeDicts: attributeDicts, hidden: hidden,
+      );
       _faceCount++;
     }
     _pendingGroups = [];

--- a/packages/dart/test/create_test.dart
+++ b/packages/dart/test/create_test.dart
@@ -824,9 +824,22 @@ void main() {
       final inst = model.root.instances.single;
       expect(inst.name, 'Table');
       expect(inst.matrix[9], 50.0);
-      // ground truth: unlike CComponentInstance, CGroup carries no dynamic
-      // attributes - properties should be empty.
+      // A group with no attributes given still gets a null attribute
+      // pointer, same as before openskp#261 - properties should be empty.
       expect(inst.properties, isEmpty);
+    });
+
+    test('group attribute dicts round-trip through Instance.properties (openskp#261)', () {
+      // Groups used to hardcode a null attribute pointer on the belief that
+      // a CGroup never carries a CAttributeContainer - real production
+      // files (SketchUp 2020-legacy export, ground truth) contradicted
+      // this.
+      final builder = create();
+      builder.addGroup((def) {
+        def.addFace(square);
+      }, name: 'Table', attributes: {'sku': 'TBL-1', 'qty': 2}, attributeDictName: 'dynamic_attributes');
+      final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+      expect(model.root.instances.single.properties, {'sku': 'TBL-1', 'qty': '2'});
     });
 
     test('a hidden group round-trips', () {
@@ -959,6 +972,26 @@ void main() {
       expect(carDef.faces.length, 1);
       expect(carDef.instances.length, 1);
       expect(carDef.instances.single.name, 'Engine');
+    });
+
+    test('a nested group-instance carries its own attribute dicts too (openskp#261)', () {
+      final builder = create();
+      final engine = builder.addComponentDefinition('Engine', (def) {
+        def.addFace(square);
+      });
+      final car = builder.addComponentDefinition('Car', (def) {
+        def.addFace(square);
+        def.addGroupInstance(
+          engine,
+          translation: (50.0, 0.0, 10.0),
+          attributes: {'part': 'V6'},
+          attributeDictName: 'dynamic_attributes',
+        );
+      });
+      builder.addInstance(car);
+      final model = SkpFile.fromBuffer(builder.toBytes()).parse();
+      final carDef = model.definitions.values.firstWhere((d) => d.name == 'Car');
+      expect(carDef.instances.single.properties, {'part': 'V6'});
     });
   });
 

--- a/packages/dotnet/OpenSkp.Tests/CreateTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CreateTests.cs
@@ -513,6 +513,40 @@ namespace OpenSkp.Tests
         }
 
         [Fact]
+        public void GroupAttributeDictsRoundTripThroughInstanceProperties()
+        {
+            // Groups used to hardcode a null attribute pointer on the belief
+            // that a CGroup never carries a CAttributeContainer - real
+            // production files (SketchUp 2020-legacy export, ground truth)
+            // contradicted this (openskp#261).
+            var builder = SkpCreate.NewFile();
+            using (var table = builder.AddGroup(
+                "Table",
+                attributes: new System.Collections.Generic.Dictionary<string, object> { ["sku"] = "TBL-1", ["qty"] = 2 },
+                attributeDictName: "dynamic_attributes"))
+            {
+                table.AddFace(Square());
+            }
+            var model = SkpFile.Parse(builder.ToBytes());
+            var instance = Assert.Single(model.Root.Instances);
+            Assert.Equal("TBL-1", instance.Properties["sku"]);
+            Assert.Equal("2", instance.Properties["qty"]);
+        }
+
+        [Fact]
+        public void GroupWithNoAttributesStillGetsNullAttributePointer()
+        {
+            var builder = SkpCreate.NewFile();
+            using (var table = builder.AddGroup("Table"))
+            {
+                table.AddFace(Square());
+            }
+            var model = SkpFile.Parse(builder.ToBytes());
+            var instance = Assert.Single(model.Root.Instances);
+            Assert.Empty(instance.Properties);
+        }
+
+        [Fact]
         public void NestedDefinitionInstanceInsideAnother()
         {
             var builder = SkpCreate.NewFile();
@@ -557,6 +591,32 @@ namespace OpenSkp.Tests
             Assert.Single(carDef.Faces);
             Assert.Single(carDef.Instances); // the nested group placement
             Assert.Single(model.Root.Instances); // the top-level Car instance
+        }
+
+        [Fact]
+        public void NestedGroupInstanceCarriesItsOwnAttributeDictsToo()
+        {
+            var builder = SkpCreate.NewFile();
+            ComponentDefinitionBuilder engine;
+            ComponentDefinitionBuilder car;
+            using (engine = builder.AddComponentDefinition("Engine"))
+            {
+                engine.AddFace(Square());
+            }
+            using (car = builder.AddComponentDefinition("Car"))
+            {
+                car.AddFace(new (double, double, double)[] { (0, 0, 0), (150, 0, 0), (150, 60, 0), (0, 60, 0) });
+                car.AddGroupInstance(
+                    engine, translation: (50, 0, 10),
+                    attributes: new System.Collections.Generic.Dictionary<string, object> { ["part"] = "V6" },
+                    attributeDictName: "dynamic_attributes");
+            }
+            builder.AddInstance(car, translation: (0, 0, 0));
+
+            var model = SkpFile.Parse(builder.ToBytes());
+            var carDef = model.Definitions.Values.Single(d => d.Name == "Car");
+            var groupInstance = Assert.Single(carDef.Instances);
+            Assert.Equal("V6", groupInstance.Properties["part"]);
         }
 
         [Fact]

--- a/packages/dotnet/OpenSkp/Create.cs
+++ b/packages/dotnet/OpenSkp/Create.cs
@@ -1307,20 +1307,28 @@ namespace OpenSkp
         /// return how many new root-entity-list slots it consumed - always
         /// 1, same contract as WriteInstance. A group is structurally
         /// almost identical to a component instance - the two real
-        /// differences are its class name/schema (CGroup, schema 1) and
-        /// that it uses a plain null attribute pointer rather than the
-        /// real (empty) CAttributeContainer instances need.</summary>
+        /// differences are its class name/schema (CGroup, schema 1) and its
+        /// attribute pointer: unlike CComponentInstance (which always
+        /// carries a real, if often empty, CAttributeContainer regardless
+        /// of whether attributes are given), a group only gets one when
+        /// attributeDicts is actually given - matching WriteFace's
+        /// conditional pattern instead. A real production Group WITH
+        /// attributes (SketchUp 2020 export, ground truth) carries a
+        /// genuine CAttributeContainer at this exact schema; a
+        /// never-attributed group still correctly gets a null pointer
+        /// either way (openskp#261).</summary>
         internal int WriteGroup(
             int definitionSlot, string name,
             (double X, double Y, double Z) translation = default,
             double[]? matrix3x3 = null,
             int groupMaterial = 0, int groupLayer = 0,
+            IReadOnlyList<AttributeDict>? attributeDicts = null,
             bool hidden = false)
         {
             WriteInstanceLike(
-                "CGroup", CreateConstants.GroupSchema, false,
+                "CGroup", CreateConstants.GroupSchema, attributeDicts != null && attributeDicts.Count > 0,
                 definitionSlot, name, translation, matrix3x3, groupMaterial, groupLayer,
-                null, hidden);
+                attributeDicts, hidden);
             return 1;
         }
 
@@ -1913,6 +1921,7 @@ namespace OpenSkp
             double[]? matrix3x3 = null,
             ((double X, double Y, double Z) Axis, double AngleRadians)? rotation = null,
             int? material = null, int? layer = null,
+            IReadOnlyDictionary<string, object>? attributes = null, string attributeDictName = "attributes",
             bool hidden = false)
         {
             CheckWritable("groups");
@@ -1928,7 +1937,8 @@ namespace OpenSkp
                 throw new SkpWriteException($"component definition '{Name}' cannot nest a group instance of itself");
             }
             var resolved = CreateMath.ResolveMatrix3x3(matrix3x3, rotation);
-            _newEntityCount += Skp.DefinitionWriter!.WriteGroup(definition.Slot, name ?? definition.Name, translation, resolved, material ?? 0, layer ?? 0, hidden);
+            var attributeDicts = BuildAttributeDicts(attributes, attributeDictName);
+            _newEntityCount += Skp.DefinitionWriter!.WriteGroup(definition.Slot, name ?? definition.Name, translation, resolved, material ?? 0, layer ?? 0, attributeDicts, hidden);
         }
 
         private static List<AttributeDict>? BuildAttributeDicts(IReadOnlyDictionary<string, object>? attributes, string dictName)
@@ -1962,8 +1972,8 @@ namespace OpenSkp
         }
     }
 
-    /// <summary>(translation, matrix3x3, material, layer, hidden) for a
-    /// group's deferred self-placement - mirrors create.py's
+    /// <summary>(translation, matrix3x3, material, layer, attributeDicts,
+    /// hidden) for a group's deferred self-placement - mirrors create.py's
     /// group_placement tuple.</summary>
     internal readonly struct GroupPlacement
     {
@@ -1971,14 +1981,16 @@ namespace OpenSkp
         public readonly double[]? Matrix3x3;
         public readonly int Material;
         public readonly int Layer;
+        public readonly IReadOnlyList<AttributeDict>? AttributeDicts;
         public readonly bool Hidden;
 
-        public GroupPlacement((double X, double Y, double Z) translation, double[]? matrix3x3, int material, int layer, bool hidden)
+        public GroupPlacement((double X, double Y, double Z) translation, double[]? matrix3x3, int material, int layer, IReadOnlyList<AttributeDict>? attributeDicts, bool hidden)
         {
             Translation = translation;
             Matrix3x3 = matrix3x3;
             Material = material;
             Layer = layer;
+            AttributeDicts = attributeDicts;
             Hidden = hidden;
         }
     }
@@ -2410,12 +2422,16 @@ namespace OpenSkp
             double[]? matrix3x3 = null,
             ((double X, double Y, double Z) Axis, double AngleRadians)? rotation = null,
             int? material = null, int? layer = null,
+            IReadOnlyDictionary<string, object>? attributes = null, string attributeDictName = "attributes",
             bool hidden = false)
         {
             CheckMaterialHandle(material, "material");
             CheckLayerHandle(layer);
             var resolved = CreateMath.ResolveMatrix3x3(matrix3x3, rotation);
-            var placement = new GroupPlacement(translation, resolved, material ?? 0, layer ?? 0, hidden);
+            var attributeDicts = attributes != null && attributes.Count > 0
+                ? new List<AttributeDict> { new AttributeDict(attributeDictName, attributes) }
+                : null;
+            var placement = new GroupPlacement(translation, resolved, material ?? 0, layer ?? 0, attributeDicts, hidden);
             return StartDefinition(name ?? "Group", "AddGroup", placement, null);
         }
 
@@ -2581,7 +2597,7 @@ namespace OpenSkp
             foreach (var (comp, placement) in _pendingGroups)
             {
                 _newEntityCount += _geometryWriter.WriteGroup(
-                    comp.Slot, comp.Name, placement.Translation, placement.Matrix3x3, placement.Material, placement.Layer, placement.Hidden);
+                    comp.Slot, comp.Name, placement.Translation, placement.Matrix3x3, placement.Material, placement.Layer, placement.AttributeDicts, placement.Hidden);
                 _faceCount += 1;
             }
             _pendingGroups.Clear();

--- a/packages/typescript/src/create.ts
+++ b/packages/typescript/src/create.ts
@@ -945,15 +945,21 @@ class ArchiveWriter {
 
   /** Write one CGroup placing a copy of `definitionSlot` - structurally
    * almost identical to writeInstance; the real differences are its
-   * class name/schema and that it uses a plain null attribute pointer
-   * rather than the real (empty) CAttributeContainer instances need. */
+   * class name/schema and its attribute pointer: unlike CComponentInstance
+   * (which always carries a real, if often empty, CAttributeContainer), a
+   * group only gets one when `attributeDicts` is actually given - matching
+   * writeFace's conditional pattern instead. A real production Group WITH
+   * attributes (SketchUp 2020 export, ground truth) carries a genuine
+   * CAttributeContainer at this exact schema; a never-attributed group
+   * still correctly gets a null pointer either way (openskp#261). */
   writeGroup(
     definitionSlot: number, name: string, translation: Point3 = [0, 0, 0], matrix3x3?: Matrix3x3,
-    groupMaterial = 0, groupLayer = 0, hidden = false
+    groupMaterial = 0, groupLayer = 0,
+    attributeDicts: ReadonlyArray<[string, AttributeDict]> = [], hidden = false
   ): number {
     this.writeInstanceLike(
-      'CGroup', GROUP_SCHEMA, false,
-      definitionSlot, name, translation, matrix3x3, groupMaterial, groupLayer, [], hidden
+      'CGroup', GROUP_SCHEMA, attributeDicts.length > 0,
+      definitionSlot, name, translation, matrix3x3, groupMaterial, groupLayer, attributeDicts, hidden
     );
     return 1;
   }
@@ -1378,6 +1384,8 @@ export interface AddGroupInstanceOptions {
   rotation?: Rotation;
   material?: number;
   layer?: number;
+  attributes?: AttributeDict;
+  attributeDictName?: string;
   hidden?: boolean;
 }
 
@@ -1393,10 +1401,12 @@ export interface AddGroupOptions {
   rotation?: Rotation;
   material?: number;
   layer?: number;
+  attributes?: AttributeDict;
+  attributeDictName?: string;
   hidden?: boolean;
 }
 
-type GroupPlacement = [Point3, Matrix3x3 | undefined, number, number, boolean];
+type GroupPlacement = [Point3, Matrix3x3 | undefined, number, number, ReadonlyArray<[string, AttributeDict]>, boolean];
 
 function toPoint3(p: readonly [number, number, number]): Point3 {
   return [Number(p[0]), Number(p[1]), Number(p[2])];
@@ -1563,9 +1573,10 @@ export class ComponentDefinitionBuilder {
       throw new SkpWriteError(`component definition ${JSON.stringify(this.name)} cannot nest a group instance of itself`);
     }
     const matrix3x3 = resolveMatrix3x3(options.matrix3x3, options.rotation);
+    const attributeDicts = attributeDictsFrom(options.attributes, options.attributeDictName ?? 'attributes');
     this.newEntityCount += this._skp._definitionWriter().writeGroup(
       definition.slot, options.name ?? definition.name, options.translation ?? [0, 0, 0], matrix3x3,
-      options.material ?? 0, options.layer ?? 0, options.hidden ?? false
+      options.material ?? 0, options.layer ?? 0, attributeDicts, options.hidden ?? false
     );
   }
 
@@ -1834,8 +1845,9 @@ export class SkpBuilder {
     this._checkMaterialHandle(options.material, 'material');
     this._checkLayerHandle(options.layer);
     const matrix3x3 = resolveMatrix3x3(options.matrix3x3, options.rotation);
+    const attributeDicts = attributeDictsFrom(options.attributes, options.attributeDictName ?? 'attributes');
     const placement: GroupPlacement = [
-      options.translation ?? [0, 0, 0], matrix3x3, options.material ?? 0, options.layer ?? 0, options.hidden ?? false,
+      options.translation ?? [0, 0, 0], matrix3x3, options.material ?? 0, options.layer ?? 0, attributeDicts, options.hidden ?? false,
     ];
     const def = this.startDefinition(options.name ?? 'Group', 'addGroup', placement);
     build(def);
@@ -1961,8 +1973,8 @@ export class SkpBuilder {
     // created - deferred until now so closing one group doesn't lock in
     // root-level slot numbering before a later addGroup/
     // addComponentDefinition call has had a chance to run.
-    for (const [comp, [translation, matrix3x3, mat, layer, hidden]] of this.pendingGroups) {
-      this.newEntityCount += this.geometryWriter.writeGroup(comp.slot, comp.name, translation, matrix3x3, mat, layer, hidden);
+    for (const [comp, [translation, matrix3x3, mat, layer, attributeDicts, hidden]] of this.pendingGroups) {
+      this.newEntityCount += this.geometryWriter.writeGroup(comp.slot, comp.name, translation, matrix3x3, mat, layer, attributeDicts, hidden);
       this.faceCount += 1;
     }
     this.pendingGroups = [];

--- a/packages/typescript/tests/create.test.ts
+++ b/packages/typescript/tests/create.test.ts
@@ -742,6 +742,25 @@ describe('Groups', () => {
     );
     expect(defRefs.size).toBe(20);
   });
+
+  it('group attribute dicts round-trip through Instance.properties (openskp#261)', () => {
+    // Groups used to hardcode a null attribute pointer on the belief that
+    // a CGroup never carries a CAttributeContainer - real production files
+    // (SketchUp 2020-legacy export, ground truth) contradicted this.
+    const builder = create();
+    builder.addGroup((table) => table.addFace(SQUARE), {
+      name: 'Table', attributes: { sku: 'TBL-1', qty: 2 }, attributeDictName: 'dynamic_attributes',
+    });
+    const model = parseSkp(toBuffer(builder.toBytes()));
+    expect(model.root.instances[0].properties).toEqual({ sku: 'TBL-1', qty: '2' });
+  });
+
+  it('a group with no attributes still gets a null attribute pointer', () => {
+    const builder = create();
+    builder.addGroup((table) => table.addFace(SQUARE), { name: 'Table' });
+    const model = parseSkp(toBuffer(builder.toBytes()));
+    expect(model.root.instances[0].properties).toEqual({});
+  });
 });
 
 describe('Nested definitions and groups', () => {
@@ -783,6 +802,21 @@ describe('Nested definitions and groups', () => {
     const carDefinition = [...model.definitions.values()].find((d) => d.name === 'Car')!;
     expect(carDefinition.instances.length).toBe(1);
     expect(carDefinition.faces.length).toBe(1);
+  });
+
+  it('a nested group-instance carries its own attribute dicts too (openskp#261)', () => {
+    const builder = create();
+    const engine = builder.addComponentDefinition('Engine', (def) => def.addFace(SQUARE));
+    const car = builder.addComponentDefinition('Car', (def) => {
+      def.addFace([[0, 0, 0], [150, 0, 0], [150, 60, 0], [0, 60, 0]]);
+      def.addGroupInstance(engine, {
+        translation: [50, 0, 10], attributes: { part: 'V6' }, attributeDictName: 'dynamic_attributes',
+      });
+    });
+    builder.addInstance(car);
+    const model = parseSkp(toBuffer(builder.toBytes()));
+    const carDefinition = [...model.definitions.values()].find((d) => d.name === 'Car')!;
+    expect(carDefinition.instances[0].properties).toEqual({ part: 'V6' });
   });
 
   it('buildScene keeps each nested level\'s own instance name in meshIndex (openskp#240)', () => {


### PR DESCRIPTION
## Summary

Ports the Python fix in #262 (openskp#261) to the other 4 languages: `write_group`/`WriteGroup`/`writeGroup` now writes a real attribute container only when attributes are actually given, instead of always hardcoding a null attribute pointer. Groups can now carry custom attribute dictionaries in every language.

- **TypeScript**: `writeGroup` gained an `attributeDicts` parameter; `AddGroupOptions`/`AddGroupInstanceOptions` gained `attributes`/`attributeDictName`.
- **.NET**: `WriteGroup` gained an `attributeDicts` parameter; `AddGroup`/`AddGroupInstance` gained `attributes`/`attributeDictName`.
- **Dart**: `writeGroup`'s trailing positional-optional `hidden` became a named parameter alongside the new `attributeDicts` (package-private, not a public API break); `addGroup`/`addGroupInstance` gained `attributes`/`attributeDictName`.
- **C++**: `write_group` gained an `AttributeDictList` parameter; `GroupOptions`/`GroupInstanceOptions` gained `attributes`/`attribute_dict_name`.

**Scope note:** this only brings `add_group`/`add_group_instance` to parity with what each language's `add_instance` already offered (one attribute dict at a time). The multi-dict `attribute_dicts` array feature from #253-257 remains Python-only by prior deliberate decision, not ported here.

Also corrected two stale doc comments (C++'s `create.hpp` module doc, a Dart test comment) that claimed groups could never carry attributes at all.

## Test plan

- [x] TypeScript: 369 tests passing, `tsc --noEmit` clean
- [x] .NET: 200 tests passing, build clean
- [x] Dart: 225 tests passing, `dart analyze --fatal-infos` clean
- [x] C++: 195 tests passing, `clang-format --dry-run -Werror` clean
- [x] Each language's new tests confirmed to genuinely fail against pre-fix code (reverted the source-only change and re-ran): compile-time failure in .NET/Dart/C++, runtime assertion failure in TypeScript
- [ ] CI green on this PR