### PR TITLE
fix: attribute_dictionaries never reached GLB/JSON metadata export (Python, C++)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `attribute_dictionaries` missing from GLB/JSON metadata export (Python, C++)
+
+Every attribute dictionary an instance carries (not just SketchUp's own
+`dynamic_attributes`, which `properties` is scoped to exclusively per
+[#254](https://github.com/iamahsanmehmood/openskp/issues/254)) was already
+correctly resolved by `build_scene()`/`build_instanced_scene()` in both
+languages, but was never written into any of the JSON-producing export
+paths — Python's `export/glb.py`, `export/json_export.py`, and
+`export/instanced_glb.py`; C++'s `json_export.cpp` (`instance_node_to_json`/
+`mesh_metadata_to_json`). Only the IFC exporter surfaced this data at all
+(as `Pset_<dict-name>` properties). A consumer reading GLB/JSON metadata
+instead of the derived `.ifc` — e.g. a third-party plugin's own named
+dictionary such as a steel-detailing tool's `steelframer-dict` — silently
+never saw it.
+
+Both `_instance_node_to_dict`/`mesh_index` (Python, all three export
+modules) and `instance_node_to_json`/`mesh_metadata_to_json` (C++) now
+include an `attribute_dictionaries` key alongside the existing `properties`
+key, keyed by each dictionary's own declared name. Verified against real
+plugin data on `Untitled.skp` (`steelframer-dict`, 45 entries) in both
+languages; no output shape change for models with no extra dictionaries
+(`attribute_dictionaries` is simply `{}`).
+
+TypeScript, .NET, and Dart don't have an `attribute_dictionaries` field at
+all yet (see [§2 of LANGUAGE_PARITY.md](docs/LANGUAGE_PARITY.md)) — out of
+scope here, tracked under the existing cross-language porting backlog
+([#285](https://github.com/iamahsanmehmood/openskp/issues/285)).
+
 ### Changed — TypeScript writer memory
 
 `ArchiveWriter` keeps the archive in a growable `Uint8Array` instead of a

--- a/docs/LANGUAGE_PARITY.md
+++ b/docs/LANGUAGE_PARITY.md
@@ -50,6 +50,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | Single attribute dictionary per entity | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Attribute dicts: full 9-value-type support (`Point3d`/`Vector3d`/`Length`/`Timestamp`/nested lists) | ✅ | ❌ str/int/float only | ❌ | ❌ | ❌ str only |
 | Attribute dicts: multiple dictionaries per entity | ✅ | ❌ single dict only | ❌ | ❌ | ✅ |
+| Attribute dicts surfaced in GLB/JSON metadata export (not just IFC Psets) | 🔶 on main | n/a, no `attribute_dictionaries` field | n/a | n/a | 🔶 on main, GitHub-only |
 | VFF pages/scenes + dimension parsing | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Legacy (pre-2021) pages/scenes reading | ✅ | ❌ VFF only | ❌ VFF only | ❌ VFF only | 🔶 on main, GitHub-only |
 | Construction lines/points reading | ✅ legacy only | ❌ | ❌ | ❌ | 🔶 legacy only, on main, GitHub-only |
@@ -105,6 +106,12 @@ It folds into a proper PyPI `1.3.0` once the cross-language porting items in
 [§2](#2-feature-matrix) and [issue #285](https://github.com/iamahsanmehmood/openskp/issues/285)
 catch up.
 
+Also merged on `main` since that preview tag, not yet part of it: a fix so
+`attribute_dictionaries` (every attribute dictionary an instance carries,
+not just `dynamic_attributes`) actually reaches GLB/JSON metadata export —
+`export/glb.py`, `export/json_export.py`, `export/instanced_glb.py` — see
+[CHANGELOG.md § Unreleased](../CHANGELOG.md).
+
 TypeScript merged, not yet released: a writer memory fix (`ArchiveWriter`
 now keeps the archive in a growable `Uint8Array` instead of a `number[]`,
 cutting peak heap on a 62 MB write from ~2.1 GB to ~0.2 GB) — see
@@ -132,6 +139,14 @@ numbered `cpp-v1.3.0` release yet. It folds into that once the known gaps
 below are closed and the cross-language porting items in
 [§2](#2-feature-matrix) and [issue #285](https://github.com/iamahsanmehmood/openskp/issues/285)
 catch up.
+
+Also merged on `main` since that preview tag, not yet part of it: a fix so
+`attribute_dictionaries` actually reaches `json_export.cpp`'s
+`instance_node_to_json`/`mesh_metadata_to_json` output (it was already
+correctly resolved by `build_scene()`, just never serialized) — see
+[CHANGELOG.md § Unreleased](../CHANGELOG.md). Note this is a distinct gap
+from the "values decode as strings only" item below — this one was a
+missing field in the export layer entirely, not a type-fidelity limit.
 
 Known gaps in this C++ work, stated honestly rather than glossed over:
 - Attribute dictionary values decode as strings only (no `Point3d`/`Length`/

--- a/packages/cpp/src/json_export.cpp
+++ b/packages/cpp/src/json_export.cpp
@@ -212,6 +212,24 @@ JsonValue definition_to_json(const Definition& defn) {
   return obj;
 }
 
+// Every attribute dictionary an instance/mesh carries, keyed by the
+// dictionary's own declared name - not just SketchUp's own
+// dynamic_attributes (which `properties` above already covers). This is
+// where a third-party plugin's own per-instance data (e.g. a
+// steel-detailing tool's own named dictionary) reaches JSON output; it
+// was already correctly resolved by build_scene()/build_instanced_scene()
+// but previously never serialized here at all.
+JsonValue attribute_dictionaries_to_json(
+    const std::map<std::string, std::map<std::string, std::string>>& dicts) {
+  auto obj = JsonValue::make_object();
+  for (const auto& [dict_name, entries] : dicts) {
+    auto entries_obj = JsonValue::make_object();
+    for (const auto& [k, v] : entries) entries_obj.set(k, v);
+    obj.set(dict_name, std::move(entries_obj));
+  }
+  return obj;
+}
+
 JsonValue instance_node_to_json(const InstanceNode& node) {
   auto obj = JsonValue::make_object();
   obj.set("name", node.name);
@@ -225,6 +243,7 @@ JsonValue instance_node_to_json(const InstanceNode& node) {
   auto props = JsonValue::make_object();
   for (const auto& [k, v] : node.properties) props.set(k, v);
   obj.set("properties", std::move(props));
+  obj.set("attribute_dictionaries", attribute_dictionaries_to_json(node.attribute_dictionaries));
   auto children = JsonValue::make_array();
   for (const auto& child : node.children) children.push(instance_node_to_json(child));
   obj.set("children", std::move(children));
@@ -244,6 +263,7 @@ JsonValue mesh_metadata_to_json(const MeshMetadata& m) {
   auto props = JsonValue::make_object();
   for (const auto& [k, v] : m.properties) props.set(k, v);
   obj.set("properties", std::move(props));
+  obj.set("attribute_dictionaries", attribute_dictionaries_to_json(m.attribute_dictionaries));
   obj.set("path", m.path);
   return obj;
 }

--- a/packages/cpp/tests/json_export_test.cpp
+++ b/packages/cpp/tests/json_export_test.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <gtest/gtest.h>
 
 #include <openskp/openskp.hpp>
@@ -79,6 +80,44 @@ TEST(JsonExport, IncludesSceneHierarchyAndMeshIndexWhenSceneIsPassed) {
   const auto& first_mesh = mesh_index[0].second;
   EXPECT_NE(first_mesh.find("definition_name"), nullptr);
   EXPECT_NE(first_mesh.find("position_mm"), nullptr);
+}
+
+// Every attribute dictionary an instance carries (not just SketchUp's own
+// dynamic_attributes, which `properties` already covers) must reach JSON
+// output too - it was already correctly resolved by build_scene() but
+// previously never serialized in mesh_index/scene_hierarchy at all,
+// silently dropping third-party plugin data (e.g. a steel-detailing
+// tool's own named dictionary) from every JSON/GLB-metadata consumer.
+// Untitled.skp's real "W1" instance carries a real "steelframer-dict"
+// (45 entries, including "generator"/"profile") - see Parser.
+// ModernUntitled for the same real data verified at the raw-parse level.
+TEST(JsonExport, IncludesAttributeDictionariesFromRealPluginData) {
+  auto model = SkpFile::open(test::fixture("Untitled.skp")).parse();
+  auto scene = SkpFile::open(test::fixture("Untitled.skp")).build_scene();
+  auto d = to_json(model, &scene);
+
+  std::function<const JsonValue*(const JsonValue&)> find_w1 =
+      [&](const JsonValue& node) -> const JsonValue* {
+    auto* name = node.find("name");
+    if (name && name->as_string() == "W1") return &node;
+    auto* children = node.find("children");
+    if (children && children->is_array()) {
+      for (auto& child : children->as_array()) {
+        if (auto* found = find_w1(child)) return found;
+      }
+    }
+    return nullptr;
+  };
+  const auto* w1 = find_w1(*d.find("scene_hierarchy"));
+  ASSERT_NE(w1, nullptr);
+
+  EXPECT_TRUE(w1->find("properties")->as_object().empty());
+  const auto* dicts = w1->find("attribute_dictionaries");
+  ASSERT_NE(dicts, nullptr);
+  const auto* steelframer = dicts->find("steelframer-dict");
+  ASSERT_NE(steelframer, nullptr);
+  EXPECT_EQ(steelframer->find("generator")->as_string(), "SteelFramer::Engine::PanelGenerator");
+  EXPECT_EQ(steelframer->find("profile")->as_string(), "362S200-43");
 }
 
 TEST(JsonExport, ProducesNonEmptySerializedOutput) {

--- a/packages/python/src/openskp/export/glb.py
+++ b/packages/python/src/openskp/export/glb.py
@@ -117,6 +117,12 @@ def _instance_node_to_dict(node) -> Dict[str, Any]:
         "layer": node.layer,
         "position_mm": list(node.position_mm),
         "properties": dict(node.properties),
+        # Every OTHER attribute dictionary this instance carries (e.g. a
+        # third-party plugin's own named dictionary) - already correctly
+        # resolved by build_scene(), but previously never reached this
+        # metadata JSON at all, silently hiding it from any consumer that
+        # reads mesh_index/scene_hierarchy instead of the derived .ifc.
+        "attribute_dictionaries": {k: dict(v) for k, v in node.attribute_dictionaries.items()},
         "children": [_instance_node_to_dict(c) for c in node.children],
     }
 
@@ -233,6 +239,7 @@ def export(
                 "layer": m.layer,
                 "position_mm": list(m.position_mm),
                 "properties": dict(m.properties),
+                "attribute_dictionaries": {k: dict(v) for k, v in m.attribute_dictionaries.items()},
                 "path": m.path,
             }
             for name, m in scene_obj.mesh_index.items()

--- a/packages/python/src/openskp/export/instanced_glb.py
+++ b/packages/python/src/openskp/export/instanced_glb.py
@@ -63,6 +63,11 @@ def _instanced_node_to_dict(node) -> Dict[str, Any]:
         "layer": node.layer,
         "position_mm": list(node.position_mm),
         "properties": dict(node.properties),
+        # Every OTHER attribute dictionary this instance carries (e.g. a
+        # third-party plugin's own named dictionary) - already correctly
+        # resolved by build_instanced_scene(), but previously never
+        # reached this export at all.
+        "attribute_dictionaries": {k: dict(v) for k, v in node.attribute_dictionaries.items()},
         "mesh_resource_id": node.mesh_resource_id,
         "children": [_instanced_node_to_dict(c) for c in node.children],
     }

--- a/packages/python/src/openskp/export/json_export.py
+++ b/packages/python/src/openskp/export/json_export.py
@@ -95,6 +95,11 @@ def _instance_node_to_dict(node: InstanceNode) -> Dict[str, Any]:
         "layer": node.layer,
         "position_mm": list(node.position_mm),
         "properties": node.properties,
+        # Every OTHER attribute dictionary this instance carries (e.g. a
+        # third-party plugin's own named dictionary) - already correctly
+        # resolved by build_scene(), but previously never reached this
+        # export at all.
+        "attribute_dictionaries": {k: dict(v) for k, v in node.attribute_dictionaries.items()},
         "children": [_instance_node_to_dict(c) for c in node.children],
     }
 
@@ -181,6 +186,9 @@ def to_dict(model: SkpModel, scene: Optional[Scene] = None) -> Dict[str, Any]:
                     "layer": m.layer,
                     "position_mm": list(m.position_mm),
                     "properties": dict(m.properties),
+                    "attribute_dictionaries": {
+                        k: dict(v) for k, v in m.attribute_dictionaries.items()
+                    },
                     "path": m.path,
                 }
                 for name, m in scene.mesh_index.items()

--- a/packages/python/tests/test_parser.py
+++ b/packages/python/tests/test_parser.py
@@ -2165,6 +2165,77 @@ class TestModernRealFile:
         # exercises the full TLV/XML decode path without touching
         # triangulation at all.
 
+    def test_untitled_skp_attribute_dictionaries_reach_glb_and_json_export(self, tmp_path) -> None:
+        """Every attribute dictionary an instance carries (not just
+        SketchUp's own dynamic_attributes) was already correctly resolved
+        by build_scene() - InstanceNode.attribute_dictionaries has held
+        it since openskp#254 - but export/glb.py's and export/json_export.py's
+        own metadata dicts never actually wrote that field out, silently
+        dropping every third-party plugin's data (e.g. this real file's
+        own SteelFramer dictionary) from any consumer reading the
+        metadata JSON/dict directly instead of a derived .ifc file."""
+        import json as _json
+
+        from openskp.export import glb as glb_export
+        from openskp.export import json_export
+
+        skp = self._model(self.FIXTURE_UNTITLED)
+        skp.parse()
+        scene = skp.build_scene()
+
+        def find_w1(node):
+            if node.name == "W1":
+                return node
+            for c in node.children:
+                found = find_w1(c)
+                if found:
+                    return found
+            return None
+
+        w1 = find_w1(scene.scene_hierarchy)
+        assert w1 is not None
+        assert w1.properties == {}
+        assert w1.attribute_dictionaries["steelframer-dict"]["generator"] == (
+            "SteelFramer::Engine::PanelGenerator"
+        )
+
+        # 1. export/glb.py's metadata JSON sidecar
+        out_glb = tmp_path / "untitled.glb"
+        glb_export.export(skp, str(out_glb))
+        with open(str(out_glb).replace(".glb", "_metadata.json"), encoding="utf-8") as f:
+            metadata = _json.load(f)
+
+        def find_w1_dict(node):
+            if node.get("name") == "W1":
+                return node
+            for c in node.get("children", []):
+                found = find_w1_dict(c)
+                if found:
+                    return found
+            return None
+
+        w1_glb = find_w1_dict(metadata["scene_hierarchy"])
+        assert w1_glb is not None
+        assert w1_glb["attribute_dictionaries"]["steelframer-dict"]["profile"] == "362S200-43"
+
+        # 2. export/json_export.py's own schema (both the scene_hierarchy
+        # tree and the mesh_index entries)
+        d = json_export.to_dict(skp.parse(), scene)
+        w1_json = find_w1_dict(d["scene_hierarchy"])
+        assert w1_json is not None
+        assert w1_json["attribute_dictionaries"]["steelframer-dict"]["generator"] == (
+            "SteelFramer::Engine::PanelGenerator"
+        )
+        mesh_with_dict = next(
+            (
+                m
+                for m in d["mesh_index"].values()
+                if m.get("attribute_dictionaries", {}).get("steelframer-dict")
+            ),
+            None,
+        )
+        assert mesh_with_dict is not None
+
     def test_su_file_skp_matches_ground_truth(self) -> None:
         skp = self._model(self.FIXTURE_SU_FILE)
         model = skp.parse()


### PR DESCRIPTION
## Summary

`build_scene()`/`build_instanced_scene()` already correctly resolve every attribute dictionary an instance carries (not just SketchUp's own `dynamic_attributes`, which `properties` covers exclusively per #254), but no JSON-producing export path in either language ever serialized it. Only the IFC exporter surfaced this data (as `Pset_<dict-name>` properties) — a consumer reading GLB/JSON metadata instead of the derived `.ifc` (e.g. a plugin's own named dictionary such as a steel-detailing tool's `steelframer-dict`) silently never saw it.

- Python: `export/glb.py`, `export/json_export.py`, `export/instanced_glb.py` now include `attribute_dictionaries` alongside `properties`.
- C++: `json_export.cpp`'s `instance_node_to_json`/`mesh_metadata_to_json` now include the same field.

TypeScript/.NET/Dart don't have an `attribute_dictionaries` field yet at all — out of scope here, tracked under #285.

## Test plan
- [x] New test `JsonExport.IncludesAttributeDictionariesFromRealPluginData` (C++) — real `Untitled.skp` fixture, asserts `steelframer-dict` reaches JSON output
- [x] New test `test_untitled_skp_attribute_dictionaries_reach_glb_and_json_export` (Python) — same fixture, asserts data reaches both `glb.export()`'s metadata sidecar and `json_export.to_dict()`
- [x] Full C++ suite: 217/217 passing
- [x] Full Python suite: 538/538 passing