### PR TITLE
fix(cpp): to_instanced_glb() was accidentally quadratic in mesh-resource count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `to_instanced_glb()` was accidentally quadratic in mesh-resource count (not a WASM-specific issue)
+
+`make_model()`'s shared binary buffer was grown via `append_values()`
+calling `buffer.reserve(buffer.size() + delta)` once per primitive per
+attribute array (positions/normals/uvs/indices) - `std::vector::reserve()`
+has no obligation to over-allocate beyond what's asked, so a size that only
+ever grows by "just enough" forces a full reallocation-and-copy of
+everything appended so far, every single call. On a scene with many mesh
+resources this turned amortized-O(1) appends into O(resource count²)
+copying - **39,016ms → 485ms (an 80x speedup) at 10,000 resources, and
+713s → 12.6s (56.6x) at 65,000**, real numbers from a synthetic 125MB file,
+fixed by reserving the true final buffer size once, upfront (byte-identical
+output, confirmed on the same file before/after).
+
+This corrects a wrong conclusion from the memory-ceiling fix entry just
+below: profiling (not just black-box timing) found the real hot path was
+`to_instanced_glb()` itself, not the legacy parser - the earlier "WASM is
+12-13x slower than native" claim compared WASM's full parse+build+GLB
+pipeline against a native benchmark that never called `to_instanced_glb()`
+at all. Once compared correctly, this bug affected native and WASM
+equally; there was no WASM-specific slowdown. See
+[issue #305](https://github.com/iamahsanmehmood/openskp/issues/305) for
+the full corrected investigation.
+
 ### Fixed — C++ WASM build hit an internal memory ceiling well below what a browser tab actually allows
 
 The `OPENSKP_BUILD_WASM` target set `-sALLOW_MEMORY_GROWTH=1` with no explicit

--- a/packages/cpp/src/instanced_glb.cpp
+++ b/packages/cpp/src/instanced_glb.cpp
@@ -231,6 +231,26 @@ gltf::Model make_model(const InstancedScene& scene, bool embed_textures) {
   model.buffers.emplace_back();
   auto& binary = model.buffers[0].data;
 
+  // append_values() below reserves the buffer to exactly its own new
+  // required size on every call (one call per primitive per attribute
+  // array) - std::vector::reserve() has no obligation to over-allocate,
+  // so a size that only ever grows by "just enough" forces a full
+  // reallocation-and-copy of everything appended so far, every single
+  // time. On a scene with many mesh resources this turns what should be
+  // amortized-O(1) appends into O(total resources squared) copying.
+  // Reserving the true final size once, upfront, is a pure amortized-cost
+  // fix - it changes no output, only how many times the buffer moves.
+  {
+    std::size_t total_bytes = 0;
+    for (const auto& resource : scene.mesh_resources) {
+      for (const auto& source : resource.primitives) {
+        total_bytes += source.positions.size() * 4 + source.normals.size() * 4 +
+                       source.uvs.size() * 4 + source.indices.size() * 4;
+      }
+    }
+    binary.reserve(total_bytes);
+  }
+
   std::map<std::string, int> mesh_index_by_id;
 
   for (const auto& resource : scene.mesh_resources) {

--- a/packages/cpp/tests/instanced_glb_test.cpp
+++ b/packages/cpp/tests/instanced_glb_test.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <array>
+#include <chrono>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -44,6 +46,26 @@ tinygltf::Model load_glb(const ByteBuffer& bytes) {
 bool contains_bytes(const ByteBuffer& haystack, std::initializer_list<std::uint8_t> needle) {
   return std::search(haystack.begin(), haystack.end(), needle.begin(), needle.end()) !=
          haystack.end();
+}
+
+constexpr std::array<double, 16> kIdentity{
+    1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1,
+};
+
+InstancedMeshResource make_box_resource(const std::string& id) {
+  InstancedMeshResource r;
+  r.id = id;
+  r.definition_id = 1;
+  r.definition_name = "Box";
+  r.variant_key = "1|255,255,255";
+  LocalPrimitive prim;
+  prim.positions = {0, 0, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 1, 1, 1, 1, 0, 1, 1};
+  prim.normals.assign(prim.positions.size(), 0.0f);
+  prim.uvs.assign((prim.positions.size() / 3) * 2, 0.0f);
+  prim.indices = {0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6};
+  prim.material_index = 0;
+  r.primitives = {prim};
+  return r;
 }
 
 TEST(InstancedGlb, SerializesInstancedSceneWithSharedMesh) {
@@ -107,6 +129,51 @@ TEST(InstancedGlb, IsSmallerThanTheBakedExportOnAFileWithRepeatedGeometry) {
   const auto instanced_bytes = to_instanced_glb(instanced_scene);
 
   EXPECT_LT(instanced_bytes.size(), baked_bytes.size());
+}
+
+TEST(InstancedGlb, ManyDistinctMeshResourcesStayNearLinearNotQuadratic) {
+  // Regression test for openskp#305: make_model() reserved its shared
+  // binary buffer to exactly its own new size on every append_values()
+  // call (once per primitive per attribute array) instead of once
+  // upfront for the true final size, forcing a full copy of everything
+  // appended so far on every single call - turning what should be
+  // amortized-O(1) appends into O(resource count squared). On a real
+  // 65,000-resource file this was 713s under WASM (56.6x slower than
+  // the ~12.6s after the fix) and 39s even natively for just 10,000
+  // resources. 8,000 distinct tiny resources is calibrated to make the
+  // quadratic behavior obvious (~9.4s, measured against the pre-fix
+  // code) while staying comfortably fast when fixed (~0.3s) - a >10x
+  // margin either way, so this isn't sensitive to normal CI slowness.
+  InstancedScene scene;
+  scene.gltf_materials = {{}};
+  constexpr int kResourceCount = 8000;
+  scene.mesh_resources.reserve(kResourceCount);
+  InstancedNode root;
+  root.name = "ROOT";
+  root.matrix = kIdentity;
+  root.children.reserve(kResourceCount);
+  for (int i = 0; i < kResourceCount; ++i) {
+    const auto id = "mesh_" + std::to_string(i);
+    scene.mesh_resources.push_back(make_box_resource(id));
+    InstancedNode leaf;
+    leaf.name = "Box" + std::to_string(i);
+    leaf.matrix = kIdentity;
+    leaf.mesh_resource_id = id;
+    root.children.push_back(std::move(leaf));
+  }
+  scene.scene_hierarchy = std::move(root);
+
+  const auto start = std::chrono::steady_clock::now();
+  const auto bytes = to_instanced_glb(scene);
+  const auto elapsed_ms =
+      std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start).count();
+
+  EXPECT_GT(bytes.size(), 0u);
+  // Fixed: comfortably under a second. Quadratic-buggy: several seconds
+  // at this size and climbing fast with scene size - 5s leaves ample
+  // margin above real (fixed) runs without being able to hide a
+  // reintroduced O(n^2).
+  EXPECT_LT(elapsed_ms, 5000.0) << "took " << elapsed_ms << "ms - looks quadratic again";
 }
 
 TEST(InstancedGlb, ExportInstancedGlbFileRoundTrips) {


### PR DESCRIPTION
## Summary
- `make_model()`'s shared binary buffer grew via `append_values()` calling `buffer.reserve(buffer.size() + delta)` once per primitive per attribute array (positions/normals/uvs/indices). `std::vector::reserve()` has no obligation to over-allocate, so a size that only ever grows by "just enough" forces a full reallocation-and-copy of everything appended so far, every single call - turning amortized-O(1) appends into O(resource count²) copying.
- Fixed by reserving the true final buffer size once, upfront, before the per-resource loop. Pure performance fix - byte-identical output confirmed on the same file before/after.

## This also corrects a wrong conclusion from #305 / #306
Profiling (`node --cpu-prof` against the WASM build, since that's what was asked for) found the real hot path was `to_instanced_glb()` itself (89.4% of samples) - not the legacy parser (`full_parse`, only 1.0%). The earlier "WASM is 12-13x slower than native" claim in #305/#306 compared WASM's full parse+build+GLB pipeline against a native benchmark (`bench.cpp`'s `build_scene()`) that never called `to_instanced_glb()` at all. Once compared against the real equivalent (a new native `build_instanced_scene()` + `to_instanced_glb()` benchmark), the bug was there natively too - worse, in fact, since native's absolute time without the fix was *slower* than WASM's on the same file. This was never a WASM-specific issue.

## Verification
Real numbers, synthetic 125MB file with many unique component definitions:

| Resources | Before | After | Speedup |
|---|---|---|---|
| 10,000 (native `to_instanced_glb`) | 39,016 ms | 485 ms | 80x |
| 65,000 (WASM `parseSkpToGLB`, full pipeline) | 713,327 ms (~11.9 min) | 12,597 ms (~12.6s) | 56.6x |

- Full C++ suite: 220/220 passed.
- New regression test (`InstancedGlb.ManyDistinctMeshResourcesStayNearLinearNotQuadratic`) calibrated against the pre-fix code: fails at 9.4s on the buggy version, passes at 0.3s on the fixed version (>10x margin either way against CI slowness). Confirmed it actually fails without the fix (temporarily reverted and reran).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)