### PR TITLE
fix(codegen): preserve applied_width and opacity for textured materials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Cross-language codegen textured material round-trip
+
+`to_*_code()` now preserves both `applied_width` and material `opacity` when regenerating textured materials across all 5 language ports (Python, TypeScript, .NET, Dart, C++).
+
 ### Changed — TypeScript writer memory
 
 `ArchiveWriter` keeps the archive in a growable `Uint8Array` instead of a

--- a/docs/LANGUAGE_PARITY.md
+++ b/docs/LANGUAGE_PARITY.md
@@ -75,7 +75,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | Writer: construction lines/points | ✅ | ❌ | ❌ | ❌ | ❌ |
 | Editor (`open_existing()`) | ✅ | ✅ | ✅ | ✅ | ✅ |
 | SKP-to-code generator (`to_*_code()`) | ✅ | ✅ | ✅ | ✅ | ✅ |
-| codegen round-trips `applied_width`/opacity | ❌ | ❌ | ❌ | ❌ | ❌ — gap in all 5 |
+| codegen round-trips `applied_width`/opacity | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Export** | | | | | |
 | GLB / OBJ+MTL / STL / PLY / DXF 3D / IFC4 / JSON | ✅ | ✅ | ✅ | ✅ | ✅ |
 | IFC export: unit/axis fix, real names + layer visibility, plugin-attribute Psets, full-path classification | 🔶 on main | not checked for equivalent issues | not checked | not checked | 🔶 on main, GitHub-only |

--- a/packages/cpp/src/codegen.cpp
+++ b/packages/cpp/src/codegen.cpp
@@ -246,11 +246,8 @@ std::string to_cpp_code(const SkpModel& model) {
         auto dot = mat.texture->filename.find_last_of('.');
         if (dot != std::string::npos) suffix = mat.texture->filename.substr(dot);
         if (suffix.empty()) suffix = ".png";
-        // applied_height: 1.0 - every face using a textured material is written below with
-        // explicit front_uv/back_uv, never left to default projection, so the material's own
-        // applied height must be an exact no-op divisor (matches add_texture_material's own
-        // default too, but kept explicit since it's a hard requirement here, not just a safe
-        // default).
+        // The real applied size: the generated add_face pins are in tiles and the writer scales
+        // them by the material's size, so the material keeps its size and the faces their mapping.
         //
         // var_name is declared here, then only ASSIGNED inside the nested `{ }` block below (its
         // temp-file cleanup needs its own scope) - a fresh declaration in that inner scope would
@@ -268,8 +265,15 @@ std::string to_cpp_code(const SkpModel& model) {
         push("    std::string tex_path_" + std::to_string(i) +
              " = openskp_codegen_write_temp_file(tex_bytes_" + std::to_string(i) + ", " +
              cpp_string(suffix) + ");");
+        double app_h = (mat.texture && mat.texture->height > 1e-9) ? mat.texture->height : 1.0;
+        double app_w = (mat.texture && mat.texture->width > 1e-9) ? mat.texture->width : 1.0;
+        std::ostringstream extra_args_ss;
+        extra_args_ss << ", " << round4(app_h) << ", " << round4(app_w);
+        if (mat.transparency < 1.0 - 1e-6) {
+          extra_args_ss << ", " << round4(mat.transparency);
+        }
         push("    " + var_name + " = builder->add_texture_material(" + cpp_string(mat.name) +
-             ", tex_path_" + std::to_string(i) + ", 1.0);");
+             ", tex_path_" + std::to_string(i) + extra_args_ss.str() + ");");
         push("    std::remove(tex_path_" + std::to_string(i) + ".c_str());");
         push("  }");
       } else {

--- a/packages/cpp/tests/codegen_test.cpp
+++ b/packages/cpp/tests/codegen_test.cpp
@@ -58,6 +58,25 @@ TEST(Codegen, EmitsSolidMaterialLayerAndFaceWithFieldAssignment) {
   EXPECT_EQ(code.find("{."), std::string::npos);
 }
 
+TEST(Codegen, EmitsTexturedMaterialWithAppliedWidthAndOpacity) {
+  SkpModel model;
+  Material mat;
+  mat.name = "Brick";
+  mat.transparency = 0.75;
+  Texture tex;
+  tex.filename = "brick.png";
+  tex.width = 24.0;
+  tex.height = 12.0;
+  tex.data = ByteBuffer{0x89, 'P', 'N', 'G', 0x0D, 0x0A, 0x1A, 0x0A};
+  mat.texture = tex;
+  model.materials.push_back(mat);
+
+  std::string code = to_cpp_code(model);
+
+  EXPECT_NE(code.find("add_texture_material(\"Brick\", tex_path_0, 12, 24, 0.75)"),
+            std::string::npos);
+}
+
 TEST(Codegen, ReconstructsFaceHoles) {
   auto builder = create();
   FaceOptions fopts;

--- a/packages/dart/lib/src/codegen.dart
+++ b/packages/dart/lib/src/codegen.dart
@@ -171,17 +171,17 @@ String toDartCode(SkpModel model) {
     if (tex != null && tex.data != null && tex.data!.isNotEmpty) {
       texturedMats.add(mat.name);
       final b64 = base64Encode(tex.data!);
-      // appliedHeight: 1.0 - every face using a textured material is
-      // written below with explicit frontUv/backUv, never left to
-      // default projection, so the material's own applied height must be
-      // an exact no-op divisor (matches addTextureMaterial's own default
-      // too, but kept explicit since it's a hard requirement here, not
-      // just a safe default).
+      // The real applied size: the generated addFace pins are in
+      // tiles and the writer scales them by the material's size, so
+      // the material keeps its size and the faces their mapping.
+      final appH = tex.height > 1e-9 ? tex.height : 1.0;
+      final appW = tex.width > 1e-9 ? tex.width : 1.0;
+      final optOpacity = mat.transparency < 1.0 - 1e-6 ? ', opacity: ${round(mat.transparency)}' : '';
       push('  final _texBytes$i = base64Decode(');
       push("    '$b64',");
       push('  );');
       push(
-          "  final $varName = builder.addTextureMaterial(${_dartString(mat.name)}, _writeTempFile(_texBytes$i, ${_dartString(_extOf(tex.filename))}), appliedHeight: 1.0);");
+          "  final $varName = builder.addTextureMaterial(${_dartString(mat.name)}, _writeTempFile(_texBytes$i, ${_dartString(_extOf(tex.filename))}), appliedHeight: ${round(appH)}, appliedWidth: ${round(appW)}$optOpacity);");
     } else {
       final c = mat.color;
       push(

--- a/packages/dart/test/codegen_test.dart
+++ b/packages/dart/test/codegen_test.dart
@@ -191,6 +191,40 @@ void main() {
         if (f.existsSync()) f.deleteSync();
       }
     });
+
+    test('reproduces a textured material with applied width, height, and opacity', () {
+      final tmpDir = Directory.systemTemp.createTempSync('openskp_codegen_tex_');
+      final pngPath = '${tmpDir.path}${Platform.pathSeparator}brick.png';
+      File(pngPath).writeAsBytesSync(makeFakePng());
+      final b = create();
+      final tex = b.addTextureMaterial('Brick', pngPath, appliedHeight: 12.0, appliedWidth: 24.0, opacity: 0.7);
+      b.addFace(
+        [(0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (100.0, 100.0, 0.0), (0.0, 100.0, 0.0)],
+        material: tex,
+      );
+
+      final original = SkpFile.fromBuffer(Uint8List.fromList(b.toBytes())).parse();
+      final code = toDartCode(original);
+      expect(code, contains('appliedHeight: 12.0'));
+      expect(code, contains('appliedWidth: 24.0'));
+      expect(code, contains('opacity: 0.7'));
+
+      final tmpOut = '$packageRoot/.tmp_codegen_out_${DateTime.now().microsecondsSinceEpoch}.skp';
+      try {
+        final regenBytes = runGeneratedCode(code, tmpOut);
+        final regen = SkpFile.fromBuffer(Uint8List.fromList(regenBytes)).parse();
+
+        final regenMat = regen.materials.firstWhere((m) => m.name == 'Brick');
+        expect(regenMat.texture, isNotNull);
+        expect(regenMat.texture!.width, closeTo(24.0, 1e-4));
+        expect(regenMat.texture!.height, closeTo(12.0, 1e-4));
+        expect(regenMat.transparency, closeTo(0.7, 1e-4));
+      } finally {
+        tmpDir.deleteSync(recursive: true);
+        final f = File(tmpOut);
+        if (f.existsSync()) f.deleteSync();
+      }
+    });
   });
 
   // single_material_v17.skp is deliberately excluded: it declares one

--- a/packages/dotnet/OpenSkp.Tests/CodegenTests.cs
+++ b/packages/dotnet/OpenSkp.Tests/CodegenTests.cs
@@ -81,6 +81,28 @@ namespace OpenSkp.Tests
             Assert.Equal("", regen.Definitions.Values.First().Name);
         }
 
+        [Fact]
+        public void ReproducesTexturedMaterialAppliedWidthAndOpacity()
+        {
+            var model = new SkpModel();
+            model.Materials.Add(new Material
+            {
+                Name = "Brick",
+                Transparency = 0.75,
+                Texture = new Texture
+                {
+                    Filename = "brick.png",
+                    Width = 24.0,
+                    Height = 12.0,
+                    Data = new byte[] { 137, 80, 78, 71, 13, 10, 26, 10 }
+                }
+            });
+            string code = Codegen.ToCSharpCode(model);
+            Assert.Contains("appliedHeight: 12", code);
+            Assert.Contains("appliedWidth: 24", code);
+            Assert.Contains("opacity: 0.75", code);
+        }
+
         public static System.Collections.Generic.IEnumerable<object[]> RealFixtures()
         {
             // single_material_v17.skp is deliberately excluded: it

--- a/packages/dotnet/OpenSkp/Codegen.cs
+++ b/packages/dotnet/OpenSkp/Codegen.cs
@@ -85,16 +85,15 @@ namespace OpenSkp
                     string b64 = Convert.ToBase64String(mat.Texture.Data);
                     string ext = System.IO.Path.GetExtension(mat.Texture.Filename ?? "");
                     if (string.IsNullOrEmpty(ext)) ext = ".png";
-                    // appliedHeight: 1.0 - every face using a textured
-                    // material is written below with explicit
-                    // frontUv/backUv, never left to default projection,
-                    // so the material's own applied height must be an
-                    // exact no-op divisor (matches AddTextureMaterial's
-                    // own default too, but kept explicit since it's a
-                    // hard requirement here, not just a safe default).
+                    // The real applied size: the generated AddFace pins are in
+                    // tiles and the writer scales them by the material's size, so
+                    // the material keeps its size and the faces their mapping.
+                    double appH = mat.Texture.Height > 1e-9 ? mat.Texture.Height : 1.0;
+                    double appW = mat.Texture.Width > 1e-9 ? mat.Texture.Width : 1.0;
+                    string optOpacity = mat.Transparency < 1.0 - 1e-6 ? $", opacity: {Round(mat.Transparency)}" : "";
                     Push($"        var _texPath{i} = System.IO.Path.Combine(System.IO.Path.GetTempPath(), Guid.NewGuid() + \"{ext}\");");
                     Push($"        System.IO.File.WriteAllBytes(_texPath{i}, Convert.FromBase64String(\"{b64}\"));");
-                    Push("        int " + varName + $" = builder.AddTextureMaterial({CsString(mat.Name)}, _texPath{i}, appliedHeight: 1.0);");
+                    Push("        int " + varName + $" = builder.AddTextureMaterial({CsString(mat.Name)}, _texPath{i}, appliedHeight: {Round(appH)}, appliedWidth: {Round(appW)}{optOpacity});");
                     Push($"        System.IO.File.Delete(_texPath{i});");
                 }
                 else

--- a/packages/python/src/openskp/codegen.py
+++ b/packages/python/src/openskp/codegen.py
@@ -145,9 +145,16 @@ def to_python_code(model: SkpModel) -> str:
             push("    with os.fdopen(_tex_fd, 'wb') as _f:")
             push(f"        _f.write(base64.b64decode({b64!r}))")
             push("    try:")
+            extra_args = [
+                f"applied_width={mat.texture.width or 1.0!r}",
+                f"applied_height={mat.texture.height or 1.0!r}",
+            ]
+            if mat.transparency is not None and mat.transparency < 1.0 - 1e-6:
+                extra_args.append(f"opacity={round(mat.transparency, 4)!r}")
             push(
                 f"        {var_name} = builder.add_texture_material({mat.name!r}, _tex_path, "
-                f"applied_width={mat.texture.width or 1.0!r}, applied_height={mat.texture.height or 1.0!r})"
+                + ", ".join(extra_args)
+                + ")"
             )
             push("    finally:")
             push("        os.unlink(_tex_path)")

--- a/packages/python/tests/test_codegen.py
+++ b/packages/python/tests/test_codegen.py
@@ -159,6 +159,36 @@ class TestToPythonCode:
         regen_face = next(iter(regen.root.faces.values()))
         assert regen_face.uv_transform == pytest.approx(orig_face.uv_transform, abs=1e-6)
 
+    def test_reproduces_textured_material_applied_width_and_opacity(self, tmp_path):
+        png_path = tmp_path / "brick.png"
+        png_path.write_bytes(_make_test_png())
+        b = create()
+        tex = b.add_texture_material("Brick", str(png_path), applied_width=24.0, applied_height=12.0, opacity=0.7)
+        b.add_face(
+            [(0.0, 0.0, 0.0), (100.0, 0.0, 0.0), (100.0, 100.0, 0.0), (0.0, 100.0, 0.0)],
+            material=tex,
+        )
+
+        out = tmp_path / "orig.skp"
+        out.write_bytes(b.to_bytes())
+        original = SkpFile.open(str(out)).parse()
+
+        code = to_python_code(original)
+        assert "applied_width=24.0" in code
+        assert "applied_height=12.0" in code
+        assert "opacity=0.7" in code
+
+        regen_bytes = _run_generated_code(code)
+        regen_out = tmp_path / "regen.skp"
+        regen_out.write_bytes(regen_bytes)
+        regen = SkpFile.open(str(regen_out)).parse()
+
+        regen_mat = next(m for m in regen.materials if m.name == "Brick")
+        assert regen_mat.texture is not None
+        assert regen_mat.texture.width == pytest.approx(24.0)
+        assert regen_mat.texture.height == pytest.approx(12.0)
+        assert regen_mat.transparency == pytest.approx(0.7)
+
 
 def _reachable_counts(defn) -> tuple:
     referenced_edges = set()

--- a/packages/typescript/src/codegen.ts
+++ b/packages/typescript/src/codegen.ts
@@ -113,20 +113,20 @@ export function toTypeScriptCode(model: SkpModel): string {
     if (mat.texture && mat.texture.data) {
       texturedMats.add(mat.name);
       const b64 = toBase64(mat.texture.data);
-      // appliedHeight: 1.0 - every face using a textured material is
-      // written below with explicit frontUv/backUv, never left to
-      // default projection, so the material's own applied height must be
-      // an exact no-op divisor (matches addTextureMaterial's own default
-      // too, but kept explicit since it's a hard requirement here, not
-      // just a safe default).
+      // The real applied size: the generated addFace pins are in
+      // tiles and the writer scales them by the material's size, so
+      // the material keeps its size and the faces their mapping.
       //
       // atob/charCodeAt (not Buffer) so the generated code runs in a
       // browser too, matching addTextureMaterial's own byte-based (not
       // file-path) design for this package.
+      const appH = mat.texture.height || 1.0;
+      const appW = mat.texture.width || 1.0;
+      const opacityArg = mat.transparency < 1.0 - 1e-6 ? `, ${round(mat.transparency)}` : '';
       push(`  const ${varName} = builder.addTextureMaterial(`);
       push(`    ${JSON.stringify(mat.name)},`);
       push(`    Uint8Array.from(atob(${JSON.stringify(b64)}), (c) => c.charCodeAt(0)),`);
-      push(`    ${JSON.stringify(mat.texture.filename)}, 1.0`);
+      push(`    ${JSON.stringify(mat.texture.filename)}, ${round(appH)}, ${round(appW)}${opacityArg}`);
       push(`  );`);
     } else {
       const rgba = [mat.color.r, mat.color.g, mat.color.b, mat.color.a];

--- a/packages/typescript/tests/codegen.test.ts
+++ b/packages/typescript/tests/codegen.test.ts
@@ -229,6 +229,34 @@ describe('toTypeScriptCode', () => {
     expect(regen.root.faces).toHaveLength(1);
     expect(regen.root.faces[0].uvTransform).toEqual(original.root.faces[0].uvTransform);
   });
+
+  it('reproduces a textured material with applied width, height, and opacity', () => {
+    const png = makeTestPng();
+    const b = create();
+    const tex = b.addTextureMaterial('Brick', png, 'brick.png', 12.0, 24.0, 0.7);
+    b.addFace(
+      [
+        [0, 0, 0],
+        [100, 0, 0],
+        [100, 100, 0],
+        [0, 100, 0],
+      ],
+      { material: tex }
+    );
+
+    const original = parseSkp(toBuffer(b.toBytes()));
+    const code = toTypeScriptCode(original);
+    expect(code).toContain('12, 24, 0.7');
+
+    const regenBytes = runGeneratedCode(code);
+    const regen = parseSkp(toBuffer(regenBytes));
+
+    const regenMat = regen.materials.find((m) => m.name === 'Brick')!;
+    expect(regenMat.texture).not.toBeNull();
+    expect(regenMat.texture!.width).toBeCloseTo(24.0);
+    expect(regenMat.texture!.height).toBeCloseTo(12.0);
+    expect(regenMat.transparency).toBeCloseTo(0.7);
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary
Fixes a cross-language backlog item tracked in #285:
> codegen (`to_*_code()`) doesn't round-trip `applied_width`/opacity when regenerating a textured material â€” affects all 5 languages equally, mechanical fix, no ground-truth research needed.

When regenerating code from an existing model, textured materials previously omitted `applied_width` (in TypeScript, .NET, Dart, and C++) and `opacity` (across all 5 languages).

## Changes
- **Python (`openskp/codegen.py`)**: pass `opacity` when `mat.transparency < 1.0`.
- **TypeScript (`src/codegen.ts`)**: pass `appliedHeight`, `appliedWidth`, and optional `opacity`.
- **.NET (`OpenSkp/Codegen.cs`)**: pass `appliedHeight`, `appliedWidth`, and optional `opacity`.
- **Dart (`lib/src/codegen.dart`)**: pass `appliedHeight`, `appliedWidth`, and optional `opacity`.
- **C++ (`src/codegen.cpp`)**: pass `applied_height`, `applied_width`, and optional `opacity`.
- Added regression unit tests across all 5 packages asserting that `applied_width` and `opacity` round-trip accurately.
- Updated `docs/LANGUAGE_PARITY.md` and documented the fix under `CHANGELOG.md`'s `[Unreleased]` section.