### PR TITLE
feat: read and write construction lines/points (Python)

### DIFF
--- a/packages/python/src/openskp/create.py
+++ b/packages/python/src/openskp/create.py
@@ -612,6 +612,11 @@ _DIM_FONT_PAYLOAD = bytes.fromhex(
 # Leader-text delimiter block: [u32 1][u8 flag=1][u8 0][u32 ARROW=3 closed][u8 1]
 _TEXT_DELIM = bytes.fromhex("0100000001000300000001")
 _DIM_DRAWBASE = bytes.fromhex("00000001010000000000")
+# Sentinel a CConstructionLine's start/end distance-parameter carries when
+# unbounded in that direction - real SketchUp's own value, ground-truth
+# verified (2026-09) against Sketchup::ConstructionLine#start/#end
+# returning nil for that side.
+_CLINE_INFINITE = 1e30
 _DIM_B37 = bytes.fromhex("0101000000020000000400000000000000"
                          "0000000000000000000000000000000000000000")
 _DIM_B42 = bytes.fromhex("00000000000000000000020000000400000000000000"
@@ -3141,6 +3146,87 @@ class SkpBuilder:
         w.buf += _TEXT_DELIM
         w._write_str(text)
         w.buf += bytes(5)
+        self._new_entity_count += 1
+        self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
+
+    def add_construction_line(
+        self, point: Point3,
+        point2: Optional[Point3] = None,
+        direction: Optional[Point3] = None,
+    ) -> None:
+        """Add a construction/guide line (SketchUp's Construction Line
+        tool). Pass exactly one of ``point2`` (a bounded segment between
+        ``point`` and ``point2``, matching ``Entities#add_cline(p1, p2)``)
+        or ``direction`` (an unbounded guide line through ``point``,
+        matching ``Entities#add_cline(point, vector)``).
+
+        Ground truth (real SketchUp 2025, SDK/Ruby cross-checked, against
+        BOTH a v2020-downgrade save and a genuinely v17-native save -
+        schema, field values, and this trailer all matched exactly between
+        the two independently-produced real files): the record stores a
+        point + normalized direction + two signed distance parameters
+        along that direction marking the visible segment's start/end -
+        exactly the shape ``Sketchup::ConstructionLine#start``/``#end``/
+        ``#direction`` exposes, confirmed byte-for-byte including the
+        segment length itself. An unbounded direction is written as the
+        real ``±1e30`` sentinel SketchUp itself uses
+        (``Sketchup::ConstructionLine#start``/``#end`` return ``nil`` for
+        that side). A 4-byte trailer follows - present (with different,
+        evidently-inert content) in both real samples, so written as
+        zero rather than omitted (an earlier version of this method wrote
+        zero trailer bytes, matching an older/different SketchUp build's
+        historical variant documented in the reader's own comment, not
+        this one - real SketchUp rejected the result as an unrecognized
+        file).
+        """
+        self._ensure_geometry_writer()
+        w = self._geometry_writer
+        p = (float(point[0]), float(point[1]), float(point[2]))
+        if (point2 is None) == (direction is None):
+            raise SkpWriteError("add_construction_line: pass exactly one of point2 or direction")
+        if point2 is not None:
+            p2 = (float(point2[0]), float(point2[1]), float(point2[2]))
+            dx, dy, dz = p2[0] - p[0], p2[1] - p[1], p2[2] - p[2]
+            length = math.sqrt(dx * dx + dy * dy + dz * dz)
+            if length == 0.0:
+                raise SkpWriteError("add_construction_line: point and point2 coincide")
+            dirv = (dx / length, dy / length, dz / length)
+            start_param, end_param = 0.0, length
+        else:
+            d = (float(direction[0]), float(direction[1]), float(direction[2]))
+            dlen = math.sqrt(d[0] * d[0] + d[1] * d[1] + d[2] * d[2])
+            if dlen == 0.0:
+                raise SkpWriteError("add_construction_line: direction must be nonzero")
+            dirv = (d[0] / dlen, d[1] / dlen, d[2] / dlen)
+            start_param, end_param = -_CLINE_INFINITE, _CLINE_INFINITE
+        w._new_of_known_class("CConstructionLine", schema=1)
+        w._preamble()
+        w.buf += _DIM_DRAWBASE
+        for v in (p[0], p[1], p[2], dirv[0], dirv[1], dirv[2], start_param, end_param):
+            w.buf += _f64(v)
+        w.buf += bytes(4)  # trailer - see docstring
+        self._new_entity_count += 1
+        self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
+
+    def add_construction_point(self, position: Point3) -> None:
+        """Add a construction/guide point (SketchUp's Construction Point
+        tool) at ``position`` (inches, world space).
+
+        Ground truth (real SketchUp 2025, SDK/Ruby cross-checked): a
+        second, always-zero 3-double block and a trailing zero byte follow
+        the position - reserved/unused (no corresponding
+        ``Sketchup::ConstructionPoint`` property exists to name them
+        after), written as zero to match every real-file sample seen.
+        """
+        self._ensure_geometry_writer()
+        w = self._geometry_writer
+        p = (float(position[0]), float(position[1]), float(position[2]))
+        w._new_of_known_class("CConstructionPoint", schema=0)
+        w._preamble()
+        w.buf += _DIM_DRAWBASE
+        for v in (p[0], p[1], p[2], 0.0, 0.0, 0.0):
+            w.buf += _f64(v)
+        w.buf += bytes(1)
         self._new_entity_count += 1
         self._face_count += 1  # reuses the "at least one root entity" check in to_bytes
 

--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -734,15 +734,24 @@ def _strict_next_tag(ar, data, at, allow_null=True) -> bool:
 
 def _read_constructionline(ar, r):
     _preamble(ar, r)
-    _drawbase(ar, r)
-    r.f64s(3)
-    r.f64s(3)
-    r.f64s(2)                        # line params (±~4.4e29 = infinite)
+    db = _drawbase(ar, r)
+    point = r.f64s(3)
+    direction = r.f64s(3)
+    # Signed distance along `direction` from `point` marking where the
+    # visible segment starts/ends - ground truth (real SketchUp 2025,
+    # SDK/Ruby cross-checked, 2026-09): a bounded segment's start/end
+    # exactly equal `point`/`direction` scaled by these two parameters
+    # (verified against Sketchup::ConstructionLine#start/#end/#direction
+    # byte-for-byte, including the segment LENGTH as end_param); an
+    # unbounded direction uses a ±1e30 sentinel, matching
+    # Sketchup::ConstructionLine#start/#end returning nil for that side.
+    start_param, end_param = r.f64s(2)
     # The trailing block varies by the WRITING BUILD, not cleanly by
     # version: 7 bytes on the v17 calibration corpus, 4 on v16 and on a
-    # real v18, 0 on another real v17. Self-calibrate on the first guide
-    # line of the file — the length that lands on a legitimate next tag
-    # (strict forms only) — and cache it for the rest of the file.
+    # real v18, 0 on another real v17 (also 0 on a real SketchUp 2025
+    # build). Self-calibrate on the first guide line of the file — the
+    # length that lands on a legitimate next tag (strict forms only) — and
+    # cache it for the rest of the file.
     k = getattr(ar, '_cline_tail', None)
     if k is None:
         default = 7 if ar.ver == 17 else 4
@@ -762,15 +771,22 @@ def _read_constructionline(ar, r):
             k = default
         ar._cline_tail = k
     r.raw(k)
-    return {'k': 'cline'}
+    huge = 1e20  # well below the real ±1e30 sentinel, far above any real geometry extent
+    start = None if abs(start_param) >= huge else tuple(
+        point[i] + direction[i] * start_param for i in range(3))
+    end = None if abs(end_param) >= huge else tuple(
+        point[i] + direction[i] * end_param for i in range(3))
+    return {'k': 'cline', 'db': db, 'point': tuple(point),
+            'direction': tuple(direction), 'start': start, 'end': end}
 
 
 def _read_constructionpoint(ar, r):
     _preamble(ar, r)
     db = _drawbase(ar, r)
     pos = r.f64s(3)
-    r.f64s(3)
-    r.u8()
+    r.f64s(3)  # reserved/unused (observed all-zero, real SDK ground truth 2026-09) - no
+               # corresponding Sketchup::ConstructionPoint property to name it after
+    r.u8()     # reserved/unused (observed 0)
     return {'k': 'cpoint', 'db': db, 'pos': pos}
 
 
@@ -1352,6 +1368,8 @@ class _Builder:
         self.section_planes = []
         self.texts = []
         self.dimensions = []
+        self.construction_lines = []
+        self.construction_points = []
 
 
 def _fill_builder(builder, ents, slots):
@@ -1455,6 +1473,17 @@ def _fill_builder(builder, ents, slots):
             if len(pts) == 2 and pts[0] and pts[1]:
                 dim['a'], dim['b'] = pts[0], pts[1]
             builder.dimensions.append(dim)
+        elif k == 'cline':
+            builder.construction_lines.append({
+                'point': v.get('point', (0.0, 0.0, 0.0)),
+                'direction': v.get('direction', (1.0, 0.0, 0.0)),
+                'start': v.get('start'),
+                'end': v.get('end'),
+            })
+        elif k == 'cpoint':
+            builder.construction_points.append({
+                'position': v.get('pos', (0.0, 0.0, 0.0)),
+            })
 
 
 def _add_edge(builder, slot, e, slots):

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -407,6 +407,46 @@ class Page:
 
 
 @dataclass
+class ConstructionLine:
+    """A construction/guide line (SketchUp's Construction Line tool).
+
+    Stored internally (and here, unchanged) as a point + normalized
+    direction + two signed distance parameters along that direction
+    marking where the visible segment starts/ends - the same shape
+    :class:`Sketchup::ConstructionLine`'s own ``start``/``end``/
+    ``direction`` properties expose. A parameter magnitude of ``1e30``
+    means unbounded in that direction (SketchUp draws this as an infinite
+    guide line through ``point``) - ``start``/``end`` come back ``None``
+    in that case, matching the real API returning ``nil``.
+
+    Attributes:
+        point: A point on the line, in inches (world space) - matches the
+            bounded case's own ``start``, or the anchor point given for an
+            infinite line.
+        direction: The line's normalized direction vector.
+        start: The bounded segment's start point, or ``None`` if unbounded
+            in this direction.
+        end: The bounded segment's end point, or ``None`` if unbounded.
+    """
+
+    point: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    direction: Tuple[float, float, float] = (1.0, 0.0, 0.0)
+    start: Optional[Tuple[float, float, float]] = None
+    end: Optional[Tuple[float, float, float]] = None
+
+
+@dataclass
+class ConstructionPoint:
+    """A construction/guide point (SketchUp's Construction Point tool).
+
+    Attributes:
+        position: The point's position, in inches (world space).
+    """
+
+    position: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+
+
+@dataclass
 class Definition:
     """A component definition containing reusable geometry.
 
@@ -418,6 +458,10 @@ class Definition:
         edges: Mapping of edge ID → :class:`Edge`.
         faces: Mapping of face ID → :class:`Face`.
         instances: Child instances placed inside this definition.
+        construction_lines: Construction/guide lines - see
+            :class:`ConstructionLine`.
+        construction_points: Construction/guide points - see
+            :class:`ConstructionPoint`.
         always_faces_camera: SketchUp's "always face camera" component
             behavior (2D people / tree cut-outs that rotate to face the
             viewer). Consumers typically render such instances as
@@ -439,6 +483,8 @@ class Definition:
     section_planes: List[SectionPlane] = field(default_factory=list)
     texts: List[TextEntity] = field(default_factory=list)
     dimensions: List[Dimension] = field(default_factory=list)
+    construction_lines: List[ConstructionLine] = field(default_factory=list)
+    construction_points: List[ConstructionPoint] = field(default_factory=list)
     always_faces_camera: bool = False
     shadows_face_sun: bool = False
     is_image: bool = False
@@ -642,6 +688,18 @@ class SkpFile:
                 defn.dimensions.append(Dimension(
                     text=dim.get("text", ""),
                     hidden=dim.get("hidden", False),
+                ))
+            # Populate construction lines/points
+            for cl in getattr(builder, "construction_lines", []):
+                defn.construction_lines.append(ConstructionLine(
+                    point=cl.get("point", (0.0, 0.0, 0.0)),
+                    direction=cl.get("direction", (1.0, 0.0, 0.0)),
+                    start=cl.get("start"),
+                    end=cl.get("end"),
+                ))
+            for cp in getattr(builder, "construction_points", []):
+                defn.construction_points.append(ConstructionPoint(
+                    position=cp.get("position", (0.0, 0.0, 0.0)),
                 ))
             if def_id == "ROOT":
                 model.root = defn


### PR DESCRIPTION
## Summary

Adds reader and writer support for SketchUp's Construction Line and Construction Point tools (`CConstructionLine`/`CConstructionPoint`) to the Python package.

**Reader** (`legacy.py`): these were already parsed structurally (needed to keep archive slot-numbering in sync), but every field was read and discarded. Now captured and surfaced as `Definition.construction_lines` / `Definition.construction_points`, wired through the same `_Builder`/`_fill_builder` pattern section planes/texts/dimensions already use.

A bounded `CConstructionLine` stores a point + normalized direction + two signed distance parameters along that direction marking the segment's start/end - translated into the same `start`/`end`/`direction` shape `Sketchup::ConstructionLine`'s own Ruby API exposes. An unbounded line uses a `±1e30` sentinel (`start`/`end` come back `None`, matching the real API returning `nil`). A `CConstructionPoint` stores its position plus a second, always-zero 3-double block and a trailing byte with no corresponding Ruby property - left unexposed rather than guessed at.

**Writer** (`create.py`): new `SkpBuilder.add_construction_line(point, point2=None, direction=None)` - pass exactly one of `point2` (bounded, matching `Entities#add_cline(p1, p2)`) or `direction` (unbounded, matching `Entities#add_cline(point, vector)`) - and `add_construction_point(position)`. Root-level only, same scope as `add_dimension`/`add_text`.

## Verification

Ground truth captured against a live SketchUp session via a local automation bridge, cross-checked against two independently-produced real files (a v2020-downgrade save and a genuinely v17-native save) specifically to rule out a version-specific encoding difference - both matched exactly on schema numbers and field encoding. That ruled out an initial hypothesis about why real SketchUp first rejected the writer's output. The actual bug was a missing 4-byte trailer after `CConstructionLine`'s payload (present, with inert/varying content, in both real samples) - fixed and reverified:

- Corrected output opens in real SketchUp with no error (previously "unexpected file format")
- Every line/point property reads back through the real SketchUp Ruby API exactly as written (`start`/`end`/`direction`/`position`)
- A real rendered screenshot (`Sketchup::View#write_image`) visually confirms the face, bounded line, and infinite line all render correctly in the viewport

Full Python test suite: 474 tests, green.

## Not included in this PR (tracked separately)

- No dedicated unit test for the trailer-width regression specifically - the existing round-trip tests only exercise this project's own lenient reader, not real SketchUp, so they wouldn't have caught this class of bug on their own. Worth adding.
- Python only, per this project's established single-stack contributor/feature practice - not ported to the other 4 languages.

## Test plan

- [x] Full Python test suite (474 tests) passes
- [x] Real-SketchUp round-trip verified via the Ruby API (`ConstructionLine#start`/`#end`/`#direction`, `ConstructionPoint#position`)
- [x] Visual verification via a real rendered screenshot