### PR TITLE
fix(cpp): port 4 IFC export correctness fixes from Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,55 @@ display names the same way Python's `instanced_scene.py`/`scene.py` do:
 attribute-dict override → instance's own name → definition's own name
 (unless auto-generated) → internal index fallback.
 
+### Fixed — C++: 4 correctness issues in IFC export
+
+Ports Python's `1.3.0` IFC fixes to `ifc_export.cpp`, verified against a
+real production file (steel-detailing plugin data included) as well as
+new unit tests mirroring Python's own (`packages/python/tests/test_ifc.py`).
+
+- **Units and axis convention** — `to_ifc()`/`export_ifc()` always declared
+  the length unit as millimetres but defaulted their coordinate scale to
+  `METRES_TO_INCHES` — every coordinate was written inch-scaled but
+  labeled millimetre, off by ~25.4x in any IFC consumer that respects the
+  unit declaration. Default scale is now `METRES_TO_MM` (1000.0). Vertex
+  positions (baked in glTF's Y-up convention for GLB export) are now
+  converted back to IFC/SketchUp's Z-up convention instead of being
+  written through raw — the previous behavior exported buildings rotated
+  ~90 degrees and mirrored.
+- **Real instance names and layer visibility** — elements were named
+  after `GlbPrimitive::geom_name` (an internal mesh-lookup key, e.g.
+  `"mesh_3115_ROOT__Component_6205261_Layer0"`) instead of the real
+  SketchUp instance name. Now uses `MeshMetadata::name`. Also switches
+  the IFC layer assignment from `IFCPRESENTATIONLAYERASSIGNMENT` to
+  `IFCPRESENTATIONLAYERWITHSTYLE`, which can actually carry a layer's
+  on/off state (`LayerOn`) — new `Scene::layer_hidden` field, threaded
+  through from the parser's existing per-layer hidden state (legacy
+  pre-2021 files only; VFF files always read visible here, a separate,
+  open gap — see [LANGUAGE_PARITY.md](docs/LANGUAGE_PARITY.md)).
+- **Plugin attribute dictionaries surfaced as element names and IFC
+  properties** — `build_scene()` (`scene.cpp`) gained the same
+  attribute-dict-override name-resolution fallback `instanced_scene.cpp`
+  already had, plus a deferred mesh backfill mechanism (mirroring
+  Python's `path_updates`) so each mesh's real per-instance name,
+  properties, and attribute dictionaries are known by the time `to_ifc()`
+  reads them — new `MeshMetadata::attribute_dictionaries` /
+  `InstanceNode::attribute_dictionaries` fields. Each dictionary becomes
+  its own `Pset_<dict-name>` in IFC output, separate from
+  `Pset_CustomProperties`. This also closes a pre-existing, previously
+  documented gap: `mesh_index[...].properties` was never populated at
+  all in the C++ baked path before this fix.
+- **Opt-in full-path keyword classification** — `classify_element()`/
+  `to_ifc()`/`export_ifc()` gain `classify_using_full_path` (default
+  `false`, so existing callers see no behavior change): when a name/layer
+  match both miss, fall back to matching the full ancestor-path string.
+
+Also fixes a latent bug this work surfaced: `dxf_export.hpp` and
+`ifc_export.hpp` each declared their own `METRES_TO_INCHES` constant in
+the same `openskp` namespace — a redefinition error in any translation
+unit including both. Moved to a single definition in `model.hpp`. The
+`openskp.hpp` umbrella header was also missing `fragments_export.hpp`
+and `ifc_export.hpp` entirely — both now included.
+
 ## [1.3.0] — 2026-09-09 — Python only, GitHub-only pre-release
 
 > **This tag is not published to PyPI.** It's a real, tested, tagged release

--- a/docs/LANGUAGE_PARITY.md
+++ b/docs/LANGUAGE_PARITY.md
@@ -53,7 +53,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | Legacy (pre-2021) pages/scenes reading | ✅ | ❌ VFF only | ❌ VFF only | ❌ VFF only | ❌ VFF only |
 | Construction lines/points reading | ✅ | ❌ | ❌ | ❌ | ❌ |
 | VFF per-layer-hidden flag reading | 🔶 on main | ❌ | ❌ | ❌ | ❌ |
-| `mesh_index[...].properties` populated | ✅ | ✅ | ✅ | ✅ | ❌ known gap |
+| `mesh_index[...].properties` populated | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `model.layers` in file order (not alphabetical) | ✅ | ✅ | ✅ | ✅ | ❌ known gap |
 | **Scene building & observability** | | | | | |
 | Scene baking / triangulation (`buildScene()`) | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -76,7 +76,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | codegen round-trips `applied_width`/opacity | ❌ | ❌ | ❌ | ❌ | ❌ — gap in all 5 |
 | **Export** | | | | | |
 | GLB / OBJ+MTL / STL / PLY / DXF 3D / IFC4 / JSON | ✅ | ✅ | ✅ | ✅ | ✅ |
-| IFC export: unit/axis fix, real names + layer visibility, plugin-attribute Psets, full-path classification | 🔶 on main | not checked for equivalent issues | not checked | not checked | not checked |
+| IFC export: unit/axis fix, real names + layer visibility, plugin-attribute Psets, full-path classification | 🔶 on main | not checked for equivalent issues | not checked | not checked | 🔶 on main, GitHub-only |
 | Direct SketchUp → Fragments (`.frag`) export | 🔶 on main, GitHub-only | 🔶 open [PR #276](https://github.com/iamahsanmehmood/openskp/pull/276), CI failing | ❌ not started | ❌ not started | 🔶 on main, GitHub-only |
 
 ## 3. Unreleased on main
@@ -111,13 +111,13 @@ C++ merged, not yet released:
 |:---|:---|:---|
 | Direct SketchUp → Fragments (`.frag`) export | `openskp::to_fragments`/`export_fragments` (`fragments_export.cpp`) | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | Multi-dictionary attribute extraction (`Instance::attribute_dictionaries` / `InstancedNode::attribute_dictionaries`) | `geometry.cpp`, `instanced_scene.cpp`, `scene.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
+| 4 IFC export correctness fixes (units/axis, real names + layer visibility, plugin-attribute Psets, opt-in full-path classification) | `ifc_export.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
+| `mesh_index[...].properties`/`.attribute_dictionaries` backfill in the baked (`build_scene`) path | `scene.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 
-Known gaps in this C++ work, stated honestly rather than glossed over:
+Known gap in this C++ work, stated honestly rather than glossed over:
 attribute dictionary values decode as strings only (no `Point3d`/`Length`/
 nested-list support, matching C++'s existing string-only property handling
-elsewhere — see the feature matrix above); `mesh_index[...].properties` is
-still not backfilled in the baked (`build_scene`) path, a pre-existing gap
-this work did not close.
+elsewhere — see the feature matrix above).
 
 ## 4. Real SketchUp file version support
 

--- a/packages/cpp/CMakeLists.txt
+++ b/packages/cpp/CMakeLists.txt
@@ -285,4 +285,7 @@ if(OPENSKP_BUILD_EXAMPLES)
 
   add_executable(openskp_parsetest examples/parsetest.cpp)
   target_link_libraries(openskp_parsetest PRIVATE OpenSkp::OpenSkp)
+
+  add_executable(openskp_ifctest examples/ifctest.cpp)
+  target_link_libraries(openskp_ifctest PRIVATE OpenSkp::OpenSkp)
 endif()

--- a/packages/cpp/examples/ifctest.cpp
+++ b/packages/cpp/examples/ifctest.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+
+#include <openskp/openskp.hpp>
+
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << "usage: openskp_ifctest model.skp output.ifc\n";
+    return 2;
+  }
+  try {
+    auto file = openskp::SkpFile::open(argv[1]);
+    auto scene = file.build_scene();
+    openskp::export_ifc(scene, argv[2]);
+    std::cout << "ok: " << scene.mesh_index.size() << " mesh entries, "
+              << scene.glb_primitives.size() << " primitives, " << scene.layer_hidden.size()
+              << " layer_hidden entries\n";
+  } catch (const std::exception& e) {
+    std::cerr << "EXC: " << e.what() << '\n';
+    return 1;
+  }
+}

--- a/packages/cpp/include/openskp/dxf_export.hpp
+++ b/packages/cpp/include/openskp/dxf_export.hpp
@@ -9,9 +9,6 @@
 
 namespace openskp {
 
-// 1 metre = 39.37007874015748 inches (SketchUp native unit)
-constexpr double METRES_TO_INCHES = 39.37007874015748;
-
 /**
  * Serialize a baked Scene into AutoCAD R2000 (AC1015) 3D ASCII DXF text format.
  * Exports Polyface Mesh (POLYLINE 70=64) entities with layer and entity RGB materials.

--- a/packages/cpp/include/openskp/ifc_export.hpp
+++ b/packages/cpp/include/openskp/ifc_export.hpp
@@ -10,8 +10,15 @@
 
 namespace openskp {
 
-// 1 metre = 39.37007874015748 inches (SketchUp native unit)
-constexpr double METRES_TO_INCHES = 39.37007874015748;
+// METRES_TO_INCHES (SketchUp's native unit) is declared once in
+// model.hpp, shared with dxf_export.hpp - kept available here for callers
+// that want inch-scaled coordinates explicitly, but it is NOT the
+// default scale below: the file always declares its length unit as
+// millimetres (see IFCSIUNIT in ifc_export.cpp), so the default scale has
+// to produce millimetre-scaled values or every coordinate reads back
+// ~25.4x too small in any IFC consumer that respects the unit
+// declaration.
+constexpr double METRES_TO_MM = 1000.0;
 
 /// A (STEP_ENTITY_TYPE, IFC_CLASS_NAME) classification, and the signature
 /// a custom classifier passed to to_ifc()/export_ifc() must match.
@@ -29,38 +36,60 @@ std::string generate_ifc_guid();
  * Tries geom_name first, then falls back to layer_name (many
  * SketchUp-for-BIM workflows organize by tag/layer - "Walls", "Doors" -
  * even when individual components are never renamed away from
- * SketchUp's own defaults like "Component#109415"), then falls back to a
- * generic, untyped element if neither matches.
+ * SketchUp's own defaults like "Component#109415").
+ *
+ * If neither matches and classify_using_full_path is set, falls back
+ * further to keyword-matching the component's full ancestor hierarchy
+ * path (e.g. "ROOT / Wall Frame / Stud 12") - a broader, noisier signal
+ * than the component's own name/layer, since it can match on an
+ * ancestor's name rather than the part itself. Off by default: matching
+ * keywords against a mangled internal path unconditionally was a past
+ * bug here (it also corrupted the element's displayed Name), so that
+ * broader matching is an explicit opt-in rather than the only behavior
+ * available. Only if nothing at all matches does this fall back to a
+ * generic, untyped element.
  */
 std::pair<std::string, std::string> classify_element(const std::string& geom_name,
-                                                     const std::string& layer_name = "");
+                                                     const std::string& layer_name = "",
+                                                     const std::string& path_name = "",
+                                                     bool classify_using_full_path = false);
 
 /**
  * Serialize a baked Scene into ISO-10303-21 STEP ASCII IFC4 format.
  *
  * @param scene The baked scene returned by SkpFile::build_scene()
- * @param scale Scale factor for vertex coordinates (default: METRES_TO_INCHES)
+ * @param scale Scale factor for vertex coordinates (default: METRES_TO_MM -
+ *   matches the millimetre length unit this exporter always declares)
  * @param schema IFC schema version (default: "IFC4")
  * @param classifier Optional override for classify_element() - supply your
  *   own naming convention or metadata-driven typing instead of the
- *   built-in keyword/layer heuristic.
+ *   built-in keyword/layer heuristic. Ignored (never called) when
+ *   classify_using_full_path is set, since that flag only affects the
+ *   built-in classifier.
+ * @param classify_using_full_path When the built-in classifier (i.e.
+ *   classifier is not given) can't type an element from its own name or
+ *   layer, also try keyword-matching its full ancestor hierarchy path.
+ *   Off by default - see classify_element() for why.
  * @return Formatted ASCII IFC text string.
  */
-std::string to_ifc(const Scene& scene, double scale = METRES_TO_INCHES,
-                   const std::string& schema = "IFC4", const IfcClassifier& classifier = nullptr);
+std::string to_ifc(const Scene& scene, double scale = METRES_TO_MM,
+                   const std::string& schema = "IFC4", const IfcClassifier& classifier = nullptr,
+                   bool classify_using_full_path = false);
 
 /**
  * Export a baked Scene directly to an ISO-10303-21 STEP ASCII IFC4 file.
  *
  * @param scene The baked scene returned by SkpFile::build_scene()
  * @param path Destination file path (.ifc)
- * @param scale Scale factor for vertex coordinates (default: METRES_TO_INCHES)
+ * @param scale Scale factor for vertex coordinates (default: METRES_TO_MM -
+ *   matches the millimetre length unit this exporter always declares)
  * @param schema IFC schema version (default: "IFC4")
  * @param classifier Optional override for classify_element() - see to_ifc().
+ * @param classify_using_full_path See to_ifc().
  */
-void export_ifc(const Scene& scene, const std::filesystem::path& path,
-                double scale = METRES_TO_INCHES, const std::string& schema = "IFC4",
-                const IfcClassifier& classifier = nullptr);
+void export_ifc(const Scene& scene, const std::filesystem::path& path, double scale = METRES_TO_MM,
+                const std::string& schema = "IFC4", const IfcClassifier& classifier = nullptr,
+                bool classify_using_full_path = false);
 
 }  // namespace openskp
 

--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -22,6 +22,13 @@ using Vec3 = std::array<double, 3>;
 using Color3 = std::array<std::uint8_t, 3>;
 using Color4 = std::array<std::uint8_t, 4>;
 
+// 1 metre = 39.37007874015748 inches (SketchUp native unit). Shared by
+// every exporter that takes a coordinate scale factor (dxf_export.hpp,
+// ifc_export.hpp, ...) - defined once here rather than duplicated per
+// header, since two same-named constexprs in the same namespace collide
+// as a redefinition error in any translation unit that includes both.
+constexpr double METRES_TO_INCHES = 39.37007874015748;
+
 /// 3D point coordinate in raw SketchUp space.
 struct Vertex {
   /// Unique TLV entity ID.

--- a/packages/cpp/include/openskp/openskp.hpp
+++ b/packages/cpp/include/openskp/openskp.hpp
@@ -5,7 +5,9 @@
 #include <openskp/dxf_export.hpp>
 #include <openskp/edit.hpp>
 #include <openskp/errors.hpp>
+#include <openskp/fragments_export.hpp>
 #include <openskp/glb.hpp>
+#include <openskp/ifc_export.hpp>
 #include <openskp/instanced_glb.hpp>
 #include <openskp/instanced_scene.hpp>
 #include <openskp/json_export.hpp>

--- a/packages/cpp/include/openskp/scene.hpp
+++ b/packages/cpp/include/openskp/scene.hpp
@@ -19,6 +19,10 @@ struct InstanceNode {
   std::array<double, 3> position_mm{};
   std::map<std::string, std::string> properties;
   std::vector<InstanceNode> children;
+  // Every attribute dictionary this instance carries, keyed by the
+  // dictionary's own declared name - not just SketchUp's own
+  // dynamic_attributes (which is what `properties` above holds).
+  std::map<std::string, std::map<std::string, std::string>> attribute_dictionaries;
 };
 
 struct MeshMetadata {
@@ -28,6 +32,10 @@ struct MeshMetadata {
   std::array<double, 3> position_mm{};
   std::map<std::string, std::string> properties;
   std::string path;
+  // Same as InstanceNode::attribute_dictionaries above - backfilled from
+  // the instance that placed this mesh's definition, matching `name`
+  // and `properties` above (see build_scene_raw's deferred backfill).
+  std::map<std::string, std::map<std::string, std::string>> attribute_dictionaries;
 };
 
 struct GlbPrimitive {
@@ -86,5 +94,11 @@ struct OPENSKP_EXPORT Scene {
   // Distinct texture images the placed materials use, deduplicated by
   // source bytes. Empty when nothing placed in the scene is textured.
   std::vector<SceneTexture> textures;
+  // Each layer's own hidden/visible state, by layer name - threaded
+  // through from the parser's existing per-layer hidden state. Legacy
+  // (pre-2021) files carry a real per-layer flag; VFF (2021+) files are
+  // not yet read here (open gap, see docs/LANGUAGE_PARITY.md), so every
+  // VFF layer is absent from this map (treated as visible by consumers).
+  std::map<std::string, bool> layer_hidden;
 };
 }  // namespace openskp

--- a/packages/cpp/src/ifc_export.cpp
+++ b/packages/cpp/src/ifc_export.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cmath>
 #include <fstream>
+#include <functional>
 #include <iomanip>
 #include <map>
 #include <optional>
@@ -83,17 +84,71 @@ std::optional<std::pair<std::string, std::string>> classify_by_keyword(const std
 }  // namespace
 
 std::pair<std::string, std::string> classify_element(const std::string& geom_name,
-                                                     const std::string& layer_name) {
+                                                     const std::string& layer_name,
+                                                     const std::string& path_name,
+                                                     bool classify_using_full_path) {
   if (auto by_name = classify_by_keyword(geom_name)) return *by_name;
   if (!layer_name.empty()) {
     if (auto by_layer = classify_by_keyword(layer_name)) return *by_layer;
   }
+  if (classify_using_full_path && !path_name.empty()) {
+    if (auto by_path = classify_by_keyword(path_name)) return *by_path;
+  }
   return {"IFCBUILDINGELEMENTPROXY", "IfcBuildingElementProxy"};
 }
 
+namespace {
+
+// One IFCPROPERTYSET (props) attached to product_id via
+// IFCRELDEFINESBYPROPERTIES. Shared by both meta.properties
+// (Pset_CustomProperties) and every other attribute dictionary an
+// instance carries (Pset_<dict-name>) below.
+void write_pset(std::ostringstream& ss, const std::function<int()>& next_id, int owner_hist_id,
+                int product_id, const std::string& pset_name,
+                const std::map<std::string, std::string>& props) {
+  if (props.empty()) return;
+  std::vector<int> prop_val_ids;
+  for (const auto& [pk, pv] : props) {
+    std::string clean_k = sanitize_name(pk);
+    std::string clean_v = sanitize_name(pv);
+    int prop_id = next_id();
+    ss << "#" << prop_id << "=IFCPROPERTYSINGLEVALUE('" << clean_k << "',$,IFCTEXT('" << clean_v
+       << "'),$);\r\n";
+    prop_val_ids.push_back(prop_id);
+  }
+
+  int pset_id = next_id();
+  std::ostringstream prop_ss;
+  for (size_t i = 0; i < prop_val_ids.size(); ++i) {
+    if (i > 0) prop_ss << ",";
+    prop_ss << "#" << prop_val_ids[i];
+  }
+  ss << "#" << pset_id << "=IFCPROPERTYSET('" << generate_ifc_guid() << "',#" << owner_hist_id
+     << ",'" << sanitize_name(pset_name) << "',$,(" << prop_ss.str() << "));\r\n";
+  ss << "#" << next_id() << "=IFCRELDEFINESBYPROPERTIES('" << generate_ifc_guid() << "',#"
+     << owner_hist_id << ",$,$,(#" << product_id << "),#" << pset_id << ");\r\n";
+}
+
+}  // namespace
+
 std::string to_ifc(const Scene& scene, double scale, const std::string& schema,
-                   const IfcClassifier& classifier) {
-  IfcClassifier classify = classifier ? classifier : IfcClassifier(classify_element);
+                   const IfcClassifier& classifier, bool classify_using_full_path) {
+  // classifier (if given) keeps its original 2-arg (name, layer) public
+  // signature; only the built-in classify_element() gains the path/
+  // full-path-matching parameters, matching openskp.export.ifc's own
+  // to_ifc()/classify_element() split.
+  std::function<std::pair<std::string, std::string>(const std::string&, const std::string&,
+                                                    const std::string&)>
+      classify;
+  if (classifier) {
+    classify = [&](const std::string& name, const std::string& layer, const std::string&) {
+      return classifier(name, layer);
+    };
+  } else {
+    classify = [&](const std::string& name, const std::string& layer, const std::string& path) {
+      return classify_element(name, layer, path, classify_using_full_path);
+    };
+  }
   std::string schema_str = schema.empty() ? "IFC4" : schema;
   std::transform(schema_str.begin(), schema_str.end(), schema_str.begin(),
                  [](unsigned char c) { return std::toupper(c); });
@@ -212,22 +267,39 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema,
     size_t v_count = prim.positions.size() / 3;
     if (tri_count == 0 || v_count == 0) continue;
 
-    std::string geom_name = sanitize_name(prim.geom_name);
-    std::string layer_name = "Layer0";
     auto meta_it = scene.mesh_index.find(prim.geom_name);
+    // prim.geom_name is an internal lookup key (mesh index + hierarchy
+    // path + layer, e.g. "mesh_3115_ROOT__Component_6205261_Layer0") -
+    // never the element's real name. meta.name is the actual SketchUp
+    // instance name (or SketchUp's own "Component_<id>" default when
+    // nobody renamed it) - use that for both classification and the
+    // element's IFC Name, falling back to the internal key only if a
+    // primitive somehow has no mesh_index entry.
+    std::string display_name = (meta_it != scene.mesh_index.end() && !meta_it->second.name.empty())
+                                   ? sanitize_name(meta_it->second.name)
+                                   : sanitize_name(prim.geom_name);
+    std::string layer_name = "Layer0";
     if (meta_it != scene.mesh_index.end() && !meta_it->second.layer.empty()) {
       layer_name = sanitize_name(meta_it->second.layer);
     }
+    std::string path_name = meta_it != scene.mesh_index.end() ? meta_it->second.path : "";
 
-    auto [step_type, _] = classify(geom_name, layer_name);
+    auto [step_type, _] = classify(display_name, layer_name, path_name);
 
+    // scene.glb_primitives positions are baked in glTF's Y-up convention
+    // (glTF.y = SketchUp Z/height, glTF.z = -SketchUp Y/depth) - correct
+    // for GLB export, but IFC (like SketchUp itself) is Z-up, so it has
+    // to be converted back rather than passed through raw, or the
+    // exported building comes out rotated ~90 degrees and mirrored.
     std::ostringstream pt_ss;
     pt_ss.imbue(std::locale::classic());
     pt_ss << std::fixed << std::setprecision(6);
     for (size_t i = 0; i < v_count; ++i) {
       if (i > 0) pt_ss << ",";
-      pt_ss << "(" << (prim.positions[i * 3] * scale) << "," << (prim.positions[i * 3 + 1] * scale)
-            << "," << (prim.positions[i * 3 + 2] * scale) << ")";
+      double vx = prim.positions[i * 3] * scale;
+      double vy = -prim.positions[i * 3 + 2] * scale;
+      double vz = prim.positions[i * 3 + 1] * scale;
+      pt_ss << "(" << vx << "," << vy << "," << vz << ")";
     }
 
     int pt_list_id = next_id();
@@ -265,7 +337,7 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema,
          << ",$,$,$,$,$,$,.FLAT.);\r\n";
 
       int style_id = next_id();
-      ss << "#" << style_id << "=IFCSURFACESTYLE('" << geom_name << "_Material',.BOTH.,(#"
+      ss << "#" << style_id << "=IFCSURFACESTYLE('" << display_name << "_Material',.BOTH.,(#"
          << rendering_id << "));\r\n";
 
       style_assign_id = next_id();
@@ -294,41 +366,38 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema,
     std::string prod_guid = generate_ifc_guid();
     if (step_type == "IFCBUILDINGELEMENTPROXY") {
       ss << "#" << product_id << "=" << step_type << "('" << prod_guid << "',#" << owner_hist_id
-         << ",'" << geom_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id
+         << ",'" << display_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id
          << ",$,.NOTDEFINED.);\r\n";
     } else {
       ss << "#" << product_id << "=" << step_type << "('" << prod_guid << "',#" << owner_hist_id
-         << ",'" << geom_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id
+         << ",'" << display_name << "',$,$,#" << prod_placement_id << ",#" << prod_shape_id
          << ",$,$);\r\n";
     }
     product_ids.push_back(product_id);
 
-    if (meta_it != scene.mesh_index.end() && !meta_it->second.properties.empty()) {
-      std::vector<int> prop_val_ids;
-      for (const auto& [pk, pv] : meta_it->second.properties) {
-        std::string clean_k = sanitize_name(pk);
-        std::string clean_v = sanitize_name(pv);
-        int prop_id = next_id();
-        ss << "#" << prop_id << "=IFCPROPERTYSINGLEVALUE('" << clean_k << "',$,IFCTEXT('" << clean_v
-           << "'),$);\r\n";
-        prop_val_ids.push_back(prop_id);
-      }
+    if (meta_it != scene.mesh_index.end()) {
+      write_pset(ss, next_id, owner_hist_id, product_id, "Pset_CustomProperties",
+                 meta_it->second.properties);
 
-      if (!prop_val_ids.empty()) {
-        int pset_id = next_id();
-        std::ostringstream prop_ss;
-        for (size_t i = 0; i < prop_val_ids.size(); ++i) {
-          if (i > 0) prop_ss << ",";
-          prop_ss << "#" << prop_val_ids[i];
-        }
-        ss << "#" << pset_id << "=IFCPROPERTYSET('" << generate_ifc_guid() << "',#" << owner_hist_id
-           << ",'Pset_CustomProperties',$,(" << prop_ss.str() << "));\r\n";
-        ss << "#" << next_id() << "=IFCRELDEFINESBYPROPERTIES('" << generate_ifc_guid() << "',#"
-           << owner_hist_id << ",$,$,(#" << product_id << "),#" << pset_id << ");\r\n";
+      // Any OTHER attribute dictionaries the instance carries (third-party
+      // BIM/steel-detailing plugins, etc. - see MeshMetadata::
+      // attribute_dictionaries) - each becomes its own named property set
+      // instead of being merged into Pset_CustomProperties, since these
+      // come from a distinct source and commonly share key names with
+      // each other (e.g. multiple plugins using "name").
+      for (const auto& [dict_name, entries] : meta_it->second.attribute_dictionaries) {
+        write_pset(ss, next_id, owner_hist_id, product_id, "Pset_" + dict_name, entries);
       }
     }
   }
 
+  // Presentation Layer Assignments (preserve layers and their on/off
+  // state). IFCPRESENTATIONLAYERWITHSTYLE - not the plain
+  // IFCPRESENTATIONLAYERASSIGNMENT neither SketchUp's own IFC exporter
+  // nor the IFC-manager SketchUp extension use - is the only IFC4 entity
+  // that can carry a layer's visibility at all (LayerOn); every other
+  // attribute here besides Name and LayerOn is left unset/false since
+  // this project doesn't track them (freeze/block/layer-level styles).
   for (const auto& [l_name, item_ids] : layer_items) {
     if (!item_ids.empty()) {
       std::ostringstream item_ss;
@@ -336,8 +405,11 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema,
         if (i > 0) item_ss << ",";
         item_ss << "#" << item_ids[i];
       }
-      ss << "#" << next_id() << "=IFCPRESENTATIONLAYERASSIGNMENT('" << l_name << "',$,("
-         << item_ss.str() << "),$);\r\n";
+      auto hidden_it = scene.layer_hidden.find(l_name);
+      const char* layer_on =
+          (hidden_it != scene.layer_hidden.end() && hidden_it->second) ? ".F." : ".T.";
+      ss << "#" << next_id() << "=IFCPRESENTATIONLAYERWITHSTYLE('" << l_name << "',$,("
+         << item_ss.str() << "),$," << layer_on << ",.F.,.F.,());\r\n";
     }
   }
 
@@ -357,7 +429,8 @@ std::string to_ifc(const Scene& scene, double scale, const std::string& schema,
 }
 
 void export_ifc(const Scene& scene, const std::filesystem::path& path, double scale,
-                const std::string& schema, const IfcClassifier& classifier) {
+                const std::string& schema, const IfcClassifier& classifier,
+                bool classify_using_full_path) {
   if (path.has_parent_path()) {
     std::filesystem::create_directories(path.parent_path());
   }
@@ -365,7 +438,7 @@ void export_ifc(const Scene& scene, const std::filesystem::path& path, double sc
   if (!file.is_open()) {
     throw std::runtime_error("Failed to open file for writing: " + path.string());
   }
-  std::string text = to_ifc(scene, scale, schema, classifier);
+  std::string text = to_ifc(scene, scale, schema, classifier, classify_using_full_path);
   file.write(text.data(), text.size());
 }
 

--- a/packages/cpp/src/scene.cpp
+++ b/packages/cpp/src/scene.cpp
@@ -33,12 +33,27 @@ bool is_generic_definition_name(const std::string& name) {
 
 Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
   Scene scene;
-  scene.scene_hierarchy = {"ROOT", "ROOT_MODEL", "Layer0", {0, 0, 0}, {}, {}};
+  scene.scene_hierarchy = {"ROOT", "ROOT_MODEL", "Layer0", {0, 0, 0}, {}, {}, {}};
+  scene.layer_hidden = p.layer_hidden;
   emit_log(o, LogLevel::information,
            "Building scene: " + std::to_string(p.definitions.size()) + " definitions available");
   std::map<GroupKey, size_t> materials;
   size_t mesh_counter = 0, instance_counter = 0;
   std::set<EntityId> active;
+
+  // Deferred mesh backfill: a mesh's own path is recorded verbatim as a
+  // path_updates key by the exact instance that placed the definition
+  // that mesh's own faces belong to (never an ancestor's), so a direct
+  // O(1) lookup per mesh after the whole tree is built is enough - no
+  // cascading from an ancestor down to its descendants' own meshes.
+  // Needed because a mesh's own MeshMetadata is built once per
+  // definition's own geometry (shared across every instance of that
+  // definition), before the instance placing it - and so its real
+  // per-instance name/properties/attribute dictionaries - is even known.
+  // Matches openskp.scene.build_scene's identical path_updates mechanism.
+  std::map<std::string, std::tuple<std::map<std::string, std::string>, std::string,
+                                   std::map<std::string, std::map<std::string, std::string>>>>
+      path_updates;
 
   // Textures deduplicated by bytes: the same image routinely backs
   // several materials, and re-embedding it per material would multiply
@@ -217,7 +232,9 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
                         {mat.size() > 9 ? mat[9] * 25.4 : 0, mat.size() > 10 ? mat[10] * 25.4 : 0,
                          mat.size() > 11 ? mat[11] * 25.4 : 0},
                         i.properties,
-                        std::move(nested)};
+                        std::move(nested),
+                        i.attribute_dicts};
+      path_updates[child_path] = {i.properties, display_name, i.attribute_dicts};
       children.push_back(std::move(node));
       if (++instance_counter % progress_interval == 0)
         emit_progress(o, ParseStage::build_scene, instance_counter, instance_counter);
@@ -227,6 +244,17 @@ Scene build_scene_raw(RawParsed&& p, const ParseOptions& o) {
   std::vector<double> identity{1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1};
   scene.scene_hierarchy.children =
       bake(p.root.builder, "ROOT_MODEL", {}, identity, "Layer0", "ROOT", {});
+
+  // Apply the deferred backfill: each mesh's real per-instance name/
+  // properties/attribute dictionaries, now that the whole tree (and so
+  // every instance's own data) has been walked.
+  for (auto& [geom_name, meta] : scene.mesh_index) {
+    auto found = path_updates.find(meta.path);
+    if (found != path_updates.end()) {
+      std::tie(meta.properties, meta.name, meta.attribute_dictionaries) = found->second;
+    }
+  }
+
   emit_log(o, LogLevel::information,
            "Scene build complete: " + std::to_string(instance_counter) + " instances, " +
                std::to_string(scene.mesh_index.size()) + " meshes, " +

--- a/packages/cpp/tests/ifc_export_test.cpp
+++ b/packages/cpp/tests/ifc_export_test.cpp
@@ -1,9 +1,51 @@
 #include "openskp/ifc_export.hpp"
 
 #include <gtest/gtest.h>
+#include <sstream>
+#include <string>
 
 namespace openskp {
 namespace {
+
+Scene create_mock_scene() {
+  GlbPrimitive prim1;
+  prim1.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  prim1.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim1.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim1.indices = {0, 1, 2};
+  prim1.material_index = 0;
+  prim1.geom_name = "Outer Wall";
+
+  GlbPrimitive prim2;
+  prim2.positions = {2.0, 0.0, 0.0, 3.0, 0.0, 0.0, 2.0, 1.0, 0.0};
+  prim2.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim2.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim2.indices = {0, 1, 2};
+  prim2.material_index = 1;
+  prim2.geom_name = "Front Door";
+
+  Scene scene;
+  scene.scene_hierarchy.name = "Root";
+  scene.glb_primitives = {prim1, prim2};
+
+  GltfMaterial mat1;
+  mat1.pbr_metallic_roughness.base_color_factor = {0.8, 0.2, 0.2, 1.0};
+  GltfMaterial mat2;
+  mat2.pbr_metallic_roughness.base_color_factor = {0.2, 0.8, 0.2, 0.9};
+  scene.gltf_materials = {mat1, mat2};
+
+  MeshMetadata wall;
+  wall.name = "Outer Wall";
+  wall.properties = {{"Thickness", "200mm"}, {"LoadBearing", "True"}};
+  scene.mesh_index["Outer Wall"] = wall;
+
+  MeshMetadata door;
+  door.name = "Front Door";
+  door.properties = {{"Material", "Wood"}};
+  scene.mesh_index["Front Door"] = door;
+
+  return scene;
+}
 
 TEST(IfcExport, GeneratesValid22CharGuid) {
   std::string guid = generate_ifc_guid();
@@ -107,6 +149,243 @@ TEST(IfcExport, SerializesSceneToIfc4StepText) {
   EXPECT_NE(ifc_text.find("IFCCARTESIANPOINTLIST3D"), std::string::npos);
   EXPECT_NE(ifc_text.find("IFCPROPERTYSET"), std::string::npos);
   EXPECT_NE(ifc_text.find("ENDSEC;"), std::string::npos);
+}
+
+// The exporter always declares millimetres - the default scale has to
+// actually produce millimetre-scaled values, or every coordinate reads
+// back ~25.4x too small in any IFC consumer that respects the unit
+// declaration (this exact bug, caught 2026-09-07 comparing against a
+// real SketchUp IFC export of the same file).
+TEST(IfcExport, ToIfcDeclaresMillimetresAndScalesToMatch) {
+  Scene scene;
+  scene.scene_hierarchy.name = "Root";
+  GlbPrimitive prim;
+  prim.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  prim.material_index = 0;
+  prim.geom_name = "Test Triangle";
+  scene.glb_primitives = {prim};
+  MeshMetadata meta;
+  meta.name = "Test Triangle";
+  scene.mesh_index["Test Triangle"] = meta;
+  GltfMaterial mat;
+  mat.pbr_metallic_roughness.base_color_factor = {0.5, 0.5, 0.5, 1.0};
+  scene.gltf_materials = {mat};
+
+  std::string ifc_text = to_ifc(scene);
+
+  EXPECT_NE(ifc_text.find("IFCSIUNIT(*,.LENGTHUNIT.,.MILLI.,.METRE.)"), std::string::npos);
+  // vertex 2 is glTF (1.0, 0.0, 0.0) = 1 metre along X, which maps
+  // straight through to IFC X - millimetres means it must come out as
+  // 1000.0, not ~39.37 (metres-to-inches, the old default).
+  EXPECT_NE(ifc_text.find("(1000.000000,-0.000000,0.000000)"), std::string::npos);
+}
+
+// scene.glb_primitives positions are baked in glTF's Y-up convention
+// (glTF.y = SketchUp Z/height, glTF.z = -SketchUp Y/depth) for GLB
+// export - IFC (like SketchUp itself) is Z-up, so to_ifc must convert
+// back rather than pass positions through raw, or the exported building
+// comes out rotated ~90 degrees and mirrored (this exact bug, caught
+// 2026-09-07 comparing against a real SketchUp IFC export of the same
+// file).
+TEST(IfcExport, ToIfcConvertsGltfYUpToIfcZUp) {
+  Scene scene;
+  scene.scene_hierarchy.name = "Root";
+  GlbPrimitive prim;
+  prim.positions = {0.0, 0.0, 0.0, 2.0, 3.0, 5.0, 0.0, 1.0, 0.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  prim.material_index = 0;
+  prim.geom_name = "Test Triangle";
+  scene.glb_primitives = {prim};
+  MeshMetadata meta;
+  meta.name = "Test Triangle";
+  scene.mesh_index["Test Triangle"] = meta;
+  GltfMaterial mat;
+  mat.pbr_metallic_roughness.base_color_factor = {0.5, 0.5, 0.5, 1.0};
+  scene.gltf_materials = {mat};
+
+  std::string ifc_text = to_ifc(scene, /*scale=*/1.0);
+
+  // glTF (2.0, 3.0, 5.0) is SketchUp (x=2.0, y=-5.0, z=3.0) - IFC/
+  // SketchUp Z-up means that vertex must appear as (2.0,-5.0,3.0), not
+  // the raw glTF-order (2.0,3.0,5.0).
+  EXPECT_NE(ifc_text.find("(2.000000,-5.000000,3.000000)"), std::string::npos);
+  EXPECT_EQ(ifc_text.find("(2.000000,3.000000,5.000000)"), std::string::npos);
+}
+
+// prim.geom_name is an internal lookup key (mesh index + hierarchy path +
+// layer, e.g. "mesh_3_ROOT__W1_Layer0") - never a name a user should
+// see. The IFC element's Name must come from MeshMetadata.name (the
+// actual SketchUp instance name) instead (this exact bug, caught
+// 2026-09-07 comparing against real IFC exports of the same file).
+TEST(IfcExport, ToIfcUsesRealInstanceNameNotInternalKey) {
+  Scene scene;
+  scene.scene_hierarchy.name = "Root";
+  GlbPrimitive prim;
+  prim.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  prim.material_index = 0;
+  prim.geom_name = "mesh_3_ROOT__W1_Layer0";
+  scene.glb_primitives = {prim};
+  MeshMetadata meta;
+  meta.name = "W1";
+  meta.layer = "Layer0";
+  scene.mesh_index["mesh_3_ROOT__W1_Layer0"] = meta;
+  GltfMaterial mat;
+  mat.pbr_metallic_roughness.base_color_factor = {0.5, 0.5, 0.5, 1.0};
+  scene.gltf_materials = {mat};
+
+  std::string ifc_text = to_ifc(scene);
+
+  EXPECT_NE(ifc_text.find("'W1'"), std::string::npos);
+  EXPECT_EQ(ifc_text.find("mesh_3_ROOT"), std::string::npos);
+}
+
+// Only IFCPRESENTATIONLAYERWITHSTYLE (not the plain
+// IFCPRESENTATIONLAYERASSIGNMENT this exporter used to write) carries a
+// layer's visibility - LayerOn must match the source file's own
+// hidden/visible state per layer, not just default to visible for
+// everything.
+TEST(IfcExport, ToIfcLayerOnReflectsSceneLayerHidden) {
+  Scene scene = create_mock_scene();
+  scene.mesh_index["Outer Wall"].layer = "Hidden Layer";
+  scene.mesh_index["Front Door"].layer = "Visible Layer";
+  scene.layer_hidden = {{"Hidden Layer", true}, {"Visible Layer", false}};
+
+  std::string ifc_text = to_ifc(scene);
+
+  EXPECT_NE(ifc_text.find("IFCPRESENTATIONLAYERWITHSTYLE"), std::string::npos);
+  EXPECT_EQ(ifc_text.find("IFCPRESENTATIONLAYERASSIGNMENT("), std::string::npos);
+  EXPECT_NE(ifc_text.find("'Hidden Layer',$,(#"), std::string::npos);
+
+  std::istringstream lines(ifc_text);
+  std::string line, hidden_line, visible_line;
+  while (std::getline(lines, line)) {
+    if (line.find("'Hidden Layer'") != std::string::npos) hidden_line = line;
+    if (line.find("'Visible Layer'") != std::string::npos) visible_line = line;
+  }
+  EXPECT_NE(hidden_line.find(",.F.,.F.,.F.,())"), std::string::npos);
+  EXPECT_NE(visible_line.find(",.T.,.F.,.F.,())"), std::string::npos);
+}
+
+// A third-party plugin's attribute dictionary (e.g. the steel-detailing
+// "fbd-einfo" seen on the Keith Street file) must reach the exported IFC
+// as its own named property set - separate from Pset_CustomProperties
+// (which stays SketchUp's own Dynamic Components data), since a second
+// source of properties commonly reuses key names like "name".
+TEST(IfcExport, ToIfcWritesAPropertySetPerExtraAttributeDictionary) {
+  Scene scene;
+  scene.scene_hierarchy.name = "Root";
+  GlbPrimitive prim;
+  prim.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  prim.material_index = 0;
+  prim.geom_name = "mesh_0_ROOT__Profile25_Layer0";
+  scene.glb_primitives = {prim};
+
+  MeshMetadata meta;
+  meta.name = "Profile25";
+  meta.properties = {{"width", "10.0"}};
+  meta.attribute_dictionaries = {{"fbd-einfo", {{"code", "aPf"}, {"angle", "90"}}}};
+  scene.mesh_index["mesh_0_ROOT__Profile25_Layer0"] = meta;
+  GltfMaterial mat;
+  mat.pbr_metallic_roughness.base_color_factor = {0.5, 0.5, 0.5, 1.0};
+  scene.gltf_materials = {mat};
+
+  std::string ifc_text = to_ifc(scene);
+
+  EXPECT_NE(ifc_text.find("'Pset_CustomProperties'"), std::string::npos);
+  EXPECT_NE(ifc_text.find("'Pset_fbd-einfo'"), std::string::npos);
+  EXPECT_NE(ifc_text.find("'width'"), std::string::npos);
+  EXPECT_NE(ifc_text.find("'code'"), std::string::npos);
+  EXPECT_NE(ifc_text.find("'aPf'"), std::string::npos);
+  EXPECT_NE(ifc_text.find("'angle'"), std::string::npos);
+  EXPECT_NE(ifc_text.find("'90'"), std::string::npos);
+}
+
+TEST(IfcExport, ToIfcSkipsEmptyAttributeDictionaries) {
+  Scene scene;
+  scene.scene_hierarchy.name = "Root";
+  GlbPrimitive prim;
+  prim.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  prim.material_index = 0;
+  prim.geom_name = "Test Triangle";
+  scene.glb_primitives = {prim};
+
+  MeshMetadata meta;
+  meta.name = "Test Triangle";
+  meta.attribute_dictionaries = {{"empty_dict", {}}};
+  scene.mesh_index["Test Triangle"] = meta;
+  GltfMaterial mat;
+  mat.pbr_metallic_roughness.base_color_factor = {0.5, 0.5, 0.5, 1.0};
+  scene.gltf_materials = {mat};
+
+  std::string ifc_text = to_ifc(scene);
+
+  EXPECT_EQ(ifc_text.find("Pset_empty_dict"), std::string::npos);
+}
+
+// #272's naming fix stopped classify_element() from matching keywords
+// against the internal mangled path string (a bug: it also corrupted the
+// displayed Name). That must stay untyped by default, and only match
+// when classify_using_full_path is set - the broader, noisier fallback
+// callers can opt into.
+TEST(IfcExport, ClassifyElementFullPathOnlyWhenOptedIn) {
+  const std::string path = "ROOT / Wall Frame / Stud 12";
+  EXPECT_EQ(classify_element("Stud 12", "Layer0", path).first, "IFCBUILDINGELEMENTPROXY");
+  EXPECT_EQ(classify_element("Stud 12", "Layer0", path, /*classify_using_full_path=*/true).first,
+            "IFCWALL");
+}
+
+// The path fallback only kicks in once name and layer both miss - it
+// must never override a real, specific match.
+TEST(IfcExport, ClassifyElementFullPathStillPrefersNameAndLayer) {
+  const std::string path = "ROOT / Wall Frame / Front Door";
+  auto result = classify_element("Front Door", "Layer0", path, /*classify_using_full_path=*/true);
+  EXPECT_EQ(result.first, "IFCDOOR");
+}
+
+TEST(IfcExport, ToIfcClassifyUsingFullPathOptIn) {
+  Scene scene;
+  scene.scene_hierarchy.name = "Root";
+  GlbPrimitive prim;
+  prim.positions = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0};
+  prim.normals = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.uvs = {0.0, 0.0, 1.0, 0.0, 0.0, 1.0};
+  prim.indices = {0, 1, 2};
+  prim.material_index = 0;
+  prim.geom_name = "mesh_0_ROOT__Wall_Frame__Stud_12_Layer0";
+  scene.glb_primitives = {prim};
+
+  MeshMetadata meta;
+  meta.name = "Stud 12";
+  meta.layer = "Layer0";
+  meta.path = "ROOT / Wall Frame / Stud 12";
+  scene.mesh_index["mesh_0_ROOT__Wall_Frame__Stud_12_Layer0"] = meta;
+  scene.gltf_materials = {GltfMaterial{}};
+
+  std::string default_text = to_ifc(scene);
+  EXPECT_NE(default_text.find("IFCBUILDINGELEMENTPROXY"), std::string::npos);
+  EXPECT_EQ(default_text.find("IFCWALL("), std::string::npos);
+
+  std::string opted_in_text =
+      to_ifc(scene, METRES_TO_MM, "IFC4", nullptr, /*classify_using_full_path=*/true);
+  EXPECT_NE(opted_in_text.find("IFCWALL("), std::string::npos);
+  // the real, clean name is still what's shown - opting into the broader
+  // classification fallback doesn't reintroduce the old mangled-name-
+  // as-Name bug.
+  EXPECT_NE(opted_in_text.find("'Stud 12'"), std::string::npos);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Ports Python's `1.3.0` IFC export correctness fixes to `ifc_export.cpp`:

1. **Units and axis convention** — default coordinate scale now matches the millimetre length unit the file always declares (was `METRES_TO_INCHES`, off by ~25.4x); vertex positions are converted from glTF's Y-up convention back to IFC/SketchUp's Z-up instead of passed through raw (was exporting buildings rotated ~90° and mirrored).
2. **Real instance names + layer visibility** — elements are now named from `MeshMetadata::name` (the real SketchUp instance name) instead of the internal `geom_name` mesh-lookup key. Layer assignment switches from `IFCPRESENTATIONLAYERASSIGNMENT` to `IFCPRESENTATIONLAYERWITHSTYLE`, which can carry a layer's on/off state — new `Scene::layer_hidden` field.
3. **Plugin attribute dictionaries as IFC properties** — every attribute dictionary an instance carries (not just `dynamic_attributes`) now reaches the exported IFC as its own `Pset_<dict-name>` property set.
4. **Opt-in full-path keyword classification** — `classify_using_full_path` (default `false`) lets a caller fall back to matching an element's full ancestor-path when its own name/layer both miss a keyword.

Fix #3 needed `scene.cpp` to actually know each mesh's real per-instance name/properties/attribute dictionaries, which it didn't have before this PR — added the same deferred `path_updates` backfill mechanism Python's `build_scene()` uses, plus the attribute-dict-override name-resolution fallback `instanced_scene.cpp` already had. This also closes a pre-existing, previously documented gap: `mesh_index[...].properties` was never populated at all in the C++ baked path before this fix (see `docs/LANGUAGE_PARITY.md`).

Also fixes a latent bug this work surfaced: `dxf_export.hpp` and `ifc_export.hpp` each declared their own `METRES_TO_INCHES` constant in the same `openskp` namespace — a hard redefinition error in any translation unit that includes both. Moved to a single definition in `model.hpp`. The `openskp.hpp` umbrella header was also missing `fragments_export.hpp` and `ifc_export.hpp` entirely (nobody had hit it before, since nothing previously included both `openskp.hpp` and `ifc_export.hpp` together).

Updates `docs/LANGUAGE_PARITY.md` and `CHANGELOG.md`.

## Test plan

- [x] Full existing C++ test suite: 210/210 passing (201 pre-existing + 9 new), zero regressions (Debug build).
- [x] 9 new tests in `ifc_export_test.cpp` mirroring Python's `test_ifc.py` additions for these same 4 fixes, byte-for-byte matching expected values (e.g. exact millimetre-scaled coordinates, exact Y-up→Z-up conversion, exact `LayerOn` flags).
- [x] Real-file verification via new `openskp_ifctest` example tool against a real production file with actual third-party steel-detailing plugin data (`fbd-einfo`): 3,023 property sets written including real `Pset_fbd-einfo` sets, 179 elements correctly classified as Wall/Beam/Column via keyword matching, real element names (`Profile11`, `Profile12`, ...) instead of internal mesh keys, plausible millimetre-scale coordinates (not off by 25.4x).