### PR TITLE
docs: fix incorrect build_instanced_scene() call pattern

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -429,11 +429,9 @@ in BIM web viewers (`@thatopen/fragments`) — directly from an
 ```python
 from openskp import SkpFile
 from openskp.export import fragments
-from openskp.instanced_scene import build_instanced_scene
 
 skp = SkpFile.open("model.skp")
-skp.parse()
-scene = build_instanced_scene(skp)
+scene = skp.build_instanced_scene()
 
 fragments.export(scene, "output.frag")          # writes the file directly
 data = fragments.to_fragments(scene, raw=True)   # or get the raw flatbuffer bytes

--- a/examples/web-viewer/docs/index.html
+++ b/examples/web-viewer/docs/index.html
@@ -1076,11 +1076,9 @@ ifc.export(scene, "output.ifc", classify_using_full_path=True)</code></pre>
       <div class="fn-desc"><a href="https://github.com/ThatOpen/engine_fragment" target="_blank" rel="noopener">ThatOpen's Fragments</a> is a public, IFC-agnostic FlatBuffers binary format built for fast loading in BIM web viewers (<code>@thatopen/fragments</code>). <code>openskp.export.fragments</code> writes it directly from an <code>InstancedScene</code> — no IFC text-generation step in between, which is the whole point: it eliminates the downstream IFC re-parse a viewer would otherwise need to do.</div>
       <pre class="language-python"><code class="language-python">from openskp import SkpFile
 from openskp.export import fragments
-from openskp.instanced_scene import build_instanced_scene
 
 skp = SkpFile.open("model.skp")
-skp.parse()
-scene = build_instanced_scene(skp)
+scene = skp.build_instanced_scene()
 
 fragments.export(scene, "output.frag")          # write the file directly
 data = fragments.to_fragments(scene, raw=True)   # or get the raw flatbuffer bytes</code></pre>


### PR DESCRIPTION
## Summary
- Both `docs/DEVELOPER_GUIDE.md` and the GitHub Pages web-viewer docs (`examples/web-viewer/docs/index.html`) showed `build_instanced_scene` called as a free function on a `SkpFile` object (`from openskp.instanced_scene import build_instanced_scene; scene = build_instanced_scene(skp)`), which raises `TypeError: 'SkpFile' object is not subscriptable`.
- The real public API is the `SkpFile.build_instanced_scene()` method - it also re-runs the parse internally, so the preceding `skp.parse()` call in both examples was redundant too.
- Fixed to `scene = skp.build_instanced_scene()`, matching the correct pattern already used elsewhere in both documents for `build_scene()`.

## Test plan
- [x] Swept the whole repo for the same buggy pattern (`build_instanced_scene(skp)`/`build_scene(skp)`) - only these two occurrences existed
- [x] N/A for tests - docs-only change