### PR TITLE
docs: sync README/ROADMAP/LANGUAGE_PARITY/DEVELOPER_GUIDE with #276 and #310

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ OpenSKP is the **first and only** open-source, cross-platform toolkit for Sketch
 | Feature | Status | Description |
 |:--------|:------:|:------------|
 | **Parse SKP 2021+ (VFF)** | ✅ | Full support for the modern VFF binary container |
-| **Parse SKP 2013–2020 (legacy MFC)** | ✅ | Broad support for the classic MFC `CArchive` container — same output shape as VFF. A real version-compatibility sweep found 8/14 old-format test files parse cleanly; the remaining 6 hit a known, tracked parsing gap — see [ROADMAP.md](ROADMAP.md#known-bugs) |
+| **Parse SKP 2013–2020 (legacy MFC)** | ✅ | Broad support for the classic MFC `CArchive` container — same output shape as VFF. A real version-compatibility sweep found 11/15 old-format test files parse cleanly (up from 8/15 — [#310](https://github.com/iamahsanmehmood/openskp/pull/310) fixed the V7/V8/2013 cluster); the remaining 4 hit a known, tracked parsing gap — see [ROADMAP.md](ROADMAP.md#known-bugs) |
 | **3D Geometry Extraction** | ✅ | Vertices, edges, faces, normals, and UV coordinates |
 | **Component Hierarchy** | ✅ | Nested component definitions and instance transforms |
 | **Scene Baking / Triangulation** | ✅ | Opt-in scene baking: full placed scene graph resolved to world-space, triangulated, GLB-ready — in all five languages |
@@ -130,7 +130,7 @@ condensed version.
 | Editor (`open_existing()`), code generator | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Export: GLB / OBJ / STL / PLY / DXF / IFC4 / JSON | ✅ | ✅ | ✅ | ✅ | ✅ |
 | IFC export correctness fixes (units, layer visibility, Psets, classification) | 🔶 | not checked | not checked | not checked | 🔶 GitHub-only |
-| **Fragments (`.frag`) export** | 🔶 GitHub-only | 🔶 [PR #276](https://github.com/iamahsanmehmood/openskp/pull/276) open, CI failing | ❌ not started | ❌ not started | 🔶 GitHub-only |
+| **Fragments (`.frag`) export** | 🔶 GitHub-only | 🔶 on `main`, npm-only pending | ❌ not started | ❌ not started | 🔶 GitHub-only |
 | **Fragments (`.frag`) import** — 6th input format | 🔶 on `main` | ❌ not started | ❌ not started | ❌ not started | ❌ not started |
 
 ### Real SketchUp file version support
@@ -141,8 +141,8 @@ across its save history) found:
 
 | Result | Versions |
 |:---|:---|
-| ✅ Parse, build, and export cleanly | 2014, 2015, 2016, 2017, 2018, 2020, 2021, 2025 |
-| ❌ Fail — 5 distinct error signatures, root cause tracked in [issue #284](https://github.com/iamahsanmehmood/openskp/issues/284) | V3, V4, V6, V7, V8, 2013, 2019 |
+| ✅ Parse, build, and export cleanly | 2014, 2015, 2016, 2017, 2018, 2020, 2021, 2025, **V7, V8, 2013** (fixed in [#310](https://github.com/iamahsanmehmood/openskp/pull/310)) |
+| ❌ Fail — 4 distinct error signatures, root cause tracked in [issue #284](https://github.com/iamahsanmehmood/openskp/issues/284) | V3, V4, V6, 2019 |
 
 Full per-version error table and investigation notes: [docs/LANGUAGE_PARITY.md § 4](docs/LANGUAGE_PARITY.md#4-real-sketchup-file-version-support).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ languages currently supports).
 | Language | Latest release | Status |
 |:---|:---|:---|
 | Python | [1.2.0 on PyPI](https://pypi.org/project/openskp/) · [1.3.0 (preview) on GitHub](https://github.com/iamahsanmehmood/openskp/releases/tag/preview-python-v1.3.2) (not on PyPI yet) | Ahead of the other 4 — see [Cross-language porting backlog](#cross-language-porting-backlog) below |
-| TypeScript | [npm](https://www.npmjs.com/package/openskp) | At 1.2.0 parity, plus an unreleased writer memory fix — see [CHANGELOG.md](CHANGELOG.md) |
+| TypeScript | [npm](https://www.npmjs.com/package/openskp) | At 1.2.0 parity, plus Fragments (`.frag`) export ([#276](https://github.com/iamahsanmehmood/openskp/pull/276), verified against the real `@thatopen/fragments` runtime) and a writer memory fix, both merged and unreleased — see [CHANGELOG.md](CHANGELOG.md) |
 | .NET | [NuGet](https://www.nuget.org/packages/OpenSkp) | At 1.2.0 parity |
 | Dart | [pub.dev](https://pub.dev/packages/openskp) | At 1.2.0 parity |
 | C++ | [GitHub releases](https://github.com/iamahsanmehmood/openskp/releases?q=cpp-) · [1.3.0 (preview) on GitHub](https://github.com/iamahsanmehmood/openskp/releases/tag/preview-cpp-v1.3.1) | Closed most of the gap with Python this round — Fragments export, multi-dictionary attributes, 4 IFC export fixes, legacy pages/scenes reading, construction lines/points reading, and attribute-dictionary GLB/JSON metadata export all now shipped on a preview tag. Still behind on full 9-value-type attribute support and the writer's dimensions/section-planes/construction-geometry — see below |
@@ -64,10 +64,11 @@ line per feature, not one issue per language per feature. Summary:
   (2021+) files.
 - Direct SketchUp → Fragments (`.frag`) export — Python and C++ (both
   GitHub-only preview tags; C++ measured 5-9x faster end to end on real
-  files). A community TypeScript port is open
-  ([PR #276](https://github.com/iamahsanmehmood/openskp/pull/276)) but its
-  required CI check is currently failing. .NET and Dart have no work
-  started.
+  files). TypeScript now has it too — a community port
+  ([#276](https://github.com/iamahsanmehmood/openskp/pull/276), merged),
+  using the real canonical ThatOpen FlatBuffers schema and verified via a
+  round-trip through the actual `@thatopen/fragments` npm package, not just
+  this project's own bindings. .NET and Dart have no work started.
 - VFF per-layer-hidden flag reading — Python and C++ (both GitHub-only).
 - 4 IFC export correctness fixes (units/axis, real instance names + layer
   visibility, plugin-attribute property sets, full-path classification) —
@@ -105,10 +106,18 @@ implementation to port from — the hard research is already done. See
 
 Tracked in [issue #284](https://github.com/iamahsanmehmood/openskp/issues/284).
 A real-world version-compatibility sweep (the same project saved across
-SketchUp versions 3 through 2025) found 8 of 14 files parse and convert
-cleanly; 6 fail, most sharing one root cause narrowed down to a slot-collision
-bug inside the legacy MFC reader, not yet fixed. Stated here plainly rather
-than glossed over — this is a real gap in the classic MFC `CArchive` support
+SketchUp versions 3 through 2025, 15 usable files) found 11 of 15 files
+parse and convert cleanly; 4 fail, each with its own distinct, still-open
+error signature (V3, V4, V6, 2019) — see
+[docs/LANGUAGE_PARITY.md § 4](docs/LANGUAGE_PARITY.md#4-real-sketchup-file-version-support)
+for the full table. The three files that used to share one root cause (V7,
+V8, 2013 — a `class-ref to non-class slot N (CAttributeNamed)`
+slot-collision) are fixed as of
+[#310](https://github.com/iamahsanmehmood/openskp/pull/310): the trailing
+instance/group GUID read was gated on the class's own schema number, which
+doesn't actually track GUID presence across versions — fixed by gating on
+the file's real version instead. Stated here plainly rather than glossed
+over — the remaining 4 are a real gap in the classic MFC `CArchive` support
 some corners of the README describe as "full."
 
 ### Fragments export: no native visibility field
@@ -138,6 +147,14 @@ a property of the format), but worth knowing before building against it.
   legacy pages/scenes, construction lines/points, attribute-dictionary
   GLB/JSON metadata export) — `openskp.com` still needs the same pass
   manually, since it isn't in this repository.
+- [x] README.md, this page, `docs/LANGUAGE_PARITY.md`, and
+  `docs/DEVELOPER_GUIDE.md` swept after TypeScript's Fragments export
+  ([#276](https://github.com/iamahsanmehmood/openskp/pull/276), merged —
+  was showing as an open, CI-failing PR) and the legacy pre-2014
+  instance/group GUID fix
+  ([#310](https://github.com/iamahsanmehmood/openskp/pull/310), fixed the
+  V7/V8/2013 file-version-support gap) — `openskp.com` still needs its own
+  manual pass for both, not done here.
 
 ---
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -497,10 +497,14 @@ What's carried through from the source `.skp` file:
 - `Model.guid` — the single model-level identifier, distinct from each
   item's own per-instance guid above — is still an unpopulated placeholder.
 - Python and C++ have this today (both GitHub-only preview tags — see
-  above). A community TypeScript port is open
-  ([PR #276](https://github.com/iamahsanmehmood/openskp/pull/276)) but its
-  required CI lint check is currently failing, so it isn't usable yet.
-  .NET and Dart have no work started on this.
+  above). TypeScript now has it too
+  ([#276](https://github.com/iamahsanmehmood/openskp/pull/276), merged on
+  `main`, not npm-published yet) — the real, canonical ThatOpen FlatBuffers
+  schema (not hand-rolled), TRS decomposition and scale/mirror baking
+  matching Python/C++, and verified via a real round-trip through the
+  `@thatopen/fragments` npm package's own `SingleThreadedFragmentsModel`,
+  not just this project's own generated bindings. .NET and Dart have no
+  work started on this.
 - C++'s attribute dictionary values are strings only (no native
   `Point3d`/`Length`/nested-list types like Python has) — matches its
   existing string-only property handling elsewhere. See

--- a/docs/LANGUAGE_PARITY.md
+++ b/docs/LANGUAGE_PARITY.md
@@ -79,7 +79,7 @@ Every feature OpenSKP has, across all 5 languages. ✅ = shipped and released.
 | **Export** | | | | | |
 | GLB / OBJ+MTL / STL / PLY / DXF 3D / IFC4 / JSON | ✅ | ✅ | ✅ | ✅ | ✅ |
 | IFC export: unit/axis fix, real names + layer visibility, plugin-attribute Psets, full-path classification | 🔶 on main | not checked for equivalent issues | not checked | not checked | 🔶 on main, GitHub-only |
-| Direct SketchUp → Fragments (`.frag`) export | 🔶 on main, GitHub-only | 🔶 open [PR #276](https://github.com/iamahsanmehmood/openskp/pull/276), CI failing | ❌ not started | ❌ not started | 🔶 on main, GitHub-only |
+| Direct SketchUp → Fragments (`.frag`) export | 🔶 on main, GitHub-only | 🔶 on `main`, [#276](https://github.com/iamahsanmehmood/openskp/pull/276) — verified against the real `@thatopen/fragments` runtime, not npm-published yet | ❌ not started | ❌ not started | 🔶 on main, GitHub-only |
 | **Import** | | | | | |
 | Read a `.frag` file back (6th input format alongside `.skp`) | 🔶 on main | ❌ not started | ❌ not started | ❌ not started | ❌ not started |
 
@@ -98,6 +98,7 @@ Python-only:
 | Section planes writer | `create.py` | [CHANGELOG.md § 1.3.0](../CHANGELOG.md) |
 | Construction lines/points read + write | `legacy.py`, `create.py` | [CHANGELOG.md § 1.3.0](../CHANGELOG.md) |
 | Large-file parser fix | `_core.py` | [#264](https://github.com/iamahsanmehmood/openskp/issues/264) |
+| Legacy pre-2014 `CComponentInstance`/`CGroup` GUID misread — fixed the V7/V8/2013 file-version-support gap (§4 below) | `legacy.py` | [#310](https://github.com/iamahsanmehmood/openskp/pull/310), [#284](https://github.com/iamahsanmehmood/openskp/issues/284) |
 | `attribute_dictionaries` surfaced in GLB/JSON metadata export (not just IFC Psets) | `export/glb.py`, `export/json_export.py`, `export/instanced_glb.py` | [CHANGELOG.md § 1.3.0](../CHANGELOG.md) |
 
 All of the above are on GitHub as the tagged
@@ -118,11 +119,20 @@ this project already has. See
 [CHANGELOG.md § 1.3.0](../CHANGELOG.md) and
 [DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md#reading-a-frag-file-back).
 
-TypeScript merged, not yet released: a writer memory fix (`ArchiveWriter`
-now keeps the archive in a growable `Uint8Array` instead of a `number[]`,
-cutting peak heap on a 62 MB write from ~2.1 GB to ~0.2 GB) — see
-[CHANGELOG.md § Unreleased](../CHANGELOG.md). .NET and Dart currently have
-nothing unreleased — their `main` matches what's published.
+TypeScript merged, not yet released:
+
+| Item | Where | Tracking |
+|:---|:---|:---|
+| Direct SketchUp → Fragments (`.frag`) export | `toFragments()` / `SkpFile.prototype.toFragments()` (`fragments.ts`) | [#276](https://github.com/iamahsanmehmood/openskp/pull/276) |
+| Writer memory fix (`ArchiveWriter` now keeps the archive in a growable `Uint8Array` instead of a `number[]`, cutting peak heap on a 62 MB write from ~2.1 GB to ~0.2 GB) | `create.ts` | [CHANGELOG.md § Unreleased](../CHANGELOG.md) |
+
+The Fragments exporter uses the real, canonical ThatOpen FlatBuffers schema
+(generated bindings, not hand-rolled), includes TRS decomposition and
+scale/mirror baking matching Python/C++, and is verified via a real
+round-trip through the `@thatopen/fragments` npm package's own
+`SingleThreadedFragmentsModel` — not just against this project's own
+generated bindings. .NET and Dart currently have nothing unreleased — their
+`main` matches what's published.
 
 C++:
 
@@ -167,15 +177,16 @@ Known gaps in this C++ work, stated honestly rather than glossed over:
 ## 4. Real SketchUp file version support
 
 **Not every real old-format file parses today — stated plainly, not glossed
-over.** A real-world version-compatibility sweep (14 `.skp` files, the same
-project saved across its history from SketchUp version 3 up through 2025)
-found:
+over.** A real-world version-compatibility sweep (15 real `.skp` files —
+16 saves of the same project across its history from SketchUp version 3 up
+through 2025, one of which, V5, saved out corrupted/empty) found:
 
-**8 files parse, build, and export cleanly**: saves from **2014, 2015, 2016,
-2017, 2018, 2020, 2021, and 2025** — consistent output (146 definitions / 131
-mesh resources) across all of them.
+**11 files parse, build, and export cleanly**: saves from **2014, 2015,
+2016, 2017, 2018, 2020, 2021, 2025, and — as of [#310](https://github.com/iamahsanmehmood/openskp/pull/310) — V7, V8, and
+2013** — consistent output (146 definitions / 131 mesh resources) across all
+of them.
 
-**The remaining files hit 5 distinct error signatures**, investigated and
+**The remaining 4 files hit 4 distinct error signatures**, investigated and
 root-caused to varying depth (tracked in
 [issue #284](https://github.com/iamahsanmehmood/openskp/issues/284)):
 
@@ -184,8 +195,23 @@ root-caused to varying depth (tracked in
 | V3 | `expected a string record` | Not investigated further |
 | V4 | `texture object is not a dib` | Not investigated further |
 | V6 | `definition list misaligned` | Not investigated further |
-| V7, V8, 2013 | `class-ref to non-class slot N (CAttributeNamed)` | Root cause narrowed to inside one nested `CGroup`'s recursive content; exact byte-level origin not yet found. Two candidate fixes tested and disproven with evidence — not guessed at. |
 | 2019 | `implausible def entity count` | Not investigated further |
+
+~~V7, V8, 2013 — `class-ref to non-class slot N (CAttributeNamed)`~~ —
+**fixed in [#310](https://github.com/iamahsanmehmood/openskp/pull/310)**.
+Root cause: `_read_instance`'s trailing-GUID read for
+`CComponentInstance`/`CGroup` was gated on the class's own reported
+`schema` number (`schema >= 5` implies a GUID), which doesn't generalize —
+a real V7 file's `CComponentInstance` reports schema 6, well above that
+threshold, yet has no GUID at all. Forcing the read anyway silently ate
+into the next sibling entity's own tag bytes, which either crashed deep in
+a nested definition (the `CAttributeNamed` collision this row was
+originally about) or — the more dangerous variant, caught only while
+verifying the fix — got silently absorbed by the root entity list's own
+over-declared-count tolerance, truncating a real 18-instance root scene
+down to 1 with no error raised at all. Fixed by gating the GUID read on
+the file's real version number (`ar.ver >= 14`) instead of schema;
+verified byte-for-byte identical to the same files' 2014+ output.
 
 This was only investigated against the **Python** legacy MFC reader. Whether
 the other 4 languages' independently-implemented legacy readers hit the same


### PR DESCRIPTION
Updates documentation that was stale after two recent merges:

- **#276** (TypeScript Fragments export) merged, but docs across README/ROADMAP/LANGUAGE_PARITY/DEVELOPER_GUIDE still described it as an open, CI-failing PR. Updated status everywhere, including a note on the real `@thatopen/fragments` interop verification that landed with it.
- **#310** (legacy pre-2014 instance/group GUID fix) resolved the V7/V8/2013 file-version-support gap. Updated the real-file sweep numbers (11/15 now parse cleanly, 4 distinct failure signatures remain) and struck through the fixed row with a root-cause summary.

No code changes, docs only.