### PR TITLE
fix(cpp): model.layers now in source-file order, not alphabetical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,20 @@ on its own file showed up independently on a different file here (5 of
 3 new unit tests exercise `collect_layers()` directly against hand-built
 TLV node trees.
 
+### Fixed — C++: `model.layers` now in source-file order, not alphabetical
+
+`RawParsed::layer_colors` is a `std::map` (sorted by key), so every
+consumer of `model.layers` previously saw layers alphabetized rather
+than in the order they actually appear in the source file (material.xml
+archive-entry order for VFF, slot-scan order for legacy) - Python's own
+`layer_colors` is a plain dict, which preserves insertion order
+natively, so this was C++-only behavior, not a cross-language
+difference in the underlying data. New `RawParsed::layer_order`
+(a `std::vector<std::string>`, populated at every layer-insertion site
+in `core.cpp`/`legacy.cpp`) is what `model.cpp`'s layer-building loop
+now iterates. Verified byte-for-byte identical order to Python's own
+output on the same real production file (30 layers, non-alphabetical).
+
 ## [1.3.0] — 2026-09-09 — Python only, GitHub-only pre-release
 
 > **This tag is not published to PyPI.** It's a real, tested, tagged release

--- a/docs/LANGUAGE_PARITY.md
+++ b/docs/LANGUAGE_PARITY.md
@@ -54,7 +54,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | Construction lines/points reading | ✅ | ❌ | ❌ | ❌ | ❌ |
 | VFF per-layer-hidden flag reading | 🔶 on main | ❌ | ❌ | ❌ | 🔶 on main, GitHub-only |
 | `mesh_index[...].properties` populated | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `model.layers` in file order (not alphabetical) | ✅ | ✅ | ✅ | ✅ | ❌ known gap |
+| `model.layers` in file order (not alphabetical) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Scene building & observability** | | | | | |
 | Scene baking / triangulation (`buildScene()`) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Instancing-preserving scene output (`build_instanced_scene()`) | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -114,6 +114,7 @@ C++ merged, not yet released:
 | 4 IFC export correctness fixes (units/axis, real names + layer visibility, plugin-attribute Psets, opt-in full-path classification) | `ifc_export.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | `mesh_index[...].properties`/`.attribute_dictionaries` backfill in the baked (`build_scene`) path | `scene.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | VFF (2021+) per-layer-hidden flag reading (`8E3C` tag) | `geometry.cpp`'s `collect_layers`, `core.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
+| `model.layers` in source-file order, not alphabetical (`RawParsed::layer_order`) | `core.cpp`, `legacy.cpp`, `model.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 
 Known gap in this C++ work, stated honestly rather than glossed over:
 attribute dictionary values decode as strings only (no `Point3d`/`Length`/

--- a/packages/cpp/src/core.cpp
+++ b/packages/cpp/src/core.cpp
@@ -317,9 +317,11 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
           p.materials[m->name] = m;
           p.materials_by_folder[folder] = m;
           if (m->name.rfind("Layer_", 0) == 0) {
-            p.layer_colors[m->name.substr(6)] = {std::uint8_t(m->r), std::uint8_t(m->g),
-                                                 std::uint8_t(m->b)};
-            p.layer_hidden[m->name.substr(6)] = false;
+            auto layer_name = m->name.substr(6);
+            if (!p.layer_colors.count(layer_name)) p.layer_order.push_back(layer_name);
+            p.layer_colors[layer_name] = {std::uint8_t(m->r), std::uint8_t(m->g),
+                                          std::uint8_t(m->b)};
+            p.layer_hidden[layer_name] = false;
           }
         }
     }
@@ -375,7 +377,10 @@ RawParsed full_parse(const ByteBuffer& data, const ParseOptions& o) {
   p.pages = parse_pages(page_node);
   p.dimensions = parse_dimensions(*model, vertex_positions, instance_world);
   if (!p.layer_id_to_name.count(1)) p.layer_id_to_name[1] = "Layer0";
-  if (!p.layer_colors.count("Layer0")) p.layer_colors["Layer0"] = {136, 136, 136};
+  if (!p.layer_colors.count("Layer0")) {
+    p.layer_order.push_back("Layer0");
+    p.layer_colors["Layer0"] = {136, 136, 136};
+  }
   if (!p.layer_hidden.count("Layer0")) p.layer_hidden["Layer0"] = false;
   emit_log(o, LogLevel::information,
            "Parse complete: " + std::to_string(p.definitions.size()) + " defs");

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -128,10 +128,18 @@ struct RawParsed {
   // meta/meta.dat. Unset for legacy files or when the tag isn't found.
   std::optional<std::string> units;
   std::map<std::string, Color3> layer_colors;
-  // Modern (VFF) files derive layers from Layer_<name>-prefixed materials,
-  // which carry no visibility flag of their own - unlike legacy MFC files,
-  // there is currently no known tag exposing a VFF layer's hidden state,
-  // so every VFF layer defaults to visible.
+  // Layer names in the order they were first encountered in the source
+  // file (material.xml archive-entry order for VFF, slot-scan order for
+  // legacy) - layer_colors above is a std::map (sorted by name), so this
+  // is the only place file order survives; model.cpp's layer-building
+  // loop iterates this instead of layer_colors directly. Mirrors
+  // Python's plain dict for the same field, which preserves insertion
+  // order natively.
+  std::vector<std::string> layer_order;
+  // Modern (VFF) files derive layer COLOR from Layer_<name>-prefixed
+  // materials, which carry no visibility flag of their own - real
+  // visibility comes from the model.dat layer manager's own 8E3C byte
+  // (see geometry.cpp's collect_layers), read here into this same map.
   std::map<std::string, bool> layer_hidden;
   std::map<EntityId, std::string> layer_id_to_name;
   std::vector<RawPage> pages;

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -1433,11 +1433,15 @@ RawParsed parse_legacy(const ByteBuffer& data, const ParseOptions& o) {
     }
     for (auto& l : layers) {
       out.layer_id_to_name[l.first] = l.second->name;
+      if (!out.layer_colors.count(l.second->name)) out.layer_order.push_back(l.second->name);
       out.layer_colors[l.second->name] = {uint8_t(l.second->r), uint8_t(l.second->g),
                                           uint8_t(l.second->b)};
       out.layer_hidden[l.second->name] = l.second->hidden != 0;
     }
-    if (!out.layer_colors.count("Layer0")) out.layer_colors["Layer0"] = {136, 136, 136};
+    if (!out.layer_colors.count("Layer0")) {
+      out.layer_order.push_back("Layer0");
+      out.layer_colors["Layer0"] = {136, 136, 136};
+    }
     if (!out.layer_hidden.count("Layer0")) out.layer_hidden["Layer0"] = false;
     // Scanned before the definitions loop below so is_image can be set
     // correctly the first time a definition is built, matching the VFF

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -100,10 +100,12 @@ SkpModel build_model(RawParsed&& p, const ParseOptions& o) {
   }
   resolve_layers(p.root);
   m.root_ = definition(0, std::move(p.root));
-  for (auto& l : p.layer_colors) {
-    auto hidden_it = p.layer_hidden.find(l.first);
+  for (auto& name : p.layer_order) {
+    auto color_it = p.layer_colors.find(name);
+    if (color_it == p.layer_colors.end()) continue;
+    auto hidden_it = p.layer_hidden.find(name);
     bool hidden = hidden_it != p.layer_hidden.end() && hidden_it->second;
-    m.layers.push_back({l.first, l.second, hidden});
+    m.layers.push_back({name, color_it->second, hidden});
   }
   // Convert pages (saved scenes) - hidden layer ids resolve to names;
   // unknown ids (stale refs) are dropped.

--- a/packages/cpp/tests/layer_hidden_test.cpp
+++ b/packages/cpp/tests/layer_hidden_test.cpp
@@ -8,8 +8,8 @@
 // from legacy MFC files (legacy.cpp's CLayer branch, via V::hidden) but
 // previously discarded before reaching the public model; now wired through
 // RawParsed::layer_hidden alongside the existing layer_colors/
-// layer_id_to_name maps. VFF files carry no known visibility tag, so they
-// always default to false.
+// layer_id_to_name maps. VFF files carry their own real visibility tag
+// too (8E3C, see vff_layer_hidden_test.cpp) - both feed the same map.
 //
 // build_model() is called directly with a synthetic RawParsed (hand-crafting
 // a real hidden-layer legacy binary stream isn't practical), matching the
@@ -20,6 +20,7 @@ namespace {
 
 TEST(LayerHidden, ReportsHiddenLayerAsHidden) {
   RawParsed parsed;
+  parsed.layer_order = {"Layer0", "Furniture"};
   parsed.layer_colors["Layer0"] = {136, 136, 136};
   parsed.layer_colors["Furniture"] = {200, 50, 50};
   parsed.layer_hidden["Layer0"] = false;
@@ -43,6 +44,7 @@ TEST(LayerHidden, ReportsHiddenLayerAsHidden) {
 
 TEST(LayerHidden, DefaultsToVisibleWhenMissingFromMap) {
   RawParsed parsed;
+  parsed.layer_order = {"Layer0"};
   parsed.layer_colors["Layer0"] = {136, 136, 136};
   // layer_hidden deliberately left empty.
 
@@ -50,6 +52,29 @@ TEST(LayerHidden, DefaultsToVisibleWhenMissingFromMap) {
 
   ASSERT_EQ(model.layers.size(), 1);
   EXPECT_FALSE(model.layers[0].hidden);
+}
+
+// model.layers must come out in the source file's own order (material.xml
+// archive-entry order for VFF, slot-scan order for legacy), not
+// alphabetical - layer_colors is a std::map (sorted by name) so
+// layer_order (a plain vector, populated in encounter order at every
+// insertion site) is the only place that order survives. Deliberately
+// picks names whose alphabetical order would differ from layer_order,
+// so a regression back to iterating layer_colors directly would fail
+// this test immediately.
+TEST(LayerHidden, PreservesFileOrderNotAlphabeticalOrder) {
+  RawParsed parsed;
+  parsed.layer_order = {"Zebra", "Apple", "Middle"};
+  parsed.layer_colors["Zebra"] = {1, 1, 1};
+  parsed.layer_colors["Apple"] = {2, 2, 2};
+  parsed.layer_colors["Middle"] = {3, 3, 3};
+
+  auto model = build_model(std::move(parsed));
+
+  ASSERT_EQ(model.layers.size(), 3);
+  EXPECT_EQ(model.layers[0].name, "Zebra");
+  EXPECT_EQ(model.layers[1].name, "Apple");
+  EXPECT_EQ(model.layers[2].name, "Middle");
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

`RawParsed::layer_colors` is a `std::map` (sorted by key), so every consumer of `model.layers` previously saw layers alphabetized rather than in the order they actually appear in the source file (material.xml archive-entry order for VFF, slot-scan order for legacy). Python's own `layer_colors` is a plain dict, which preserves insertion order natively — this was C++-only behavior, not a cross-language difference in the underlying parsed data.

New `RawParsed::layer_order` (a `std::vector<std::string>`, populated at every layer-insertion site in `core.cpp`/`legacy.cpp`, only appending a name the first time it's seen) is what `model.cpp`'s layer-building loop now iterates instead of `layer_colors` directly.

Updates `docs/LANGUAGE_PARITY.md` and `CHANGELOG.md`.

## Test plan

- [x] Full existing C++ test suite: 214/214 passing (213 pre-existing + 1 new), zero regressions.
- [x] New `PreservesFileOrderNotAlphabeticalOrder` test picks names whose alphabetical order differs from insertion order, so a regression back to iterating `layer_colors` directly fails immediately.
- [x] Real-file verification: byte-for-byte identical layer order to Python's own output on the same real production file (30 layers, genuinely non-alphabetical — `Layer0, group_label, wall_external_cladding_1, wall_internal_cladding_1, ...`, not sorted).
- [x] Updated the two existing `layer_hidden_test.cpp` cases that construct a `RawParsed` directly to also populate `layer_order` (previously implicit/unset, now required — `model.layers` would otherwise come out empty).