### PR TITLE
python: disambiguate duplicate source GUIDs in Fragments export

### DIFF
--- a/packages/python/src/openskp/export/fragments.py
+++ b/packages/python/src/openskp/export/fragments.py
@@ -411,6 +411,30 @@ def to_fragments(scene: "InstancedScene", *, raw: bool = False) -> bytes:
     # structure builder below to place a leaf's local_id at its real
     # position in the tree instead of flattening everything under one root.
     item_index_by_node_id: Dict[int, int] = {}
+    # Real-world SketchUp files can carry a non-unique per-instance GUID:
+    # an engineer authors one instance (a framing plugin writes its own
+    # identity into that instance's attribute dictionary), then duplicates
+    # it 10-20 times via SketchUp's own native Copy/Move+Copy/Array tools
+    # instead of re-running the plugin per placement. A plain SketchUp
+    # entity duplication carries the source instance's attribute
+    # dictionaries - and whatever GUID field a plugin wrote into one - to
+    # every copy verbatim; each copy gets its own distinct transform but
+    # not its own distinct identity (confirmed against a real production
+    # file: 74 distinct GUID values each shared by exactly 17 different
+    # physical instances, cross-checked with a second real file from the
+    # same pipeline that has zero duplicates - openskp#290). A GUID that
+    # doesn't uniquely identify its instance is exactly as broken as one
+    # that's missing entirely for any GUID-keyed lookup (a viewer's
+    # "select every member of this assembly" resolves a GUID back to a
+    # scene item via a map that can only hold one value per key - 16 of
+    # 17 colliding instances silently overwrite each other, and every
+    # click on any of them resolves to whichever was registered last).
+    # Reuses the exact same synthetic-fallback mechanism already used for
+    # a genuinely missing GUID, just triggered on a second (or third...)
+    # sighting of the same value instead of only on emptiness - the first
+    # instance to claim a real GUID keeps it, every later instance sharing
+    # that same value falls back to a synthetic one instead.
+    seen_guids: set = set()
 
     for item_index, (node, world_matrix) in enumerate(leaves):
         resource_id = node.mesh_resource_id
@@ -429,15 +453,21 @@ def to_fragments(scene: "InstancedScene", *, raw: bool = False) -> bytes:
         categories.append(node.layer or "Layer0")
         names.append(node.name or "")
         # Real SketchUp instance GUID when the source file carries one
-        # (VFF/2021+); a stable synthetic fallback otherwise (legacy-format
-        # files don't currently expose a per-instance GUID). Either way,
-        # every tracked item gets a non-empty, unique-within-this-export
-        # identifier - consumers keyed on GUID<->local_id parity (e.g. a
-        # viewer's own id-bridge, zipping Model.guids against Model.local_ids
+        # (VFF/2021+) AND it hasn't already been claimed by an earlier
+        # item in this same export (see seen_guids above); a stable
+        # synthetic fallback otherwise (legacy-format files don't
+        # currently expose a per-instance GUID, and a duplicate real GUID
+        # is treated the same as a missing one). Either way, every tracked
+        # item gets a non-empty, unique-within-this-export identifier -
+        # consumers keyed on GUID<->local_id parity (e.g. a viewer's own
+        # id-bridge, zipping Model.guids against Model.local_ids
         # index-for-index) silently get an empty map otherwise, since a
         # zero-length guids vector zips to nothing regardless of how many
-        # real items exist.
-        item_guid = node.guid or f"openskp-{item_index}"
+        # real items exist - and a collided (non-unique) GUID breaks that
+        # same lookup just as thoroughly as an empty one would.
+        raw_guid = node.guid or ""
+        item_guid = raw_guid if raw_guid and raw_guid not in seen_guids else f"openskp-{item_index}"
+        seen_guids.add(item_guid)
         guids.append(item_guid)
         if node.name_is_generated:
             generated_name_guids.append(item_guid)

--- a/packages/python/tests/test_fragments.py
+++ b/packages/python/tests/test_fragments.py
@@ -191,6 +191,45 @@ class TestToFragmentsGuids:
         assert model.GuidsLength() == 1
         assert model.Guids(0).decode() == real_guid
 
+    def test_a_duplicated_source_guid_does_not_collide(self):
+        """openskp#290: SketchUp's own native Copy/Move+Copy/Array tools
+        carry an instance's attribute dictionaries - and whatever GUID a
+        framing plugin wrote into one - to every copy verbatim, so a real
+        file can have several DIFFERENT physical instances all sharing the
+        exact same non-empty InstancedNode.guid. The first instance to
+        claim a real GUID keeps it; every later instance sharing that same
+        value must fall back to a synthetic one instead of silently
+        colliding - a collision breaks any GUID-keyed lookup exactly like
+        a missing GUID would (see test_items_without_a_source_guid_get_a_
+        unique_synthetic_one above), just with real, non-obviously-wrong-
+        looking values instead of an empty string."""
+        resource = InstancedMeshResource(
+            id="mesh_0", definition_id=1, definition_name="Truss",
+            variant_key="1|255,255,255", primitives=[_box_primitive()],
+        )
+        duplicated_guid = "F160C36229782F47A9857FC88DD1F2CB"
+        nodes = [
+            InstancedNode(
+                name=f"Truss{i}", layer="Framing", matrix=IDENTITY,
+                mesh_resource_id="mesh_0", guid=duplicated_guid,
+            )
+            for i in range(3)
+        ]
+        root = InstancedNode(name="ROOT", matrix=IDENTITY, children=nodes)
+        scene = InstancedScene(
+            bounds=None, scene_hierarchy=root, mesh_resources=[resource],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [1.0, 1.0, 1.0, 1.0]}}],
+            textures=[],
+        )
+        data = fragments.to_fragments(scene, raw=True)
+        model = Model.GetRootAsModel(bytearray(data), 0)
+
+        assert model.GuidsLength() == 3
+        guids = [model.Guids(i).decode() for i in range(3)]
+        assert len(set(guids)) == 3  # never duplicated, even though the source was
+        assert duplicated_guid in guids  # the first claimant keeps the real value
+        assert guids.count(duplicated_guid) == 1  # but only the first one
+
     def test_shell_geometry_matches_the_source_primitive(self):
         scene = _make_two_instance_scene()
         data = fragments.to_fragments(scene, raw=True)


### PR DESCRIPTION
## Summary
Closes #290. A real SketchUp file can carry a non-unique per-instance GUID: an instance is authored once (a framing plugin writes its own identity into that instance's attribute dictionary), then duplicated via SketchUp's own native Copy/Move+Copy/Array tools instead of re-running the plugin per placement. A plain entity duplication carries the source instance's attribute dictionaries - and whatever GUID field a plugin wrote into one - to every copy verbatim, so several physically distinct instances (each with its own correct transform) end up sharing one GUID value.

`to_fragments()` previously used a node's own `guid` directly whenever it was non-empty, only falling back to a synthetic identifier when the guid was *missing*. A collision passed straight through untouched - two (or seventeen) different items sharing one GUID - which breaks any GUID-keyed lookup exactly like a missing GUID would (a viewer resolving "what did I click on" or "select every member of this assembly" through a `Map<guid, item>` can only hold one value per key), just with real-looking values instead of an obviously-wrong empty string.

## Fix
Track which GUIDs have already been claimed within a single export. The first instance to use a given real GUID keeps it; any later instance sharing that same value falls back to a synthetic one instead - reusing the exact same fallback mechanism already in place for a genuinely missing GUID (`node.guid or f"openskp-{item_index}"`), just also triggered on a repeat, not only on emptiness. `generated_name_guids` tracking (a separate, pre-existing concern for synthesized *names*) is unaffected.

`export/ifc.py` and `scene.py`/`export/glb.py` are unaffected - IFC export assigns a fresh random `GlobalId` per product regardless of source data, and the GLB path has no GUID concept at all.

## Test plan
- [x] New regression test (`test_a_duplicated_source_guid_does_not_collide`) - three `InstancedNode`s sharing one source GUID; asserts the exported `Model.guids` are all distinct, the real GUID is preserved for exactly one of them, and the other two get synthetic fallbacks.
- [x] Full suite: 537 passed, `ruff check` clean.