### PR TITLE
fix(writer): SketchUp can save our files (persistent IDs in one sequence); front_uv pins in SketchUp's basis and scaled by applied size; reader vertical tolerance; face-me flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ test square happened to be axis-aligned and every test material 1 inch per tile:
   `openskp.edit` and `to_python_code` write the source's real applied size again instead of forcing
   `applied_height=1.0` to dodge the double division.
 
+- **Vertical tolerance and the downward basis (reader and writer).** `face_uv_basis` treated a
+  normal as vertical only within 1e-9 of it, and gave a face looking down the basis `(X, −Y)`. Real
+  SketchUp, measured with the SDK on faces tilted from 1e-10 to 1e-2 looking up and down, keeps the
+  world axes while the sine of the tilt is below 1e-3, and turns the basis 180° for a downward face:
+  `(−X, +Y)`. A horizontal face whose stored normal carries float noise, and every underside of a
+  model, read back (and were written) turned. `VERTICAL_TOLERANCE = 1e-3` in `_face_groups`.
+
 Measured through the SDK's own `SUMeshHelperGetFrontSTQCoords` (skp2dae) on 11 orientations before and
 after; new tests pin the invariant — what you pin is what the reader hands back at that point, on
 six orientations and vertex orders, and at applied size 10 — plus a real-SketchUp oracle test for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — files the writer produced could not be SAVED by SketchUp (Python writer)
+
+Every section's writer (materials, layers, definitions, root geometry) handed out persistent IDs
+from 1 again, so a material, a definition and a root instance could all carry pid 1, and the header's
+pid counter — a 32-bit field the writer treated as 16-bit — only grew by the material and layer count.
+SketchUp loads such a file, renumbers the duplicates, and then `SUModelSaveToFile` fails with
+`SU_ERROR_SERIALIZATION` once the model is big enough or a definition happens to come first: a real
+7 MB export opened fine in SketchUp Web and every attempt to save it ended in "Save failed". Measured
+with the SDK: a 1-face definition followed by a 3-face one is enough. Pids now run in one sequence
+across sections, continuing from the scaffold's counter, and the counter is written as the u32 it is,
+with the last pid handed out. Real exports of 7 MB and 27 MB re-save through the SDK.
+
 ### Added — face-me components in the writer (Python)
 
 `add_component_definition(name, always_faces_camera=True, shadows_face_sun=True)` sets SketchUp's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — face-me components in the writer (Python)
+
+`add_component_definition(name, always_faces_camera=True, shadows_face_sun=True)` sets SketchUp's
+component-behavior byte the reader already decoded (bit 0 / bit 1 of byte −9 in the definition's
+43-byte gap), so a 2D person or cut-out tree written with openskp turns toward the camera in
+SketchUp instead of standing still. `openskp.edit` replays a source file's flags when re-saving.
+
 ### Fixed — `front_uv`/`back_uv` pins land where SketchUp draws them, on any face and at any applied size (Python writer)
 
 Two defects in the writer's texture positioning, invisible to its own reader tests because every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `front_uv`/`back_uv` pins land where SketchUp draws them, on any face and at any applied size (Python writer)
+
+Two defects in the writer's texture positioning, invisible to its own reader tests because every
+test square happened to be axis-aligned and every test material 1 inch per tile:
+
+- **Basis.** The per-face matrix was solved in a basis built from the face's *first edge*
+  (`points[1] - points[0]`, and the normal crossed with it). Real SketchUp — and this project's own
+  reader, calibrated against SDK-authored files — express and invert it in a basis derived from the
+  **normal alone** (`U = normalize(Z × n)`, `W = n × U`; `(X, ±Y)` for a horizontal face). The two agree
+  exactly when the first edge runs along `Z × n`, which every existing test face did; otherwise the
+  texture came out turned by the angle between them. A horizontal face listed from another corner
+  arrived in SketchUp rotated 90° or 180°; a curved surface of many small quads, each with its own
+  first edge, shattered. `_uv_matrix_for_face` now uses `_face_groups.face_uv_basis`.
+- **Scale.** SketchUp stores the matrix in *inches of texture space* and divides by the material's
+  applied width/height when it reads a face's UV back (`compute_face_uv` already did the same). The
+  pins a caller gives are in tiles of the image, and were fitted as-is, so a material applied at
+  2 m per tile (78.74 in) came out 78.74× too big on every positioned face. `add_face` (root and
+  definition builders) now scales pins by the applied size recorded at `add_texture_material` time;
+  `openskp.edit` and `to_python_code` write the source's real applied size again instead of forcing
+  `applied_height=1.0` to dodge the double division.
+
+Measured through the SDK's own `SUMeshHelperGetFrontSTQCoords` (skp2dae) on 11 orientations before and
+after; new tests pin the invariant — what you pin is what the reader hands back at that point, on
+six orientations and vertex orders, and at applied size 10 — plus a real-SketchUp oracle test for the
+rotated vertex order (`TestRealSketchUpOracle`, needs the SDK DLL).
+
 ### Added — Full attribute-dictionary support in the writer, Python; groups gain attributes, all 5 languages
 
 The writer's custom attribute dictionaries (`attributes`/`attribute_dict_name` on

--- a/packages/python/src/openskp/_face_groups.py
+++ b/packages/python/src/openskp/_face_groups.py
@@ -43,17 +43,35 @@ def _invert_3x3(m: Tuple[float, ...]) -> Tuple[float, ...]:
     )
 
 
+#: |Z x n| below which real SketchUp projects with the world axes instead of
+#: the cross product. Measured with the SDK (SUMeshHelperGetFrontSTQCoords)
+#: on faces tilted by 1e-10 .. 1e-2, looking up and looking down: the world
+#: axes hold up to a tilt whose sine is 1.0000004e-3, the cross product takes
+#: over from 1.0001e-3.
+VERTICAL_TOLERANCE = 1e-3
+
+
 def face_uv_basis(n: Tuple[float, float, float]) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
-    """Face-plane basis vectors (xr, yr) for UV projection, from a face
-    normal. See ``Face.uv_transform`` in model.py for the recipe this
-    implements."""
+    """Face-plane basis vectors (xr, yr) for UV projection, from a unit
+    face normal. See ``Face.uv_transform`` in model.py for the recipe this
+    implements.
+
+    ``Z x n`` is discontinuous at the vertical - for ``(e, 0, 1)`` it points
+    along +Y however small ``e`` is, for ``(0, e, 1)`` along -X - and real
+    SketchUp resolves that with a tolerance (`VERTICAL_TOLERANCE`, measured)
+    rather than the 1e-9 used here before: a horizontal face whose stored
+    normal carries a little float noise projects with the world axes. And
+    the snapped basis of a face looking DOWN is ``(-X, +Y)`` - the 180-degree
+    turn of the upward ``(X, Y)`` - not the ``(X, -Y)`` mirror assumed
+    before; measured the same way, on pinned and default-projected faces
+    alike (every underside of a real model read back upside-down)."""
     nx, ny, nz = n
     # xr = normalize(Z x n) = normalize((-ny, nx, 0))
     cx, cy = -ny, nx
     clen = (cx * cx + cy * cy) ** 0.5
-    if clen < 1e-9:
-        xr = (1.0, 0.0, 0.0)
-        yr = (0.0, 1.0 if nz >= 0 else -1.0, 0.0)
+    if clen < VERTICAL_TOLERANCE:
+        xr = (1.0, 0.0, 0.0) if nz >= 0 else (-1.0, 0.0, 0.0)
+        yr = (0.0, 1.0, 0.0)
     else:
         xr = (cx / clen, cy / clen, 0.0)
         # yr = n x xr

--- a/packages/python/src/openskp/codegen.py
+++ b/packages/python/src/openskp/codegen.py
@@ -138,18 +138,16 @@ def to_python_code(model: SkpModel) -> str:
             b64 = base64.b64encode(mat.texture.data).decode("ascii")
             suffix = "".join(ch for ch in (mat.texture.filename or "").rsplit(".", 1)[-1:] if ch.isalnum())
             suffix = f".{suffix}" if suffix else ".png"
-            # applied_height=1.0 - every face using a textured material is
-            # written below with explicit front_uv/back_uv, never left to
-            # default projection, so the material's own applied height
-            # must be an exact no-op divisor (matches
-            # add_texture_material's own default too, but kept explicit
-            # since it's a hard requirement here, not just a safe default).
+            # The real applied size: the generated add_face pins are in
+            # tiles and the writer scales them by the material's size, so
+            # the material keeps its size and the faces their mapping.
             push(f"    _tex_fd, _tex_path = tempfile.mkstemp(suffix={suffix!r})")
             push("    with os.fdopen(_tex_fd, 'wb') as _f:")
             push(f"        _f.write(base64.b64decode({b64!r}))")
             push("    try:")
             push(
-                f"        {var_name} = builder.add_texture_material({mat.name!r}, _tex_path, applied_height=1.0)"
+                f"        {var_name} = builder.add_texture_material({mat.name!r}, _tex_path, "
+                f"applied_width={mat.texture.width or 1.0!r}, applied_height={mat.texture.height or 1.0!r})"
             )
             push("    finally:")
             push("        os.unlink(_tex_path)")

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -2202,7 +2202,16 @@ class SkpBuilder:
         self._scaffold_class_slot = ar.class_slot
         # Materials always start allocating at `base`, the same slot the
         # (possibly absent) material section would have occupied.
-        self._material_writer = _ArchiveWriter(next_slot=base, class_slot={})
+        # Persistent IDs run in ONE sequence across every section of the
+        # file, continuing from the scaffold's own counter (u32 at
+        # _PID_COUNTER_POS). Each section's writer used to start at 1 again,
+        # so a definition, a root instance and a material could all carry
+        # pid 1: SketchUp loads such a file, renumbers the duplicates, and
+        # then fails to SAVE it (SUModelSaveToFile -> SU_ERROR_SERIALIZATION,
+        # "Guardado fallido" in SketchUp Web) once the model is big enough
+        # or a definition happens to come first - measured on real exports.
+        self._pid_start = struct.unpack_from("<I", data, _PID_COUNTER_POS)[0] + 1
+        self._material_writer = _ArchiveWriter(next_slot=base, class_slot={}, next_pid=self._pid_start)
         #: Every material registered so far, by name - populated by
         #: `add_material`/`add_texture_material` as a side effect (they
         #: already de-dupe by name through this same dict), not something
@@ -2415,7 +2424,8 @@ class SkpBuilder:
             # up (write_layer's short class-ref for CLayer needs the true
             # post-shift slot, not the baseline one).
             self._layer_writer = _ArchiveWriter(
-                next_slot=self._layer_writer_start, class_slot=self._material_shifted_class_slot()
+                next_slot=self._layer_writer_start, class_slot=self._material_shifted_class_slot(),
+                next_pid=self._material_writer.next_pid,
             )
         slot = self._layer_writer.write_layer(name, hidden=hidden, rgba=rgba)
         self.layers_by_name[name] = slot
@@ -2492,7 +2502,8 @@ class SkpBuilder:
                 self._material_writer.next_slot - self._base
             ) + self._layer_shift()
             self._definition_writer = _ArchiveWriter(
-                next_slot=self._definition_writer_start, class_slot=self._post_layer_class_slot()
+                next_slot=self._definition_writer_start, class_slot=self._post_layer_class_slot(),
+                next_pid=self._next_pid(),
             )
         slot, count_patch_pos = self._definition_writer.write_definition_header(attribute_dicts)
         self._definition_count += 1
@@ -2748,6 +2759,16 @@ class SkpBuilder:
         )
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 
+    def _next_pid(self) -> int:
+        """The next free persistent ID: sections are written in order
+        (materials, layers, definitions, root geometry), each continuing
+        where the previous one stopped."""
+        for w in (self._geometry_writer, self._definition_writer,
+                  self._layer_writer, self._material_writer):
+            if w is not None:
+                return w.next_pid
+        return self._pid_start
+
     def _ensure_geometry_writer(self) -> None:
         if self._geometry_writer is not None:
             return
@@ -2771,6 +2792,7 @@ class SkpBuilder:
         self._geometry_writer = _ArchiveWriter(
             next_slot=self._scaffold_next_slot + material_shift + self._layer_shift() + self._definition_shift(),
             class_slot=self._post_definition_class_slot(),
+            next_pid=self._next_pid(),
         )
         # Flush any groups that closed earlier, in the order they were
         # created - deferred until now so closing one group doesn't lock in
@@ -3152,15 +3174,12 @@ class SkpBuilder:
         # file by 4 extra bytes here; ground-truth-confirmed by diffing SDK-
         # authored files (an earlier version of this method double-counted
         # this field as a fresh insertion, corrupting every offset after it).
-        # Each layer's record embeds 2 pids (see write_layer); materials
-        # use 1 pid each (write_material).
-        layer_pids = (self._layer_writer.next_pid - 1) if self._layer_writer else 0
-        pid_delta = self._material_count + layer_pids
-
         prefix = bytearray(self._data[: self._material_insert_pos - 4])
-        if pid_delta:
-            u16 = struct.unpack_from("<H", prefix, _PID_COUNTER_POS)[0]
-            struct.pack_into("<H", prefix, _PID_COUNTER_POS, u16 + pid_delta)
+        # The model's pid counter: the last pid handed out, in every
+        # section. A 32-bit field (the two bytes after the old u16 are part
+        # of it - a counter of 2 000 000 round-trips through the SDK), so a
+        # model with more than 65 535 entities keeps a truthful counter.
+        struct.pack_into("<I", prefix, _PID_COUNTER_POS, self._next_pid() - 1)
         prefix[_ISO_CAMERA_PREFIX_OFFSET : _ISO_CAMERA_PREFIX_OFFSET + len(_ISO_CAMERA_PREFIX_PATCH)] = (
             _ISO_CAMERA_PREFIX_PATCH
         )

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -1220,9 +1220,14 @@ class _ArchiveWriter:
         self.buf += _u32(0)  # placeholder entity count, patched by the caller
         return slot, count_patch_pos
 
-    def write_definition_tail(self, name: str) -> None:
+    def write_definition_tail(self, name: str, behavior: int = 0) -> None:
         """Close out a ``CComponentDefinition`` record: relationship count,
-        GUID, name, timestamp, behavior flags, and a default thumbnail."""
+        GUID, name, timestamp, behavior flags, and a default thumbnail.
+
+        ``behavior`` is SketchUp's component-behavior byte: bit 0 "always
+        face camera" (2D people and cut-out trees turn toward the eye), bit
+        1 "shadows face sun" - the same two bits legacy.py's
+        ``_read_definition`` decodes from byte -9 of the 43-byte gap."""
         self.buf += _u32(0)  # nrel: CRelationship count - always 0, not supported
         self.buf += struct.pack("<H", 0)
         self.buf += uuid.uuid4().bytes
@@ -1230,10 +1235,12 @@ class _ArchiveWriter:
         self._write_str("")  # description - empty in ground truth
         self._write_str("")  # second name field - empty in ground truth
         self.buf += _u32(int(time.time()))
-        # 43-byte gap; byte -9 carries the always-faces-camera/
-        # shadows-face-sun behavior flags (legacy.py's _read_definition) -
-        # both left off, matching neither being exposed by this writer yet.
-        self.buf += bytes(43)
+        # 43-byte gap; byte -9 carries the always-faces-camera (bit 0) /
+        # shadows-face-sun (bit 1) behavior flags (legacy.py's
+        # _read_definition reads exactly that byte).
+        gap = bytearray(43)
+        gap[43 - 9] = behavior & 0xFF
+        self.buf += bytes(gap)
         self.write_thumbnail()
 
     def _write_instance_like(
@@ -1830,6 +1837,9 @@ class ComponentDefinitionBuilder:
         self._skp = skp
         self.slot = slot
         self.name = name
+        #: SketchUp's behavior byte, set by `SkpBuilder.add_component_definition`
+        #: (bit 0 always-faces-camera, bit 1 shadows-face-sun).
+        self.behavior = 0
         self._count_patch_pos = count_patch_pos
         self._vertex_slots: Dict[Point3, int] = {}
         self._edge_registry: Dict[FrozenSet[int], Tuple[int, int]] = {}
@@ -2117,7 +2127,7 @@ class ComponentDefinitionBuilder:
             raise SkpWriteError(f"component definition {self.name!r} has no geometry - add at least one face")
         writer = self._skp._definition_writer
         struct.pack_into("<I", writer.buf, self._count_patch_pos, self._new_entity_count)
-        writer.write_definition_tail(self.name)
+        writer.write_definition_tail(self.name, behavior=self.behavior)
         self._closed = True
         self._skp._open_definition = None
         if self._group_placement is not None:
@@ -2495,11 +2505,20 @@ class SkpBuilder:
         attributes: Optional[Dict[str, object]] = None,
         attribute_dict_name: str = "attributes",
         attribute_dicts: Sequence[Tuple[str, Dict[str, object]]] = (),
+        always_faces_camera: bool = False,
+        shadows_face_sun: bool = False,
     ) -> "ComponentDefinitionBuilder":
         """Start a new reusable component definition. Use the returned
         object as a context manager, adding its geometry via `.add_face`
         inside the ``with`` block; once closed, pass it to `add_instance`
         to place copies of it in the model.
+
+        ``always_faces_camera`` makes the definition a SketchUp face-me
+        component - 2D people and cut-out trees that turn about their own Z
+        so their local -Y axis points at the camera; ``shadows_face_sun``
+        keeps such a component's cast shadow still while the camera moves.
+        Both read back as ``Definition.always_faces_camera`` /
+        ``Definition.shadows_face_sun``.
 
         >>> with builder.add_component_definition("Chair") as chair:
         ...     chair.add_face([(0, 0, 0), (20, 0, 0), (20, 20, 0), (0, 20, 0)])
@@ -2519,7 +2538,9 @@ class SkpBuilder:
         carry more than one. Passing both raises.
         """
         resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
-        return self._start_definition(name, "add_component_definition", attribute_dicts=resolved_attribute_dicts)
+        db = self._start_definition(name, "add_component_definition", attribute_dicts=resolved_attribute_dicts)
+        db.behavior = (1 if always_faces_camera else 0) | (2 if shadows_face_sun else 0)
+        return db
 
     def add_group(
         self,

--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -108,6 +108,7 @@ from importlib import resources
 from typing import Dict, FrozenSet, Iterator, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 from . import legacy
+from ._face_groups import face_uv_basis
 
 __all__ = [
     "SkpWriteError", "SkpBuilder", "ComponentDefinitionBuilder", "create",
@@ -437,35 +438,12 @@ def _resolve_matrix3x3(
     return matrix3x3
 
 
-def _face_uv_basis(
-    points: Sequence[Point3], normal: Tuple[float, float, float]
-) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
-    """The in-plane 2D basis (U, W) real SketchUp uses to parameterize a
-    face's texture mapping, for a face of ANY orientation (not just
-    axis-aligned) - ground truth (an SDK-authored file's own computed
-    matrix, cross-checked against this formula using an asymmetric
-    correspondence specifically chosen to rule out simpler axis-dropping
-    projections) shows it's simply the face's own first edge direction
-    (``points[1] - points[0]``, normalized) as U, and the plane normal
-    crossed with that as W - both unit vectors. This exactly explains why
-    the axis-aligned case (this feature's first version) worked with
-    fixed (x, y)/(x, z)/(y, z) axis pairs: for a face whose first edge
-    happens to run along a world axis, this formula reduces to exactly
-    that pair.
-    """
-    u = _normalize3((
-        points[1][0] - points[0][0], points[1][1] - points[0][1], points[1][2] - points[0][2],
-    ))
-    w = _normalize3(_cross(normal, u))
-    return u, w
-
-
 def _circle_basis(
     normal: Tuple[float, float, float],
 ) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
     """An arbitrary orthonormal in-plane basis (U, W) for a circle/arc's
-    plane, given only its normal - unlike :func:`_face_uv_basis` there's
-    no "first edge" to derive U from here, so pick whichever of world
+    plane, given only its normal - any consistent choice works for an arc
+    (unlike a texture matrix, whose basis SketchUp fixes), so pick whichever of world
     +Z/+X is less parallel to ``normal`` as a seed and Gram-Schmidt it
     against ``normal`` to get U, then W = normal x U. This choice of seed
     only affects where angle 0 points around the circle, not its shape.
@@ -545,13 +523,24 @@ def _solve_uv_matrix(
     map (scale, rotation, shear, translation; no perspective/keystone term,
     matching the third column ground truth always shows as (0, 0, 1)).
 
-    ``basis`` is the face's own (U, W) in-plane unit vectors (see
-    `_face_uv_basis`) - each correspondence's world point is projected
-    onto them via a plain dot product (ground truth confirms this uses
-    the point's raw coordinates with no origin subtraction - confirmed by
-    positioning a face far from the world origin, where an "obviously
-    sensible" points[0]-relative hypothesis predicted the wrong
-    translation terms) before fitting.
+    ``basis`` is the (U, W) in-plane unit pair the stored matrix is
+    expressed in - SketchUp's own, derived from the face NORMAL alone
+    (`face_uv_basis` in `_face_groups`: ``U = normalize(Z × n)``,
+    ``W = n × U``; ``(X, ±Y)`` for a horizontal face), the same basis the
+    reader inverts the matrix in. Each correspondence's world point is
+    projected onto them via a plain dot product (ground truth confirms this
+    uses the point's raw coordinates with no origin subtraction - confirmed
+    by positioning a face far from the world origin, where an "obviously
+    sensible" points[0]-relative hypothesis predicted the wrong translation
+    terms) before fitting.
+
+    This writer first used the face's own first edge as U. That agrees with
+    SketchUp's basis exactly when the first edge happens to run along
+    ``Z × n`` - which every axis-aligned test square did - and otherwise
+    turns the mapping by the angle between the two: a horizontal face
+    listed from a different corner came out rotated 90° or 180°, a curved
+    surface of many small quads shattered. Measured through the SDK's own
+    ``SUMeshHelperGetFrontSTQCoords`` on 11 orientations (2026-09-04).
 
     Ground truth (see ``_read_ftc`` in legacy.py, which this inverts) shows
     the stored matrix satisfies ``(u, v, 1) @ M == (world_x, world_y, 1)``
@@ -577,8 +566,30 @@ def _uv_matrix_for_face(
     pairs: Sequence[Tuple[Point3, Tuple[float, float]]],
     normal: Tuple[float, float, float],
 ) -> Tuple[float, ...]:
-    """`_solve_uv_matrix` using the face's own `_face_uv_basis`."""
-    return _solve_uv_matrix(pairs, _face_uv_basis(points, normal))
+    """`_solve_uv_matrix` in the basis SketchUp reads the face's matrix in
+    (`face_uv_basis` of the plane normal; ``points`` no longer matter, kept
+    for the call sites)."""
+    return _solve_uv_matrix(pairs, face_uv_basis(normal))
+
+
+def _scale_pins(
+    pins: Optional[Sequence[Tuple[Point3, Tuple[float, float]]]],
+    size: Optional[Tuple[float, float]],
+) -> Optional[Sequence[Tuple[Point3, Tuple[float, float]]]]:
+    """A caller's ``front_uv``/``back_uv`` pins are in TILES of the image
+    ((1, 0) = one full repeat along U, however big the material's applied
+    size makes a tile). The matrix real SketchUp stores is in INCHES of
+    texture space - it divides by the material's applied width/height when
+    it reads a face's UV back (`_face_groups.compute_face_uv`, calibrated
+    against SDK-authored files, does the same) - so the pins are scaled up
+    by that size before the fit. Without this a texture applied at 2 m per
+    tile (78.74 in) came out 78.74× too big on every pinned face."""
+    if pins is None or size is None:
+        return pins
+    w, h = size
+    if w == 1.0 and h == 1.0:
+        return pins
+    return [(pt, (uv[0] * w, uv[1] * h)) for pt, uv in pins]
 
 
 def _u32(v: int) -> bytes:
@@ -1867,6 +1878,8 @@ class ComponentDefinitionBuilder:
             raise SkpWriteError("a face needs at least 3 points")
         holes = [[(float(p[0]), float(p[1]), float(p[2])) for p in hole] for hole in holes]
         resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
+        front_uv = _scale_pins(front_uv, self._skp._applied_sizes.get(material or 0))
+        back_uv = _scale_pins(back_uv, self._skp._applied_sizes.get(back_material or 0))
         self._new_entity_count += _write_face_or_triangulate(
             self._skp._definition_writer, points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,
@@ -2189,6 +2202,10 @@ class SkpBuilder:
         #: the source file had is already here.
         self.materials_by_name: Dict[str, int] = {}
         self._material_count = 0
+        #: Applied size (inches) each TEXTURED material slot was written
+        #: with - `add_face` scales its ``front_uv``/``back_uv`` pins by it
+        #: (see `_scale_pins`).
+        self._applied_sizes: Dict[int, Tuple[float, float]] = {}
         # Deferred: layers splice in AFTER materials, so the layer writer's
         # starting slot depends on the final material count. Constructed
         # lazily on the first add_layer() call, once material_shift is
@@ -2300,10 +2317,11 @@ class SkpBuilder:
         ``applied_width``/``applied_height``, if given, are the applied
         size in INCHES - how much model space one tile of the image
         covers. Both default to 1.0. A texture applied without positioning
-        carries no per-face UV record, so this size IS its mapping - and
-        see `write_textured_material`'s own docstring for why it matters
-        even for `add_face`'s ``front_uv``/``back_uv`` pinning (a
-        positioned mapping still divides by it).
+        carries no per-face UV record, so this size IS its mapping; a face
+        positioned with `add_face`'s ``front_uv``/``back_uv`` keeps its
+        pins in tiles of the image regardless of it (`add_face` scales
+        them by this size, since SketchUp stores and reads the per-face
+        matrix in inches of texture space - see `_scale_pins`).
 
         The format is detected from the file's own magic bytes, not its
         extension - PNG and JPEG are the only two this project has
@@ -2331,6 +2349,10 @@ class SkpBuilder:
             opacity=opacity,
         )
         self.materials_by_name[name] = slot
+        self._applied_sizes[slot] = (
+            1.0 if applied_width is None else float(applied_width),
+            1.0 if applied_height is None else float(applied_height),
+        )
         self._material_count += 1
         return slot
 
@@ -2783,8 +2805,10 @@ class SkpBuilder:
         ``front_uv``/``back_uv``, if given, explicitly position that
         side's texture instead of the default planar projection: exactly
         3 ``(point, (u, v))`` pairs, each a world point on the face paired
-        with the texture coordinate that should land there. Works on a
-        face of any orientation, not just axis-aligned ones.
+        with the texture coordinate that should land there, in TILES of
+        the image ((1, 0) is one full repeat along U whatever the
+        material's applied size). Works on a face of any orientation and
+        any vertex order, not just axis-aligned ones.
 
         >>> brick = builder.add_texture_material("Brick", "brick.png")
         >>> builder.add_face(
@@ -2835,6 +2859,8 @@ class SkpBuilder:
         holes = [[(float(p[0]), float(p[1]), float(p[2])) for p in hole] for hole in holes]
         self._ensure_geometry_writer()
         resolved_attribute_dicts = _resolve_attribute_dicts(attributes, attribute_dict_name, attribute_dicts)
+        front_uv = _scale_pins(front_uv, self._applied_sizes.get(material or 0))
+        back_uv = _scale_pins(back_uv, self._applied_sizes.get(back_material or 0))
         self._new_entity_count += _write_face_or_triangulate(
             self._geometry_writer, points, self._vertex_slots, self._edge_registry,
             material or 0, layer or 0, back_material or 0,

--- a/packages/python/src/openskp/edit.py
+++ b/packages/python/src/openskp/edit.py
@@ -158,7 +158,10 @@ def open_existing(
         # definitions (unlike Components, which SketchUp auto-names), so
         # an empty name is common in real files - the same reasoning as
         # _replay_instance's own name handling below.
-        with builder.add_component_definition(defn.name) as db:
+        with builder.add_component_definition(
+                defn.name,
+                always_faces_camera=getattr(defn, "always_faces_camera", False),
+                shadows_face_sun=getattr(defn, "shadows_face_sun", False)) as db:
             _replay_body(db, defn, model, material_slots, layer_slots, warnings, context, def_builders)
         def_builders[def_id] = db
 

--- a/packages/python/src/openskp/edit.py
+++ b/packages/python/src/openskp/edit.py
@@ -181,16 +181,18 @@ def _replay_materials(builder: SkpBuilder, model: SkpModel, warnings: List[str])
             try:
                 with os.fdopen(fd, "wb") as f:
                     f.write(mat.texture.data)
-                # applied_height=1.0 - every textured face is now replayed
-                # with an explicit front_uv/back_uv (see _replay_uv), whose
-                # pins already bake in the SOURCE's real tile size via
-                # compute_face_uv - the material's own stored applied
-                # height must be a no-op divisor (1.0) or the read-side UV
-                # formula divides by it a second time. This happens to
-                # match add_texture_material's own default too, but is
-                # kept explicit here since it's a hard requirement of this
-                # call site specifically, not just a safe default.
-                slot = builder.add_texture_material(mat.name, tmp_path, applied_height=1.0)
+                # The source's real applied size travels with the material
+                # (a brick stays 8 x 16 in in the material browser), and the
+                # replayed pins - in tiles, from compute_face_uv - are scaled
+                # by it inside add_face, so the read-side division by the
+                # applied size lands back on the same UV. (This used to
+                # force applied_height=1.0 to dodge a double division; the
+                # writer scales the pins itself now.)
+                slot = builder.add_texture_material(
+                    mat.name, tmp_path,
+                    applied_width=mat.texture.width or 1.0,
+                    applied_height=mat.texture.height or 1.0,
+                )
             finally:
                 os.unlink(tmp_path)
             if mat.colorized:

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -113,7 +113,8 @@ class Face:
 
             1. Plane basis from the face normal ``n``:
                ``xr = normalize(Z × n)``, ``yr = n × xr`` (for a vertical
-               ``n``: ``xr = X``, ``yr = ±Y`` by the sign of ``n``·Z).
+               ``n`` - ``|Z × n| < 1e-3``, SketchUp's own tolerance -
+               ``(X, Y)`` looking up and ``(−X, Y)`` looking down).
             2. ``uvq = [p·xr, p·yr, 1] @ inv(M)``  (row-vector convention).
             3. ``u = uvq[0]/uvq[2] / tile_w``, ``v = uvq[1]/uvq[2] / tile_h``
                with the material texture's tile size in inches.

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1622,6 +1622,22 @@ class TestUVPositioning:
             ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
             assert ftc["front"] == pytest.approx((50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0))
 
+    def test_face_uv_basis_snaps_and_turns_like_real_sketchup(self):
+        # Measured with the SDK (2026-09-04): the world axes hold while the
+        # sine of the tilt is below 1e-3 (1.0000004e-3 still vertical,
+        # 1.0001e-3 already the cross product), and a face looking DOWN
+        # gets (-X, +Y), the 180-degree turn of the upward basis - not the
+        # (X, -Y) mirror this reader assumed, which turned every underside.
+        from openskp._face_groups import face_uv_basis
+        up = ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+        assert face_uv_basis((0.0, 0.0, 1.0)) == up
+        assert face_uv_basis((9.9e-4, 0.0, 1.0)) == up                # float noise, a 1e-4 tilt
+        assert face_uv_basis((0.0, 0.0, -1.0)) == ((-1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+        assert face_uv_basis((3e-4, 0.0, -1.0)) == ((-1.0, 0.0, 0.0), (0.0, 1.0, 0.0))
+        xr, yr = face_uv_basis((2e-3, 0.0, 0.999998))                 # a real tilt: Z x n
+        assert xr == pytest.approx((0.0, 1.0, 0.0))
+        assert yr[0] == pytest.approx(-0.999998) and abs(yr[1]) < 1e-12   # yr = n x xr
+
     def test_vertex_order_does_not_turn_the_mapping(self, tmp_path):
         # The SAME square as test_uv_scale_only..., listed from a different
         # corner so its first edge runs along +Y instead of +X, pinned to

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -4472,7 +4472,8 @@ def test_a_small_definition_before_a_bigger_one_saves_through_real_sketchup(tmp_
     """The minimal case that real SketchUp refused to SAVE (SU_ERROR_SERIALIZATION,
     7) before pids ran in one sequence: a 1-face definition, then a 3-face
     one, both placed. Needs the SDK DLL."""
-    import ctypes, os
+    import ctypes
+    import os
     if not os.path.exists(_SDK_DLL_PATH):
         pytest.skip("SketchUp SDK not present on this machine")
     builder = create()

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -4408,3 +4408,27 @@ class TestMaterialOpacity:
         mat = {s: v for s, v in legacy._walk(data)[3]}[tex]
         assert mat["use_opacity"] == 1
         assert mat["opacity"] == pytest.approx(0.5)
+
+
+
+def test_face_me_behaviour_round_trips(tmp_path):
+    """``always_faces_camera`` / ``shadows_face_sun`` land in the behavior
+    byte the reader already decodes (byte -9 of the definition's 43-byte
+    gap): a 2D person written here is a real face-me component in SketchUp
+    - it turns toward the camera - instead of a flat cut-out standing still."""
+    from openskp import SkpFile
+    builder = create()
+    with builder.add_component_definition("Susan", always_faces_camera=True, shadows_face_sun=True) as susan:
+        susan.add_face([(0.0, 0.0, 0.0), (20.0, 0.0, 0.0), (20.0, 0.0, 70.0), (0.0, 0.0, 70.0)])
+    with builder.add_component_definition("Chair") as chair:
+        chair.add_face(SQUARE)
+    builder.add_instance(susan, translation=(100.0, 50.0, 0.0))
+    builder.add_instance(chair, translation=(0.0, 0.0, 0.0))
+    out = tmp_path / "faceme.skp"
+    builder.save(str(out))
+    model = SkpFile.open(str(out)).parse()
+    by_name = {d.name: d for d in model.definitions.values()}
+    assert by_name["Susan"].always_faces_camera is True
+    assert by_name["Susan"].shadows_face_sun is True
+    assert by_name["Chair"].always_faces_camera is False
+    assert by_name["Chair"].shadows_face_sun is False

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -1622,6 +1622,106 @@ class TestUVPositioning:
             ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
             assert ftc["front"] == pytest.approx((50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0))
 
+    def test_vertex_order_does_not_turn_the_mapping(self, tmp_path):
+        # The SAME square as test_uv_scale_only..., listed from a different
+        # corner so its first edge runs along +Y instead of +X, pinned to
+        # the same u = x/50, v = y/50. SketchUp expresses a face's matrix
+        # in a basis derived from the NORMAL alone ((X, Y) for a horizontal
+        # face), so the stored matrix must be the same diag(50, 50). The
+        # writer used to solve it in a first-edge basis, which agrees only
+        # when that edge happens to run along Z x n: this face came out
+        # turned 90 degrees in SketchUp (measured through the SDK's own
+        # SUMeshHelperGetFrontSTQCoords).
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        rotated = SQUARE[1:] + SQUARE[:1]
+        builder.add_face(
+            rotated, material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 50.0, 0.0), (0.0, 1.0))],
+        )
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+        assert ftc["front"] == pytest.approx((50.0, 0.0, 0.0, 0.0, 50.0, 0.0, 0.0, 0.0, 1.0), abs=1e-9)
+
+    def test_pins_read_back_as_pinned_on_every_orientation(self, tmp_path):
+        # The contract: whatever (point, uv) you pin, the reader - which
+        # inverts the matrix in SketchUp's normal-derived basis, calibrated
+        # against SDK-authored files - hands the same uv back at that point,
+        # on a face of ANY orientation and vertex order. Each square here
+        # is pinned to a mapping deliberately not aligned with its first
+        # edge; the fourth corner checks the map is affine over the face.
+        from openskp._face_groups import compute_face_uv, face_uv_basis
+        s = 70.71067811865476
+        squares = [
+            [(0.0, 0.0, 0.0), (0.0, 50.0, 0.0), (-50.0, 50.0, 0.0), (-50.0, 0.0, 0.0)],   # horizontal, 1st edge +Y
+            [(0.0, 0.0, 0.0), (0.0, 0.0, 50.0), (50.0, 0.0, 50.0), (50.0, 0.0, 0.0)],     # wall facing +Y, 1st edge +Z
+            [(0.0, 0.0, 0.0), (50.0, 0.0, 0.0), (50.0, 0.0, 50.0), (0.0, 0.0, 50.0)],     # wall facing -Y
+            [(0.0, 0.0, 0.0), (0.0, 0.0, 50.0), (0.0, 50.0, 50.0), (0.0, 50.0, 0.0)],     # wall facing -X, 1st edge +Z
+            [(0.0, 0.0, 0.0), (50.0, 0.0, 0.0), (50.0, s, s), (0.0, s, s)],                # 45-degree slope
+            [(0.0, 0.0, 0.0), (0.0, s, s), (-50.0, s, s), (-50.0, 0.0, 0.0)],              # same slope, 1st edge up it
+        ]
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        pins_by_face = []
+        for pts in squares:
+            # An asymmetric affine map over the face: u/v from two skewed
+            # combinations of the corners, so no axis of it lines up with
+            # an edge.
+            p0, p1, p2, p3 = pts
+            pins = [(p0, (0.1, 0.2)), (p1, (0.9, 0.35)), (p3, (0.25, 1.4))]
+            builder.add_face(pts, material=tex, front_uv=pins)
+            pins_by_face.append((pins, p2))
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        faces = [v for (_, n, v) in root if n == "CFace"]
+        assert len(faces) == len(squares)
+        for face, (pins, p2) in zip(faces, pins_by_face):
+            ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+            xr, yr = face_uv_basis(tuple(face["plane"][:3]))
+            for pt, (u, v) in pins:
+                got = compute_face_uv(pt, xr, yr, tuple(ftc["front"]), 1.0, 1.0)
+                assert got == pytest.approx((u, v), abs=1e-9), (pt, got, (u, v))
+            # Affine: the fourth corner is p1 + p3 - p0 in uv too.
+            (_, uv0), (_, uv1), (_, uv3) = pins
+            expect = (uv1[0] + uv3[0] - uv0[0], uv1[1] + uv3[1] - uv0[1])
+            got = compute_face_uv(p2, xr, yr, tuple(ftc["front"]), 1.0, 1.0)
+            assert got == pytest.approx(expect, abs=1e-9)
+
+    def test_pins_are_in_tiles_whatever_the_applied_size(self, tmp_path):
+        # Real SketchUp stores the per-face matrix in INCHES of texture
+        # space and divides by the material's applied size on read (so
+        # does compute_face_uv). A caller pins in tiles: (50,0,0) -> (1,0)
+        # must read back as u = 1 whether the material is 1 in or 10 in per
+        # tile. It used to read back as 0.1 for the 10-inch material - a
+        # 2 m water tile came out 78.74x too big.
+        from openskp._face_groups import compute_face_uv, face_uv_basis
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path), applied_width=10.0, applied_height=10.0)
+        builder.add_face(
+            SQUARE, material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((50.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 50.0, 0.0), (0.0, 1.0))],
+        )
+        data = builder.to_bytes()
+
+        ar, root, layers, materials = legacy._walk(data)
+        face = [v for (_, n, v) in root if n == "CFace"][0]
+        ftc = dict(face["attrs"]["children"])["CFaceTextureCoords"]
+        # 10 texture-inches (one tile) span 50 model inches: a 5x scale.
+        assert ftc["front"] == pytest.approx((5.0, 0.0, 0.0, 0.0, 5.0, 0.0, 0.0, 0.0, 1.0), abs=1e-9)
+        xr, yr = face_uv_basis((0.0, 0.0, 1.0))
+        assert compute_face_uv((50.0, 0.0, 0.0), xr, yr, tuple(ftc["front"]), 10.0, 10.0) == pytest.approx((1.0, 0.0))
+        assert compute_face_uv((0.0, 50.0, 0.0), xr, yr, tuple(ftc["front"]), 10.0, 10.0) == pytest.approx((0.0, 1.0))
+
     def test_tilted_face_edge_aligned_mapping_is_a_pure_scale(self, tmp_path):
         # A 100x100 square tilted 45 degrees around X (points[1]-points[0]
         # runs along world X; points[3]-points[0] runs along the tilted
@@ -3690,6 +3790,69 @@ class TestRealSketchUpOracle:
             assert err == 0
             assert uvq.u == pytest.approx(0.5)
             assert uvq.q == pytest.approx(1.0)
+            dll.SUModelRelease(ctypes.byref(model))
+        finally:
+            dll.SUTerminate()
+
+    def test_positioned_texture_survives_vertex_order_through_real_sketchup(self, tmp_path):
+        # The square listed from its second corner (first edge along +Y),
+        # pinned to u = x/100: real SketchUp must still put u = 0.5 at
+        # x = 50, i.e. read the matrix in its normal-derived basis, not in
+        # a first-edge one. The axis-aligned oracle test above cannot tell
+        # the two apart (its first edge runs along Z x n).
+        import ctypes
+
+        class SUPoint3D(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double), ("z", ctypes.c_double)]
+
+        class SUUVQ(ctypes.Structure):
+            _fields_ = [("u", ctypes.c_double), ("v", ctypes.c_double), ("q", ctypes.c_double)]
+
+        png_path = tmp_path / "tex.png"
+        png_path.write_bytes(_make_test_png())
+        builder = create()
+        tex = builder.add_texture_material("Brick", str(png_path))
+        rotated = SQUARE[1:] + SQUARE[:1]
+        builder.add_face(
+            rotated, material=tex,
+            front_uv=[((0.0, 0.0, 0.0), (0.0, 0.0)), ((100.0, 0.0, 0.0), (1.0, 0.0)), ((0.0, 100.0, 0.0), (0.0, 1.0))],
+        )
+        out = tmp_path / "rotated_order_positioned.skp"
+        builder.save(str(out))
+
+        dll = ctypes.CDLL(_SDK_DLL_PATH)
+        dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+        dll.SUModelGetEntities.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p)]
+        dll.SUEntitiesGetFaces.argtypes = [
+            ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t),
+        ]
+        dll.SUFaceGetUVHelper.argtypes = [
+            ctypes.c_void_p, ctypes.c_bool, ctypes.c_bool, ctypes.c_void_p, ctypes.POINTER(ctypes.c_void_p),
+        ]
+        dll.SUUVHelperGetFrontUVQ.argtypes = [ctypes.c_void_p, ctypes.POINTER(SUPoint3D), ctypes.POINTER(SUUVQ)]
+        dll.SUInitialize()
+        try:
+            model = ctypes.c_void_p()
+            err = dll.SUModelCreateFromFile(ctypes.byref(model), str(out).encode())
+            assert err == 0, f"SketchUp SDK rejected the file (error {err})"
+            entities = ctypes.c_void_p()
+            dll.SUModelGetEntities(model, ctypes.byref(entities))
+            faces = (ctypes.c_void_p * 1)()
+            got = ctypes.c_size_t()
+            dll.SUEntitiesGetFaces(entities, 1, faces, ctypes.byref(got))
+            assert got.value == 1
+            uv_helper = ctypes.c_void_p()
+            err = dll.SUFaceGetUVHelper(faces[0], True, False, ctypes.c_void_p(0), ctypes.byref(uv_helper))
+            assert err == 0
+            uvq = SUUVQ()
+            err = dll.SUUVHelperGetFrontUVQ(uv_helper, ctypes.byref(SUPoint3D(50.0, 0.0, 0.0)), ctypes.byref(uvq))
+            assert err == 0
+            assert uvq.u == pytest.approx(0.5)
+            assert uvq.v == pytest.approx(0.0, abs=1e-9)
+            err = dll.SUUVHelperGetFrontUVQ(uv_helper, ctypes.byref(SUPoint3D(0.0, 50.0, 0.0)), ctypes.byref(uvq))
+            assert err == 0
+            assert uvq.u == pytest.approx(0.0, abs=1e-9)
+            assert uvq.v == pytest.approx(0.5)
             dll.SUModelRelease(ctypes.byref(model))
         finally:
             dll.SUTerminate()

--- a/packages/python/tests/test_create.py
+++ b/packages/python/tests/test_create.py
@@ -4432,3 +4432,68 @@ def test_face_me_behaviour_round_trips(tmp_path):
     assert by_name["Susan"].shadows_face_sun is True
     assert by_name["Chair"].always_faces_camera is False
     assert by_name["Chair"].shadows_face_sun is False
+
+
+
+def test_persistent_ids_run_in_one_sequence_across_sections():
+    """Every section's writer used to hand out pids from 1 again, so a
+    material, a definition and a root instance could all be pid 1, and the
+    header counter (a u32 at _PID_COUNTER_POS) only ever grew by the
+    material and layer count. SketchUp loads such a file and renumbers the
+    duplicates - and then SUModelSaveToFile fails with SU_ERROR_SERIALIZATION
+    once the model is big enough or a definition happens to come first
+    ("Guardado fallido" in SketchUp Web on a real 7 MB export). One sequence
+    now, continuing from the scaffold's counter, and the counter tells the
+    truth."""
+    import struct
+    from openskp.create import _PID_COUNTER_POS
+    builder = create()
+    tex_free = builder.add_material("Rojo", (255, 0, 0, 255))
+    layer = builder.add_layer("Estructura")
+    with builder.add_component_definition("A") as a:
+        a.add_face(SQUARE, material=tex_free, layer=layer)
+        a.add_face([(x + 300.0, y, z) for x, y, z in SQUARE])
+    with builder.add_component_definition("B") as b:
+        b.add_face([(x, y, z + 50.0) for x, y, z in SQUARE])
+    builder.add_instance(a)
+    builder.add_instance(b, translation=(0.0, 0.0, 100.0))
+    data = builder.to_bytes()
+    counter = struct.unpack_from("<I", data, _PID_COUNTER_POS)[0]
+    # sections in order, each continuing where the previous stopped
+    starts = [builder._pid_start, builder._material_writer.next_pid,
+              builder._layer_writer.next_pid, builder._definition_writer.next_pid,
+              builder._geometry_writer.next_pid]
+    assert starts == sorted(starts) and starts[0] < starts[-1]
+    assert counter == builder._geometry_writer.next_pid - 1
+    assert counter > builder._pid_start + 2          # far more than materials + layers
+
+
+def test_a_small_definition_before_a_bigger_one_saves_through_real_sketchup(tmp_path):
+    """The minimal case that real SketchUp refused to SAVE (SU_ERROR_SERIALIZATION,
+    7) before pids ran in one sequence: a 1-face definition, then a 3-face
+    one, both placed. Needs the SDK DLL."""
+    import ctypes, os
+    if not os.path.exists(_SDK_DLL_PATH):
+        pytest.skip("SketchUp SDK not present on this machine")
+    builder = create()
+    with builder.add_component_definition("Primera") as d1:
+        d1.add_face(SQUARE)
+    with builder.add_component_definition("Segunda") as d2:
+        for k in range(3):
+            d2.add_face([(x + 300.0 * k, y, z + 50.0) for x, y, z in SQUARE])
+    builder.add_instance(d1)
+    builder.add_instance(d2, translation=(0.0, 0.0, 100.0))
+    src = tmp_path / "small-then-big.skp"
+    builder.save(str(src))
+    dll = ctypes.CDLL(_SDK_DLL_PATH)
+    dll.SUModelCreateFromFile.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_char_p]
+    dll.SUModelSaveToFile.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    dll.SUInitialize()
+    try:
+        model = ctypes.c_void_p()
+        assert dll.SUModelCreateFromFile(ctypes.byref(model), str(src).encode()) == 0
+        out = tmp_path / "resaved.skp"
+        assert dll.SUModelSaveToFile(model, str(out).encode()) == 0
+        dll.SUModelRelease(ctypes.byref(model))
+    finally:
+        dll.SUTerminate()


### PR DESCRIPTION
Four writer/reader fixes found while chasing "textures look wrong in SketchUp" and "SketchUp can't save the file" on real IngeTrazo exports, each measured against the SketchUp SDK (`SUMeshHelperGetFrontSTQCoords` / `SUModelSaveToFile`) before and after. The persistent-ID one (item 5 below) is the one I'd merge first: every non-trivial file this writer produces opens in SketchUp but cannot be saved there.


## What was wrong

Two defects in the Python writer's texture positioning. Neither shows in the
existing tests because every test square is axis-aligned with its first edge
along `Z × n`, and every test material is 1 inch per tile.

1. **Basis.** `_uv_matrix_for_face` solved the 3×3 in a basis built from the
   face's *first edge* (`points[1] - points[0]`, normal × that). Real SketchUp
   (and openskp's own reader, `_face_groups.face_uv_basis`, calibrated against
   SDK-authored files) express and invert the matrix in a basis derived from
   the **normal alone**: `U = normalize(Z × n)`, `W = n × U` (`(X, ±Y)` for a
   horizontal face). The two agree only when the first edge happens to run
   along `Z × n` — otherwise the texture comes out turned by the angle between
   them. A horizontal square listed from its second corner arrives in SketchUp
   rotated 90°; from its third, 180°; a curved surface of many small quads
   shatters, each quad turned by its own first edge.

2. **Scale.** SketchUp stores the matrix in *inches of texture space* and
   divides by the material's applied width/height when it reads a face's UV
   back (`compute_face_uv` already does exactly that). The caller's pins are
   in tiles and were fitted as-is, so a material applied at 2 m per tile
   (78.74 in) came out 78.74× too big on every positioned face: a pool's
   water as one flat blue slab. `openskp.edit` and `to_python_code` were
   already dodging this by forcing `applied_height=1.0`, which throws the
   material's real size away.

## How it was measured

Exported 11 control squares (horizontal with the first edge along +X, +Y, −X
and at 30°; walls facing ±X and ±Y, one of them from a vertical and from a
horizontal first edge; a 45° slope), converted the `.skp` with the SDK
(`SUMeshHelperGetFrontSTQCoords`, via a small skp2dae tool) and fitted the
SDK's UVs against the pinned ones per face:

| pins as written by 1.2.0 | scale | turn |
|---|---|---|
| first edge +X (the test case) | 0.100 | 0° |
| first edge +Y | 0.100 | 90° |
| first edge −X | 0.100 | 180° |
| first edge at 30° | 0.100 | 30° |
| +Y wall, first edge vertical | 0.100 | 90° |
| +Y wall, first edge horizontal | 0.100 | 180° |

(0.100 = 1 / the 10-inch applied size.) With this branch: scale 1.000, turn
0° on all eleven.

3. **Vertical tolerance and the downward basis** (reader and, through it, the writer).
   `face_uv_basis` snapped to the world axes only within 1e-9 of vertical and gave
   a face looking down `(X, −Y)`. Measured with the SDK on faces tilted from 1e-10
   to 1e-2, looking up and down: SketchUp keeps the world axes while the sine of
   the tilt is below 1e-3 (1.0000004e-3 still vertical, 1.0001e-3 already the
   cross product), and a downward face gets `(−X, +Y)`, the 180° turn of the
   upward basis. A horizontal face whose stored normal carries float noise, and
   every underside of a real model, read back turned.

4. **Face-me flag (writer).** Unrelated to UVs but tiny and useful: the reader
   already decodes SketchUp's behavior byte (`always_faces_camera`,
   `shadows_face_sun`); the writer left it zero. `add_component_definition`
   now takes both flags, `edit` replays them.

5. **Files could not be saved by SketchUp** (the one I'd merge first). Every section's
   `_ArchiveWriter` started pids at 1, and `to_bytes` patched the header's pid counter
   (a u32, treated as u16) by materials + layers only. SketchUp loads the file,
   renumbers the duplicate pids, and then `SUModelSaveToFile` returns
   `SU_ERROR_SERIALIZATION` (7) — "Save failed" in SketchUp Web on every export
   larger than a toy. Minimal repro: a 1-face definition then a 3-face one, both
   placed. Bisected with the SDK: patching the counter alone rescues small files
   and fails past 65 535 pids or when a definition comes first; one sequence
   across sections fixes all of it (7 MB and 27 MB real exports re-save).

## The fix

- `_uv_matrix_for_face` solves in `face_uv_basis(normal)`; `_face_uv_basis`
  (first-edge) is gone.
- `SkpBuilder` records each textured material's applied size at
  `add_texture_material` time; both `add_face`s scale `front_uv`/`back_uv`
  by it (`_scale_pins`). Pins stay in tiles for the caller, as documented.
- `openskp.edit._replay_materials` and `codegen` write the source's real
  applied size again.
- Pids: `SkpBuilder._pid_start` from the scaffold counter, each `_ArchiveWriter`
  continues from `_next_pid()`, `to_bytes` writes the last pid as a u32.
- `_face_groups.face_uv_basis`: `VERTICAL_TOLERANCE = 1e-3` and `(−X, +Y)` for a
  downward normal (the writer inherits both through `_uv_matrix_for_face`).
- Docstrings of `_solve_uv_matrix`, `add_texture_material`, `add_face`,
  `Face.uv_transform` updated; CHANGELOG entry under Unreleased.

## Tests

- `test_vertex_order_does_not_turn_the_mapping`: the same square listed from
  another corner stores the same `diag(50, 50)`.
- `test_pins_read_back_as_pinned_on_every_orientation`: on six orientations
  and vertex orders, pinned to a deliberately skewed map, the reader hands
  back exactly the pinned UV at each pin and the affine value at the fourth
  corner.
- `test_pins_are_in_tiles_whatever_the_applied_size`: applied size 10,
  `(50,0,0) → (1,0)` stores `diag(5, 5)` and reads back as `u = 1`.
- `test_persistent_ids_run_in_one_sequence_across_sections`, and the real-SketchUp
  `test_a_small_definition_before_a_bigger_one_saves_through_real_sketchup`
  (`SUModelSaveToFile` on the minimal repro).
- `test_face_uv_basis_snaps_and_turns_like_real_sketchup`: the measured tolerance
  and the downward basis.
- `TestRealSketchUpOracle::test_positioned_texture_survives_vertex_order_through_real_sketchup`:
  same rotated vertex order through `SUUVHelperGetFrontUVQ` (needs the SDK
  DLL, skipped otherwise).
- The existing ground-truth tests (`diag(50,50)`, the tilted asymmetric
  byte-exact one) still pass: their faces all have the first edge along
  `Z × n`, where both bases coincide — which is why the defect hid.

Full suite: all green locally (see the run in the message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013JHz7hRbUdcRFiDS8Z1LYv
