### PR TITLE
fix(python): .frag reader must follow Representation.Id(), not its vector position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -453,15 +453,21 @@ output — ThatOpen's real `IfcImporter` output, or anyone else's — and
 rides every other export this project already has (GLB, OBJ, STL, PLY,
 DXF, IFC4, JSON, `.skp` itself via the writer) for free, once parsed.
 
-Verified two ways: round-trips this project's own output exactly (world-
+Verified three ways: round-trips this project's own output exactly (world-
 space vertex positions across a real `.skp`-derived scene match to the
-last bit, not just object/vertex counts), and reads a real ThatOpen-
-produced production file cleanly (a genuine IFC-derived building, 5,751
-nodes / 100,332 vertices, not a synthetic fixture) — re-exporting that
-file through this same module and loading the result back through the
-actual `@thatopen/fragments` runtime preserves real IFC GUIDs and
-category names. A smaller real ThatOpen fixture (MIT-licensed, from their
-own `resources/frags/`) is committed at
+last bit, not just object/vertex counts); reads a real ThatOpen-produced
+production file cleanly (a genuine IFC-derived building, 5,751 nodes /
+100,332 vertices, not a synthetic fixture) — re-exporting that file
+through this same module and loading the result back through the actual
+`@thatopen/fragments` runtime preserves real IFC GUIDs and category
+names; and, independently of any pre-existing fixture, converts real IFC
+source files (a Revit-exported wall, and a real ~8.6 MB structural model)
+through ThatOpen's own actual `IfcImporter` and reads the freshly-produced
+`.frag` output straight into an `InstancedScene` — correct spatial
+hierarchy, GUIDs, and geometry counts, with `CIRCLE_EXTRUSION` samples
+(present in the structural model) skipped with a warning as documented.
+A smaller real ThatOpen fixture (MIT-licensed, from their own
+`resources/frags/`) is committed at
 `tests/fixtures/thatopen_small_test.frag` for CI.
 
 **Known gaps, stated honestly:**
@@ -480,6 +486,24 @@ own `resources/frags/`) is committed at
   has no reader yet, only `SHELL`. A real `IfcImporter`-produced file can
   contain these; such samples are skipped with a warning, not silently
   misread as shells.
+
+### Fixed — `.frag` reader crashed on real ThatOpen-produced files (wrong shell lookup)
+
+`from_fragments` resolved each sample's geometry via `Representation`'s
+own position in the `Representations` vector, treating that position as
+the index into `Meshes.Shells`. That's only true of this project's own
+writer, which happens to always keep the two equal — `Representation.Id()`
+is the actual `Shells` index, and a real ThatOpen `IfcImporter`-produced
+file does not keep it equal to the representation's vector position.
+Surfaced as an `IndexError` reading a `.frag` file freshly converted from
+a real structural IFC model via ThatOpen's own `IfcImporter` (not caught
+by any prior test, since every previous fixture — including this
+project's own writer's output — happened not to exercise the divergence).
+Fixed by following `Representation.Id()`, matching the real reader's own
+`meshes.shells(repr.id!, ...)` (`Utils/edit/fetch-functions.ts` in
+`@thatopen/fragments`). Regression test patches a representation's
+`Id()` in place to diverge from its vector position and confirms the
+correct (not merely non-crashing) shell comes back.
 
 ## [1.2.0] — 2026-09-04
 

--- a/packages/python/src/openskp/export/fragments.py
+++ b/packages/python/src/openskp/export/fragments.py
@@ -1006,7 +1006,16 @@ def from_fragments(data: bytes) -> "InstancedScene":
                     warned_unsupported = True
                 continue
             signature.append((rep_idx, mat_idx))
-            points, triangles = decode_shell(rep_idx)
+            # Representation.Id() is the index into Meshes.Shells - NOT the
+            # representation's own position in the Representations vector.
+            # OpenSKP's writer happens to keep the two equal, but a real
+            # ThatOpen-produced file does not, so this must follow Id()
+            # (matches the real reader's own `meshes.shells(repr.id!, ...)`
+            # in fetch-functions.ts).
+            shell_idx = representation.Id()
+            if shell_idx >= n_shells:
+                continue
+            points, triangles = decode_shell(shell_idx)
             normals = _compute_flat_normals(points, triangles)
             positions = array("f")
             normals_arr = array("f")

--- a/packages/python/tests/test_fragments.py
+++ b/packages/python/tests/test_fragments.py
@@ -862,3 +862,79 @@ class TestFromFragments:
         # sample referencing it is skipped - zero primitives anywhere in
         # the resulting scene, not a crash and not misread geometry.
         assert sum(len(r.primitives) for r in result.mesh_resources) == 0
+
+    def test_follows_representation_id_not_its_vector_position_for_shell_lookup(self):
+        """Representation.Id() is the index into Meshes.Shells - it is NOT
+        guaranteed to equal the representation's own position in the
+        Representations vector. OpenSKP's writer always keeps the two
+        equal, so this divergence never showed up in any round trip
+        through our own encoder (or even in ThatOpen's small fixture) -
+        it only surfaced reading a real ThatOpen IfcImporter file, where
+        it crashed with an IndexError. This proves the fix: the reader
+        must follow Id(), matching the real reader's own
+        `meshes.shells(repr.id!, ...)` (fetch-functions.ts)."""
+        box = InstancedMeshResource(
+            id="mesh_box", definition_id=1, definition_name="Box",
+            variant_key="1|255,255,255", primitives=[_box_primitive()],
+        )
+        triangle = LocalPrimitive(
+            positions=array("f", [0, 0, 0, 1, 0, 0, 0, 1, 0]),
+            normals=array("f", [0.0] * 9),
+            uvs=array("f", [0.0] * 6),
+            indices=array("I", [0, 1, 2]),
+            material_index=0,
+        )
+        flag = InstancedMeshResource(
+            id="mesh_flag", definition_id=2, definition_name="Flag",
+            variant_key="2|255,255,255", primitives=[triangle],
+        )
+        node_a = InstancedNode(name="Item_Box", matrix=IDENTITY, mesh_resource_id="mesh_box")
+        node_b = InstancedNode(name="Item_Flag", matrix=IDENTITY, mesh_resource_id="mesh_flag")
+        root = InstancedNode(name="ROOT", matrix=IDENTITY, children=[node_a, node_b])
+        scene = InstancedScene(
+            bounds=None, scene_hierarchy=root, mesh_resources=[box, flag],
+            gltf_materials=[{"pbrMetallicRoughness": {"baseColorFactor": [1.0, 1.0, 1.0, 1.0]}}],
+            textures=[],
+        )
+        data = fragments.to_fragments(scene, raw=True)
+
+        model = Model.GetRootAsModel(bytearray(data), 0)
+        meshes = model.Meshes()
+        assert meshes.ShellsLength() == 2
+        assert meshes.RepresentationsLength() == 2
+
+        rep0 = meshes.Representations(0)
+        rep1 = meshes.Representations(1)
+        id0, id1 = rep0.Id(), rep1.Id()
+        assert id0 != id1
+
+        # Swap the two representations' Id() fields (Uint32 at struct
+        # offset 0 - see Representation.py) while leaving their positions
+        # in the Representations vector untouched, so position-based
+        # lookup and Id()-based lookup now disagree.
+        patched = bytearray(data)
+        import struct
+        struct.pack_into("<I", patched, rep0._tab.Pos, id1)
+        struct.pack_into("<I", patched, rep1._tab.Pos, id0)
+
+        result = fragments.from_fragments(bytes(patched))
+
+        def find(node, name):
+            if node.name == name:
+                return node
+            for c in node.children:
+                found = find(c, name)
+                if found is not None:
+                    return found
+            return None
+
+        def vert_count(node):
+            resource = next(r for r in result.mesh_resources if r.id == node.mesh_resource_id)
+            return sum(len(p.positions) // 3 for p in resource.primitives)
+
+        # Whichever shell each representation's swapped Id() now points
+        # at is what must come out - the box's item now resolves to the
+        # 3-vertex triangle shell, and vice versa. Reading by vector
+        # position instead would show the ORIGINAL, unswapped counts.
+        assert vert_count(find(result.scene_hierarchy, "Item_Box")) == 3
+        assert vert_count(find(result.scene_hierarchy, "Item_Flag")) == 8


### PR DESCRIPTION
## Summary
- `from_fragments` read each sample's shell geometry using the `Representation`'s own position in the `Representations` vector, treating that as the index into `Meshes.Shells`. That's only true of this project's own writer (which always keeps the two equal) — `Representation.Id()` is the real `Shells` index, and a real ThatOpen `IfcImporter`-produced file does not keep it equal to the representation's vector position.
- Found by converting real IFC source files (a Revit-exported wall, and a real ~8.6 MB structural model) through ThatOpen's own actual `IfcImporter` and reading the freshly-produced `.frag` output — crashed with `IndexError`, since no prior fixture (including this project's own encoder's round-trip output) happened to exercise the divergence.
- Fix follows `Representation.Id()`, matching the real reader's own `meshes.shells(repr.id!, ...)` in `@thatopen/fragments`' `Utils/edit/fetch-functions.ts`.

## Test plan
- [x] New regression test patches a representation's `Id()` field in place to diverge from its vector position and asserts the *correct* shell comes back (not just "doesn't crash").
- [x] Confirmed the new test fails against the pre-fix code and passes after the fix.
- [x] Full Python suite: 546 passed.
- [x] `ruff check` clean.
- [x] Manually re-verified against both real converted files: the wall (correct GUID/hierarchy/geometry, no warnings) and the structural model (1,526 geometry leaves, 869 deduped mesh resources, one expected warning for `CIRCLE_EXTRUSION` samples — rebar/round columns — which this reader intentionally skips).