### PR TITLE
Surface third-party plugin attribute dictionaries as element names and IFC properties

### DIFF
--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import datetime
 import pathlib
 import uuid
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from ..scene import Scene
 
@@ -217,6 +217,35 @@ def to_ifc(
         f"#{owner_hist_id}=IFCOWNERHISTORY(#{person_org_id},#{app_id},$,.READWRITE.,$,$,$,{timestamp_epoch});"
     )
 
+    def write_pset(product_id: int, pset_name: str, props: Dict[str, Any]) -> None:
+        """Write one IFCPROPERTYSET from a flat string-keyed dict and attach
+        it to ``product_id`` via IFCRELDEFINESBYPROPERTIES."""
+        prop_val_ids: List[int] = []
+        for p_key, p_val in props.items():
+            clean_k = sanitize_name(str(p_key))
+            clean_v = sanitize_name(str(p_val))
+            prop_id = next_id()
+            lines.append(
+                f"#{prop_id}=IFCPROPERTYSINGLEVALUE('{clean_k}',$,IFCTEXT('{clean_v}'),$);"
+            )
+            prop_val_ids.append(prop_id)
+
+        if not prop_val_ids:
+            return
+
+        pset_guid = generate_ifc_guid()
+        pset_id = next_id()
+        prop_refs = ",".join(f"#{pid}" for pid in prop_val_ids)
+        lines.append(
+            f"#{pset_id}=IFCPROPERTYSET('{pset_guid}',#{owner_hist_id},'{sanitize_name(pset_name)}',$,({prop_refs}));"
+        )
+
+        rel_prop_guid = generate_ifc_guid()
+        rel_prop_id = next_id()
+        lines.append(
+            f"#{rel_prop_id}=IFCRELDEFINESBYPROPERTIES('{rel_prop_guid}',#{owner_hist_id},$,$,(#{product_id}),#{pset_id});"
+        )
+
     length_unit_id = next_id()
     lines.append(f"#{length_unit_id}=IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.);")
 
@@ -417,35 +446,20 @@ def to_ifc(
         product_ids.append(product_id)
 
         # 5. Property Sets (if scene metadata contains dynamic properties)
-        if (
-            meta
-            and hasattr(meta, "properties")
-            and isinstance(meta.properties, dict)
-            and meta.properties
-        ):
-            prop_val_ids: List[int] = []
-            for p_key, p_val in meta.properties.items():
-                clean_k = sanitize_name(str(p_key))
-                clean_v = sanitize_name(str(p_val))
-                prop_id = next_id()
-                lines.append(
-                    f"#{prop_id}=IFCPROPERTYSINGLEVALUE('{clean_k}',$,IFCTEXT('{clean_v}'),$);"
-                )
-                prop_val_ids.append(prop_id)
+        if meta and hasattr(meta, "properties") and isinstance(meta.properties, dict) and meta.properties:
+            write_pset(product_id, "Pset_CustomProperties", meta.properties)
 
-            if prop_val_ids:
-                pset_guid = generate_ifc_guid()
-                pset_id = next_id()
-                prop_refs = ",".join(f"#{pid}" for pid in prop_val_ids)
-                lines.append(
-                    f"#{pset_id}=IFCPROPERTYSET('{pset_guid}',#{owner_hist_id},'Pset_CustomProperties',$,({prop_refs}));"
-                )
-
-                rel_prop_guid = generate_ifc_guid()
-                rel_prop_id = next_id()
-                lines.append(
-                    f"#{rel_prop_id}=IFCRELDEFINESBYPROPERTIES('{rel_prop_guid}',#{owner_hist_id},$,$,(#{product_id}),#{pset_id});"
-                )
+        # Any OTHER attribute dictionaries the instance carries (third-party
+        # BIM/steel-detailing plugins, etc. - see
+        # openskp.scene.InstanceNode.attribute_dictionaries) - each becomes
+        # its own named property set instead of being merged into
+        # Pset_CustomProperties, since these come from a distinct source and
+        # commonly share key names with each other (e.g. multiple plugins
+        # using "name").
+        if meta and getattr(meta, "attribute_dictionaries", None):
+            for dict_name, entries in meta.attribute_dictionaries.items():
+                if entries:
+                    write_pset(product_id, f"Pset_{dict_name}", entries)
 
     # 6. Presentation Layer Assignments (preserve layers and their on/off
     # state). IfcPresentationLayerWithStyle - not the plain

--- a/packages/python/src/openskp/instanced_scene.py
+++ b/packages/python/src/openskp/instanced_scene.py
@@ -102,6 +102,8 @@ class InstancedNode:
     matrix: Tuple[float, ...] = IDENTITY_GLTF
     position_mm: Tuple[float, float, float] = (0.0, 0.0, 0.0)
     properties: Dict[str, str] = field(default_factory=dict)
+    # See openskp.scene.InstanceNode.attribute_dictionaries.
+    attribute_dictionaries: Dict[str, Dict[str, str]] = field(default_factory=dict)
     mesh_resource_id: Optional[str] = None
     children: List["InstancedNode"] = field(default_factory=list)
 
@@ -395,6 +397,8 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
             l_name = parent_layer
             inst_color = inherited_color
             properties: Dict[str, str] = dict(inst.get("properties") or {})
+            attribute_dicts: Dict[str, Dict[str, str]] = {}
+            name_override: Optional[str] = None
 
             d007 = next((c for c in inst["children"] if c["tag"] == "D007"), None)
             if d007:
@@ -414,14 +418,32 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
                         inst_color = (c["r"], c["g"], c["b"])
 
                 try:
-                    properties = _core.extract_dynamic_properties(d007)
+                    all_dicts = _core.extract_attribute_dictionaries(d007)
+                    dynamic = all_dicts.get("dynamic_attributes", {})
+                    properties = {k: _core._stringify_vff_attr_value(v) for k, v in dynamic.items()}
+                    # See openskp.scene.build_scene's identical loop for why
+                    # SU_InstanceSet is skipped and name/label/code take
+                    # priority as the display-name override.
+                    for dict_name, entries in all_dicts.items():
+                        if dict_name in ("dynamic_attributes", "SU_InstanceSet"):
+                            continue
+                        attribute_dicts[dict_name] = {
+                            k: _core._stringify_vff_attr_value(v) for k, v in entries.items()
+                        }
+                        if name_override is None:
+                            for key in ("name", "label", "code"):
+                                val = entries.get(key)
+                                if val:
+                                    name_override = str(val)
+                                    break
                 except Exception:
                     logger.debug(
-                        "Failed to extract dynamic properties for instance %r (ref_idx=%r)",
+                        "Failed to extract attribute dictionaries for instance %r (ref_idx=%r)",
                         inst.get("name"), ref_idx, exc_info=True,
                     )
 
             inst_name = inst["name"] or f"Component_{ref_idx}"
+            display_name = name_override or inst_name
             instance_counter[0] += 1
             if instance_counter[0] % _PROGRESS_INTERVAL == 0:
                 logger.debug("Processed %d placed instances", instance_counter[0])
@@ -441,12 +463,13 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
 
             nodes.append(
                 InstancedNode(
-                    name=inst_name,
+                    name=display_name,
                     definition_name=(defs_dict.get(ref_idx) or {}).get("name") or "",
                     layer=l_name,
                     matrix=_to_gltf_matrix(inst["matrix"]),
                     position_mm=(round(tx, 2), round(ty, 2), round(tz, 2)),
                     properties=properties,
+                    attribute_dictionaries=attribute_dicts,
                     mesh_resource_id=mesh_resource_for(ref_idx, inst_color, l_name),
                     children=children,
                 )

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -48,6 +48,14 @@ class InstanceNode:
     layer: str = ""
     position_mm: Tuple[float, float, float] = (0.0, 0.0, 0.0)
     properties: Dict[str, str] = field(default_factory=dict)
+    # Every OTHER attribute dictionary this instance carries, keyed by the
+    # dictionary's own name, values stringified the same way `properties`
+    # already is - `properties` stays exactly SketchUp's own Dynamic
+    # Components data (`dynamic_attributes`) for backward compatibility;
+    # third-party plugins (BIM/steel-detailing tools, etc.) commonly
+    # attach their own richer per-instance data under their own dictionary
+    # name instead, which this project never surfaced before.
+    attribute_dictionaries: Dict[str, Dict[str, str]] = field(default_factory=dict)
     children: List["InstanceNode"] = field(default_factory=list)
 
 
@@ -61,6 +69,8 @@ class MeshMetadata:
     layer: str = ""
     position_mm: Tuple[float, float, float] = (0.0, 0.0, 0.0)
     properties: Dict[str, str] = field(default_factory=dict)
+    # See InstanceNode.attribute_dictionaries.
+    attribute_dictionaries: Dict[str, Dict[str, str]] = field(default_factory=dict)
     path: str = ""
 
 
@@ -191,7 +201,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
     # match the wrong meshes (a shallow instance's path is always a string
     # prefix of every deeper descendant's path too, so "in" matched far
     # more than intended - see openskp#240).
-    path_updates: Dict[str, Tuple[Dict[str, str], str]] = {}
+    path_updates: Dict[str, Tuple[Dict[str, str], str, Dict[str, Dict[str, str]]]] = {}
 
     # Textures deduplicated by bytes: the same image routinely backs
     # several materials, and re-embedding it per material would multiply
@@ -413,6 +423,8 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             # this stays {} for them and gets overwritten below via the
             # D007/DC05 TLV walk instead.
             properties: Dict[str, str] = dict(inst.get("properties") or {})
+            attribute_dicts: Dict[str, Dict[str, str]] = {}
+            name_override: Optional[str] = None
 
             d007 = next((c for c in inst["children"] if c["tag"] == "D007"), None)
             if d007:
@@ -432,14 +444,41 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
                         inst_color = (c["r"], c["g"], c["b"])
 
                 try:
-                    properties = _core.extract_dynamic_properties(d007)
+                    all_dicts = _core.extract_attribute_dictionaries(d007)
+                    dynamic = all_dicts.get("dynamic_attributes", {})
+                    properties = {k: _core._stringify_vff_attr_value(v) for k, v in dynamic.items()}
+                    # Every other dictionary a third-party plugin (BIM
+                    # workflow, steel-detailing tool, ...) attached to
+                    # this specific instance - SU_InstanceSet is
+                    # SketchUp's own always-present, always-empty
+                    # Owner/Status boilerplate, not worth surfacing.
+                    for dict_name, entries in all_dicts.items():
+                        if dict_name in ("dynamic_attributes", "SU_InstanceSet"):
+                            continue
+                        attribute_dicts[dict_name] = {
+                            k: _core._stringify_vff_attr_value(v) for k, v in entries.items()
+                        }
+                        if name_override is None:
+                            for key in ("name", "label", "code"):
+                                val = entries.get(key)
+                                if val:
+                                    name_override = str(val)
+                                    break
                 except Exception:
                     logger.debug(
-                        "Failed to extract dynamic properties for instance %r (ref_idx=%r)",
+                        "Failed to extract attribute dictionaries for instance %r (ref_idx=%r)",
                         inst.get("name"), ref_idx, exc_info=True,
                     )
 
+            # inst_name (never overridden) is what keeps full_path_name -
+            # and so path_updates' own keys - locally unique: a plugin's
+            # "name"/"label" field (used for display_name below) is
+            # frequently a shared type/catalog label ("Profile25" for
+            # every instance of that profile), not a real per-instance
+            # identifier, and using it here would collide different
+            # instances' path_updates entries onto each other.
             inst_name = inst["name"] or f"Component_{ref_idx}"
+            display_name = name_override or inst_name
             full_path_name = f"{path_name} / {inst_name}"
             instance_counter[0] += 1
             if instance_counter[0] % _PROGRESS_INTERVAL == 0:
@@ -459,16 +498,17 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             tz = new_matrix[11] * INCHES_TO_MM if len(new_matrix) > 11 else 0.0
 
             inst_info = InstanceNode(
-                name=inst_name,
+                name=display_name,
                 definition_name=(defs_dict.get(ref_idx) or {}).get("name") or "",
                 layer=l_name,
                 position_mm=(round(tx, 2), round(ty, 2), round(tz, 2)),
                 properties=properties,
+                attribute_dictionaries=attribute_dicts,
                 children=child_nodes,
             )
             child_instances_info.append(inst_info)
 
-            path_updates[full_path_name] = (properties, inst_name)
+            path_updates[full_path_name] = (properties, display_name, attribute_dicts)
 
         return child_instances_info
 
@@ -488,7 +528,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
     # was exactly this bug (openskp#240).
     for existing in mesh_index.values():
         if existing.path in path_updates:
-            existing.properties, existing.name = path_updates[existing.path]
+            existing.properties, existing.name, existing.attribute_dictionaries = path_updates[existing.path]
 
     for geom_name, existing in mesh_index.items():
         if existing.path == "ROOT":
@@ -497,6 +537,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             existing.layer = "Layer0"
             existing.position_mm = (0.0, 0.0, 0.0)
             existing.properties = {}
+            existing.attribute_dictionaries = {}
 
     scene_hierarchy = InstanceNode(
         name="ROOT",

--- a/packages/python/tests/test_ifc.py
+++ b/packages/python/tests/test_ifc.py
@@ -286,6 +286,64 @@ class TestIfcExporter:
         assert ",.F.,.F.,.F.,())" in hidden_line
         assert ",.T.,.F.,.F.,())" in visible_line
 
+    def test_to_ifc_writes_a_property_set_per_extra_attribute_dictionary(self):
+        """A third-party plugin's attribute dictionary (e.g. the
+        steel-detailing "fbd-einfo" seen on the Keith Street file) must
+        reach the exported IFC as its own named property set - separate
+        from Pset_CustomProperties (which stays SketchUp's own Dynamic
+        Components data), since a second source of properties commonly
+        reuses key names like "name"."""
+        prim = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="mesh_0_ROOT__Profile25_Layer0",
+        )
+        scene = Scene(
+            scene_hierarchy=InstanceNode(name="Root"),
+            mesh_index={
+                "mesh_0_ROOT__Profile25_Layer0": MeshMetadata(
+                    name="Profile25",
+                    properties={"width": "10.0"},
+                    attribute_dictionaries={"fbd-einfo": {"code": "aPf", "angle": "90"}},
+                )
+            },
+            glb_primitives=[prim],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene)
+
+        assert "'Pset_CustomProperties'" in ifc_text
+        assert "'Pset_fbd-einfo'" in ifc_text
+        assert "'width'" in ifc_text
+        assert "'code'" in ifc_text and "'aPf'" in ifc_text
+        assert "'angle'" in ifc_text and "'90'" in ifc_text
+
+    def test_to_ifc_skips_empty_attribute_dictionaries(self):
+        prim = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="Test Triangle",
+        )
+        scene = Scene(
+            scene_hierarchy=InstanceNode(name="Root"),
+            mesh_index={
+                "Test Triangle": MeshMetadata(
+                    name="Test Triangle", properties={}, attribute_dictionaries={"empty_dict": {}}
+                )
+            },
+            glb_primitives=[prim],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene)
+
+        assert "Pset_empty_dict" not in ifc_text
+
     def test_export_file(self):
         scene = create_mock_scene()
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2628,6 +2628,197 @@ class TestBuildSceneMeshIndexPerInstanceMetadata:
         assert names == ["LeafInstance", "MiddleInstance", "OuterInstance"]
 
 
+class TestBuildSceneAttributeDictionaries:
+    """Regression coverage for the Keith Street fix: a third-party
+    steel-detailing plugin's per-instance attribute dictionary (seen in
+    production as ``fbd-einfo``/``fbd-profile``/``fbd-profile-cords``)
+    carries the element's REAL identity (``name``/``label``/``code``) and
+    rich structural metadata that build_scene previously discarded
+    entirely - only ``dynamic_attributes`` (SketchUp's own Dynamic
+    Components dictionary) was ever surfaced. Per the user's explicit
+    choice, this data now surfaces BOTH ways: as the displayed
+    name/InstanceNode.name (name/label/code, in that priority) and as
+    MeshMetadata/InstanceNode.attribute_dictionaries, keyed by the
+    dictionary's own name.
+    """
+
+    @staticmethod
+    def _tlv(tag_hex: str, payload: bytes) -> bytes:
+        return bytes.fromhex(tag_hex) + struct.pack('<I', len(payload)) + payload
+
+    @classmethod
+    def _value(cls, inner: bytes = b"") -> bytes:
+        return cls._tlv('A438', inner)
+
+    @classmethod
+    def _entry(cls, key: str, value_bytes: bytes) -> bytes:
+        return cls._tlv('B636', key.encode('utf-8')) + value_bytes
+
+    @classmethod
+    def _dict(cls, name: str, entries: bytes) -> bytes:
+        return cls._tlv('B436', name.encode('utf-8')) + cls._tlv('B536', entries)
+
+    @classmethod
+    def _d007_with_dicts(cls, *dicts: bytes):
+        from openskp import _core
+        dc05_payload = b"".join(dicts)
+        d007_bytes = cls._tlv('D007', cls._tlv('DC05', dc05_payload))
+        elements = _core.parse_tlv_recursive(d007_bytes, 0, len(d007_bytes))
+        return elements[0]
+
+    @classmethod
+    def _instance(cls, ref_idx, name, d007=None):
+        return {
+            "offset": 0, "ref_guid": "", "ref_idx": ref_idx, "name": name,
+            "matrix": [1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1.0],
+            "material_id": None, "children": [d007] if d007 else [],
+        }
+
+    @staticmethod
+    def _parsed(defs_dict):
+        return {
+            "defs_dict": defs_dict,
+            "layer_colors": {},
+            "layer_id_to_name": {},
+            "material_id_to_name": {},
+            "materials": {},
+            "materials_by_folder": {},
+        }
+
+    def test_plugin_dict_name_overrides_displayed_name(self) -> None:
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        d007 = self._d007_with_dicts(
+            self._dict("fbd-einfo", self._entry("name", self._value(self._tlv("AD38", b"Profile25"))))
+        )
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, "GLB-12", d007))
+        defs_dict = {
+            1: {"guid": "g1", "name": "wall_def", "builder": _GeometryBuilder()},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        scene = build_scene(self._parsed(defs_dict))
+
+        assert scene.scene_hierarchy.children[0].name == "Profile25"
+
+    def test_name_label_code_priority_order(self) -> None:
+        """label beats code, and (from the other test) name beats label."""
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        d007 = self._d007_with_dicts(
+            self._dict(
+                "fbd-einfo",
+                self._entry("label", self._value(self._tlv("AD38", b"W1")))
+                + self._entry("code", self._value(self._tlv("AD38", b"aPf"))),
+            )
+        )
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, "GLB-12", d007))
+        defs_dict = {
+            1: {"guid": "g1", "name": "wall_def", "builder": _GeometryBuilder()},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        scene = build_scene(self._parsed(defs_dict))
+
+        assert scene.scene_hierarchy.children[0].name == "W1"
+
+    def test_no_override_falls_back_to_real_instance_name(self) -> None:
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        d007 = self._d007_with_dicts(
+            self._dict("fbd-einfo", self._entry("angle", self._value(self._tlv("A738", struct.pack("<i", 90)))))
+        )
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, "GLB-12", d007))
+        defs_dict = {
+            1: {"guid": "g1", "name": "wall_def", "builder": _GeometryBuilder()},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        scene = build_scene(self._parsed(defs_dict))
+
+        assert scene.scene_hierarchy.children[0].name == "GLB-12"
+
+    def test_extra_dictionaries_exposed_on_instance_node(self) -> None:
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        d007 = self._d007_with_dicts(
+            self._dict(
+                "fbd-einfo",
+                self._entry("name", self._value(self._tlv("AD38", b"Profile25")))
+                + self._entry("angle", self._value(self._tlv("A738", struct.pack("<i", 90)))),
+            )
+        )
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, "GLB-12", d007))
+        defs_dict = {
+            1: {"guid": "g1", "name": "wall_def", "builder": _GeometryBuilder()},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        scene = build_scene(self._parsed(defs_dict))
+
+        node = scene.scene_hierarchy.children[0]
+        assert node.attribute_dictionaries == {"fbd-einfo": {"name": "Profile25", "angle": "90"}}
+
+    def test_su_instance_set_and_dynamic_attributes_excluded_from_extras(self) -> None:
+        """SU_InstanceSet is SketchUp's own always-present, always-empty
+        boilerplate and dynamic_attributes already has its own dedicated
+        `properties` field - neither belongs in the extras dict too."""
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        d007 = self._d007_with_dicts(
+            self._dict("SU_InstanceSet", self._entry("Owner", self._value(self._tlv("AD38", b"")))),
+            self._dict("dynamic_attributes", self._entry("width", self._value(self._tlv("AF38", struct.pack("<d", 10.0))))),
+        )
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, "GLB-12", d007))
+        defs_dict = {
+            1: {"guid": "g1", "name": "wall_def", "builder": _GeometryBuilder()},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        scene = build_scene(self._parsed(defs_dict))
+
+        node = scene.scene_hierarchy.children[0]
+        assert node.attribute_dictionaries == {}
+        assert node.properties == {"width": "10.0"}
+
+    def test_non_unique_plugin_label_does_not_collide_mesh_index_paths(self) -> None:
+        """Two sibling instances sharing the same plugin-supplied "name"
+        (a catalog/type label like "Profile25" is frequently shared across
+        every instance of that profile, not a per-instance identifier)
+        must still resolve to two separate, correctly-backfilled mesh_index
+        entries - path_updates keys off the real (locally-unique)
+        inst_name, never the display_name override."""
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        d007 = self._d007_with_dicts(
+            self._dict("fbd-einfo", self._entry("name", self._value(self._tlv("AD38", b"Profile25"))))
+        )
+        child_builder = _GeometryBuilder()  # no faces - forces the deferred path_updates backfill
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, "GLB-11", d007))
+        root_builder.instances.append(self._instance(1, "GLB-12", d007))
+        defs_dict = {
+            1: {"guid": "g1", "name": "shared_def", "builder": child_builder},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+
+        scene = build_scene(self._parsed(defs_dict))
+
+        names = sorted(c.name for c in scene.scene_hierarchy.children)
+        assert names == ["Profile25", "Profile25"]
+
+
 class TestGlbExport:
     """``export.glb.export()`` bakes via ``scene.build_scene()`` (the same
     step ``SkpFile.build_scene()`` exposes directly) and hands the


### PR DESCRIPTION
## Summary
- Steel-detailing/BIM plugins attach their own per-instance attribute dictionary (production example: `fbd-einfo`/`fbd-profile`/`fbd-profile-cords`) carrying the element's real identity and rich metadata - previously discarded entirely, so every such instance fell back to an internal generated key with no real per-part name.
- `build_scene`/`build_instanced_scene` now extract every attribute dictionary an instance carries, use `name`/`label`/`code` (in that priority) as the displayed name when present, and expose the full contents via a new `attribute_dictionaries` field. The real SketchUp instance name is kept for path-uniqueness so a shared plugin label never collides sibling instances.
- `export/ifc.py` writes each extra dictionary as its own named property set (`Pset_<dict-name>`), separate from `Pset_CustomProperties`.

## Verification
- 8 new tests (`TestBuildSceneAttributeDictionaries` in `test_parser.py`, two new tests in `test_ifc.py`) covering name-override priority, path-uniqueness preservation, `SU_InstanceSet`/`dynamic_attributes` exclusion, and per-dictionary IFC property sets.
- Full suite: 493 passed. `ruff check` clean.
- Verified end-to-end against the real production file this was reported against: 17,224 of 18,382 meshes now carry real plugin-supplied names (e.g. `Profile16`) and properties, and the exported IFC contains 50,238 correctly-named property sets from these dictionaries.

## Test plan
- [x] `PYTHONPATH=src python -m pytest -q` (packages/python)
- [x] `ruff check src/ tests/`
- [x] Full parse + IFC export against real production file, confirmed real names and property sets in output