### PR TITLE
feat(cpp): read pages/scenes for legacy (pre-2021) files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,46 @@ in `core.cpp`/`legacy.cpp`) is what `model.cpp`'s layer-building loop
 now iterates. Verified byte-for-byte identical order to Python's own
 output on the same real production file (30 layers, non-alphabetical).
 
+### Added — C++: read pages/scenes for legacy (pre-2021) files
+
+Ports Python's `legacy._scan_pages` (narrow scope) to `legacy.cpp`'s new
+`scan_pages_for_layers`. Legacy (pre-2021 MFC) `.skp` files had no page/
+scene reading code at all in C++ - `SkpModel.pages` was only ever
+populated for the VFF path, matching a gap Python itself only closed
+recently.
+
+CViewPage's full record also embeds a camera, an optional thumbnail, a
+font, and (for any of several independently-optional capture flags
+beyond hidden-layers) an entire Style sub-object of undocumented size.
+Scoped down deliberately, matching Python exactly: only the flag
+combination capturing nothing, or only hidden-layers, is supported;
+anything else is silently skipped rather than guessed at, so an
+unsupported page is simply absent from `model.pages` instead of
+producing wrong data. Runs as an independent scan over the file tail
+(from where the main entity walk stops) rather than part of the
+sequential archive read, to avoid needing to fully bound each page's
+opaque tail.
+
+Also exposes `LegacySlotEntry`/`LegacySlotTable`/`scan_pages_for_layers`
+via `internal.hpp` (`struct V` moved out of `legacy.cpp`'s own anonymous
+namespace to make this possible without duplicating it) so this feature
+is unit-testable the same way VFF's `parse_pages`/`parse_dimensions`
+already are - previously, legacy.cpp's internals were only reachable
+through real fixture files. 2 new unit tests exercise
+`scan_pages_for_layers` directly against hand-built byte records
+mirroring Python's own `test_scan_pages_legacy_synthetic` test exactly
+(three candidate pages, one with an unsupported flag combination
+correctly rejected).
+
+**Known gap, stated honestly:** not exercised against a real file that
+actually contains a legacy scene - none of the committed fixtures or
+the real production files available while building this had one (5
+real files smoke-tested: no crash, no false positives, all correctly
+report zero pages since none of them have any). Ground truth for the
+byte layout itself was already established by Python's own
+implementation, ground-truthed against real v17-native SketchUp saves;
+this port carries that over faithfully rather than re-deriving it.
+
 ## [1.3.0] — 2026-09-09 — Python only, GitHub-only pre-release
 
 > **This tag is not published to PyPI.** It's a real, tested, tagged release

--- a/docs/LANGUAGE_PARITY.md
+++ b/docs/LANGUAGE_PARITY.md
@@ -50,7 +50,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | Attribute dicts: full 9-value-type support (`Point3d`/`Vector3d`/`Length`/`Timestamp`/nested lists) | ✅ | ❌ str/int/float only | ❌ | ❌ | ❌ str only |
 | Attribute dicts: multiple dictionaries per entity | ✅ | ❌ single dict only | ❌ | ❌ | ✅ |
 | VFF pages/scenes + dimension parsing | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Legacy (pre-2021) pages/scenes reading | ✅ | ❌ VFF only | ❌ VFF only | ❌ VFF only | ❌ VFF only |
+| Legacy (pre-2021) pages/scenes reading | ✅ | ❌ VFF only | ❌ VFF only | ❌ VFF only | 🔶 on main, GitHub-only |
 | Construction lines/points reading | ✅ | ❌ | ❌ | ❌ | ❌ |
 | VFF per-layer-hidden flag reading | 🔶 on main | ❌ | ❌ | ❌ | 🔶 on main, GitHub-only |
 | `mesh_index[...].properties` populated | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -115,11 +115,18 @@ C++ merged, not yet released:
 | `mesh_index[...].properties`/`.attribute_dictionaries` backfill in the baked (`build_scene`) path | `scene.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | VFF (2021+) per-layer-hidden flag reading (`8E3C` tag) | `geometry.cpp`'s `collect_layers`, `core.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | `model.layers` in source-file order, not alphabetical (`RawParsed::layer_order`) | `core.cpp`, `legacy.cpp`, `model.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
+| Legacy (pre-2021) pages/scenes reading (`scan_pages_for_layers`) | `legacy.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 
-Known gap in this C++ work, stated honestly rather than glossed over:
-attribute dictionary values decode as strings only (no `Point3d`/`Length`/
-nested-list support, matching C++'s existing string-only property handling
-elsewhere — see the feature matrix above).
+Known gaps in this C++ work, stated honestly rather than glossed over:
+- Attribute dictionary values decode as strings only (no `Point3d`/`Length`/
+  nested-list support, matching C++'s existing string-only property handling
+  elsewhere — see the feature matrix above).
+- The legacy pages/scenes reader has not been exercised against a real
+  file that actually contains a scene (none of the committed fixtures or
+  the real production files available while building it had one) — only
+  against a synthetic byte-level test mirroring Python's own
+  ground-truthed test case, plus real-file smoke testing (no crash, no
+  false positives) on 5 real files with no scenes at all.
 
 ## 4. Real SketchUp file version support
 

--- a/packages/cpp/examples/parsetest.cpp
+++ b/packages/cpp/examples/parsetest.cpp
@@ -10,7 +10,11 @@ int main(int argc, char** argv) {
   try {
     auto file = openskp::SkpFile::open(argv[1]);
     auto model = file.parse();
-    std::cout << "ok: " << model.definitions.size() << " definitions\n";
+    std::cout << "ok: " << model.definitions.size() << " definitions, " << model.pages.size()
+              << " pages\n";
+    for (auto& pg : model.pages) {
+      std::cout << "  page '" << pg.name << "' hidden_layers=" << pg.hidden_layers.size() << "\n";
+    }
   } catch (const std::exception& e) {
     std::cerr << "EXC: " << e.what() << '\n';
     return 1;

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <set>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
@@ -177,6 +178,110 @@ std::optional<V20FillerHit> find_count_after_v20_filler(const ByteBuffer&, std::
 RawParsed full_parse(const ByteBuffer&, const ParseOptions&);
 std::string decode_xml_entities(const std::string&);
 RawParsed parse_legacy(const ByteBuffer&, const ParseOptions&);
+
+// legacy.cpp's own MFC object-graph value type - one decoded entity
+// (material/layer/component/edge/face/... - `k` says which). Moved here
+// (out of legacy.cpp's own anonymous namespace, alongside LegacySlotEntry
+// below) rather than forward-declared only: a slot-table entry needs to
+// hold a real, complete shared_ptr<V>, and legacy.cpp's own code (which
+// sees this same type via ordinary unqualified lookup, exactly as before)
+// must keep resolving to this one definition, not a second, incomplete
+// one - two same-named types in nested scopes are different types in
+// C++, so this can't be split into "forward-declared here, defined
+// there" without every V-typed field silently binding to the wrong one.
+struct V {
+  std::string k;
+  std::string name;
+  std::string label;
+  std::string text;
+  std::string guid;
+  Vec3 xyz{};
+  std::vector<double> plane;
+  std::vector<double> xf;
+  std::vector<double> uvf;
+  std::vector<double> uvb;
+  bool front_projected{};
+  bool back_projected{};
+  std::uint64_t v1{};
+  std::uint64_t v2{};
+  std::uint64_t edge{};
+  std::uint64_t def{};
+  // Slot of this entity's CAttributeContainer (resolved through
+  // Archive::slots), or nullopt when it has none. Not a bare slot number:
+  // slot 0 is a legitimate real slot (the first object allocated in the
+  // archive), so 0 can't double as a sentinel for "absent."
+  std::optional<std::uint64_t> attrs;
+  // Only populated for "dict" (CAttributeNamed) entities: this
+  // dictionary's own key/value pairs, already stringified (see
+  // Archive::typed()).
+  std::map<std::string, std::string> entries;
+  std::uint64_t tex_dib{};
+  bool sense{};
+  bool faces_camera{};
+  bool shadows_face_sun{};
+  bool colorized{};
+  int mat{};
+  int back_mat{};
+  int layer{};
+  int hidden{};
+  int soft{};
+  int smooth{};
+  int r{128};
+  int g{128};
+  int b{128};
+  int a{255};
+  double opacity{};
+  double tw{};
+  double th{};
+  std::string tex_file;
+  ByteBuffer blob;
+  std::vector<std::shared_ptr<V>> loops;
+  std::vector<std::shared_ptr<V>> uses;
+  std::vector<std::tuple<uint64_t, std::string, std::shared_ptr<V>>> ents;
+};
+
+/// One legacy MFC archive slot-table entry: either a class declaration
+/// (cls=true, name/schema identify the class, v unused) or a read
+/// object (cls=false, v holds its decoded value, possibly null for
+/// object kinds this port doesn't decode into V). Exposed here (moved
+/// out of legacy.cpp's own anonymous namespace) purely so
+/// scan_pages_for_layers below is unit-testable without needing
+/// legacy.cpp's full ~750-line Archive type - matches
+/// find_count_after_v20_filler's precedent just above.
+struct LegacySlotEntry {
+  bool cls{};
+  std::string name;
+  int schema{};
+  std::shared_ptr<V> v;
+};
+
+/// A minimal view into an Archive's slot-table bookkeeping - the only
+/// pieces legacy.cpp's page (scene) scanner needs, exposed narrowly
+/// (rather than the full Archive type) so that feature is unit-testable.
+/// A real caller (legacy.cpp's parse_legacy) wraps its own Archive's
+/// slots/class_slot/next members; a test can hand-build just the
+/// entries a specific case needs.
+struct LegacySlotTable {
+  std::unordered_map<std::uint64_t, LegacySlotEntry>& slots;
+  std::unordered_map<std::string, std::uint64_t>& class_slot;
+  std::uint64_t& next;
+
+  std::uint64_t alloc(LegacySlotEntry e) {
+    auto s = next++;
+    slots[s] = std::move(e);
+    return s;
+  }
+};
+
+/// Best-effort scan for CViewPage (scene) records in a legacy (pre-2021
+/// MFC) file: name + hidden-layer slot ids only, for the narrow
+/// CViewPage capture-flag combinations this reader understands. See
+/// legacy.cpp's own scan_pages for the full rationale and byte layout -
+/// mirrors Python's legacy._scan_pages exactly. `start_pos` is the byte
+/// offset to begin scanning from (the main entity walk's own stopping
+/// point in a real parse).
+std::vector<RawPage> scan_pages_for_layers(const ByteBuffer& data, std::size_t start_pos,
+                                           LegacySlotTable slots);
 void collect_geometry(const std::vector<TlvNode>&, GeometryBuilder&);
 void collect_layers(const std::vector<TlvNode>&, std::map<EntityId, std::string>&,
                     std::map<std::string, bool>&);

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cmath>
 #include <exception>
+#include <functional>
 #include <optional>
 #include <regex>
 #include <unordered_map>
@@ -121,6 +122,11 @@ struct R {
     return p + 3 <= d.size() && d[p] == 255 && d[p + 1] == 254 && d[p + 2] == 255;
   }
 
+  uint16_t peek_u16() {
+    need(2);
+    return read_u16(d, p);
+  }
+
   std::string utf16() {
     if (!marker()) throw std::runtime_error("expected legacy string record");
     p += 3;
@@ -150,63 +156,15 @@ struct R {
   }
 };
 
-struct V {
-  std::string k;
-  std::string name;
-  std::string label;
-  std::string text;
-  std::string guid;
-  Vec3 xyz{};
-  std::vector<double> plane;
-  std::vector<double> xf;
-  std::vector<double> uvf;
-  std::vector<double> uvb;
-  bool front_projected{};
-  bool back_projected{};
-  std::uint64_t v1{};
-  std::uint64_t v2{};
-  std::uint64_t edge{};
-  std::uint64_t def{};
-  // Slot of this entity's CAttributeContainer (resolved through
-  // Archive::slots), or nullopt when it has none. Not a bare slot number:
-  // slot 0 is a legitimate real slot (the first object allocated in the
-  // archive), so 0 can't double as a sentinel for "absent."
-  std::optional<std::uint64_t> attrs;
-  // Only populated for "dict" (CAttributeNamed) entities: this
-  // dictionary's own key/value pairs, already stringified (see
-  // Archive::typed()).
-  std::map<std::string, std::string> entries;
-  std::uint64_t tex_dib{};
-  bool sense{};
-  bool faces_camera{};
-  bool shadows_face_sun{};
-  bool colorized{};
-  int mat{};
-  int back_mat{};
-  int layer{};
-  int hidden{};
-  int soft{};
-  int smooth{};
-  int r{128};
-  int g{128};
-  int b{128};
-  int a{255};
-  double opacity{};
-  double tw{};
-  double th{};
-  std::string tex_file;
-  ByteBuffer blob;
-  std::vector<std::shared_ptr<V>> loops;
-  std::vector<std::shared_ptr<V>> uses;
-  std::vector<std::tuple<uint64_t, std::string, std::shared_ptr<V>>> ents;
-};
+// V is now defined in internal.hpp (moved out of this anonymous
+// namespace so LegacySlotEntry there can hold a real shared_ptr<V> - see
+// that struct's own comment).
 
-struct Entry {
-  bool cls{};
-  std::string name;
-  int schema{};
-  std::shared_ptr<V> v;
-};
+// Same shape as internal.hpp's LegacySlotEntry (which is exposed there
+// purely for scan_pages_for_layers's testability - see its own comment)
+// - aliased here so every existing use of Entry throughout this file
+// stays unchanged.
+using Entry = LegacySlotEntry;
 
 // True when the bytes at p are an MFC class-ref to class `slot`. Mirrors both
 // encodings Archive::object() decodes: the short 16-bit form (0x8000|slot)
@@ -1344,7 +1302,188 @@ void fill(GeometryBuilder& b,
     }
   }
 }
+
+// ── pages (scenes) ────────────────────────────────────────────────────
+//
+// CViewPage's full record embeds a camera, an optional thumbnail image, a
+// font, and - whenever any of its several independent "use_*" capture
+// flags beyond hidden-layers is set - an entire Style sub-object with no
+// documented fixed size. Reverse engineering that is out of scope, so
+// only the narrow case is supported: a page whose captured flags are
+// exactly the baseline (nothing captured) or baseline + hidden-layers.
+// Ground truth for both (the flags bitmask, the hidden-layers list shape)
+// was captured from real v17-native SketchUp saves - mirrors Python's
+// legacy._scan_pages exactly.
+constexpr uint32_t kPageAllowedFlags[] = {0xc00, 0xc20};
+constexpr uint32_t kPageHiddenLayersBit = 0x20;
+
+bool is_allowed_page_flags(uint32_t flags) {
+  for (auto f : kPageAllowedFlags)
+    if (f == flags) return true;
+  return false;
+}
+
+// Same conversion R::utf16() applies per UTF-16 code unit (no surrogate
+// pairing - matches this file's existing, already-shipped string
+// decoding elsewhere), just addressed by a raw (pos, char_count) range
+// instead of a cursor, since the page scan below needs to decode a name
+// it has already found the bounds of without re-walking a marker.
+std::string decode_utf16le_range(const ByteBuffer& d, size_t pos, size_t char_count) {
+  std::string s;
+  for (size_t i = 0; i < char_count; ++i) {
+    uint16_t c = uint16_t(d[pos]) | uint16_t(d[pos + 1]) << 8;
+    pos += 2;
+    if (c < 0x80) {
+      s += char(c);
+    } else if (c < 0x800) {
+      s += char(0xc0 | (c >> 6));
+      s += char(0x80 | (c & 63));
+    } else {
+      s += char(0xe0 | (c >> 12));
+      s += char(0x80 | ((c >> 6) & 63));
+      s += char(0x80 | (c & 63));
+    }
+  }
+  return s;
+}
+
+// Consume one reference to an object of `cls_name` - a null tag, a
+// back-ref (value unneeded here, so left unresolved), a class-ref to an
+// already-declared class, or (rarely, if this is the class's first use
+// in the file) a fresh declaration - without relying on the referenced
+// object's slot already being known to `slots` the way Archive::object()
+// requires. The page scan below runs over a region of the file the main
+// walk never visits, so back-refs into that region can't be resolved.
+// Mirrors Python's legacy._skip_typed_ref exactly.
+void skip_typed_ref(LegacySlotTable& slots, R& r, const std::string& cls_name,
+                    const std::function<void(R&)>& read_body) {
+  auto tag = r.peek_u16();
+  if (tag == 0) {
+    r.u16();
+    return;
+  }
+  if (tag == 0xffff) {
+    r.u16();
+    auto schema = r.u16();
+    auto namelen = r.u16();
+    if (namelen > 40) throw std::runtime_error("implausible class name length");
+    auto raw_name = r.raw(namelen);
+    std::string name(raw_name.begin(), raw_name.end());
+    if (name != cls_name) throw std::runtime_error("expected " + cls_name + " decl, got " + name);
+    if (!slots.class_slot.count(cls_name))
+      slots.class_slot[cls_name] = slots.alloc({true, cls_name, int(schema), {}});
+    read_body(r);
+    return;
+  }
+  if (tag & 0x8000) {
+    uint64_t cslot = tag & 0x7fff;
+    auto it = slots.slots.find(cslot);
+    if (it == slots.slots.end() || !it->second.cls || it->second.name != cls_name)
+      throw std::runtime_error("unexpected " + cls_name + " class-ref");
+    r.u16();
+    read_body(r);
+    return;
+  }
+  r.u16();  // plain back-ref - the referenced value isn't needed here
+}
+
+// Same byte layout as the CCamera/CDib branches of Archive::object()'s
+// dispatch above (r.raw(137); r.u16(); r.utf16(); r.raw(33) / r.u32();
+// z=r.u32(); r.raw(z)) - duplicated here as standalone bodies since
+// skip_typed_ref can't safely route through the full object() dispatch
+// (see its own comment) but still needs to consume the exact same bytes
+// when a page candidate's camera/thumbnail happens to be a fresh
+// declaration or class-ref rather than the usual null tag.
+void read_camera_body(R& r) {
+  r.raw(137);
+  r.u16();
+  r.utf16();
+  r.raw(33);
+}
+
+void read_dib_body(R& r) {
+  r.u32();
+  auto z = r.u32();
+  if (z > r.d.size()) throw std::runtime_error("implausible dib length");
+  r.raw(z);
+}
+
 }  // namespace
+
+// Best-effort scan for CViewPage (scene) records: name + hidden-layer
+// slot ids only, for the narrow flag combinations this reader
+// understands (see kPageAllowedFlags above).
+//
+// Runs as an independent scan over the file tail (from where the main
+// entity walk stops) rather than as a sequential archive read: each
+// candidate is validated by its own local structure (a name string
+// immediately followed by an empty second string and a recognized flags
+// word), and any candidate that doesn't fully validate - an unsupported
+// flag combination, or a reference into a part of the file this scan
+// never visited - is silently skipped rather than guessed at, so a page
+// this reader can't fully understand is just absent from the result
+// instead of producing wrong data. Mirrors Python's legacy._scan_pages
+// exactly. Declared in internal.hpp (see LegacySlotTable's own comment
+// for why) - not just a parse_legacy() implementation detail.
+std::vector<RawPage> scan_pages_for_layers(const ByteBuffer& data, std::size_t start_pos,
+                                           LegacySlotTable slots) {
+  std::vector<RawPage> pages;
+  size_t pos = start_pos;
+  const size_t n = data.size();
+  while (true) {
+    size_t idx = std::string::npos;
+    for (size_t i = pos; i + 3 <= n; ++i) {
+      if (data[i] == 255 && data[i + 1] == 254 && data[i + 2] == 255) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx == std::string::npos) break;
+    pos = idx + 1;
+    size_t nlen_pos = idx + 3;
+    if (nlen_pos >= n) break;
+    uint8_t nlen = data[nlen_pos];
+    if (nlen == 0 || nlen > 40) continue;
+    size_t name_start = nlen_pos + 1;
+    size_t name_end = name_start + 2 * size_t(nlen);
+    if (name_end + 7 > n) continue;
+    if (!(data[name_end] == 255 && data[name_end + 1] == 254 && data[name_end + 2] == 255 &&
+          data[name_end + 3] == 0)) {
+      continue;  // second name must be empty
+    }
+    size_t flags_pos = name_end + 4;
+    uint32_t flags = read_u32(data, flags_pos);
+    if (!is_allowed_page_flags(flags)) continue;
+    std::string name = decode_utf16le_range(data, name_start, nlen);
+    try {
+      R r{data, flags_pos + 4};
+      skip_typed_ref(slots, r, "CCamera", read_camera_body);
+      skip_typed_ref(slots, r, "CDib", read_dib_body);
+      std::vector<EntityId> hidden_ids;
+      if (flags & kPageHiddenLayersBit) {
+        while (true) {
+          size_t save = r.p;
+          auto v = r.u16();
+          auto it = slots.slots.find(v);
+          if (it != slots.slots.end() && !it->second.cls && it->second.name == "CLayer") {
+            hidden_ids.push_back(static_cast<EntityId>(v));
+          } else {
+            r.p = save;
+            break;
+          }
+        }
+        if (r.u32() != 1) throw std::runtime_error("unexpected hidden-layers marker");
+      }
+      RawPage page;
+      page.name = std::move(name);
+      page.hidden_layer_ids = std::move(hidden_ids);
+      pages.push_back(std::move(page));
+    } catch (const std::exception&) {
+      continue;
+    }
+  }
+  return pages;
+}
 
 RawParsed parse_legacy(const ByteBuffer& data, const ParseOptions& o) {
   emit_log(o, LogLevel::information,
@@ -1463,6 +1602,12 @@ RawParsed parse_legacy(const ByteBuffer& data, const ParseOptions& o) {
         out.definitions[s.first] = std::move(d);
       }
     fill(out.root.builder, root, ar.slots);
+    try {
+      out.pages =
+          scan_pages_for_layers(data, ar.r.p, LegacySlotTable{ar.slots, ar.class_slot, ar.next});
+    } catch (const std::exception&) {
+      out.pages.clear();
+    }
     emit_progress(o, ParseStage::legacy_defs, out.definitions.size(), out.definitions.size());
     emit_log(o, LogLevel::information,
              "Parse complete: " + std::to_string(out.definitions.size()) + " defs");

--- a/packages/cpp/tests/pages_dimensions_test.cpp
+++ b/packages/cpp/tests/pages_dimensions_test.cpp
@@ -186,4 +186,92 @@ TEST(PagesDimensions, FileWithNoPagesParsesWithEmptyPagesList) {
   auto model = SkpFile::open(test::fixture("SU_File.skp")).parse();
   EXPECT_TRUE(model.pages.empty());
 }
+
+// ── legacy scenes (pages) ────────────────────────────────────────────────
+//
+// CViewPage's full record also embeds a camera, an optional thumbnail, a
+// font, and - for any flag combination beyond hidden-layers - an entire
+// Style sub-object of undocumented size, so the legacy scanner only
+// supports the narrow flag set it fully understands (see
+// scan_pages_for_layers's own comment in legacy.cpp); everything else is
+// silently skipped. Ground truth (the flags bitmask, the hidden-layers
+// list shape) was captured from real v17-native SketchUp saves - ported
+// byte-for-byte from Python's legacy._scan_pages / its own
+// test_scan_pages_legacy_synthetic.
+
+namespace {
+
+ByteBuffer legacy_page_record(const std::string& name, std::uint32_t flags,
+                              const std::vector<std::uint16_t>& hidden_ids = {}) {
+  ByteBuffer out;
+  auto push_marker = [&]() {
+    out.push_back(255);
+    out.push_back(254);
+    out.push_back(255);
+  };
+  push_marker();
+  out.push_back(static_cast<std::uint8_t>(name.size()));
+  for (char c : name) {
+    out.push_back(static_cast<std::uint8_t>(c));
+    out.push_back(0);
+  }
+  push_marker();
+  out.push_back(0);  // second name: always empty
+  for (int i = 0; i < 4; ++i) out.push_back(static_cast<std::uint8_t>(flags >> (i * 8)));
+  out.push_back(0);
+  out.push_back(0);  // camera: null ref
+  out.push_back(0);
+  out.push_back(0);  // thumbnail dib: null ref
+  constexpr std::uint32_t kHiddenLayersBit = 0x20;
+  if (flags & kHiddenLayersBit) {
+    for (auto hid : hidden_ids) {
+      out.push_back(static_cast<std::uint8_t>(hid & 0xff));
+      out.push_back(static_cast<std::uint8_t>((hid >> 8) & 0xff));
+    }
+    out.push_back(1);
+    out.push_back(0);
+    out.push_back(0);
+    out.push_back(0);  // u32 marker (also stops the u16 list)
+  }
+  return out;
+}
+
+}  // namespace
+
+TEST(PagesDimensions, ScanPagesLegacySynthetic) {
+  auto data = test::concat({
+      legacy_page_record("Baseline", 0xc00),
+      legacy_page_record("WithHidden", 0xc20, {5, 6}),
+      legacy_page_record("TooFull", 0xfff, {5}),
+  });
+
+  std::unordered_map<std::uint64_t, LegacySlotEntry> slots;
+  std::unordered_map<std::string, std::uint64_t> class_slot;
+  std::uint64_t next = 0;
+  slots[5] = LegacySlotEntry{false, "CLayer", 0, {}};
+  slots[6] = LegacySlotEntry{false, "CLayer", 0, {}};
+
+  auto pages = scan_pages_for_layers(data, 0, LegacySlotTable{slots, class_slot, next});
+
+  ASSERT_EQ(pages.size(), 2u);
+  EXPECT_EQ(pages[0].name, "Baseline");
+  EXPECT_EQ(pages[1].name, "WithHidden");
+  EXPECT_TRUE(pages[0].hidden_layer_ids.empty());
+  ASSERT_EQ(pages[1].hidden_layer_ids.size(), 2u);
+  EXPECT_EQ(pages[1].hidden_layer_ids[0], 5);
+  EXPECT_EQ(pages[1].hidden_layer_ids[1], 6);
+}
+
+TEST(PagesDimensions, ScanPagesLegacyIgnoresUnrelatedNoise) {
+  // Random bytes containing the marker sequence but not shaped like a
+  // real page record must never crash or fabricate a page.
+  ByteBuffer noise{255, 254, 255, 5, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  std::unordered_map<std::uint64_t, LegacySlotEntry> slots;
+  std::unordered_map<std::string, std::uint64_t> class_slot;
+  std::uint64_t next = 0;
+
+  auto pages = scan_pages_for_layers(noise, 0, LegacySlotTable{slots, class_slot, next});
+
+  EXPECT_TRUE(pages.empty());
+}
 }  // namespace openskp


### PR DESCRIPTION
## Summary

Ports Python's `legacy._scan_pages` (narrow scope) to `legacy.cpp`'s new `scan_pages_for_layers`. Legacy (pre-2021 MFC) `.skp` files had no page/scene reading code at all in C++ - `SkpModel.pages` was only ever populated for the VFF path.

CViewPage's full record also embeds a camera, an optional thumbnail, a font, and (for any of several independently-optional capture flags beyond hidden-layers) an entire Style sub-object of undocumented size. Scoped down deliberately, matching Python exactly: only the flag combination capturing nothing, or only hidden-layers, is supported; anything else is silently skipped rather than guessed at, so an unsupported page is simply absent from `model.pages` instead of producing wrong data. Runs as an independent scan over the file tail (from where the main entity walk stops) rather than part of the sequential archive read.

Also exposes `LegacySlotEntry`/`LegacySlotTable`/`scan_pages_for_layers` via `internal.hpp` (`struct V` moved out of `legacy.cpp`'s own anonymous namespace to make this possible without duplicating it) so this feature is unit-testable the same way VFF's `parse_pages`/`parse_dimensions` already are - previously, `legacy.cpp`'s internals were only reachable through real fixture files.

Updates `docs/LANGUAGE_PARITY.md` and `CHANGELOG.md`, including one honest gap: this hasn't been exercised against a real file that actually contains a legacy scene - none of the committed fixtures or the real production files available while building this had one.

## Test plan

- [x] Full existing C++ test suite: 216/216 passing (214 pre-existing + 2 new), zero regressions from the `struct V`/`Entry` refactor.
- [x] 2 new unit tests exercise `scan_pages_for_layers` directly against hand-built byte records mirroring Python's own `test_scan_pages_legacy_synthetic` exactly - 3 candidate pages, one with an unsupported flag combination (`0xfff`) correctly rejected, hidden-layer slot ids correctly resolved through a hand-built slot table.
- [x] Real-file smoke test: 5 real production files (including a 376MB one) parse successfully with the new code active, no crash, no false positives - all correctly report zero pages since none of them are legacy-format with real scenes.