### PR TITLE
fix: correct IFC export units and axis convention (Python)

### DIFF
--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -3,8 +3,10 @@
 Serializes a baked :class:`~openskp.scene.Scene` into ISO-10303-21 STEP ASCII format
 conforming to the IFC4 schema (FILE_SCHEMA(('IFC4'))).
 
-Uses native ``IfcTriangulatedFaceSet`` geometry representation for direct 1:1
-mapping of triangulated vertex positions and face indices from baked scene primitives.
+Uses native ``IfcTriangulatedFaceSet`` geometry representation, reusing the
+baked scene's triangulated face indices as-is and its vertex positions after
+converting them back from glTF's Y-up convention to IFC's (SketchUp's own)
+Z-up convention.
 """
 
 from __future__ import annotations
@@ -16,8 +18,14 @@ from typing import Callable, Dict, List, Optional, Tuple, Union
 
 from ..scene import Scene
 
-# 1 metre = 39.37007874015748 inches (SketchUp native unit)
+# 1 metre = 39.37007874015748 inches (SketchUp native unit) - kept for
+# callers that want inch-scaled coordinates explicitly, but NOT the
+# default scale below: the file always declares its length unit as
+# millimetres (see IFCSIUNIT below), so the default scale has to produce
+# millimetre-scaled values or every coordinate reads back ~25.4x too
+# small in any IFC consumer that respects the unit declaration.
 METRES_TO_INCHES = 39.37007874015748
+METRES_TO_MM = 1000.0
 
 _IFC_BASE64 = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_$"
 
@@ -105,7 +113,7 @@ def _get_prim_rgb(scene: Scene, prim_mat_idx: int) -> Tuple[float, float, float,
 
 def to_ifc(
     scene: Scene,
-    scale: float = METRES_TO_INCHES,
+    scale: float = METRES_TO_MM,
     schema: str = "IFC4",
     classifier: Optional[Callable[[str, str], Tuple[str, str]]] = None,
 ) -> str:
@@ -114,7 +122,7 @@ def to_ifc(
     Args:
 
         scene: The baked scene returned by :meth:`SkpFile.build_scene`.
-        scale: Coordinate scale factor (default: METRES_TO_INCHES).
+        scale: Coordinate scale factor (default: METRES_TO_MM - matches the millimetre length unit this exporter always declares).
         schema: IFC schema version (default: "IFC4").
         classifier: Optional override for :func:`classify_element`, called
             as ``classifier(geom_name, layer_name)`` and expected to return
@@ -273,11 +281,18 @@ def to_ifc(
         step_type, ifc_class = classify(geom_name, layer_name)
 
         # 1. Coordinate Point List 3D
+        #
+        # scene.glb_primitives positions are baked in glTF's Y-up
+        # convention (see Scene/scene.py: glTF.y = SketchUp Z (height),
+        # glTF.z = -SketchUp Y (depth)) - correct for GLB export, but IFC
+        # (like SketchUp itself) is Z-up, so it has to be converted back
+        # rather than passed through raw, or the exported building comes
+        # out rotated ~90 degrees and mirrored.
         pt_coords: List[str] = []
         for i in range(v_count):
             vx = round(prim.positions[i * 3] * scale, 6)
-            vy = round(prim.positions[i * 3 + 1] * scale, 6)
-            vz = round(prim.positions[i * 3 + 2] * scale, 6)
+            vy = round(-prim.positions[i * 3 + 2] * scale, 6)
+            vz = round(prim.positions[i * 3 + 1] * scale, 6)
             pt_coords.append(f"({vx},{vy},{vz})")
 
         pt_list_id = next_id()
@@ -413,7 +428,7 @@ def to_ifc(
 def export(
     scene: Scene,
     output_path: Union[str, pathlib.Path],
-    scale: float = METRES_TO_INCHES,
+    scale: float = METRES_TO_MM,
     schema: str = "IFC4",
     classifier: Optional[Callable[[str, str], Tuple[str, str]]] = None,
 ) -> None:
@@ -422,7 +437,7 @@ def export(
     Args:
         scene: The baked scene returned by :meth:`SkpFile.build_scene`.
         output_path: Destination path (.ifc).
-        scale: Coordinate scale factor (default: METRES_TO_INCHES).
+        scale: Coordinate scale factor (default: METRES_TO_MM - matches the millimetre length unit this exporter always declares).
         schema: IFC schema version (default: "IFC4").
         classifier: Optional override for :func:`classify_element` - see
             :func:`to_ifc` for the calling convention.

--- a/packages/python/tests/test_ifc.py
+++ b/packages/python/tests/test_ifc.py
@@ -129,6 +129,64 @@ class TestIfcExporter:
         assert "IFCRELCONTAINEDINSPATIALSTRUCTURE" in ifc_text
         assert "ENDSEC;" in ifc_text
 
+    def test_to_ifc_declares_millimetres_and_scales_to_match(self):
+        """The exporter always declares millimetres - the default scale has
+        to actually produce millimetre-scaled values, or every coordinate
+        reads back ~25.4x too small in any IFC consumer that respects the
+        unit declaration (this exact bug, caught 2026-09-07 comparing
+        against a real SketchUp IFC export of the same file)."""
+        prim = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="Test Triangle",
+        )
+        scene = Scene(
+            scene_hierarchy=InstanceNode(name="Root"),
+            mesh_index={"Test Triangle": MeshMetadata(name="Test Triangle", properties={})},
+            glb_primitives=[prim],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene)
+
+        assert "IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.)" in ifc_text
+        # vertex 2 is glTF (1.0, 0.0, 0.0) = 1 metre along X, which maps
+        # straight through to IFC X - millimetres means it must come out
+        # as 1000.0, not ~39.37 (metres-to-inches, the old default).
+        assert "(1000.0,-0.0,0.0)" in ifc_text
+
+    def test_to_ifc_converts_gltf_y_up_to_ifc_z_up(self):
+        """scene.glb_primitives positions are baked in glTF's Y-up
+        convention (glTF.y = SketchUp Z/height, glTF.z = -SketchUp
+        Y/depth) for GLB export - IFC (like SketchUp itself) is Z-up, so
+        to_ifc must convert back rather than pass positions through raw,
+        or the exported building comes out rotated ~90 degrees and
+        mirrored (this exact bug, caught 2026-09-07 comparing against a
+        real SketchUp IFC export of the same file)."""
+        prim = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 2.0, 3.0, 5.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="Test Triangle",
+        )
+        scene = Scene(
+            scene_hierarchy=InstanceNode(name="Root"),
+            mesh_index={"Test Triangle": MeshMetadata(name="Test Triangle", properties={})},
+            glb_primitives=[prim],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene, scale=1.0)
+
+        # glTF (2.0, 3.0, 5.0) is SketchUp (x=2.0, y=-5.0, z=3.0) - IFC/
+        # SketchUp Z-up means that vertex must appear as (2.0,-5.0,3.0),
+        # not the raw glTF-order (2.0,3.0,5.0).
+        assert "(2.0,-5.0,3.0)" in ifc_text
+        assert "(2.0,3.0,5.0)" not in ifc_text
+
     def test_export_file(self):
         scene = create_mock_scene()
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- `to_ifc()` always declares the length unit as millimetres (`IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.)`), but defaulted its coordinate `scale` to `METRES_TO_INCHES` (39.37) - every coordinate was written as an inch-scaled value labeled as millimetres, off by ~25.4x in any IFC consumer that respects the unit declaration. Default scale is now `METRES_TO_MM` (1000.0), matching the declared unit.
- `Scene.glb_primitives` positions are baked in glTF's Y-up convention (`scene.py`: glTF.y = SketchUp Z/height, glTF.z = -SketchUp Y/depth) for GLB export, but `to_ifc()` reused those same values directly as IFC's (x, y, z). IFC (like SketchUp itself) is Z-up, so the exported building came out rotated ~90° and mirrored. Now converts back to Z-up.

Root-caused by converting a real 359MB production file (`Sunner Arch + Framing.skp`) and comparing against the same file's native SketchUp IFC export - this is what FrameSmart's downstream pipeline was hitting.

## Test plan
- [x] Two new regression tests: unit/scale (`test_to_ifc_declares_millimetres_and_scales_to_match`) and axis conversion (`test_to_ifc_converts_gltf_y_up_to_ifc_z_up`)
- [x] Full suite passes (477 passed)
- [x] Isolated controlled verification: a known 100"x120" wall now produces exactly 2540mm x 3048mm with height on Z; a triangle varying independently on X/Y/Z round-trips to the correct axis and scale on each
- [x] Re-ran the full 359MB production file end-to-end (parse -> build_scene -> to_ifc) with the fix applied; well-formed IFC4 STEP output, correct entity counts