### PR TITLE
fix: write real per-item GUIDs in Fragments export

### DIFF
--- a/packages/python/src/openskp/export/fragments.py
+++ b/packages/python/src/openskp/export/fragments.py
@@ -377,6 +377,7 @@ def to_fragments(scene: "InstancedScene", *, raw: bool = False) -> bytes:
     local_ids: List[int] = []
     categories: List[str] = []
     names: List[str] = []
+    guids: List[str] = []
     sample_material: List[int] = []
     sample_representation: List[int] = []
     meshes_items: List[int] = []
@@ -396,6 +397,16 @@ def to_fragments(scene: "InstancedScene", *, raw: bool = False) -> bytes:
         local_ids.append(item_index)
         categories.append(node.layer or "Layer0")
         names.append(node.name or "")
+        # Real SketchUp instance GUID when the source file carries one
+        # (VFF/2021+); a stable synthetic fallback otherwise (legacy-format
+        # files don't currently expose a per-instance GUID). Either way,
+        # every tracked item gets a non-empty, unique-within-this-export
+        # identifier - consumers keyed on GUID<->local_id parity (e.g. a
+        # viewer's own id-bridge, zipping Model.guids against Model.local_ids
+        # index-for-index) silently get an empty map otherwise, since a
+        # zero-length guids vector zips to nothing regardless of how many
+        # real items exist.
+        guids.append(node.guid or f"openskp-{item_index}")
         item_index_by_node_id[id(node)] = item_index
         for prim_idx, prim in enumerate(res.primitives):
             sample_material.append(get_material_index(prim.material_index))
@@ -482,9 +493,30 @@ def to_fragments(scene: "InstancedScene", *, raw: bool = False) -> bytes:
     local_ids_vec = builder.EndVector()
 
     guid_str = builder.CreateString("00000000-0000-0000-0000-000000000000")
-    Model.StartGuidsVector(builder, 0)
+
+    # Per-item GUIDs. `guids[i]` is that item's identifier; `guids_items[i]`
+    # is which local_id it belongs to - real consumers use both forms: some
+    # (the library's own internal category/property indexing) walk
+    # guids_items-paired-with-guids as a sparse map, but the more common
+    # public entry point (a viewer's own id-bridge, matching the real
+    # IfcImporter's own output shape) simply zips model.getGuids() against
+    # model.getLocalIds() index-for-index - which only works when the two
+    # vectors are the same length, in the same order, one entry per tracked
+    # item. A zero-length guids vector (this export's previous behavior)
+    # zips to an empty map regardless of how many real items exist, which
+    # is silent and easy to miss: geometry still renders fine (nothing
+    # about drawing a mesh needs a GUID), but every GUID-keyed interaction -
+    # click-to-select's property/context-menu lookup, hide-by-id, anything
+    # built on "resolve what was clicked" - has nothing to resolve against.
+    guid_offsets = [builder.CreateString(g) for g in guids]
+    Model.StartGuidsVector(builder, len(guids))
+    for off in reversed(guid_offsets):
+        builder.PrependUOffsetTRelative(off)
     guids_vec = builder.EndVector()
-    Model.StartGuidsItemsVector(builder, 0)
+
+    Model.StartGuidsItemsVector(builder, len(local_ids))
+    for lid in reversed(local_ids):
+        builder.PrependUint32(lid)
     guids_items_vec = builder.EndVector()
 
     # One Attribute per tracked item (same order as local_ids/categories),

--- a/packages/python/src/openskp/instanced_scene.py
+++ b/packages/python/src/openskp/instanced_scene.py
@@ -96,6 +96,14 @@ class InstancedNode:
     name: str = ""
     definition_name: str = ""
     layer: str = ""
+    # This instance's own persistent GUID (a real one from the source SKP
+    # file when available - modern/VFF files carry a genuine 16-byte
+    # instance GUID per placement, see openskp._core's '6819' tag; legacy
+    # (pre-2021) files don't currently expose one, so this is "" for them).
+    # Never used for geometry/placement - purely an identity string a
+    # consumer (e.g. a Fragments-format exporter) can carry through so a
+    # clicked/selected element has something stable to key off of.
+    guid: str = ""
     # This node's transform RELATIVE TO ITS PARENT, as a 16-element
     # column-major glTF matrix (metres, Y-up) - directly usable as a glTF
     # node `matrix`. The root node's matrix is the identity.
@@ -475,6 +483,7 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
                     position_mm=(round(tx, 2), round(ty, 2), round(tz, 2)),
                     properties=properties,
                     attribute_dictionaries=attribute_dicts,
+                    guid=inst.get("ref_guid") or "",
                     mesh_resource_id=mesh_resource_for(ref_idx, inst_color, l_name),
                     children=children,
                 )

--- a/packages/python/tests/test_fragments.py
+++ b/packages/python/tests/test_fragments.py
@@ -135,6 +135,62 @@ class TestToFragments:
         assert x1.X() == pytest.approx(math.cos(math.radians(45)), abs=1e-5)
         assert x1.Y() == pytest.approx(math.sin(math.radians(45)), abs=1e-5)
 
+
+class TestToFragmentsGuids:
+    """Model.guids/guids_items were previously written as empty vectors
+    unconditionally - geometry still rendered fine (nothing about drawing a
+    mesh needs a GUID), but any consumer that zips model.getGuids() against
+    model.getLocalIds() index-for-index (the real IfcImporter's own output
+    shape, and what a viewer's own id-bridge typically does to resolve
+    "what did I click on") silently got an empty map, breaking every
+    GUID-keyed interaction: selection lookups, context menus, hide-by-id."""
+
+    def test_guids_and_local_ids_are_the_same_length_and_order(self):
+        scene = _make_two_instance_scene()
+        data = fragments.to_fragments(scene, raw=True)
+        model = Model.GetRootAsModel(bytearray(data), 0)
+
+        n = model.LocalIdsLength()
+        assert n == 2
+        assert model.GuidsLength() == n
+        assert model.GuidsItemsLength() == n
+        # guids_items[i] names which local_id guids[i] belongs to - a real
+        # consumer's simpler zip (getGuids() against getLocalIds(),
+        # index-for-index) only works when this parity actually holds.
+        for i in range(n):
+            assert model.GuidsItems(i) == model.LocalIds(i)
+
+    def test_items_without_a_source_guid_get_a_unique_synthetic_one(self):
+        # _make_two_instance_scene's nodes don't set InstancedNode.guid -
+        # the common case for legacy (pre-2021) SKP files, which don't
+        # currently expose a per-instance GUID at parse time.
+        scene = _make_two_instance_scene()
+        data = fragments.to_fragments(scene, raw=True)
+        model = Model.GetRootAsModel(bytearray(data), 0)
+
+        guids = [model.Guids(i).decode() for i in range(model.GuidsLength())]
+        assert all(g for g in guids)  # never empty
+        assert len(set(guids)) == len(guids)  # never duplicated
+
+    def test_a_real_source_guid_is_preserved_exactly(self):
+        resource = InstancedMeshResource(
+            id="mesh_0", definition_id=1, definition_name="Box",
+            variant_key="1|255,255,255", primitives=[_box_primitive()],
+        )
+        real_guid = "F160C36229782F47A9857FC88DD1F2CB"
+        node = InstancedNode(name="Box", layer="Framing", matrix=IDENTITY, mesh_resource_id="mesh_0", guid=real_guid)
+        root = InstancedNode(name="ROOT", matrix=IDENTITY, children=[node])
+        scene = InstancedScene(
+            bounds=None, scene_hierarchy=root, mesh_resources=[resource],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [1.0, 1.0, 1.0, 1.0]}}],
+            textures=[],
+        )
+        data = fragments.to_fragments(scene, raw=True)
+        model = Model.GetRootAsModel(bytearray(data), 0)
+
+        assert model.GuidsLength() == 1
+        assert model.Guids(0).decode() == real_guid
+
     def test_shell_geometry_matches_the_source_primitive(self):
         scene = _make_two_instance_scene()
         data = fragments.to_fragments(scene, raw=True)


### PR DESCRIPTION
## Summary

\`Model.guids\`/\`guids_items\` were previously written as empty vectors unconditionally. Geometry rendered fine regardless - nothing about drawing a mesh needs a GUID - but every GUID-keyed interaction on the resulting \`.frag\` broke **silently**.

Root-caused by reading a real production Fragments viewer's own id-resolution code: it resolves "what was clicked" by zipping \`model.getGuids()\` against \`model.getLocalIds()\` index-for-index (the same shape the real \`IfcImporter\`'s own output has). A zero-length \`guids\` vector zips to an empty map regardless of how many real items exist - so selection lookups, context menus, and hide-by-id all had nothing to resolve against, while the model still loaded and rendered normally. Easy to miss without specifically exercising those interactions.

## Fix

\`InstancedNode\` gets a new \`guid\` field, threaded through from each instance's own real SketchUp GUID when the source file has one - VFF/2021+ files carry a genuine 16-byte per-instance GUID already parsed into \`inst['ref_guid']\`, just never carried through to the instanced scene graph before. Legacy (pre-2021) files don't currently expose a per-instance GUID at parse time, so those items get a stable, unique synthetic fallback (\`openskp-{item_index}\`) instead - still satisfies the same-length-same-order contract real consumers depend on, just without a real SketchUp-native identifier behind it.

## Verification

- Real file, modern format (\`Vigors IFA01_2021.skp\`): **136/136 items got their real, distinct source GUID** through unchanged.
- Real file, no per-instance GUIDs available: all items get unique synthetic fallbacks, none empty, none duplicated.
- **Verified against the actual @thatopen/fragments runtime**, not just this exporter's own output: loaded a real exported \`.frag\`, called the real \`model.getGuids()\`/\`getLocalIds()\`, and replicated a real viewer's own id-resolution zip logic by hand. The resulting map went from **0 entries (before) to 81/81 (after)** on the same test file.

## Test plan

- [x] Full suite: 530 passing (3 new: length/order parity between \`guids\` and \`local_ids\`, synthetic-fallback uniqueness, real-guid preservation)
- [x] \`ruff check\` - clean
- [x] Manual round-trip through the real \`@thatopen/fragments\` library in a browser, not just this repo's own reader