### PR TITLE
Include layer_hidden in both GLB exporters' metadata sidecar

### DIFF
--- a/packages/python/src/openskp/export/glb.py
+++ b/packages/python/src/openskp/export/glb.py
@@ -224,6 +224,7 @@ def export(
         "total_meshes": len(scene_obj.mesh_index),
         "total_layers": len(layers_list),
         "layers": layers_list,
+        "layer_hidden": dict(scene_obj.layer_hidden),
         "materials": [_json_safe_material(m) for m in parsed["materials"].values()],
         "mesh_index": {
             name: {

--- a/packages/python/src/openskp/export/instanced_glb.py
+++ b/packages/python/src/openskp/export/instanced_glb.py
@@ -185,6 +185,7 @@ def export(
         "total_mesh_resources": len(scene_obj.mesh_resources),
         "total_layers": len(layers_list),
         "layers": layers_list,
+        "layer_hidden": dict(scene_obj.layer_hidden),
         "bounds": (
             {
                 "min": list(scene_obj.bounds.min),

--- a/packages/python/tests/test_instanced_scene.py
+++ b/packages/python/tests/test_instanced_scene.py
@@ -275,3 +275,9 @@ class TestInstancedGlbExport:
         assert meta["instanced"] is True
         assert meta["total_mesh_resources"] == 3
         assert meta["scene_hierarchy"]["name"] == "ROOT"
+        # InstancedScene.layer_hidden exists on the dataclass but was never
+        # threaded into this sidecar - a consumer wanting to match the
+        # source file's own default layer visibility (as glb.export()'s own
+        # sidecar already lets them) had no way to get it from here.
+        assert "layer_hidden" in meta
+        assert isinstance(meta["layer_hidden"], dict)

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2984,6 +2984,13 @@ class TestGlbExport:
         assert "definition_name" in first_child
         assert "position_mm" in first_child
 
+        # Scene.layer_hidden exists but was never threaded into this
+        # sidecar - a consumer wanting to match the source file's own
+        # default layer visibility had no way to get it from export()'s
+        # output at all.
+        assert "layer_hidden" in metadata
+        assert isinstance(metadata["layer_hidden"], dict)
+
     def test_export_rejects_unsupported_coordinate_system(self, tmp_path) -> None:
         # The underlying conversion is hardcoded to y-up/mm - passing
         # anything else must raise, not silently produce y-up/mm output


### PR DESCRIPTION
## Summary

- Both \`Scene.layer_hidden\` (baked path) and \`InstancedScene.layer_hidden\` (instanced path) already carry the source file's own per-layer visibility, but neither GLB exporter's \`_metadata.json\` sidecar ever surfaced it - a consumer wanting to match SketchUp's own default layer visibility had no way to get it from either GLB export path (the Fragments exporter's \`Model.metadata\` already provides this, so this closes the same gap for GLB).
- One-line addition to each of \`export.glb.export()\` and \`export.instanced_glb.export()\`.

## Verification

While checking this, also validated \`instanced_glb.export()\` (already shipped, PR #200) against two real fixtures - not something this repo's tests currently assert on directly:

- \`gondola_v20.skp\` (heavy component repetition): triangle count and bounds match the baked export to sub-millimetre precision; instanced output is ~16% of the baked file size and exports ~16x faster.
- \`capilla_quiroz_v17.skp\` (little repetition): bounds match exactly; size is comparable, as expected for a model without much reuse.

## Test plan

- [x] Full suite: 519 passing (2 new assertions added to existing tests, not new test functions)
- [x] \`ruff check\` - clean
- [x] Manual verification of the instanced/baked equivalence claim above against real fixtures