### PR TITLE
feat(cpp): read the real per-layer hidden flag from VFF (2021+) files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,25 @@ unit including both. Moved to a single definition in `model.hpp`. The
 `openskp.hpp` umbrella header was also missing `fragments_export.hpp`
 and `ifc_export.hpp` entirely — both now included.
 
+### Added — C++: read the real per-layer hidden flag from VFF (2021+) files
+
+Ports Python's VFF layer-hidden fix to `geometry.cpp`'s `collect_layers()`.
+VFF-format files previously derived a layer's visibility only from
+`Layer_<name>`-prefixed materials, which carry no hidden/visible bit of
+their own — every VFF layer's hidden state silently defaulted to visible
+regardless of the file's actual Tags panel state, which also meant the
+IFC exporter's `IFCPRESENTATIONLAYERWITHSTYLE.LayerOn` (above) always
+reported visible for VFF files.
+
+The real flag lives right alongside the already-parsed layer id/name:
+each layer's `8C3C` node carries an `8E3C` single-byte sibling (`1` =
+hidden, `0` = visible). Verified against two real production files: the
+same cladding/sheeting-layer + label-layer hidden pattern Python found
+on its own file showed up independently on a different file here (5 of
+30 layers correctly flagged hidden, all cladding/sheeting/label layers).
+3 new unit tests exercise `collect_layers()` directly against hand-built
+TLV node trees.
+
 ## [1.3.0] — 2026-09-09 — Python only, GitHub-only pre-release
 
 > **This tag is not published to PyPI.** It's a real, tested, tagged release

--- a/docs/LANGUAGE_PARITY.md
+++ b/docs/LANGUAGE_PARITY.md
@@ -52,7 +52,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | VFF pages/scenes + dimension parsing | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Legacy (pre-2021) pages/scenes reading | ✅ | ❌ VFF only | ❌ VFF only | ❌ VFF only | ❌ VFF only |
 | Construction lines/points reading | ✅ | ❌ | ❌ | ❌ | ❌ |
-| VFF per-layer-hidden flag reading | 🔶 on main | ❌ | ❌ | ❌ | ❌ |
+| VFF per-layer-hidden flag reading | 🔶 on main | ❌ | ❌ | ❌ | 🔶 on main, GitHub-only |
 | `mesh_index[...].properties` populated | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `model.layers` in file order (not alphabetical) | ✅ | ✅ | ✅ | ✅ | ❌ known gap |
 | **Scene building & observability** | | | | | |
@@ -113,6 +113,7 @@ C++ merged, not yet released:
 | Multi-dictionary attribute extraction (`Instance::attribute_dictionaries` / `InstancedNode::attribute_dictionaries`) | `geometry.cpp`, `instanced_scene.cpp`, `scene.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | 4 IFC export correctness fixes (units/axis, real names + layer visibility, plugin-attribute Psets, opt-in full-path classification) | `ifc_export.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | `mesh_index[...].properties`/`.attribute_dictionaries` backfill in the baked (`build_scene`) path | `scene.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
+| VFF (2021+) per-layer-hidden flag reading (`8E3C` tag) | `geometry.cpp`'s `collect_layers`, `core.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 
 Known gap in this C++ work, stated honestly rather than glossed over:
 attribute dictionary values decode as strings only (no `Point3d`/`Length`/

--- a/packages/cpp/examples/ifctest.cpp
+++ b/packages/cpp/examples/ifctest.cpp
@@ -14,6 +14,14 @@ int main(int argc, char** argv) {
     std::cout << "ok: " << scene.mesh_index.size() << " mesh entries, "
               << scene.glb_primitives.size() << " primitives, " << scene.layer_hidden.size()
               << " layer_hidden entries\n";
+    int hidden_count = 0;
+    for (auto& [name, hidden] : scene.layer_hidden) {
+      if (hidden) {
+        std::cout << "  hidden: " << name << "\n";
+        ++hidden_count;
+      }
+    }
+    std::cout << hidden_count << " of " << scene.layer_hidden.size() << " layers hidden\n";
   } catch (const std::exception& e) {
     std::cerr << "EXC: " << e.what() << '\n';
     return 1;

--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -343,7 +343,7 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
       auto one = parse_tlv_recursive(*model, hs[i].offset, hs[i].offset + 6 + hs[i].size);
       if (one.empty()) continue;
       tag = one[0].tag;
-      collect_layers(one, p.layer_id_to_name);
+      collect_layers(one, p.layer_id_to_name, p.layer_hidden);
       collect_material_ids(one, p.material_id_to_name);
       collect_definitions(one, p.definitions);
       scan_vertex_positions(one[0], vertex_positions);

--- a/packages/cpp/src/geometry.cpp
+++ b/packages/cpp/src/geometry.cpp
@@ -310,15 +310,24 @@ void collect_geometry(const std::vector<TlvNode>& es, GeometryBuilder& b) {
   }
 }
 
-void collect_layers(const std::vector<TlvNode>& ns, std::map<EntityId, std::string>& out) {
+void collect_layers(const std::vector<TlvNode>& ns, std::map<EntityId, std::string>& out,
+                    std::map<std::string, bool>& hidden) {
   for (auto& e : ns) {
     if (e.tag == "993A")
       for (auto& c : e.children)
         if (c.tag == "8C3C") {
           auto *d = find_node(c.children, "DC05"), *n = find_node(c.children, "8D3C");
           if (d && n && !d->payload.empty()) out[dc_id(d->payload)] = text(n->payload);
+          // 8E3C: a single byte, 1 = hidden / 0 = visible - the VFF-format
+          // counterpart of the legacy format's already-known layer-hidden
+          // flag, confirmed byte-for-byte against a real production
+          // file's own Tags panel (matches Python's _core.py exactly).
+          if (n) {
+            auto* h = find_node(c.children, "8E3C");
+            if (h && !h->payload.empty()) hidden[text(n->payload)] = h->payload[0] == 1;
+          }
         }
-    collect_layers(e.children, out);
+    collect_layers(e.children, out, hidden);
   }
 }
 

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -170,7 +170,8 @@ RawParsed full_parse(const ByteBuffer&, const ParseOptions&);
 std::string decode_xml_entities(const std::string&);
 RawParsed parse_legacy(const ByteBuffer&, const ParseOptions&);
 void collect_geometry(const std::vector<TlvNode>&, GeometryBuilder&);
-void collect_layers(const std::vector<TlvNode>&, std::map<EntityId, std::string>&);
+void collect_layers(const std::vector<TlvNode>&, std::map<EntityId, std::string>&,
+                    std::map<std::string, bool>&);
 void collect_material_ids(const std::vector<TlvNode>&, std::map<EntityId, std::string>&);
 void collect_definitions(const std::vector<TlvNode>&, std::map<EntityId, RawDefinition>&);
 SkpModel build_model(RawParsed&&, const ParseOptions& = {});

--- a/packages/cpp/tests/CMakeLists.txt
+++ b/packages/cpp/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   stl_export_test.cpp
   texture_test.cpp
   triangulator_test.cpp
+  vff_layer_hidden_test.cpp
   xml_entities_test.cpp
   zip_entry_size_cap_test.cpp
 )

--- a/packages/cpp/tests/vff_layer_hidden_test.cpp
+++ b/packages/cpp/tests/vff_layer_hidden_test.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+
+#include <openskp/openskp.hpp>
+
+#include "internal.hpp"
+
+// The VFF-format (2021+) counterpart of the legacy layer-hidden flag
+// (see layer_hidden_test.cpp): each layer's 8C3C node (under a 993A
+// layer-manager list) carries a single-byte 8E3C child sibling to the
+// already-parsed DC05 (id) and 8D3C (name) - 1 = hidden, 0 = visible.
+// Confirmed byte-for-byte against a real production file's own Tags
+// panel: every layer shown with a hollow/hidden eye icon had 8E3C=01,
+// every visible one had 8E3C=00, with no exceptions. Mirrors Python's
+// TestVffLayerHidden.
+//
+// collect_layers() is called directly with a hand-built TlvNode tree
+// (not a real binary stream - TlvNode's own fields are trivial to
+// construct directly and this is the same level Python's C-extension
+// tests operate at for TLV-shaped input), matching layer_hidden_test.cpp's
+// existing pattern of testing one level below full SkpFile::open().
+
+namespace openskp::test {
+namespace {
+
+TlvNode leaf(const std::string& tag, ByteBuffer payload) {
+  TlvNode n;
+  n.tag = tag;
+  n.payload = std::move(payload);
+  return n;
+}
+
+ByteBuffer str_payload(const std::string& s) { return ByteBuffer(s.begin(), s.end()); }
+
+TEST(VffLayerHidden, HiddenAndVisibleLayersReadCorrectly) {
+  TlvNode hidden_layer;
+  hidden_layer.tag = "8C3C";
+  hidden_layer.children = {
+      leaf("DC05", {5}),
+      leaf("8D3C", str_payload("wall_external_cladding_1")),
+      leaf("8E3C", {1}),
+  };
+
+  TlvNode visible_layer;
+  visible_layer.tag = "8C3C";
+  visible_layer.children = {
+      leaf("DC05", {6}),
+      leaf("8D3C", str_payload("wall")),
+      leaf("8E3C", {0}),
+  };
+
+  TlvNode manager;
+  manager.tag = "993A";
+  manager.children = {hidden_layer, visible_layer};
+
+  std::vector<TlvNode> roots = {manager};
+  std::map<EntityId, std::string> id_to_name;
+  std::map<std::string, bool> hidden;
+  collect_layers(roots, id_to_name, hidden);
+
+  ASSERT_TRUE(hidden.count("wall_external_cladding_1"));
+  EXPECT_TRUE(hidden.at("wall_external_cladding_1"));
+  ASSERT_TRUE(hidden.count("wall"));
+  EXPECT_FALSE(hidden.at("wall"));
+}
+
+TEST(VffLayerHidden, LayerWithNoNameGetsNoHiddenEntry) {
+  // The hidden-flag branch is gated on the name (8D3C) node being
+  // present, matching Python's find_child_tag(child['children'], '8E3C')
+  // only being reached once the name lookup already succeeded.
+  TlvNode nameless_layer;
+  nameless_layer.tag = "8C3C";
+  nameless_layer.children = {
+      leaf("DC05", {7}),
+      leaf("8E3C", {1}),
+  };
+
+  TlvNode manager;
+  manager.tag = "993A";
+  manager.children = {nameless_layer};
+
+  std::vector<TlvNode> roots = {manager};
+  std::map<EntityId, std::string> id_to_name;
+  std::map<std::string, bool> hidden;
+  collect_layers(roots, id_to_name, hidden);
+
+  EXPECT_TRUE(hidden.empty());
+}
+
+TEST(VffLayerHidden, LayerWithNo8E3CTagLeavesHiddenMapUntouched) {
+  // A layer manager entry with no 8E3C sibling at all (e.g. an older
+  // file predating this bit) must not add a false entry - the caller's
+  // pre-seeded "assume visible" default (core.cpp) stays authoritative.
+  TlvNode layer_no_flag;
+  layer_no_flag.tag = "8C3C";
+  layer_no_flag.children = {
+      leaf("DC05", {8}),
+      leaf("8D3C", str_payload("no_flag_layer")),
+  };
+
+  TlvNode manager;
+  manager.tag = "993A";
+  manager.children = {layer_no_flag};
+
+  std::vector<TlvNode> roots = {manager};
+  std::map<EntityId, std::string> id_to_name;
+  std::map<std::string, bool> hidden;
+  collect_layers(roots, id_to_name, hidden);
+
+  EXPECT_TRUE(hidden.empty());
+}
+
+}  // namespace
+}  // namespace openskp::test


### PR DESCRIPTION
## Summary

Ports Python's VFF layer-hidden fix to `geometry.cpp`'s `collect_layers()`. VFF-format files previously derived a layer's visibility only from `Layer_<name>`-prefixed materials, which carry no hidden/visible bit of their own — every VFF layer's hidden state silently defaulted to visible regardless of the file's actual Tags panel state. This also meant the IFC exporter's `IFCPRESENTATIONLAYERWITHSTYLE.LayerOn` (from #294) always reported visible for VFF files.

The real flag lives right alongside the already-parsed layer id/name: each layer's `8C3C` node carries an `8E3C` single-byte sibling (`1` = hidden, `0` = visible).

`collect_layers()` signature grows a `std::map<std::string, bool>&` output param; `core.cpp`'s existing material-pass "assume visible" default (set before the `model.dat` walk) is correctly overwritten by any real flag found during the walk.

Updates `docs/LANGUAGE_PARITY.md` and `CHANGELOG.md`.

## Test plan

- [x] Full existing C++ test suite: 213/213 passing (210 pre-existing + 3 new), zero regressions.
- [x] 3 new unit tests exercising `collect_layers()` directly against hand-built `TlvNode` trees (hidden layer, visible layer, layer with no name, layer with no `8E3C` tag).
- [x] Real-file verification via `openskp_ifctest`: the same cladding/sheeting-layer + label-layer hidden pattern Python found on its own production file showed up independently on a different real file here — 5 of 30 layers correctly flagged hidden, all cladding/sheeting/label layers, no false positives.