### PR TITLE
python: make the plugin-name-override key vocabulary configurable

### DIFF
--- a/packages/python/src/openskp/instanced_scene.py
+++ b/packages/python/src/openskp/instanced_scene.py
@@ -25,7 +25,7 @@ import re
 import time
 from array import array
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from . import _core
 from ._face_groups import FaceGroupContext, build_local_face_groups
@@ -204,7 +204,10 @@ def _mul4(a: Tuple[float, ...], b: Tuple[float, ...]) -> Tuple[float, ...]:
     return tuple(out)
 
 
-def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
+def build_instanced_scene(
+    parsed: Dict[str, Any],
+    name_override_keys: Sequence[str] = ("name", "label", "code"),
+) -> InstancedScene:
     """Build an instanced scene from already-parsed raw data.
 
     Walks the same placed scene graph as :func:`openskp.scene.build_scene`
@@ -215,6 +218,9 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
     Args:
         parsed: Output of ``_core.full_parse()`` (same input as
             :func:`openskp.scene.build_scene`).
+        name_override_keys: See :func:`openskp.scene.build_scene` - same
+            meaning, same default, same generic (not tied to any one
+            plugin's own dictionary name) lookup.
 
     Returns:
         A populated :class:`InstancedScene`.
@@ -463,7 +469,7 @@ def build_instanced_scene(parsed: Dict[str, Any]) -> InstancedScene:
                             k: _core._stringify_vff_attr_value(v) for k, v in entries.items()
                         }
                         if name_override is None:
-                            for key in ("name", "label", "code"):
+                            for key in name_override_keys:
                                 val = entries.get(key)
                                 if val:
                                     name_override = str(val)

--- a/packages/python/src/openskp/model.py
+++ b/packages/python/src/openskp/model.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import pathlib
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 if TYPE_CHECKING:
     from . import instanced_scene, scene
@@ -789,7 +789,10 @@ class SkpFile:
 
         return model
 
-    def build_scene(self) -> "scene.Scene":
+    def build_scene(
+        self,
+        name_override_keys: Sequence[str] = ("name", "label", "code"),
+    ) -> "scene.Scene":
         """Bake every instance actually placed in the model into
         world-space, triangulated mesh data - SketchUp's component/group
         nesting fully resolved and flattened, ready for a GLB export or any
@@ -803,6 +806,18 @@ class SkpFile:
         instances, the baked output can be far larger than the file's raw
         geometry - that's the reason this isn't part of :meth:`parse`.
 
+        Args:
+            name_override_keys: Attribute-dictionary key names (checked in
+                order, first match wins) that identify an instance's real,
+                plugin-assigned name. This is deliberately generic, not
+                tied to any one SketchUp extension: it's tried across
+                *every* non-boilerplate attribute dictionary an instance
+                carries, whichever plugin (FrameBuilder, TechSteel, or any
+                other tool that attaches its own dictionary) wrote it. The
+                default ``("name", "label", "code")`` covers the common
+                convention - pass your own tuple if your plugin instead
+                uses a key like ``"mark"`` or ``"partNumber"``.
+
         Returns:
             A populated :class:`openskp.scene.Scene`.
         """
@@ -810,9 +825,12 @@ class SkpFile:
         from . import scene as _scene
 
         parsed = _core.full_parse(str(self.path))
-        return _scene.build_scene(parsed)
+        return _scene.build_scene(parsed, name_override_keys=name_override_keys)
 
-    def build_instanced_scene(self) -> "instanced_scene.InstancedScene":
+    def build_instanced_scene(
+        self,
+        name_override_keys: Sequence[str] = ("name", "label", "code"),
+    ) -> "instanced_scene.InstancedScene":
         """Build the placed scene graph with SketchUp's component/group
         INSTANCING PRESERVED, instead of baked into world-space vertex data.
 
@@ -826,6 +844,11 @@ class SkpFile:
         Same separate, opt-in re-parse as :meth:`build_scene` - see that
         method's docstring.
 
+        Args:
+            name_override_keys: See :meth:`build_scene` - same meaning,
+                same default, same generic (not tied to any one plugin's
+                own dictionary name) lookup.
+
         Returns:
             A populated :class:`openskp.instanced_scene.InstancedScene`.
         """
@@ -833,5 +856,5 @@ class SkpFile:
         from . import instanced_scene
 
         parsed = _core.full_parse(str(self.path))
-        return instanced_scene.build_instanced_scene(parsed)
+        return instanced_scene.build_instanced_scene(parsed, name_override_keys=name_override_keys)
 

--- a/packages/python/src/openskp/scene.py
+++ b/packages/python/src/openskp/scene.py
@@ -23,7 +23,7 @@ import re
 import time
 from array import array
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from . import _core
 from ._face_groups import FaceGroupContext, build_local_face_groups
@@ -185,7 +185,10 @@ def _sniff_image_mime(data: bytes) -> Optional[str]:
     return None
 
 
-def build_scene(parsed: Dict[str, Any]) -> Scene:
+def build_scene(
+    parsed: Dict[str, Any],
+    name_override_keys: Sequence[str] = ("name", "label", "code"),
+) -> Scene:
     """Bake every instance actually placed in ``parsed`` (the output of
     :func:`openskp._core.full_parse` / ``full_parse_legacy``) into
     world-space, triangulated mesh data.
@@ -195,6 +198,15 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
             this by calling :meth:`SkpFile.parse` first is *not* required -
             :meth:`SkpFile.build_scene` re-runs the raw parse independently,
             so a plain ``parse()`` call never carries this cost.
+        name_override_keys: Attribute-dictionary key names (checked in
+            order, first match wins) that identify an instance's real,
+            plugin-assigned name - tried across every non-boilerplate
+            dictionary the instance carries, whichever third-party plugin
+            (FrameBuilder, TechSteel, or any other SketchUp extension that
+            attaches its own attribute dictionary) wrote it, not a specific
+            plugin's own dictionary name. The default covers the common
+            convention; pass your own tuple to also recognize a plugin
+            that instead uses e.g. ``"mark"`` or ``"partNumber"``.
 
     Returns:
         A populated :class:`Scene`.
@@ -480,7 +492,7 @@ def build_scene(parsed: Dict[str, Any]) -> Scene:
                             k: _core._stringify_vff_attr_value(v) for k, v in entries.items()
                         }
                         if name_override is None:
-                            for key in ("name", "label", "code"):
+                            for key in name_override_keys:
                                 val = entries.get(key)
                                 if val:
                                     name_override = str(val)

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2859,6 +2859,35 @@ class TestBuildSceneAttributeDictionaries:
 
         assert scene.scene_hierarchy.children[0].name == "GLB-12"
 
+    def test_name_override_keys_recognizes_a_non_default_key(self) -> None:
+        """The name/label/code vocabulary is a convention, not a hardcoded
+        requirement - openskp is not FrameBuilder-specific, so any plugin
+        that instead calls its identifier field e.g. "mark" must be able to
+        opt in without forking the source."""
+        from openskp._core import _GeometryBuilder
+        from openskp.scene import build_scene
+
+        d007 = self._d007_with_dicts(
+            self._dict("techsteel-data", self._entry("mark", self._value(self._tlv("AD38", b"RT-2"))))
+        )
+        root_builder = _GeometryBuilder()
+        root_builder.instances.append(self._instance(1, "GLB-12", d007))
+        defs_dict = {
+            1: {"guid": "g1", "name": "truss_def", "builder": _GeometryBuilder()},
+            "ROOT": {"guid": "ROOT", "name": "ROOT_MODEL", "builder": root_builder},
+        }
+        parsed = self._parsed(defs_dict)
+
+        # Default vocabulary doesn't know "mark" - falls back to the
+        # instance's own real SketchUp name, same as no override at all.
+        default_scene = build_scene(parsed)
+        assert default_scene.scene_hierarchy.children[0].name == "GLB-12"
+
+        # Opting a custom plugin's key into the vocabulary picks it up,
+        # with no change to openskp's own source needed.
+        custom_scene = build_scene(parsed, name_override_keys=("mark", "name", "label", "code"))
+        assert custom_scene.scene_hierarchy.children[0].name == "RT-2"
+
     def test_extra_dictionaries_exposed_on_instance_node(self) -> None:
         from openskp._core import _GeometryBuilder
         from openskp.scene import build_scene


### PR DESCRIPTION
## Summary
- `build_scene`/`build_instanced_scene` already resolve an instance's real name from *any* attribute dictionary it carries, generically - not tied to FrameBuilder or any specific plugin's dictionary name. But the key vocabulary itself (`"name"`, `"label"`, `"code"`) was hardcoded, so a plugin using a different identifier key (e.g. `"mark"`, `"partNumber"`) had no way to opt in.
- Both functions, plus `SkpFile.build_scene()`/`SkpFile.build_instanced_scene()`, now accept an optional `name_override_keys` sequence. Default is unchanged (`("name", "label", "code")`), fully backward compatible.

## Test plan
- [x] Full Python suite: 536 passed, `ruff check` clean
- [x] New test proves a custom key (`"mark"`, as a hypothetical different plugin's convention) is ignored by default and picked up once added to `name_override_keys`
- [x] Manually verified the same behavior for `build_instanced_scene` (Fragments path), which mirrors `build_scene`'s logic