### PR TITLE
fix(cpp): restore explicit WASM memory ceiling to prevent internal OOM well below the browser's own limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — C++ WASM build hit an internal memory ceiling well below what a browser tab actually allows
+
+The `OPENSKP_BUILD_WASM` target set `-sALLOW_MEMORY_GROWTH=1` with no explicit
+`-sMAXIMUM_MEMORY`. Without one, the WASM heap hit an internal allocation
+failure - caught generically and surfaced as a misleading `legacy .skp parse
+failed` error, with the real exception type lost - well before a browser's
+own ~4GB ceiling would actually be reached. Confirmed directly: a synthetic
+125MB file with 65,000 component definitions failed outright under the old
+config; adding an explicit `-sMAXIMUM_MEMORY=4GB` (plus a 256MB
+`-sINITIAL_MEMORY` to avoid repeated grow-and-copy on real files) removed the
+failure. See [issue #305](https://github.com/iamahsanmehmood/openskp/issues/305)
+for the fuller investigation, including a separate, still-open WASM-vs-native
+performance gap this fix does not address.
+
 ### Fixed — Cross-language codegen textured material round-trip
 
 `to_*_code()` now preserves both `applied_width` and material `opacity` when regenerating textured materials across all 5 language ports (Python, TypeScript, .NET, Dart, C++).

--- a/packages/cpp/CMakeLists.txt
+++ b/packages/cpp/CMakeLists.txt
@@ -238,6 +238,13 @@ if(EMSCRIPTEN OR OPENSKP_BUILD_WASM)
       "--bind"
       "-sWASM=1"
       "-sALLOW_MEMORY_GROWTH=1"
+      # Without an explicit ceiling, the WASM heap hits an internal
+      # allocation failure - caught generically and surfaced as a
+      # misleading "legacy .skp parse failed" - at a MUCH lower size than
+      # the ~4GB a browser tab actually allows (openskp#305). A modest
+      # initial size avoids repeated grow-and-copy on any real file.
+      "-sMAXIMUM_MEMORY=4GB"
+      "-sINITIAL_MEMORY=268435456"
       "-sMODULARIZE=1"
       "-sEXPORT_ES6=1"
       "-sEXPORT_NAME=OpenSkpModule"


### PR DESCRIPTION
## Summary
- `OPENSKP_BUILD_WASM` set `-sALLOW_MEMORY_GROWTH=1` with no explicit `-sMAXIMUM_MEMORY` (an earlier commit in #300 had one; it was dropped in a later commit addressing review feedback, apparently as an unrelated side effect).
- Without it, the WASM heap hits an internal allocation failure - caught generically by `legacy.cpp`'s catch-all and reported as a misleading `legacy .skp parse failed`, with the real exception type/message lost - well before the ~4GB a browser tab actually allows.
- Fixes closes/addresses the first of the two issues tracked in #305 (the outright-failure one). The second - a separate, still-open ~12-13x WASM-vs-native performance gap - is NOT fixed by this and remains open; ruled out exception-handling scheme (`-fwasm-exceptions`) and allocator (`dlmalloc`) as causes via direct experiments, neither moved the needle, so it needs real profiling rather than more guessing.

## Verification
- Rebuilt `openskp.wasm` from this branch and reproduced the original failure disappearing: a synthetic 125MB/65,000-definition file that failed outright under the old config no longer errors under the new one (it does still hit the separate, documented performance issue at that size - not something this PR claims to fix).
- Confirmed no regression on a smaller (38MB/20,000-definition) file that already worked.
- This target isn't currently built in CI (no CI job builds `OPENSKP_BUILD_WASM`), so this was verified manually by building via `emcmake`/Ninja locally - worth considering as a separate follow-up (a CI job that at least confirms the WASM target builds) but out of scope here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)