### PR TITLE
fix: preserve real instance names and layer visibility in IFC export (Python)

### DIFF
--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -272,13 +272,20 @@ def to_ifc(
         if tri_count == 0 or v_count == 0:
             continue
 
-        geom_name = sanitize_name(prim.geom_name)
-        layer_name = "Layer0"
         meta = scene.mesh_index.get(prim.geom_name)
+        # prim.geom_name is an internal lookup key (mesh index + hierarchy
+        # path + layer, e.g. "mesh_3115_ROOT__Component_6205261_Layer0") -
+        # never the element's real name. meta.name is the actual SketchUp
+        # instance name (or SketchUp's own "Component_<id>" default when
+        # nobody renamed it) - use that for both classification and the
+        # element's IFC Name, falling back to the internal key only if a
+        # primitive somehow has no mesh_index entry.
+        display_name = sanitize_name(meta.name) if meta and meta.name else sanitize_name(prim.geom_name)
+        layer_name = "Layer0"
         if meta and getattr(meta, "layer", None):
             layer_name = sanitize_name(meta.layer)
 
-        step_type, ifc_class = classify(geom_name, layer_name)
+        step_type, ifc_class = classify(display_name, layer_name)
 
         # 1. Coordinate Point List 3D
         #
@@ -328,7 +335,7 @@ def to_ifc(
 
             style_id = next_id()
             lines.append(
-                f"#{style_id}=IFCSURFACESTYLE('{geom_name}_Material',.BOTH.,(#{rendering_id}));"
+                f"#{style_id}=IFCSURFACESTYLE('{display_name}_Material',.BOTH.,(#{rendering_id}));"
             )
 
             style_assign_id = next_id()
@@ -364,11 +371,11 @@ def to_ifc(
         product_id = next_id()
         if step_type == "IFCBUILDINGELEMENTPROXY":
             lines.append(
-                f"#{product_id}={step_type}('{prod_guid}',#{owner_hist_id},'{geom_name}',$,$,#{prod_placement_id},#{prod_shape_id},$,.NOTDEFINED.);"
+                f"#{product_id}={step_type}('{prod_guid}',#{owner_hist_id},'{display_name}',$,$,#{prod_placement_id},#{prod_shape_id},$,.NOTDEFINED.);"
             )
         else:
             lines.append(
-                f"#{product_id}={step_type}('{prod_guid}',#{owner_hist_id},'{geom_name}',$,$,#{prod_placement_id},#{prod_shape_id},$,$);"
+                f"#{product_id}={step_type}('{prod_guid}',#{owner_hist_id},'{display_name}',$,$,#{prod_placement_id},#{prod_shape_id},$,$);"
             )
 
         product_ids.append(product_id)
@@ -404,13 +411,21 @@ def to_ifc(
                     f"#{rel_prop_id}=IFCRELDEFINESBYPROPERTIES('{rel_prop_guid}',#{owner_hist_id},$,$,(#{product_id}),#{pset_id});"
                 )
 
-    # 6. Presentation Layer Assignments (Preserve Layers)
+    # 6. Presentation Layer Assignments (preserve layers and their on/off
+    # state). IfcPresentationLayerWithStyle - not the plain
+    # IfcPresentationLayerAssignment neither SketchUp's own IFC exporter
+    # nor the IFC-manager SketchUp extension use - is the only IFC4 entity
+    # that can carry a layer's visibility at all (LayerOn); every other
+    # attribute here besides Name and LayerOn is left unset/false since
+    # this project doesn't track them (freeze/block/layer-level styles).
     for l_name, item_ids in sorted(layer_items.items()):
         if item_ids:
             item_refs = ",".join(f"#{iid}" for iid in item_ids)
+            layer_on = ".F." if scene.layer_hidden.get(l_name) else ".T."
             layer_assign_id = next_id()
             lines.append(
-                f"#{layer_assign_id}=IFCPRESENTATIONLAYERASSIGNMENT('{l_name}',$,({item_refs}),$);"
+                f"#{layer_assign_id}=IFCPRESENTATIONLAYERWITHSTYLE("
+                f"'{l_name}',$,({item_refs}),$,{layer_on},.F.,.F.,());"
             )
 
     # 7. Containment Relation in Spatial Hierarchy

--- a/packages/python/src/openskp/instanced_scene.py
+++ b/packages/python/src/openskp/instanced_scene.py
@@ -421,6 +421,7 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
                         inst.get("name"), ref_idx, exc_info=True,
                     )
 
+            inst_name = inst["name"] or f"Component_{ref_idx}"
             instance_counter[0] += 1
             if instance_counter[0] % _PROGRESS_INTERVAL == 0:
                 logger.debug("Processed %d placed instances", instance_counter[0])
@@ -440,7 +441,7 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
 
             nodes.append(
                 InstancedNode(
-                    name=inst["name"] or "",
+                    name=inst_name,
                     definition_name=(defs_dict.get(ref_idx) or {}).get("name") or "",
                     layer=l_name,
                     matrix=_to_gltf_matrix(inst["matrix"]),

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -135,6 +135,13 @@ class Scene:
     # textures=True)) - most callers just want geometry, and photographic
     # textures can multiply file size.
     textures: List[SceneTexture] = field(default_factory=list)
+    # Each layer's own visibility checkbox in SketchUp (the parsed file's
+    # own "layer_hidden", keyed by layer name) - independent of whether any
+    # placed geometry on that layer ended up in glb_primitives. Consumers
+    # that expose a layer list (e.g. the IFC exporter's IfcPresentationLayerWithStyle.LayerOn)
+    # use this to match SketchUp's own on/off state instead of always
+    # defaulting every layer to visible.
+    layer_hidden: Dict[str, bool] = field(default_factory=dict)
 
 
 def _sniff_image_mime(data: bytes) -> Optional[str]:
@@ -452,7 +459,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             tz = new_matrix[11] * INCHES_TO_MM if len(new_matrix) > 11 else 0.0
 
             inst_info = InstanceNode(
-                name=inst["name"] or "",
+                name=inst_name,
                 definition_name=(defs_dict.get(ref_idx) or {}).get("name") or "",
                 layer=l_name,
                 position_mm=(round(tx, 2), round(ty, 2), round(tz, 2)),
@@ -461,7 +468,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             )
             child_instances_info.append(inst_info)
 
-            path_updates[full_path_name] = (properties, inst["name"] or "")
+            path_updates[full_path_name] = (properties, inst_name)
 
         return child_instances_info
 
@@ -512,4 +519,5 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
         glb_primitives=glb_primitives,
         gltf_materials=gltf_materials,
         textures=textures,
+        layer_hidden=dict(parsed.get("layer_hidden") or {}),
     )

--- a/packages/python/tests/test_ifc.py
+++ b/packages/python/tests/test_ifc.py
@@ -187,6 +187,53 @@ class TestIfcExporter:
         assert "(2.0,-5.0,3.0)" in ifc_text
         assert "(2.0,3.0,5.0)" not in ifc_text
 
+    def test_to_ifc_uses_real_instance_name_not_internal_key(self):
+        """prim.geom_name is an internal lookup key (mesh index + hierarchy
+        path + layer, e.g. "mesh_3_ROOT__W1_Layer0") - never a name a user
+        should see. The IFC element's Name must come from
+        MeshMetadata.name (the actual SketchUp instance name) instead
+        (this exact bug, caught 2026-09-07 comparing against real IFC
+        exports of the same file)."""
+        prim = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="mesh_3_ROOT__W1_Layer0",
+        )
+        scene = Scene(
+            scene_hierarchy=InstanceNode(name="Root"),
+            mesh_index={"mesh_3_ROOT__W1_Layer0": MeshMetadata(name="W1", layer="Layer0")},
+            glb_primitives=[prim],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene)
+
+        assert "'W1'" in ifc_text
+        assert "mesh_3_ROOT" not in ifc_text
+
+    def test_to_ifc_layer_on_reflects_scene_layer_hidden(self):
+        """Only IfcPresentationLayerWithStyle (not the plain
+        IfcPresentationLayerAssignment this exporter used to write)
+        carries a layer's visibility - LayerOn must match the source
+        file's own hidden/visible state per layer, not just default to
+        visible for everything."""
+        scene = create_mock_scene()
+        scene.mesh_index["Outer Wall"].layer = "Hidden Layer"
+        scene.mesh_index["Front Door"].layer = "Visible Layer"
+        scene.layer_hidden = {"Hidden Layer": True, "Visible Layer": False}
+
+        ifc_text = to_ifc(scene)
+
+        assert "IFCPRESENTATIONLAYERWITHSTYLE" in ifc_text
+        assert "IFCPRESENTATIONLAYERASSIGNMENT(" not in ifc_text
+        assert "'Hidden Layer',$,(#" in ifc_text
+        hidden_line = next(l for l in ifc_text.splitlines() if "'Hidden Layer'" in l)
+        visible_line = next(l for l in ifc_text.splitlines() if "'Visible Layer'" in l)
+        assert ",.F.,.F.,.F.,())" in hidden_line
+        assert ",.T.,.F.,.F.,())" in visible_line
+
     def test_export_file(self):
         scene = create_mock_scene()
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/packages/python/tests/test_ifc.py
+++ b/packages/python/tests/test_ifc.py
@@ -229,8 +229,8 @@ class TestIfcExporter:
         assert "IFCPRESENTATIONLAYERWITHSTYLE" in ifc_text
         assert "IFCPRESENTATIONLAYERASSIGNMENT(" not in ifc_text
         assert "'Hidden Layer',$,(#" in ifc_text
-        hidden_line = next(l for l in ifc_text.splitlines() if "'Hidden Layer'" in l)
-        visible_line = next(l for l in ifc_text.splitlines() if "'Visible Layer'" in l)
+        hidden_line = next(line for line in ifc_text.splitlines() if "'Hidden Layer'" in line)
+        visible_line = next(line for line in ifc_text.splitlines() if "'Visible Layer'" in line)
         assert ",.F.,.F.,.F.,())" in hidden_line
         assert ",.T.,.F.,.F.,())" in visible_line
 

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2522,6 +2522,77 @@ class TestBuildSceneRecursionGuard:
         scene = build_scene(self._parsed(defs_dict))
         assert len(scene.scene_hierarchy.children) == 2
 
+    def test_unnamed_instance_gets_readable_fallback_not_empty_string(self) -> None:
+        """An instance nobody renamed in SketchUp (inst["name"] == "")
+        must still get the same readable "Component_<id>" fallback the
+        mesh-level path already uses - InstanceNode.name and
+        MeshMetadata.name (via the deferred path_updates backfill) used a
+        different, empty-string fallback for the exact same case, so a
+        nested unnamed instance's real name silently vanished (caught
+        2026-09-07 comparing IFC export element names against a real
+        SketchUp export of the same file)."""
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        child_builder = _GeometryBuilder()  # no faces - forces the deferred path_updates backfill
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, name=""))
+        defs_dict = {
+            1: {"guid": "g1", "name": "unnamed_def", "builder": child_builder},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        scene = build_scene(self._parsed(defs_dict))
+
+        assert scene.scene_hierarchy.children[0].name == "Component_1"
+
+
+class TestBuildSceneLayerHidden:
+    """Scene.layer_hidden must carry the source file's own per-layer
+    visibility through from parsed["layer_hidden"] - consumers that
+    expose a layer list (e.g. the IFC exporter's
+    IfcPresentationLayerWithStyle.LayerOn) rely on this rather than
+    always defaulting every layer to visible."""
+
+    def test_layer_hidden_passed_through_from_parsed(self) -> None:
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        root_builder = _GeometryBuilder()
+        parsed = {
+            "defs_dict": {"ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder}},
+            "layer_colors": {},
+            "layer_id_to_name": {},
+            "material_id_to_name": {},
+            "materials": {},
+            "materials_by_folder": {},
+            "layer_hidden": {"Layer0": False, "Framing": True},
+        }
+
+        scene = build_scene(parsed)
+
+        assert scene.layer_hidden == {"Layer0": False, "Framing": True}
+
+    def test_missing_layer_hidden_defaults_to_empty(self) -> None:
+        """An older/synthetic parsed dict with no layer_hidden key at all
+        must not crash build_scene - just produce an empty mapping."""
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        root_builder = _GeometryBuilder()
+        parsed = {
+            "defs_dict": {"ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder}},
+            "layer_colors": {},
+            "layer_id_to_name": {},
+            "material_id_to_name": {},
+            "materials": {},
+            "materials_by_folder": {},
+        }
+
+        scene = build_scene(parsed)
+
+        assert scene.layer_hidden == {}
+
 
 class TestBuildSceneMeshIndexPerInstanceMetadata:
     """Regression for openskp#240: each mesh's own ``name`` must reflect


### PR DESCRIPTION
## Summary
- `to_ifc()` named every element after its internal mesh-lookup key (e.g. `"mesh_3115_ROOT__Component_6205261_Layer0"`) instead of the actual SketchUp instance name. Now uses `MeshMetadata.name` (the real instance name, or SketchUp's own `"Component_<id>"` default if nobody renamed it).
- Root cause traced one level deeper: `Scene`'s own name-backfill mechanism (`scene.py`, and the equivalent in `instanced_scene.py`) fell back to an **empty string** for unnamed instances, while the original mesh-level name construction already had a working `"Component_<id>"` fallback - the two disagreed, so any instance reached via the deferred `path_updates` backfill silently lost its name. Both now use the same fallback.
- Switches the IFC layer assignment from `IfcPresentationLayerAssignment` to `IfcPresentationLayerWithStyle`, which can actually carry a layer's on/off state (`LayerOn`) - neither SketchUp's own IFC exporter nor the popular "IFC-manager for SketchUp" extension use this either. `Scene` gained a `layer_hidden` field, threaded through from the parser's existing per-layer hidden state.
- **Known limitation, not closed by this PR**: legacy (pre-2021) files get correct per-layer `LayerOn`; VFF (2021+) files always read visible - the VFF binary format's layer-hidden encoding has never been reverse-engineered by this project (documented in `_core.py`). Separate follow-up.

Root-caused the same way as #271: converting a real production file and comparing element names/layers against the same file's native SketchUp IFC export and a separately-exported IFC from the IFC-manager extension.

## Test plan
- [x] New regression tests: real-name-not-internal-key, LayerOn reflects `layer_hidden`, `layer_hidden` plumbing (`parsed` -> `Scene`), and the unnamed-instance fallback consistency bug
- [x] Full suite passes (482 passed)
- [x] Re-ran the full 359MB production file end-to-end three times as each fix landed; confirmed real instance names and `IfcPresentationLayerWithStyle` now appear correctly in the actual output