### PR TITLE
feat: read pages/scenes (legacy, narrow scope) (Python)

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -817,6 +817,120 @@ def _read_skfont(ar, r):
     return {'k': 'font'}
 
 
+# ── pages (scenes) ──────────────────────────────────────────────────────
+#
+# CViewPage's full record embeds a camera, an optional thumbnail image, a
+# font, and — whenever any of its several independent "use_*" capture
+# flags beyond hidden-layers is set — an entire Style sub-object with no
+# documented fixed size. Reverse engineering that is out of scope, matching
+# this project's existing CCamera precedent, so only the narrow case is
+# supported: a page whose captured flags are exactly the baseline (nothing
+# captured) or baseline + hidden-layers. Ground truth for both was captured
+# from real v17-native SketchUp saves; ``_PAGE_ALLOWED_FLAGS`` and the
+# 0x20 hidden-layers bit are empirical, not documented by SketchUp.
+_PAGE_ALLOWED_FLAGS = (0xc00, 0xc20)
+_PAGE_HIDDEN_LAYERS_BIT = 0x20
+
+
+def _skip_typed_ref(ar, r, cls_name, reader_fn):
+    """Consume one reference to an object of *cls_name* — a null tag, a
+    back-ref (value unneeded here, so left unresolved), a class-ref to an
+    already-declared class, or (rarely, if this is the class's first use
+    in the file) a fresh declaration — without relying on the referenced
+    object's slot already being known to *ar* the way ``ar.read_object``
+    requires. The page scan below runs over a region of the file the main
+    walk never visits, so back-refs into that region can't be resolved."""
+    tag = r.peek_u16()
+    if tag == 0:
+        r.u16()
+        return
+    if tag == 0xFFFF:
+        r.u16()
+        schema = r.u16()
+        namelen = r.u16()
+        if namelen > 40:
+            raise LegacyParseError("implausible class name length")
+        name = r.raw(namelen).decode('ascii')
+        if name != cls_name:
+            raise LegacyParseError(f"expected {cls_name} decl, got {name}")
+        if cls_name not in ar.class_slot:
+            ar.class_slot[cls_name] = ar.alloc(('class', cls_name, schema))
+        reader_fn(ar, r)
+        return
+    if tag & 0x8000:
+        cslot = tag & 0x7FFF
+        ent = ar.slots.get(cslot)
+        if not (ent and ent[0] == 'class' and ent[1] == cls_name):
+            raise LegacyParseError(f"unexpected {cls_name} class-ref")
+        r.u16()
+        reader_fn(ar, r)
+        return
+    r.u16()   # plain back-ref — the referenced value isn't needed here
+
+
+def _scan_pages(data: bytes, ar) -> list:
+    """Best-effort scan for CViewPage (scene) records: name + hidden-layer
+    slot ids only, for the narrow flag combinations this reader
+    understands (see ``_PAGE_ALLOWED_FLAGS`` above).
+
+    This runs as an independent scan over the file tail (from where the
+    main entity walk stops) rather than as a sequential archive read:
+    each candidate is validated by its own local structure (a name string
+    immediately followed by an empty second string and a recognized flags
+    word) and any candidate that doesn't fully validate — an unsupported
+    flag combination, or a reference into a part of the file this scan
+    never visited — is silently skipped rather than guessed at, so a page
+    this reader can't fully understand is just absent from the result
+    instead of producing wrong data.
+    """
+    pages = []
+    pos = ar.r.pos
+    n = len(data)
+    while True:
+        idx = data.find(_STR_MARKER, pos)
+        if idx == -1:
+            break
+        pos = idx + 1
+        nlen_pos = idx + 3
+        if nlen_pos >= n:
+            break
+        nlen = data[nlen_pos]
+        if nlen == 0 or nlen > 40:
+            continue
+        name_start = nlen_pos + 1
+        name_end = name_start + 2 * nlen
+        if name_end + 7 > n:
+            continue
+        if data[name_end:name_end + 3] != _STR_MARKER or data[name_end + 3] != 0:
+            continue                                  # second name must be empty
+        flags_pos = name_end + 4
+        flags = struct.unpack_from('<I', data, flags_pos)[0]
+        if flags not in _PAGE_ALLOWED_FLAGS:
+            continue
+        name = data[name_start:name_end].decode('utf-16-le', errors='replace')
+        try:
+            r = _R(data, flags_pos + 4)
+            _skip_typed_ref(ar, r, 'CCamera', _read_camera)
+            _skip_typed_ref(ar, r, 'CDib', _read_dib)
+            hidden_ids = []
+            if flags & _PAGE_HIDDEN_LAYERS_BIT:
+                while True:
+                    save = r.pos
+                    v = r.u16()
+                    ent = ar.slots.get(v)
+                    if ent and ent[0] == 'obj' and ent[1] == 'CLayer':
+                        hidden_ids.append(v)
+                    else:
+                        r.pos = save
+                        break
+                if r.u32() != 1:
+                    raise LegacyParseError("unexpected hidden-layers marker")
+        except (LegacyParseError, struct.error, IndexError):
+            continue
+        pages.append({'name': name, 'hidden_layer_ids': hidden_ids})
+    return pages
+
+
 def _entity_ref(ar, r):
     """A reference-to-entity tag: dimension connection points and text
     leader attachments. Unlike ``read_object``'s back-ref path, this
@@ -1613,6 +1727,11 @@ def full_parse_legacy(skp_path: str) -> Dict[str, Any]:
     defs_dict['ROOT'] = {'guid': 'ROOT', 'name': 'ROOT_MODEL',
                          'builder': root_builder}
 
+    try:
+        pages = _scan_pages(data, ar)
+    except (LegacyParseError, struct.error, IndexError):
+        pages = []
+
     logger.info(
         "Parse complete: %s (%d defs, %.2fs)",
         skp_path, len(defs_dict), time.monotonic() - t0,
@@ -1630,6 +1749,7 @@ def full_parse_legacy(skp_path: str) -> Dict[str, Any]:
         'materials_by_folder': {},
         'defs_dict': defs_dict,
         'elements': [],
+        'pages': pages,
         'thumbnail_data': None,
         'styles': [],
         # Legacy (pre-2021 MFC) files carry no meta/meta.dat container -

--- a/packages/python/tests/test_pages_dimensions.py
+++ b/packages/python/tests/test_pages_dimensions.py
@@ -11,7 +11,7 @@ import math
 import struct
 from pathlib import Path
 
-from openskp import _core
+from openskp import _core, legacy
 from openskp.model import SkpFile
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -132,3 +132,42 @@ def test_pages_absent_is_empty():
     assert _core._parse_pages(None) == []
     model = SkpFile.open(str(FIXTURES / "SU_File.skp")).parse()
     assert model.pages == []
+
+
+# ── legacy pages (scenes) ───────────────────────────────────────────────
+#
+# CViewPage's full record also embeds a camera, an optional thumbnail, a
+# font, and — for any flag combination beyond hidden-layers — an entire
+# Style sub-object of undocumented size, so the legacy scanner only
+# supports the narrow flag set it fully understands (see
+# ``legacy._PAGE_ALLOWED_FLAGS``); everything else is silently skipped.
+# Ground truth (the flags bitmask, the hidden-layers list shape) was
+# captured from real v17-native SketchUp saves via the live SAIE bridge.
+
+def _legacy_page_record(name: str, flags: int, hidden_ids=()) -> bytes:
+    marker = legacy._STR_MARKER
+    out = marker + bytes([len(name)]) + name.encode('utf-16-le')
+    out += marker + bytes([0])              # second name: always empty
+    out += struct.pack('<I', flags)
+    out += bytes(2)                         # camera: null ref
+    out += bytes(2)                         # thumbnail dib: null ref
+    if flags & legacy._PAGE_HIDDEN_LAYERS_BIT:
+        for hid in hidden_ids:
+            out += struct.pack('<H', hid)
+        out += struct.pack('<I', 1)         # marker; also stops the u16 list
+    return out
+
+
+def test_scan_pages_legacy_synthetic():
+    data = (_legacy_page_record("Baseline", 0xc00)
+            + _legacy_page_record("WithHidden", 0xc20, hidden_ids=(5, 6))
+            + _legacy_page_record("TooFull", 0xfff, hidden_ids=(5,)))
+    ar = legacy._Archive(data, 17)
+    ar.slots[5] = ('obj', 'CLayer', {'name': 'Layer0'})
+    ar.slots[6] = ('obj', 'CLayer', {'name': 'Roof'})
+
+    pages = legacy._scan_pages(data, ar)
+
+    assert [p['name'] for p in pages] == ["Baseline", "WithHidden"]
+    assert pages[0]['hidden_layer_ids'] == []
+    assert pages[1]['hidden_layer_ids'] == [5, 6]


### PR DESCRIPTION
## Summary
- `SkpModel.pages` was only ever populated for the VFF (2021+) reader path — legacy (pre-2021 MFC) files had no page/scene reading code at all. Adds `legacy._scan_pages`, surfacing `Page.name` and `Page.hidden_layers` for legacy files too.
- `CViewPage`'s full record also embeds a camera, an optional thumbnail, a font, and — for any of several independently-optional capture flags beyond hidden-layers — an entire Style sub-object of undocumented size. Scoped down deliberately: only the flag combination capturing nothing, or only hidden-layers, is supported (`_PAGE_ALLOWED_FLAGS = (0xc00, 0xc20)`, both empirical); anything else is silently skipped rather than guessed at, so an unsupported page is simply absent from `model.pages` instead of producing wrong data.
- Implemented as an independent scan over the file tail rather than part of the sequential archive walk, specifically to avoid needing to fully bound each page's opaque tail (the Style sub-object has no documented fixed size).
- Ground truth (the flags bitmask, the hidden-layers list shape) captured from real v17-native SketchUp saves via the live SAIE bridge.

## Test plan
- [x] New `test_scan_pages_legacy_synthetic` unit test
- [x] Full suite passes (475 passed)
- [x] Cross-checked against ~10 real SAIE-produced `.skp` files: multiple/zero hidden layers resolve correctly by name, and a full-capture page (`use_style`/`use_camera`/etc. on) is correctly rejected rather than misparsed
- [x] Zero false positives on existing non-page legacy fixtures