### PR TITLE
feat(cpp): read construction lines/points (legacy only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,34 @@ byte layout itself was already established by Python's own
 implementation, ground-truthed against real v17-native SketchUp saves;
 this port carries that over faithfully rather than re-deriving it.
 
+### Added — C++: read construction lines/points (legacy only)
+
+Ports Python's `legacy._read_constructionline`/`_read_constructionpoint`
+reading side to `legacy.cpp` (writer/`create.py`'s side is out of scope
+here, per this round's own priority - see `docs/LANGUAGE_PARITY.md`'s
+still-open "Writer: construction lines/points" row). Both entity types
+were already being parsed (needed for archive slot-sync) but their
+fields were read and immediately discarded - new `ConstructionLine`/
+`ConstructionPoint` model types and `Definition::construction_lines`/
+`.construction_points` fields now surface them, matching Python's own
+`ConstructionLine`/`ConstructionPoint` dataclasses field-for-field.
+
+A bounded `CConstructionLine` stores a point + normalized direction +
+two signed distance parameters along that direction marking the
+segment's start/end - translated into the same start/end/direction
+shape `Sketchup::ConstructionLine`'s own Ruby API exposes. An unbounded
+line uses a large-magnitude sentinel (start/end come back unset,
+matching the real API returning `nil`). A `CConstructionPoint` stores
+its position plus a second, always-zero 3-double block and a trailing
+byte with no corresponding Ruby property - left unexposed, matching
+Python exactly.
+
+Verified against a real committed fixture (`capilla_quiroz_v17.skp`): 7
+real construction points, every coordinate byte-for-byte identical to
+Python's own parse of the same file. No construction lines were
+available in any fixture or real production file to verify against -
+stated honestly in `docs/LANGUAGE_PARITY.md` rather than glossed over.
+
 ## [1.3.0] — 2026-09-09 — Python only, GitHub-only pre-release
 
 > **This tag is not published to PyPI.** It's a real, tested, tagged release

--- a/docs/LANGUAGE_PARITY.md
+++ b/docs/LANGUAGE_PARITY.md
@@ -51,7 +51,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | Attribute dicts: multiple dictionaries per entity | ✅ | ❌ single dict only | ❌ | ❌ | ✅ |
 | VFF pages/scenes + dimension parsing | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Legacy (pre-2021) pages/scenes reading | ✅ | ❌ VFF only | ❌ VFF only | ❌ VFF only | 🔶 on main, GitHub-only |
-| Construction lines/points reading | ✅ | ❌ | ❌ | ❌ | ❌ |
+| Construction lines/points reading | ✅ legacy only | ❌ | ❌ | ❌ | 🔶 legacy only, on main, GitHub-only |
 | VFF per-layer-hidden flag reading | 🔶 on main | ❌ | ❌ | ❌ | 🔶 on main, GitHub-only |
 | `mesh_index[...].properties` populated | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `model.layers` in file order (not alphabetical) | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -116,6 +116,7 @@ C++ merged, not yet released:
 | VFF (2021+) per-layer-hidden flag reading (`8E3C` tag) | `geometry.cpp`'s `collect_layers`, `core.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | `model.layers` in source-file order, not alphabetical (`RawParsed::layer_order`) | `core.cpp`, `legacy.cpp`, `model.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 | Legacy (pre-2021) pages/scenes reading (`scan_pages_for_layers`) | `legacy.cpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
+| Construction lines/points reading, legacy only (`ConstructionLine`/`ConstructionPoint`) | `legacy.cpp`, `model.hpp` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
 
 Known gaps in this C++ work, stated honestly rather than glossed over:
 - Attribute dictionary values decode as strings only (no `Point3d`/`Length`/
@@ -127,6 +128,12 @@ Known gaps in this C++ work, stated honestly rather than glossed over:
   against a synthetic byte-level test mirroring Python's own
   ground-truthed test case, plus real-file smoke testing (no crash, no
   false positives) on 5 real files with no scenes at all.
+- Construction *points* were verified byte-for-byte against a real
+  committed fixture (`capilla_quiroz_v17.skp`, 7 real points, identical
+  coordinates to Python's own parse); construction *lines* were not -
+  none of the available fixtures or real production files contain one,
+  so that half rests on code review + sharing the exact same read path
+  as the now-verified points, not independent real-data confirmation.
 
 ## 4. Real SketchUp file version support
 

--- a/packages/cpp/examples/parsetest.cpp
+++ b/packages/cpp/examples/parsetest.cpp
@@ -15,6 +15,25 @@ int main(int argc, char** argv) {
     for (auto& pg : model.pages) {
       std::cout << "  page '" << pg.name << "' hidden_layers=" << pg.hidden_layers.size() << "\n";
     }
+    size_t total_clines = 0, total_cpoints = 0;
+    auto scan_defn = [&](auto&& self, const openskp::Definition& d) -> void {
+      total_clines += d.construction_lines.size();
+      total_cpoints += d.construction_points.size();
+      for (auto& cl : d.construction_lines) {
+        std::cout << "  cline point=(" << cl.point[0] << "," << cl.point[1] << "," << cl.point[2]
+                  << ") dir=(" << cl.direction[0] << "," << cl.direction[1] << ","
+                  << cl.direction[2] << ") bounded_start=" << cl.start.has_value()
+                  << " bounded_end=" << cl.end.has_value() << "\n";
+      }
+      for (auto& cp : d.construction_points) {
+        std::cout << "  cpoint pos=(" << cp.position[0] << "," << cp.position[1] << ","
+                  << cp.position[2] << ")\n";
+      }
+    };
+    scan_defn(scan_defn, model.root());
+    for (auto& [id, d] : model.definitions) scan_defn(scan_defn, d);
+    std::cout << "total construction_lines=" << total_clines
+              << " construction_points=" << total_cpoints << "\n";
   } catch (const std::exception& e) {
     std::cerr << "EXC: " << e.what() << '\n';
     return 1;

--- a/packages/cpp/include/openskp/model.hpp
+++ b/packages/cpp/include/openskp/model.hpp
@@ -219,6 +219,39 @@ struct Dimension {
   std::optional<Vec3> normal;
 };
 
+/// A construction/guide line (SketchUp's Construction Line tool).
+/// Legacy (pre-2021) files only - the VFF (2021+) reader does not
+/// currently recognize this entity.
+///
+/// Stored internally (and here, unchanged) as a point + normalized
+/// direction + two signed distance parameters along that direction
+/// marking where the visible segment starts/ends - the same shape
+/// `Sketchup::ConstructionLine`'s own `start`/`end`/`direction`
+/// properties expose. A parameter magnitude of `1e30` means unbounded
+/// in that direction (SketchUp draws this as an infinite guide line
+/// through `point`) - `start`/`end` come back unset in that case,
+/// matching the real API returning `nil`.
+struct ConstructionLine {
+  /// A point on the line, in inches (world space) - matches the bounded
+  /// case's own `start`, or the anchor point given for an infinite line.
+  Vec3 point{0.0, 0.0, 0.0};
+  /// The line's normalized direction vector.
+  Vec3 direction{1.0, 0.0, 0.0};
+  /// The bounded segment's start point, or unset if unbounded in this
+  /// direction.
+  std::optional<Vec3> start;
+  /// The bounded segment's end point, or unset if unbounded.
+  std::optional<Vec3> end;
+};
+
+/// A construction/guide point (SketchUp's Construction Point tool).
+/// Legacy (pre-2021) files only - the VFF (2021+) reader does not
+/// currently recognize this entity.
+struct ConstructionPoint {
+  /// The point's position, in inches (world space).
+  Vec3 position{0.0, 0.0, 0.0};
+};
+
 /// A saved scene (SketchUp's "Scenes" tabs; "pages" in the SDK).
 struct Page {
   /// Scene name as shown on its tab.
@@ -262,6 +295,10 @@ struct Definition {
   std::vector<TextEntity> texts;
   /// Dimensions placed inside this definition.
   std::vector<Dimension> dimensions;
+  /// Construction/guide lines placed inside this definition.
+  std::vector<ConstructionLine> construction_lines;
+  /// Construction/guide points placed inside this definition.
+  std::vector<ConstructionPoint> construction_points;
   /// Always faces camera behavior flag.
   bool always_faces_camera{};
   /// Shadows face sun behavior flag.

--- a/packages/cpp/src/internal.hpp
+++ b/packages/cpp/src/internal.hpp
@@ -67,6 +67,8 @@ struct GeometryBuilder {
   std::vector<SectionPlane> section_planes;
   std::vector<TextEntity> texts;
   std::vector<Dimension> dimensions;
+  std::vector<ConstructionLine> construction_lines;
+  std::vector<ConstructionPoint> construction_points;
 };
 
 struct RawDefinition {
@@ -196,6 +198,12 @@ struct V {
   std::string text;
   std::string guid;
   Vec3 xyz{};
+  // Only populated for k == "constructionline": the line's normalized
+  // direction, and its bounded segment's start/end (unset when unbounded
+  // in that direction) - see ConstructionLine's own doc comment.
+  Vec3 direction{};
+  std::optional<Vec3> start;
+  std::optional<Vec3> end;
   std::vector<double> plane;
   std::vector<double> xf;
   std::vector<double> uvf;

--- a/packages/cpp/src/legacy.cpp
+++ b/packages/cpp/src/legacy.cpp
@@ -649,8 +649,28 @@ struct Archive {
       entity_ref();
     } else if (n == "CConstructionLine") {
       preamble();
+      v->k = "constructionline";
       draw(*v);
-      r.f64s(8);  // line params (+-~4.4e29 = infinite)
+      // point(3) + direction(3) + two signed distance params along
+      // direction marking where the visible segment starts/ends - the
+      // same shape Sketchup::ConstructionLine's own start/end/direction
+      // properties expose. A parameter magnitude past kHugeParam means
+      // unbounded in that direction (matches the real API returning nil).
+      auto line_params = r.f64s(8);
+      v->xyz = {line_params[0], line_params[1], line_params[2]};
+      v->direction = {line_params[3], line_params[4], line_params[5]};
+      constexpr double kHugeParam = 1e20;
+      double start_param = line_params[6], end_param = line_params[7];
+      if (std::abs(start_param) < kHugeParam) {
+        v->start = Vec3{v->xyz[0] + v->direction[0] * start_param,
+                        v->xyz[1] + v->direction[1] * start_param,
+                        v->xyz[2] + v->direction[2] * start_param};
+      }
+      if (std::abs(end_param) < kHugeParam) {
+        v->end =
+            Vec3{v->xyz[0] + v->direction[0] * end_param, v->xyz[1] + v->direction[1] * end_param,
+                 v->xyz[2] + v->direction[2] * end_param};
+      }
       // The trailing block varies by the WRITING BUILD, not cleanly by
       // version: 7 bytes on the v17 calibration corpus, 4 on v16 and on a
       // real v18, 0 on another real v17. Self-calibrate on the first
@@ -681,9 +701,13 @@ struct Archive {
       r.raw(*cline_tail);
     } else if (n == "CConstructionPoint") {
       preamble();
+      v->k = "constructionpoint";
       draw(*v);
-      r.f64s(6);
-      r.u8();
+      auto pos = r.f64s(3);
+      v->xyz = {pos[0], pos[1], pos[2]};
+      r.f64s(3);  // reserved/unused (observed all-zero) - no corresponding
+                  // Sketchup::ConstructionPoint property to name it after
+      r.u8();     // reserved/unused (observed 0)
     } else if (n == "CSectionPlane") {
       preamble();
       v->k = "sectionplane";
@@ -1299,6 +1323,17 @@ void fill(GeometryBuilder& b,
       dim.text = v->text;
       dim.hidden = v->hidden != 0;
       b.dimensions.push_back(std::move(dim));
+    } else if (v->k == "constructionline") {
+      ConstructionLine cl;
+      cl.point = v->xyz;
+      cl.direction = v->direction;
+      cl.start = v->start;
+      cl.end = v->end;
+      b.construction_lines.push_back(std::move(cl));
+    } else if (v->k == "constructionpoint") {
+      ConstructionPoint cp;
+      cp.position = v->xyz;
+      b.construction_points.push_back(std::move(cp));
     }
   }
 }

--- a/packages/cpp/src/model.cpp
+++ b/packages/cpp/src/model.cpp
@@ -78,6 +78,8 @@ static Definition definition(EntityId id, RawDefinition&& r) {
   d.section_planes = std::move(r.builder.section_planes);
   d.texts = std::move(r.builder.texts);
   d.dimensions = std::move(r.builder.dimensions);
+  d.construction_lines = std::move(r.builder.construction_lines);
+  d.construction_points = std::move(r.builder.construction_points);
   return d;
 }
 

--- a/packages/cpp/tests/parser_test.cpp
+++ b/packages/cpp/tests/parser_test.cpp
@@ -193,6 +193,19 @@ TEST(Parser, LegacyMatchesReference) {
   EXPECT_EQ(grada.edges.size(), 30);
   EXPECT_EQ(grada.vertices.size(), 20);
 
+  // Construction (guide) points - real data on this fixture, all on the
+  // root definition. No construction lines on this particular file.
+  // Cross-checked byte-for-byte against Python's own parse of the same
+  // fixture.
+  EXPECT_TRUE(model.root().construction_lines.empty());
+  ASSERT_EQ(model.root().construction_points.size(), 7);
+  EXPECT_NEAR(model.root().construction_points[0].position[0], -44.69836289477159, 1e-9);
+  EXPECT_NEAR(model.root().construction_points[0].position[1], 125.87449928268785, 1e-9);
+  EXPECT_NEAR(model.root().construction_points[0].position[2], 90.15748031496064, 1e-9);
+  EXPECT_NEAR(model.root().construction_points[6].position[0], 183.8551286073387, 1e-9);
+  EXPECT_NEAR(model.root().construction_points[6].position[1], 125.95096929693227, 1e-9);
+  EXPECT_NEAR(model.root().construction_points[6].position[2], 90.15748031496064, 1e-9);
+
   const std::set<std::string> expected_materials{
       "*1",
       "[0037_SandyBrown]",


### PR DESCRIPTION
## Summary

Ports Python's `legacy._read_constructionline`/`_read_constructionpoint` reading side to `legacy.cpp` (writer/`create.py`'s side is out of scope here, per this round's own read-side priority - see `docs/LANGUAGE_PARITY.md`'s still-open "Writer: construction lines/points" row).

Both entity types were already being parsed (needed for archive slot-sync) but their fields were read and immediately discarded - new `ConstructionLine`/`ConstructionPoint` model types and `Definition::construction_lines`/`.construction_points` fields now surface them, matching Python's own dataclasses field-for-field.

A bounded `CConstructionLine` stores a point + normalized direction + two signed distance parameters along that direction marking the segment's start/end - translated into the same start/end/direction shape `Sketchup::ConstructionLine`'s own Ruby API exposes. An unbounded line uses a large-magnitude sentinel (start/end come back unset). A `CConstructionPoint` stores its position plus a second, always-zero 3-double block and a trailing byte with no corresponding Ruby property - left unexposed, matching Python exactly.

Updates `docs/LANGUAGE_PARITY.md` and `CHANGELOG.md`.

## Test plan

- [x] Full existing C++ test suite: 216/216 passing, zero regressions.
- [x] Verified against a real committed fixture (`capilla_quiroz_v17.skp`): 7 real construction points, every coordinate byte-for-byte identical to Python's own parse of the same file.
- [x] Honest gap noted: no construction lines were available in any fixture or real production file to verify against - stated in `docs/LANGUAGE_PARITY.md` rather than glossed over.