### PR TITLE
fix(python): legacy parser - CCamera class-ref can precede this scan's own visit to its declaration

### DIFF
--- a/packages/python/src/openskp/legacy.py
+++ b/packages/python/src/openskp/legacy.py
@@ -860,7 +860,16 @@ def _skip_typed_ref(ar, r, cls_name, reader_fn):
     if tag & 0x8000:
         cslot = tag & 0x7FFF
         ent = ar.slots.get(cslot)
-        if not (ent and ent[0] == 'class' and ent[1] == cls_name):
+        if ent is None:
+            # A class declared in a part of the file this scan never
+            # visited (this project's writer references CCamera's class
+            # this way, itself declared in the scaffold's own prefix,
+            # well before where the main walk even starts) — same
+            # "learn it from context" fallback _Archive._new_of_class
+            # already uses for the same situation.
+            ent = ('class', cls_name, None)
+            ar.slots[cslot] = ent
+        if not (ent[0] == 'class' and ent[1] == cls_name):
             raise LegacyParseError(f"unexpected {cls_name} class-ref")
         r.u16()
         reader_fn(ar, r)


### PR DESCRIPTION
## Summary
- `_skip_typed_ref` raised `LegacyParseError` when a class-ref's target slot wasn't yet in `ar.slots` — but this project's own writer references `CCamera`'s class this way before the scan reaches where `CCamera` is actually declared (in the scaffold's own prefix, well before the main walk starts).
- Falls back to learning the class from context in that case, the same way `_Archive._new_of_class` already does for the same situation, instead of treating it as malformed input.

## Test plan
- [x] Full Python suite: 546 passed (no regressions).