### PR TITLE
python: give named organizational wrappers real IfcElementAssembly grouping

### DIFF
--- a/packages/python/src/openskp/export/ifc.py
+++ b/packages/python/src/openskp/export/ifc.py
@@ -330,6 +330,61 @@ def to_ifc(
     layer_items: Dict[str, List[int]] = {}
     mat_style_cache: Dict[Tuple[float, float, float, float], int] = {}
 
+    # Assembly grouping: a named organizational wrapper with no geometry of
+    # its own (e.g. FrameBuilder's "W-2" wall group, whose only children are
+    # its studs/plates/cladding) becomes a real IFCELEMENTASSEMBLY, with its
+    # member elements related to it via IFCRELAGGREGATES - mirroring the
+    # named-wrapper local-id behavior already shipped for Fragments export
+    # (export/fragments.py's _collect_leaves), so an IFC viewer's model tree
+    # groups parts under "W-2" the same way FrameSmart's own tree already
+    # does, instead of showing every part as a flat, ungrouped sibling.
+    # Keyed by InstanceNode.path, which is built with the exact same
+    # full-path string as MeshMetadata.path (see scene.py's instantiate()),
+    # so a primitive's owning node can be found by a direct dict lookup.
+    assembly_ids_by_path: Dict[str, int] = {}
+    # One list per assembly of EVERY object it directly decomposes into -
+    # both leaf member elements and nested child assemblies together, so
+    # each assembly is the RelatingObject of exactly one IFCRELAGGREGATES
+    # (some IFC consumers only look at the first such relation for a given
+    # object, so splitting members and child assemblies across two
+    # relations here would silently hide one set of them in those tools).
+    assembly_related_objects: Dict[int, List[int]] = {}
+    top_level_assembly_ids: List[int] = []
+    nearest_assembly_by_path: Dict[str, Optional[int]] = {}
+
+    def walk_assemblies(node, parent_assembly_id: Optional[int], is_root: bool = False) -> None:
+        is_assembly = not is_root and not node.name_is_generated and bool(node.children)
+        own_assembly_id = parent_assembly_id
+        if is_assembly:
+            placement_id = next_id()
+            lines.append(
+                f"#{placement_id}=IFCLOCALPLACEMENT(#{storey_placement_id},#{axis_placement_id});"
+            )
+            combined = f"{node.name} {node.layer}".lower()
+            predefined = "TRUSS" if "truss" in combined else "NOTDEFINED"
+            assembly_id = next_id()
+            lines.append(
+                f"#{assembly_id}=IFCELEMENTASSEMBLY('{generate_ifc_guid()}',#{owner_hist_id},"
+                f"'{sanitize_name(node.name)}',$,$,#{placement_id},$,$,$,.{predefined}.);"
+            )
+            if node.properties:
+                write_pset(assembly_id, "Pset_CustomProperties", node.properties)
+            for dict_name, entries in (node.attribute_dictionaries or {}).items():
+                if entries:
+                    write_pset(assembly_id, f"Pset_{dict_name}", entries)
+            if parent_assembly_id is not None:
+                assembly_related_objects.setdefault(parent_assembly_id, []).append(assembly_id)
+            else:
+                top_level_assembly_ids.append(assembly_id)
+            assembly_ids_by_path[node.path] = assembly_id
+            own_assembly_id = assembly_id
+
+        nearest_assembly_by_path[node.path] = own_assembly_id
+        for child in node.children:
+            walk_assemblies(child, own_assembly_id)
+
+    walk_assemblies(scene.scene_hierarchy, None, is_root=True)
+
     for prim in scene.glb_primitives:
         tri_count = len(prim.indices) // 3
         v_count = len(prim.positions) // 3
@@ -443,7 +498,11 @@ def to_ifc(
                 f"#{product_id}={step_type}('{prod_guid}',#{owner_hist_id},'{display_name}',$,$,#{prod_placement_id},#{prod_shape_id},$,$);"
             )
 
-        product_ids.append(product_id)
+        assembly_id = nearest_assembly_by_path.get(path_name) if path_name else None
+        if assembly_id is not None:
+            assembly_related_objects.setdefault(assembly_id, []).append(product_id)
+        else:
+            product_ids.append(product_id)
 
         # 5. Property Sets (if scene metadata contains dynamic properties)
         if meta and hasattr(meta, "properties") and isinstance(meta.properties, dict) and meta.properties:
@@ -478,9 +537,23 @@ def to_ifc(
                 f"'{l_name}',$,({item_refs}),$,{layer_on},.F.,.F.,());"
             )
 
-    # 7. Containment Relation in Spatial Hierarchy
-    if product_ids:
-        prod_refs = ",".join(f"#{pid}" for pid in product_ids)
+    # 7. Assembly Aggregation, then Containment Relation in Spatial
+    # Hierarchy. Per IFC4 semantics an element belongs to exactly one
+    # containment context: an assembly's members are related to it via
+    # IFCRELAGGREGATES (not spatially contained themselves), a nested
+    # assembly is aggregated into its parent assembly the same way, and
+    # only the outermost assemblies - alongside any genuinely ungrouped
+    # elements - are ever related to the storey via
+    # IFCRELCONTAINEDINSPATIALSTRUCTURE.
+    for assembly_id, related_ids in assembly_related_objects.items():
+        related_refs = ",".join(f"#{rid}" for rid in related_ids)
+        lines.append(
+            f"#{next_id()}=IFCRELAGGREGATES('{generate_ifc_guid()}',#{owner_hist_id},$,$,#{assembly_id},({related_refs}));"
+        )
+
+    contained_ids = product_ids + top_level_assembly_ids
+    if contained_ids:
+        prod_refs = ",".join(f"#{pid}" for pid in contained_ids)
         contain_rel_id = next_id()
         lines.append(
             f"#{contain_rel_id}=IFCRELCONTAINEDINSPATIALSTRUCTURE('{generate_ifc_guid()}',#{owner_hist_id},$,$,({prod_refs}),#{storey_id});"

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -72,6 +72,12 @@ class InstanceNode:
     # name instead, which this project never surfaced before.
     attribute_dictionaries: Dict[str, Dict[str, str]] = field(default_factory=dict)
     children: List["InstanceNode"] = field(default_factory=list)
+    # Same full-path string that scoping instance's own meshes (and every
+    # nested descendant's meshes) carry as MeshMetadata.path - lets a
+    # consumer (e.g. export/ifc.py's assembly grouping) correlate a flat
+    # GlbPrimitive back to its owning tree node by exact string match,
+    # without re-deriving SketchUp's own name-resolution/override rules.
+    path: str = ""
 
 
 @dataclass
@@ -531,6 +537,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
                 properties=properties,
                 attribute_dictionaries=attribute_dicts,
                 children=child_nodes,
+                path=full_path_name,
             )
             child_instances_info.append(inst_info)
 
@@ -572,6 +579,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
         position_mm=(0.0, 0.0, 0.0),
         properties={},
         children=root_children,
+        path="ROOT",
     )
 
     logger.info(

--- a/packages/python/tests/test_ifc.py
+++ b/packages/python/tests/test_ifc.py
@@ -344,6 +344,255 @@ class TestIfcExporter:
 
         assert "Pset_empty_dict" not in ifc_text
 
+    def test_to_ifc_wraps_named_wrapper_in_element_assembly(self):
+        """A pure organizational group with real, per-instance identity
+        (FrameBuilder's "W-2" wall, whose own children are its studs/
+        plates/cladding) has no geometry of its own - export/fragments.py
+        already gives it its own trackable identity for Fragments export
+        (openskp#286); IFC needs the equivalent: a real IFCELEMENTASSEMBLY
+        with its members related via IFCRELAGGREGATES, not a flat sibling
+        list under the storey."""
+        stud = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="mesh_0_ROOT__W-2__Stud_1_Layer0",
+        )
+        plate = GlbPrimitive(
+            positions=array("f", [2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 2.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="mesh_1_ROOT__W-2__Plate_1_Layer0",
+        )
+        scene_hierarchy = InstanceNode(
+            name="ROOT",
+            path="ROOT",
+            children=[
+                InstanceNode(
+                    name="W-2",
+                    path="ROOT / W-2",
+                    properties={"MarkID": "W-2"},
+                    children=[
+                        InstanceNode(name="Stud 1", path="ROOT / W-2 / Stud 1"),
+                        InstanceNode(name="Plate 1", path="ROOT / W-2 / Plate 1"),
+                    ],
+                ),
+            ],
+        )
+        scene = Scene(
+            scene_hierarchy=scene_hierarchy,
+            mesh_index={
+                "mesh_0_ROOT__W-2__Stud_1_Layer0": MeshMetadata(
+                    name="Stud 1", path="ROOT / W-2 / Stud 1",
+                ),
+                "mesh_1_ROOT__W-2__Plate_1_Layer0": MeshMetadata(
+                    name="Plate 1", path="ROOT / W-2 / Plate 1",
+                ),
+            },
+            glb_primitives=[stud, plate],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene)
+
+        assert ifc_text.count("IFCELEMENTASSEMBLY(") == 1
+        assembly_line = next(
+            line for line in ifc_text.splitlines() if "IFCELEMENTASSEMBLY(" in line
+        )
+        assert "'W-2'" in assembly_line
+        assembly_id = assembly_line.split("=")[0].lstrip("#")
+
+        # Member elements go through IFCRELAGGREGATES to the assembly...
+        rel_agg_line = next(
+            line for line in ifc_text.splitlines()
+            if line.startswith("#") and "IFCRELAGGREGATES(" in line and f",#{assembly_id},(" in line
+        )
+        stud_id = next(
+            line for line in ifc_text.splitlines() if "'Stud 1'" in line and "IFCBUILDINGELEMENTPROXY" in line
+        ).split("=")[0].lstrip("#")
+        plate_id = next(
+            line for line in ifc_text.splitlines() if "'Plate 1'" in line and "IFCBUILDINGELEMENTPROXY" in line
+        ).split("=")[0].lstrip("#")
+        assert f"#{stud_id}" in rel_agg_line
+        assert f"#{plate_id}" in rel_agg_line
+
+        # ...and only the assembly itself (never its individual members)
+        # is related to the storey via IFCRELCONTAINEDINSPATIALSTRUCTURE.
+        contain_line = next(
+            line for line in ifc_text.splitlines() if "IFCRELCONTAINEDINSPATIALSTRUCTURE(" in line
+        )
+        assert f"#{assembly_id}" in contain_line
+        assert f"#{stud_id}" not in contain_line
+        assert f"#{plate_id}" not in contain_line
+
+        # The wrapper's own properties (FrameBuilder's own Mark ID, here)
+        # attach to the assembly element itself, not to its members.
+        assert "'MarkID'" in ifc_text
+        assert "'W-2'" in ifc_text  # both the element Name and the pset value
+
+    def test_to_ifc_generic_wrapper_stays_flat(self):
+        """A generated/placeholder group name (SketchUp's own auto "Group#1"
+        style, or simply no children) must NOT become an IFCELEMENTASSEMBLY -
+        only a real, named organizational wrapper should."""
+        prim = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="mesh_0_ROOT__Group#1__Stud_1_Layer0",
+        )
+        scene_hierarchy = InstanceNode(
+            name="ROOT",
+            path="ROOT",
+            children=[
+                InstanceNode(
+                    name="Component_2",
+                    name_is_generated=True,
+                    path="ROOT / Component_2",
+                    children=[
+                        InstanceNode(name="Stud 1", path="ROOT / Component_2 / Stud 1"),
+                    ],
+                ),
+            ],
+        )
+        scene = Scene(
+            scene_hierarchy=scene_hierarchy,
+            mesh_index={
+                "mesh_0_ROOT__Group#1__Stud_1_Layer0": MeshMetadata(
+                    name="Stud 1", path="ROOT / Component_2 / Stud 1",
+                ),
+            },
+            glb_primitives=[prim],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene)
+
+        assert "IFCELEMENTASSEMBLY(" not in ifc_text
+        # IFCRELAGGREGATES still appears 3 times for the boilerplate
+        # Project -> Site -> Building -> Storey hierarchy - just not for
+        # this generated-name wrapper.
+        assert ifc_text.count("IFCRELAGGREGATES(") == 3
+        contain_line = next(
+            line for line in ifc_text.splitlines() if "IFCRELCONTAINEDINSPATIALSTRUCTURE(" in line
+        )
+        assert "'Stud 1'" not in contain_line  # sanity: Name isn't in this line at all
+        stud_id = next(
+            line for line in ifc_text.splitlines() if "'Stud 1'" in line
+        ).split("=")[0].lstrip("#")
+        assert f"#{stud_id}" in contain_line
+
+    def test_to_ifc_nests_assemblies_via_rel_aggregates(self):
+        """A named wrapper nested inside another named wrapper (e.g. a
+        "door1" sub-assembly inside wall "W-2") must be related to its
+        *parent assembly* via IFCRELAGGREGATES, not directly to the
+        storey - only the outermost assembly is ever spatially contained."""
+        hinge = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="mesh_0_ROOT__W-2__door1__Hinge_Layer0",
+        )
+        scene_hierarchy = InstanceNode(
+            name="ROOT",
+            path="ROOT",
+            children=[
+                InstanceNode(
+                    name="W-2",
+                    path="ROOT / W-2",
+                    children=[
+                        InstanceNode(
+                            name="door1",
+                            path="ROOT / W-2 / door1",
+                            children=[
+                                InstanceNode(name="Hinge", path="ROOT / W-2 / door1 / Hinge"),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+        scene = Scene(
+            scene_hierarchy=scene_hierarchy,
+            mesh_index={
+                "mesh_0_ROOT__W-2__door1__Hinge_Layer0": MeshMetadata(
+                    name="Hinge", path="ROOT / W-2 / door1 / Hinge",
+                ),
+            },
+            glb_primitives=[hinge],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene)
+
+        assert ifc_text.count("IFCELEMENTASSEMBLY(") == 2
+        w2_line = next(
+            line for line in ifc_text.splitlines()
+            if "IFCELEMENTASSEMBLY(" in line and "'W-2'" in line
+        )
+        door_line = next(
+            line for line in ifc_text.splitlines()
+            if "IFCELEMENTASSEMBLY(" in line and "'door1'" in line
+        )
+        w2_id = w2_line.split("=")[0].lstrip("#")
+        door_id = door_line.split("=")[0].lstrip("#")
+
+        # door1 is aggregated INTO W-2...
+        rel_line = next(
+            line for line in ifc_text.splitlines()
+            if "IFCRELAGGREGATES(" in line and f",#{w2_id},(" in line
+        )
+        assert f"#{door_id}" in rel_line
+
+        # ...and only W-2 (not door1) is contained in the storey.
+        contain_line = next(
+            line for line in ifc_text.splitlines() if "IFCRELCONTAINEDINSPATIALSTRUCTURE(" in line
+        )
+        assert f"#{w2_id}" in contain_line
+        assert f"#{door_id}" not in contain_line
+
+    def test_to_ifc_assembly_predefined_type_matches_truss_keyword(self):
+        prim = GlbPrimitive(
+            positions=array("f", [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0]),
+            normals=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            uvs=array("f", [0.0, 0.0, 1.0, 0.0, 0.0, 1.0]),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+            geom_name="mesh_0_ROOT__RT-2__Profile_Layer0",
+        )
+        scene_hierarchy = InstanceNode(
+            name="ROOT",
+            path="ROOT",
+            children=[
+                InstanceNode(
+                    name="RT-2 truss",
+                    path="ROOT / RT-2 truss",
+                    children=[
+                        InstanceNode(name="Profile", path="ROOT / RT-2 truss / Profile"),
+                    ],
+                ),
+            ],
+        )
+        scene = Scene(
+            scene_hierarchy=scene_hierarchy,
+            mesh_index={
+                "mesh_0_ROOT__RT-2__Profile_Layer0": MeshMetadata(
+                    name="Profile", path="ROOT / RT-2 truss / Profile",
+                ),
+            },
+            glb_primitives=[prim],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [0.5, 0.5, 0.5, 1.0]}}],
+        )
+        ifc_text = to_ifc(scene)
+        assembly_line = next(
+            line for line in ifc_text.splitlines() if "IFCELEMENTASSEMBLY(" in line
+        )
+        assert assembly_line.rstrip(";").endswith(".TRUSS.)")
+
     def test_export_file(self):
         scene = create_mock_scene()
         with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary
- `export/ifc.py` only ever walked the flat `scene.glb_primitives`/`mesh_index`, never `scene.scene_hierarchy` - a FrameBuilder wall like "W-2" (a pure group wrapping studs/plates that carry all the geometry) never appeared anywhere in IFC output, even though the equivalent Fragments gap was already fixed in #286.
- `scene.py`'s `InstanceNode` gains a `path` field (the same full-path string `MeshMetadata.path` already carries) so a flat primitive can be correlated back to its owning tree node by direct lookup.
- `to_ifc()` now walks the tree once up front: a real-named, non-root node with children becomes an `IFCELEMENTASSEMBLY` (plus its own property sets, e.g. FrameBuilder's own Mark ID data). Members and nested child assemblies are related via a single `IFCRELAGGREGATES` each; only the outermost assemblies (and any genuinely ungrouped elements) are related to the storey via `IFCRELCONTAINEDINSPATIALSTRUCTURE` - matching real IFC4 aggregation semantics.
- A "truss" in the wrapper's name/layer maps to `IfcElementAssemblyTypeEnum.TRUSS`; everything else is `.NOTDEFINED.`.

## Test plan
- [x] Full Python suite: 535 passed, `ruff check` clean
- [x] 4 new tests: named wrapper -> assembly, generic/generated-name wrapper stays flat, nested assemblies aggregate correctly, truss predefined-type keyword match
- [x] Ran the real exporter against two real production files: `Vigors IFA01_2025.skp` now emits 13 `IFCELEMENTASSEMBLY` entities including W-1 through W-9; `Beeton IFC01.skp` emits 98, including nested truss-profile sub-assemblies - each with exactly one `IFCRELAGGREGATES` grouping its members, confirmed by direct STEP-text inspection